### PR TITLE
[#446] foremost event 다른 기기에서 삭제된 경우 sync 안맞는 이슈 수정

### DIFF
--- a/Repository/Sources/Repository+Imple/Event/ForemostEvent/ForemostEventId+Mapping.swift
+++ b/Repository/Sources/Repository+Imple/Event/ForemostEvent/ForemostEventId+Mapping.swift
@@ -70,7 +70,11 @@ struct ForemostMarkableEventResponseMapper: Decodable {
     
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let isTodo: Bool = try container.decode(Bool.self, forKey: .isTodo)
+        guard let isTodo = try? container.decode(Bool.self, forKey: .isTodo)
+        else {
+            self.event = nil
+            return
+        }
         if isTodo {
             let todo = try container.decodeIfPresent(TodoEventMapper.self, forKey: .event)
             self.event = todo?.todo


### PR DESCRIPTION
- foremost event 존재 안하는 경우 응답 빈 객체로 변경
- 이 경우 없는것으로 간주하도록 수정