### PR TITLE
[#48] CalendarSettingUsecase prepare 추가

### DIFF
--- a/CalendarScenes/CalendarScenesTests/CalendarPager/CalendarPagerViewModelImpleTests.swift
+++ b/CalendarScenes/CalendarScenesTests/CalendarPager/CalendarPagerViewModelImpleTests.swift
@@ -48,7 +48,7 @@ class CalendarPagerViewModelImpleTests: BaseTestCase, PublisherWaitable {
     ) -> CalendarPagerViewModelImple {
         
         let calendarUsecase = StubCalendarUsecase(today: today)
-        self.stubSettingUsecase.selectTimeZone(TimeZone(abbreviation: "KST")!)
+        self.stubSettingUsecase.prepare()
         
         let viewModel = CalendarPagerViewModelImple(
             calendarUsecase: calendarUsecase,

--- a/Domain/DomainTests/Usecases/CalendarSettingUsecaseImpleTests.swift
+++ b/Domain/DomainTests/Usecases/CalendarSettingUsecaseImpleTests.swift
@@ -50,13 +50,15 @@ class CalendarSettingUsecaseImpleTests: BaseTestCase, PublisherWaitable {
 
 extension CalendarSettingUsecaseImpleTests {
         
-    func testUsecase_whenSubscribeCurrentTimeZone_startWithSavedTimeZone() {
+    func testUsecase_whenPrepare_startWithSavedTimeZone() {
         // given
         let expect = expectation(description: "timezone 정보 구독시에 저장되어있는 정보 같이 구독")
         let usecase = self.makeUsecase(savedTimeZone: TimeZone(abbreviation: "KST"))
         
         // when
-        let timeZones = self.waitOutputs(expect, for: usecase.currentTimeZone)
+        let timeZones = self.waitOutputs(expect, for: usecase.currentTimeZone) {
+            usecase.prepare()
+        }
         
         // then
         XCTAssertEqual(timeZones, [
@@ -72,6 +74,7 @@ extension CalendarSettingUsecaseImpleTests {
         
         // when
         let timeZones = self.waitOutputs(expect, for: usecase.currentTimeZone) {
+            usecase.prepare()
             usecase.selectTimeZone(TimeZone(abbreviation: "UTC")!)
         }
             
@@ -85,19 +88,21 @@ extension CalendarSettingUsecaseImpleTests {
 
 extension CalendarSettingUsecaseImpleTests {
     
-    func testUsecase_whenSubscribeCurrentFirstWeekDayWithoutSavedValue_startWithSundayDefaultValue() {
+    func testUsecase_whenPrepareAndSaveCurrentTimeZoneNotExists_startWithSundayDefaultValue() {
         // given
         let expect = expectation(description: "저장된 주 시작요일 없는데 구독된 경우 월요일로 방출")
         let usecase = self.makeUsecase(savedFirstWeekDay: nil)
         
         // when
-        let day = self.waitFirstOutput(expect, for: usecase.firstWeekDay)
+        let day = self.waitFirstOutput(expect, for: usecase.firstWeekDay) {
+            usecase.prepare()
+        }
         
         // then
         XCTAssertEqual(day, .sunday)
     }
     
-    func testUsecase_whenSubscribeCurrentFirstWeekDayAndUpdate_updateCurrentValue() {
+    func testUsecase_whenPrepareAndSaveCurrentTimeZoneExists_updateCurrentValue() {
         // given
         let expect = expectation(description: "주 요일 시작일 구독 이후에 변경")
         expect.expectedFulfillmentCount = 2
@@ -105,6 +110,7 @@ extension CalendarSettingUsecaseImpleTests {
         
         // when
         let days = self.waitOutputs(expect, for: usecase.firstWeekDay) {
+            usecase.prepare()
             usecase.updateFirstWeekDay(.saturday)
         }
         

--- a/Domain/DomainTests/Usecases/CalendarUsecaseImpleTests.swift
+++ b/Domain/DomainTests/Usecases/CalendarUsecaseImpleTests.swift
@@ -34,8 +34,7 @@ class CalendarUsecaseImpleTests: BaseTestCase, PublisherWaitable {
     private func makeUsecaseWithStub(
         firstWeekDay: DayOfWeeks = .sunday
     ) -> CalendarUsecaseImple {
-        self.stubSettingUsecase.updateFirstWeekDay(firstWeekDay)
-        self.stubSettingUsecase.selectTimeZone(TimeZone(abbreviation: "KST")!)
+        self.stubSettingUsecase.prepare()
         
         let holidayUsecase = StubHolidayUsecase(
             holidays: [2023: [

--- a/TestDoubles/TestDoubles/Usecases/StubCalendarSettingUsecase.swift
+++ b/TestDoubles/TestDoubles/Usecases/StubCalendarSettingUsecase.swift
@@ -14,6 +14,11 @@ open class StubCalendarSettingUsecase: CalendarSettingUsecase {
     
     public init() { }
     
+    open func prepare() {
+        self.firstWeekDaySubject.send(.sunday)
+        self.currentTimeZoneSubject.send(TimeZone(abbreviation: "KST")!)
+    }
+    
     private let firstWeekDaySubject = CurrentValueSubject<DayOfWeeks?, Never>(nil)
     open func updateFirstWeekDay(_ newValue: DayOfWeeks) {
         self.firstWeekDaySubject.send(newValue)


### PR DESCRIPTION
- prepapre시에 명시적으로 저장된 firstWeekDay, currentTimeZone 로드해서 세팅하도록 수정 + 구독시 세팅하는 부분 제거