### PR TITLE
[#177] Apple 로그인 구현

### DIFF
--- a/Domain/Sources/Models/Account/OAuth2.swift
+++ b/Domain/Sources/Models/Account/OAuth2.swift
@@ -15,8 +15,22 @@ public protocol OAuth2ServiceProvider: Sendable {
     var identifier: String { get }
 }
 
-public struct AppleOAuth2ServiceProvider: OAuth2ServiceProvider {
+public final class AppleOAuth2ServiceProvider: OAuth2ServiceProvider, @unchecked Sendable {
+    
+    public struct AppleLoginIDTokenWithMetaData {
+        public let appleIDToken: String
+        public let nonce: String
+        public init(
+            appleIDToken: String,
+            nonce: String
+        ) {
+            self.appleIDToken = appleIDToken
+            self.nonce = nonce
+        }
+    }
+    
     public let identifier: String = "apple"
+    public var appleSignInResult: Result<AppleLoginIDTokenWithMetaData, any Error>?
     public init() { }
 }
 
@@ -35,7 +49,6 @@ public struct AppleOAuth2Credential: OAuth2Credential {
     public let provider: String
     public let idToken: String
     public let nonce: String
-    public var accessToken: String?
     
     public init(
         provider: String,

--- a/Domain/Sources/Usecases/Account/OAuth2/AppleOAuth2ServiceUsecaseImple.swift
+++ b/Domain/Sources/Usecases/Account/OAuth2/AppleOAuth2ServiceUsecaseImple.swift
@@ -1,0 +1,47 @@
+//
+//  AppleOAuth2ServiceUsecaseImple.swift
+//  Domain
+//
+//  Created by sudo.park on 4/17/24.
+//  Copyright © 2024 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Extensions
+
+
+public final class AppleOAuth2ServiceUsecaseImple: OAuth2ServiceUsecase, @unchecked Sendable {
+    
+    private let preHandleResult: Result<AppleOAuth2ServiceProvider.AppleLoginIDTokenWithMetaData, any Error>?
+    init(
+        preHandleResult: Result<AppleOAuth2ServiceProvider.AppleLoginIDTokenWithMetaData, any Error>?
+    ) {
+        self.preHandleResult = preHandleResult
+    }
+}
+
+
+extension AppleOAuth2ServiceUsecaseImple {
+    
+    @MainActor
+    public func requestAuthentication() async throws -> any OAuth2Credential {
+        switch self.preHandleResult {
+        case .success(let data):
+            let credential = AppleOAuth2Credential(
+                provider: "apple.com",
+                idToken: data.appleIDToken,
+                nonce: data.nonce
+            )
+            return credential
+            
+        case .failure(let error):
+            throw error
+        case .none:
+            throw RuntimeError("apple login not handled")
+        }
+    }
+    
+    public func handle(open url: URL) -> Bool {
+        return false
+    }
+}

--- a/Domain/Sources/Usecases/Account/OAuth2/GoogleOAuth2ServiceUsecaseImple.swift
+++ b/Domain/Sources/Usecases/Account/OAuth2/GoogleOAuth2ServiceUsecaseImple.swift
@@ -19,10 +19,6 @@ public final class GoogleOAuth2ServiceUsecaseImple: OAuth2ServiceUsecase, @unche
     public init(topViewControllerFinding: @escaping () -> UIViewController?) {
         self.topViewControllerFinding = topViewControllerFinding
     }
-    
-    public var provider: OAuth2ServiceProvider {
-        GoogleOAuth2ServiceProvider()
-    }
 }
 
 extension GoogleOAuth2ServiceUsecaseImple {

--- a/Domain/Sources/Usecases/Account/OAuth2/OAuth2ServiceUsecase.swift
+++ b/Domain/Sources/Usecases/Account/OAuth2/OAuth2ServiceUsecase.swift
@@ -11,8 +11,6 @@ import UIKit
 
 public protocol OAuth2ServiceUsecase: Sendable {
     
-    var provider: any OAuth2ServiceProvider { get }
-    
     @MainActor
     func requestAuthentication() async throws -> any OAuth2Credential
     
@@ -44,6 +42,11 @@ public final class OAuth2ServiceUsecaseProviderImple: OAuth2ServiceUsecaseProvid
                 topViewControllerFinding: self.topViewControllerFinding
             )
             
+        case let apple as AppleOAuth2ServiceProvider:
+            return AppleOAuth2ServiceUsecaseImple(
+                preHandleResult: apple.appleSignInResult
+            )
+            
         default:
             return nil
         }
@@ -51,7 +54,8 @@ public final class OAuth2ServiceUsecaseProviderImple: OAuth2ServiceUsecaseProvid
     
     public var supportOAuth2Service: [any OAuth2ServiceProvider] {
         return [
-            GoogleOAuth2ServiceProvider()
+            GoogleOAuth2ServiceProvider(),
+            AppleOAuth2ServiceProvider()
         ]
     }
 }

--- a/Presentations/CommonPresentation/Sources/Utils/SignInButtonProvider.swift
+++ b/Presentations/CommonPresentation/Sources/Utils/SignInButtonProvider.swift
@@ -8,7 +8,11 @@
 
 import SwiftUI
 import Domain
+import Extensions
 import GoogleSignInSwift
+import AuthenticationServices
+import CryptoKit
+
 
 public protocol SignInButtonProvider {
     
@@ -32,8 +36,84 @@ public struct SignInButtonProviderImple: SignInButtonProvider {
             let model = GoogleSignInButtonViewModel(style: .wide)
             return GoogleSignInButton(viewModel: model, action: action)
             
+        case let apple as AppleOAuth2ServiceProvider:
+            return self.makeAppleSignInButton(apple, action)
+            
         default:
             return EmptyView()
         }
+    }
+    
+    private func makeAppleSignInButton(
+        _ apple: AppleOAuth2ServiceProvider,
+        _ actionCallback: @escaping () -> Void
+    ) -> some View {
+        
+        let nonce = self.makeNonce()
+        
+        let handleSuccessResult: (ASAuthorization) -> Void = { authorization in
+            guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential
+            else {
+                apple.appleSignInResult = .failure(
+                    RuntimeError("no ASAuthorizationAppleIDCredential")
+                )
+                return
+            }
+            
+            guard let appleIDToken = credential.identityToken,
+                  let idTokenString = String(data: appleIDToken, encoding: .utf8)
+            else {
+                apple.appleSignInResult = .failure(
+                    RuntimeError("unavail to serialize IdToken")
+                )
+                return
+            }
+            apple.appleSignInResult = .success(
+                .init(
+                    appleIDToken: idTokenString,
+                    nonce: nonce
+                )
+            )
+        }
+        
+        return SignInWithAppleButton(
+            onRequest: { request in
+                request.requestedScopes = [.email]
+                request.nonce = nonce
+                    .data(using: .utf8)
+                    .map { SHA256.hash(data: $0) }
+                    .map { $0.map { String(format: "%02x", $0) }.joined() }
+            },
+            onCompletion: { result in
+                switch result {
+                case .success(let authorize):
+                    handleSuccessResult(authorize)
+                    actionCallback()
+                    
+                case .failure(let error):
+                    apple.appleSignInResult = .failure(error)
+                    actionCallback()
+                }
+            }
+        )
+        .signInWithAppleButtonStyle(.whiteOutline)
+        .frame(height: 40)
+    }
+    
+    private func makeNonce() -> String {
+        let charset: [Character] =
+              Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        
+        let makeRandIndexes: () -> Int = {
+            var random: UInt8 = 0
+            let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+            if errorCode != errSecSuccess {
+              fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+            }
+            return Int(random) % charset.count
+        }
+        
+        let randIndexes = (0..<16).map { _ in }.map(makeRandIndexes)
+        return randIndexes.map { charset[$0] }.map { "\($0)" }.joined()
     }
 }

--- a/Repository/Tests/Auth/AuthRepositoryImpleTests.swift
+++ b/Repository/Tests/Auth/AuthRepositoryImpleTests.swift
@@ -59,6 +59,18 @@ extension AuthRepositoryImpleTests {
         XCTAssertNotNil(result)
     }
     
+    func testRepository_signInApple() async {
+        // given
+        let repository = self.makeRepository()
+        
+        // when
+        let credential = AppleOAuth2Credential(provider: "apple", idToken: "token", nonce: "nonce")
+        let result = try? await repository.signIn(credential)
+        
+        // then
+        XCTAssertNotNil(result)
+    }
+    
     func testRepository_failSignIn() async {
         // given
         let repository = self.makeRepository(shouldFail: true)

--- a/TodoCalendarApp/TodoCalendarApp.entitlements
+++ b/TodoCalendarApp/TodoCalendarApp.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.sudo.park.todo-calendar</string>


### PR DESCRIPTION
- SignInButtonProvider AppleOAuth2ServiceProvider의 경우 swiftUI 애플로그인 버튼 제공하도록 기능 추가 
ㄴ SignInWithAppleButton에서 기본 애플아이디 인증이 진행됨 -> 해당 결과를 AppleOAuth2ServiceProvider의 AppleLoginIDTokenWithMetaData에 저장
- OAuth2ServiceUsecase AppleOAuth2ServiceProvider의 경우 사용하는 AppleOAuth2ServiceUsecaseImple는 provider에 있는 AppleLoginIDTokenWithMetaData 값 판단
- authRepository 쪽에서도 firebase sdk를 이용하여 애플로그인을 지원할수있도록 설정