### PR TITLE
[#173] 이벤트 알림시간 계산로직 변경

### DIFF
--- a/Domain/Sources/Models/Notifications/EventNotificationTimeOption.swift
+++ b/Domain/Sources/Models/Notifications/EventNotificationTimeOption.swift
@@ -16,5 +16,5 @@ public enum EventNotificationTimeOption: Sendable, Equatable {
     case allDay9AM
     case allDay12AM
     case allDay9AMBefore(seconds: TimeInterval)
-    case custom(_ timeZone: TimeZone, _ components: DateComponents)
+    case custom(_ components: DateComponents)
 }

--- a/Presentations/CommonPresentation/Sources/Extensions/EventNotificationTimeOption+Extensions.swift
+++ b/Presentations/CommonPresentation/Sources/Extensions/EventNotificationTimeOption+Extensions.swift
@@ -37,8 +37,8 @@ extension EventNotificationTimeOption {
             return "event_notification_setting::option_title::allday_12am".localized()
         case .allDay9AMBefore(let seconds):
             return seconds.alldayBeforeText
-        case .custom(let timeZone, let componets):
-            let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
+        case .custom(let componets):
+            let calendar = Calendar(identifier: .gregorian)
             return calendar.customTimeText(componets).map {
                 "event_notification_setting::option_title::customTime".localized(with: $0)
             }

--- a/Presentations/SettingScene/Sources/Event/EventNotificationDefaultTimeOption/EventNotificationDefaultTimeOptionView.swift
+++ b/Presentations/SettingScene/Sources/Event/EventNotificationDefaultTimeOption/EventNotificationDefaultTimeOptionView.swift
@@ -206,6 +206,8 @@ private extension Optional where Wrapped == EventNotificationTimeOption {
         case .allDay9AM: return "allDay9AM"
         case .allDay12AM: return "allDay12AM"
         case .allDay9AMBefore(let seconds): return "allDay9AMBefore:\(seconds)"
+        case .custom(let components):
+            return "custom:\(components)"
         }
     }
 }

--- a/Repository/Sources/Repository+Imple/Event/EventNotification/Local/EventNotificationTimeOption+Mapping.swift
+++ b/Repository/Sources/Repository+Imple/Event/EventNotification/Local/EventNotificationTimeOption+Mapping.swift
@@ -15,7 +15,6 @@ struct EventNotificationTimeOptionMapper: Codable {
     private enum CodingKeys: String, CodingKey {
         case typeText = "type_text"
         case beforeSeconds = "before_seconds"
-        case customTimeZone = "custom_timezone"
         case customTimeComponents = "custom_components"
     }
     
@@ -46,9 +45,8 @@ struct EventNotificationTimeOptionMapper: Codable {
             self = .init(option: .allDay9AMBefore(seconds: seconds))
             
         case "custom":
-            let timeZone = try container.decode(TimeZone.self, forKey: .customTimeZone)
             let components = try container.decode(DateComponents.self, forKey: .customTimeComponents)
-            self = .init(option: .custom(timeZone, components))
+            self = .init(option: .custom(components))
             
         default:
             throw RuntimeError("invalid value")
@@ -59,7 +57,6 @@ struct EventNotificationTimeOptionMapper: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.typeText, forKey: .typeText)
         try? container.encode(self.beforeSeconds, forKey: .beforeSeconds)
-        try? container.encode(self.customTimeTimeZone, forKey: .customTimeZone)
         try? container.encode(self.customTimeComponents, forKey: .customTimeComponents)
     }
     
@@ -80,17 +77,10 @@ struct EventNotificationTimeOptionMapper: Codable {
         default: return nil
         }
     }
-    
-    private var customTimeTimeZone: TimeZone? {
-        switch self.option {
-        case .custom(let timeZone, _): return timeZone
-        default: return nil
-        }
-    }
-    
+
     private var customTimeComponents: DateComponents? {
         switch self.option {
-        case .custom(_, let compos): return compos
+        case .custom(let compos): return compos
         default: return nil
         }
     }

--- a/Repository/Tests/Notification/EventNotificationRepositoryImpleTests.swift
+++ b/Repository/Tests/Notification/EventNotificationRepositoryImpleTests.swift
@@ -71,10 +71,10 @@ extension EventNotificationRepositoryImpleTests {
         parameterizeTest(forAllDay: true, expectValue: .allDay12AM)
         parameterizeTest(forAllDay: true, expectValue: .allDay9AMBefore(seconds: 100))
         parameterizeTest(
-            forAllDay: false, expectValue: .custom(self.kstTimeZone, self.dummyComponents)
+            forAllDay: false, expectValue: .custom(self.dummyComponents)
         )
         parameterizeTest(
-            forAllDay: true, expectValue: .custom(self.kstTimeZone, self.dummyComponents)
+            forAllDay: true, expectValue: .custom(self.dummyComponents)
         )
     }
 }


### PR DESCRIPTION
- atTime, period + not custom option => 이벤트 시간 - interval 적용해서 UNTimeIntervalNotificationTrigger로 트리깅
- allDay + not custom option => allDay가 지정하는 날짜 기준으로 UNCalendarNotificationTrigger 으로 트리깅
- atTime, period, allDay + custom option => custom option으로 선택한 날짜 + 시간 기준으로 UNCalendarNotificationTrigger 으로 트리깅
- customOption에 timeZone 정보 제거