### PR TITLE
[#474] NextEvent Widget 구글 캘린더 이벤트 표시시 장소정보 표시하도록 설정

### DIFF
--- a/Domain/Sources/Models/Events/ExternalCalendar/GoogleCalendarEvent.swift
+++ b/Domain/Sources/Models/Events/ExternalCalendar/GoogleCalendarEvent.swift
@@ -224,6 +224,7 @@ extension GoogleCalendar {
         public let eventTime: EventTime
         public var htmlLink: String?
         public var status: EventStatus?
+        public var location: String?
         
         public var nextRepeatingTimes: [RepeatingTimes] = []
         public var repeatingTimeToExcludes: Set<String> = []
@@ -233,6 +234,7 @@ extension GoogleCalendar {
             name: String,
             colorId: String?,
             htmlLink: String? = nil,
+            location: String? = nil,
             time: EventTime
         ) {
             self.eventId = eventId
@@ -243,6 +245,7 @@ extension GoogleCalendar {
             self.name = name
             self.colorId = colorId
             self.htmlLink = htmlLink
+            self.location = location
             self.eventTime = time
         }
         
@@ -260,6 +263,8 @@ extension GoogleCalendar {
             let start = origin.start?.supportEventTimeElemnt(defaultTimeZone)
             let end = origin.end?.supportEventTimeElemnt(defaultTimeZone)
             self.status = origin.status
+            
+            self.location = origin.location
             
             switch (start, end) {
             case (.period(let st), .period(let et)):

--- a/Presentations/CalendarScenes/Sources/Common/CalendarEvents/CalendarEvent.swift
+++ b/Presentations/CalendarScenes/Sources/Common/CalendarEvents/CalendarEvent.swift
@@ -57,6 +57,7 @@ public protocol CalendarEvent: Sendable {
     var eventTagId: EventTagId { get }
     var isForemost: Bool { get }
     var isRepeating: Bool { get }
+    var locationText: String? { get }
     
     var compareKey: String { get }
 }
@@ -80,7 +81,7 @@ extension Array where Element == any CalendarEvent {
 extension CalendarEvent {
     
     public var compareKey: String {
-        return "\(String(describing: Self.self))-\(eventId)-\(name)-\(eventTime?.hashValue ?? -1)-\(eventTimeOnCalendar?.hashValue ?? -1)-\(eventTagId.hashValue)-\(self.isForemost)"
+        return "\(String(describing: Self.self))-\(eventId)-\(name)-\(eventTime?.hashValue ?? -1)-\(eventTimeOnCalendar?.hashValue ?? -1)-\(eventTagId.hashValue)-\(self.isForemost)-\(self.locationText ?? "nil")"
     }
 }
 
@@ -97,6 +98,8 @@ public struct TodoCalendarEvent: CalendarEvent {
     public let isRepeating: Bool
     public var isForemost: Bool = false
     public var createdAt: TimeInterval?
+    // TODO: locationText 세팅 필요
+    public var locationText: String?
     
     public init(current todo: TodoEvent, isForemost: Bool) {
         self.eventId = todo.uuid
@@ -147,6 +150,8 @@ public struct ScheduleCalendarEvent: CalendarEvent {
     public var turn: Int = 0
     public let isRepeating: Bool
     public var isForemost: Bool = false
+    // TODO: locationText 세팅 필요
+    public var locationText: String?
     
     public static func events(
         from schedule: ScheduleEvent,
@@ -182,6 +187,7 @@ public struct HolidayCalendarEvent: CalendarEvent {
     public let eventTagId: EventTagId
     public let isRepeating: Bool = true
     public let isForemost: Bool = false
+    public var locationText: String?
     
     public init?(_ holiday: Holiday, in timeZone: TimeZone) {
         let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
@@ -217,6 +223,7 @@ public struct GoogleCalendarEvent: CalendarEvent {
     public let htmlLink: String?
     public let isForemost: Bool
     public let isRepeating: Bool
+    public let locationText: String?
     
     public init(_ event: GoogleCalendar.Event, in timeZone: TimeZone) {
         self.eventId = event.eventId
@@ -241,10 +248,11 @@ public struct GoogleCalendarEvent: CalendarEvent {
         self.htmlLink = event.htmlLink
         self.isForemost = false
         self.isRepeating = false
+        self.locationText = event.location
     }
     
     public var compareKey: String {
-        return "\(String(describing: Self.self))-\(eventId)-\(name)-\(eventTime?.hashValue ?? -1)-\(eventTimeOnCalendar?.hashValue ?? -1)-\(eventTagId.hashValue)-\(self.isForemost)-\(self.colorId ?? "nil")-\(self.htmlLink ?? "nil")"
+        return "\(String(describing: Self.self))-\(eventId)-\(name)-\(eventTime?.hashValue ?? -1)-\(eventTimeOnCalendar?.hashValue ?? -1)-\(eventTagId.hashValue)-\(self.isForemost)-\(self.colorId ?? "nil")-\(self.htmlLink ?? "nil")-\(self.locationText ?? "nil")"
     }
 }
 

--- a/Presentations/CalendarScenes/Sources/Month/MonthView.swift
+++ b/Presentations/CalendarScenes/Sources/Month/MonthView.swift
@@ -479,6 +479,7 @@ private struct DummyCalendarEvent: CalendarEvent {
     var eventTagId: EventTagId
     var isRepeating: Bool = false
     var isForemost: Bool = false
+    var locationText: String?
 
     init(_ id: String, _ name: String, hasPeriod: Bool = true) {
         self.eventId = id

--- a/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Google/Local/GoogleCalendarLocalStorage.swift
+++ b/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Google/Local/GoogleCalendarLocalStorage.swift
@@ -112,7 +112,7 @@ extension GoogleCalendarLocalStorageImple {
     ) async throws -> [GoogleCalendar.Event] {
         let timeQuery = Times.overlapQuery(with: range)
         let eventQuery = Events
-            .selectSome { [$0.id, $0.summary, $0.colorId, $0.htmlLink] }
+            .selectSome { [$0.id, $0.summary, $0.colorId, $0.htmlLink, $0.location] }
             .where { $0.calendarId == calendarId }
         let query = eventQuery.innerJoin(with: timeQuery, on: { ($0.id, $1.eventId) })
         let mapping: (CursorIterator) throws -> GoogleCalendar.Event = { cursor in
@@ -122,6 +122,7 @@ extension GoogleCalendarLocalStorageImple {
                 name: try cursor.next().unwrap(),
                 colorId: cursor.next(),
                 htmlLink: cursor.next(),
+                location: cursor.next(),
                 time: try Times.Entity(cursor).eventTime.unwrap()
             )
         }

--- a/Repository/Tests/Event/ExternalCalendar/GoogleCalendarRepositoryImple+Tests.swift
+++ b/Repository/Tests/Event/ExternalCalendar/GoogleCalendarRepositoryImple+Tests.swift
@@ -220,7 +220,7 @@ extension GoogleCalendarRepositoryImple_Tests {
         }
     }
     
-    @Test func repository_loadEvents_witHCache() async throws {
+    @Test func repository_loadEvents_withCache() async throws {
         try await self.runTestWithOpenClose("test_google_event_2") {
             // given
             try await self.saveCache()
@@ -240,6 +240,9 @@ extension GoogleCalendarRepositoryImple_Tests {
             #expect(eventFromCache?.map { $0.name } == ["old"])
             #expect(eventFromCache?.map { $0.colorId } == ["color"])
             #expect(eventFromCache?.map { $0.htmlLink } == ["link"])
+            #expect(eventFromCache?.map { $0.location } == [
+                "Hangang Kukdong Apartments, 38-6 Toseong-ro, Songpa District, Seoul, South Korea"
+            ])
             
             let eventFromRemote = eventLists.last
             #expect(eventFromRemote?.map { $0.eventId } == [
@@ -306,6 +309,7 @@ extension GoogleCalendarRepositoryImple_Tests {
         #expect(event?.eventId == "time_is_date")
         #expect(event?.calendarId == "c_id")
         #expect(event?.name == "하루죙일")
+        #expect(event?.location == "Hangang Kukdong Apartments, 38-6 Toseong-ro, Songpa District, Seoul, South Korea")
         
         let kst = TimeZone(identifier: "Asia/Seoul")!
         let start = "2025-04-11".asAllDayDate(kst)!
@@ -386,6 +390,7 @@ extension GoogleCalendarRepositoryImple_Tests {
             |> \.end .~ end
             |> \.colorId .~ "color"
             |> \.htmlLink .~ "link"
+            |> \.location .~ "Hangang Kukdong Apartments, 38-6 Toseong-ro, Songpa District, Seoul, South Korea"
         let timeZone = "Asia/Seoul"
         let originEvent = GoogleCalendar.Event(origin, "c_id", timeZone)!
         let list = GoogleCalendar.EventOriginValueList()

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/NextEventWidget/Next/NextEventWidget.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/NextEventWidget/Next/NextEventWidget.swift
@@ -8,6 +8,8 @@
 
 import WidgetKit
 import SwiftUI
+import Prelude
+import Optics
 import Domain
 import Extensions
 import CommonPresentation
@@ -56,6 +58,10 @@ struct NextEventRectangleWidgetView: View {
             VStack(alignment: .leading) {
                 if let time = model.timeText {
                     Text(time.singleLineAttrText())
+                        .font(.callout)
+                }
+                if let location = model.locationText {
+                    Text(location)
                         .font(.callout)
                 }
                 
@@ -118,6 +124,7 @@ struct NextEventWidgetView_Provider: PreviewProvider {
     
     static var previews: some View {
         let model = NextEventWidgetViewModel.sample
+            |> \.locationText .~ "회의실"
         let entry = ResultTimelineEntry(date: Date(), result: .success(model))
         
         return Group {

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/NextEventWidget/NextEventWidgetViewModelProvider.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/NextEventWidget/NextEventWidgetViewModelProvider.swift
@@ -19,11 +19,14 @@ import CalendarScenes
 struct NextEventWidgetViewModel: Sendable {
     let timeText: EventTimeText?
     let eventTitle: String
+    var locationText: String?
     var refreshAfter: Date?
     fileprivate var timeRawValue: EventTime?
     
     init(
-        timeText: EventTimeText?, eventTitle: String, refreshAfter: Date? = nil
+        timeText: EventTimeText?,
+        eventTitle: String,
+        refreshAfter: Date? = nil
     ) {
         self.timeText = timeText
         self.eventTitle = eventTitle
@@ -110,6 +113,7 @@ struct NextEventWidgetViewModelBuilder {
             timeText: EventTimeText.fromLowerBound(time, timeZone, !is24Form),
             eventTitle: event.name
         )
+        |> \.locationText .~ event.locationText
         |> \.timeRawValue .~ time
     }
     

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/WeekEventsWidget/WeekEventsWidgetViewModelProvider.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/WeekEventsWidget/WeekEventsWidgetViewModelProvider.swift
@@ -349,6 +349,7 @@ private struct DummyCalendarEvent: CalendarEvent {
     var eventTagId: EventTagId
     var isRepeating: Bool = false
     var isForemost: Bool = false
+    var locationText: String?
 
     init(_ id: String, _ name: String, hasPeriod: Bool = true, tag: EventTagId = .default) {
         self.eventId = id

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/NextEventWidgetViewModelProviderTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/NextEventWidgetViewModelProviderTests.swift
@@ -77,6 +77,7 @@ extension NextEventWidgetViewModelProviderTests {
     private var nextGoogleCalendarEvent: TodayNextEvent {
         let google = GoogleCalendar.Event(
             "some", "cal", name: "google", colorId: nil,
+            location: "location",
             time: .period(1000..<2000)
         )
         let event = GoogleCalendarEvent(google, in: self.kst)
@@ -94,6 +95,7 @@ extension NextEventWidgetViewModelProviderTests {
         #expect(model.timeText?.text == "9:16")
         #expect(model.eventTitle == "todo")
         #expect(model.refreshAfter == nil)
+        #expect(model.locationText == nil)
     }
     
     @Test func provideNextEventIsSchedule() async throws {
@@ -107,6 +109,7 @@ extension NextEventWidgetViewModelProviderTests {
         #expect(model.timeText?.text == "9:16")
         #expect(model.eventTitle == "schedule")
         #expect(model.refreshAfter == nil)
+        #expect(model.locationText == nil)
     }
     
     @Test func provideNextEventIsGoogleCalendarEvent() async throws {
@@ -120,6 +123,7 @@ extension NextEventWidgetViewModelProviderTests {
         #expect(model.timeText?.text == "9:16")
         #expect(model.eventTitle == "google")
         #expect(model.refreshAfter == nil)
+        #expect(model.locationText == "location")
     }
     
     enum SecondNextEventTime: TimeInterval {


### PR DESCRIPTION
- GoogleCalendar.Event 로컬에서 읽어오는 경우 location 정보 같이 읽도록 설정
- CalendarEvent locationText 요건 추가
- NextEventWidget + accessoryRectangular 사이즈일때 location 정보 있으면 노출

resolved #474 