### PR TITLE
[#426] 로그인시 sharedDataStore 에서 계정정보 지워지는 이슈 수정

### DIFF
--- a/TodoCalendarApp/Sources/Root/ApplicationPrepareUsecase.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationPrepareUsecase.swift
@@ -85,7 +85,7 @@ extension ApplicationPrepareUsecaseImple {
     func prepareSignedIn(_ auth: Auth) async {
         self.sharedDataStore.clearAll {
             $0 != ShareDataKeys.accountInfo.rawValue
-            || $0 != ShareDataKeys.externalCalendarAccounts.rawValue
+            && $0 != ShareDataKeys.externalCalendarAccounts.rawValue
         }
         let closeResult = self.database.close()
         switch closeResult {


### PR DESCRIPTION
- clearAll시 삭제에서 제외되어야하는 정보 필터링하는 조건 잘못됨