### PR TITLE
[#467] 위젯 - eventFetch 시에 offTagId는 제외 가능하도록 설정

### DIFF
--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/MonthWidget/MonthWidgetViewModelProvider.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/MonthWidget/MonthWidgetViewModelProvider.swift
@@ -166,7 +166,7 @@ extension MonthWidgetViewModelProvider {
         _ range: Range<TimeInterval>,
         _ timeZone: TimeZone
     ) async -> Set<String> {
-        guard let events = try? await self.eventFetchUsecase.fetchEvents(in: range, timeZone)
+        guard let events = try? await self.eventFetchUsecase.fetchEvents(in: range, timeZone, withoutOffTagIds: true)
         else { return [] }
         
         let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/WeekEventsWidget/WeekEventsWidgetViewModelProvider.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/WeekEventsWidget/WeekEventsWidgetViewModelProvider.swift
@@ -222,7 +222,7 @@ extension WeekEventsWidgetViewModelProvider {
         let targetMonthDate = calenar.targetMonthRefDate(date, for: range)
         let targetMonth = calenar.component(.month, from: targetMonthDate)
         let weeks = try self.getWeeks(date, firstWeekDay, range, calenar)
-        let events = try await self.eventFetchUsecase.fetchEvents(in: weeks.range, timeZone)
+        let events = try await self.eventFetchUsecase.fetchEvents(in: weeks.range, timeZone, withoutOffTagIds: true)
         let targetDate = CalendarComponent.Day(date, calendar: calenar)
         
         return WeekEventsViewModel(

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/Doubles/StubCalendarEventsFetchUescase.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/Doubles/StubCalendarEventsFetchUescase.swift
@@ -21,7 +21,7 @@ class StubCalendarEventsFetchUescase: CalendarEventFetchUsecase {
     var withoutAnyEvents: Bool = false
     
     func fetchEvents(
-        in range: Range<TimeInterval>, _ timeZone: TimeZone
+        in range: Range<TimeInterval>, _ timeZone: TimeZone, withoutOffTagIds: Bool
     ) async throws -> CalendarEvents {
         
         var sender: CalendarEvents = .init()

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/EventListWidgetViewModelProviderTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/EventListWidgetViewModelProviderTests.swift
@@ -183,7 +183,7 @@ extension EventListWidgetViewModelProviderTests {
             self.eventWithTimes = eventWithTimes
         }
         
-        override func fetchEvents(in range: Range<TimeInterval>, _ timeZone: TimeZone) async throws -> CalendarEvents {
+        override func fetchEvents(in range: Range<TimeInterval>, _ timeZone: TimeZone, withoutOffTagIds: Bool) async throws -> CalendarEvents {
             return CalendarEvents()
                 |> \.currentTodos .~ self.currentTodos
                 |> \.eventWithTimes .~ self.eventWithTimes
@@ -442,7 +442,7 @@ extension EventListWidgetViewModelProviderTests {
             self.event = event
         }
         
-        override func fetchEvents(in range: Range<TimeInterval>, _ timeZone: TimeZone) async throws -> CalendarEvents {
+        override func fetchEvents(in range: Range<TimeInterval>, _ timeZone: TimeZone, withoutOffTagIds: Bool) async throws -> CalendarEvents {
             return CalendarEvents()
                 |> \.eventWithTimes .~ [self.event]
         }
@@ -504,7 +504,7 @@ extension EventListWidgetViewModelProviderTests {
         init(refDate: Date) { self.refDate = refDate }
         
         func fetchEvents(
-            in range: Range<TimeInterval>, _ timeZone: TimeZone
+            in range: Range<TimeInterval>, _ timeZone: TimeZone, withoutOffTagIds: Bool
         ) async throws -> CalendarEvents {
             
             let refTime = self.refDate.timeIntervalSince1970
@@ -586,7 +586,9 @@ extension EventListWidgetViewModelProviderTests {
         
         final class EventsWithTagFetchUescase: CalendarEventFetchUsecase {
             
-            func fetchEvents(in range: Range<TimeInterval>, _ timeZone: TimeZone) async throws -> CalendarEvents {
+            func fetchEvents(
+                in range: Range<TimeInterval>, _ timeZone: TimeZone, withoutOffTagIds: Bool
+            ) async throws -> CalendarEvents {
                 let kst = TimeZone(abbreviation: "KST")!
                 let currents = (0..<10).map { int -> TodoEvent in
                     let tagId: EventTagId = int % 3 == 0

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/WeekEventsWidgetViewModelProviderTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/WeekEventsWidgetViewModelProviderTests.swift
@@ -371,8 +371,8 @@ extension WeekEventsWidgetViewModelProviderTests{
 
 private final class PrivateEventsFetchUsecase: StubCalendarEventsFetchUescase {
     
-    override func fetchEvents(in range: Range<TimeInterval>, _ timeZone: TimeZone) async throws -> CalendarEvents {
-        let events = try await super.fetchEvents(in: range, timeZone)
+    override func fetchEvents(in range: Range<TimeInterval>, _ timeZone: TimeZone, withoutOffTagIds: Bool) async throws -> CalendarEvents {
+        let events = try await super.fetchEvents(in: range, timeZone, withoutOffTagIds: withoutOffTagIds)
         let eventsWithoutHoliday = events.eventWithTimes.filter { !($0 is HolidayCalendarEvent) }
         let dummyHoliday = Holiday(uuid: "2024-06-19-dummy_holiday", dateString: "2024-06-19", name: "dummy_holiday")
         let holidayEvent = HolidayCalendarEvent(dummyHoliday, in: timeZone)!


### PR DESCRIPTION
resolved #467 
- 기존 fetchEvents에 withoutOffTagIds 추가 
ㄴ true시 off된 tag의 이벤트는 제외하고 전달 / false면 별도 필터링 없음
- fetchNextEvent, fetchNextEvents 조회시 withoutOffTagIds = true로 조회