### PR TITLE
[#492] 구글 캘린더 비공개 이벤트 파싱 못하는 이슈 수정

### DIFF
--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
@@ -282,7 +282,7 @@ extension GoogleCalendarEventDetailViewModelImple {
         
         return self.subject.origin
             .compactMap { $0 }
-            .map { $0.summary }
+            .map { $0.summaryText }
             .removeDuplicates()
             .eraseToAnyPublisher()
     }

--- a/Repository/Sources/Local/SQLiteLocalStorage+Migration.swift
+++ b/Repository/Sources/Local/SQLiteLocalStorage+Migration.swift
@@ -50,6 +50,9 @@ extension SQLiteService {
             case 2:
                 try self?.runMigrationVersion2to3(database)
                 
+            case 3:
+                try self?.runMigrationVersion3to4(database)
+                
             default:
                 break
             }
@@ -110,6 +113,16 @@ extension SQLiteService {
         do {
             try database.migrate(GoogleCalendarEventTagTable.self, version: 2)
             logger.log(level: .info, "migratiob version 2 -> 3, GoogleCalendarEventTagTable finished")
+        } catch {
+            logger.log(level: .error, "migration version 2 -> 3 faield.. will drop GoogleCalendarEventTagTable")
+            try? database.dropTable(GoogleCalendarEventTagTable.self)
+        }
+    }
+    
+    func runMigrationVersion3to4(_ database: any DataBase) throws -> Void {
+        do {
+            try database.migrate(GoogleCalendarEventOriginTable.self, version: 3)
+            logger.log(level: .info, "migratiob version 2 -> 3, GoogleCalendarEventOriginTable finished")
         } catch {
             logger.log(level: .error, "migration version 2 -> 3 faield.. will drop GoogleCalendarEventOriginTable")
             try? database.dropTable(GoogleCalendarEventOriginTable.self)

--- a/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Google/Local/GoogleCalendarTables.swift
+++ b/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Google/Local/GoogleCalendarTables.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Domain
 import SQLiteService
+import Extensions
 
 
 // MARK: - Colors
@@ -103,6 +104,7 @@ struct GoogleCalendarEventOriginTable: Table {
         case attachments
         case eventType
         case status
+        case visibility
         
         var dataType: ColumnDataType {
             switch self {
@@ -128,6 +130,7 @@ struct GoogleCalendarEventOriginTable: Table {
             case .attachments: return .text([])
             case .eventType: return .text([])
             case .status: return .text([])
+            case .visibility: return .text([])
             }
         }
     }
@@ -160,6 +163,8 @@ struct GoogleCalendarEventOriginTable: Table {
         switch version {
         case 1:
             return Self.addColumnStatement(.status)
+        case 3:
+            return Self.addColumnStatement(.visibility)
         default: return nil
         }
     }
@@ -172,7 +177,7 @@ struct GoogleCalendarEventOriginTable: Table {
         case .calendarId: return entity.calendarId
         case .defaultTimeZone: return entity.defaultTimeZone
         case .id: return entity.origin.id
-        case .summary: return entity.origin.summary
+        case .summary: return entity.origin.summary ?? ""
         case .htmlLink: return entity.origin.htmlLink
         case .description: return entity.origin.description
         case .location: return entity.origin.location
@@ -191,6 +196,7 @@ struct GoogleCalendarEventOriginTable: Table {
         case .attachments: return entity.origin.attachments?.asText()
         case .eventType: return entity.origin.eventType
         case .status: return entity.origin.status?.rawValue
+        case .visibility: return entity.origin.visibility?.rawValue
         }
     }
     
@@ -201,7 +207,7 @@ extension GoogleCalendar.EventOrigin {
     public init(_ cursor: CursorIterator) throws {
         self.init(
             id: try cursor.next().unwrap(),
-            summary: try cursor.next().unwrap()
+            summary: cursor.next()
         )
         self.htmlLink = cursor.next()
         self.description = cursor.next()
@@ -222,6 +228,8 @@ extension GoogleCalendar.EventOrigin {
         self.eventType = cursor.next()
         let statusText: String? = cursor.next()
         self.status = statusText.flatMap { .init(rawValue: $0) }
+        let visibilityText: String? = cursor.next()
+        self.visibility = visibilityText.flatMap { .init(rawValue: $0) }
     }
 }
 

--- a/Repository/Tests/Event/Schedule/ScheduleEventRemoteRepositoryImpleTests.swift
+++ b/Repository/Tests/Event/Schedule/ScheduleEventRemoteRepositoryImpleTests.swift
@@ -346,7 +346,7 @@ extension ScheduleEventRemoteRepositoryImpleTests {
         
         // when
         let loading = repository.scheduleEvent("some")
-        let error = self.waitError(expect, for: loading)
+        let error = self.waitError(expect, for: loading, timeout: 0.1)
         
         // then
         XCTAssertNotNil(error)

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -380,6 +380,8 @@
 
 "external_service.name::google" = "Google Calendar";
 "external_service.expired::message" = "%@ integration has expired. Please go to Settings and try again";
+"external_service::google::hidden_event" = "Hidden";
+"external_service::google::unknown_event" = "Unknown";
 
 
 // MARK: - widget

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -379,6 +379,8 @@
 
 "external_service.name::google" = "구글 캘린더";
 "external_service.expired::message" = "%@ 연동이 만료되었습니다. 설정 화면으로 이동하여 다시 시도해주세요.";
+"external_service::google::hidden_event" = "숨겨진 일정";
+"external_service::google::unknown_event" = "알 수 없음";
 
 
 // MARK: - widget

--- a/Supports/Extensions/Sources/Type+Extensions/String+Extensions.swift
+++ b/Supports/Extensions/Sources/Type+Extensions/String+Extensions.swift
@@ -67,6 +67,10 @@ extension String {
         let range = NSRange(location: 0, length: urlString.utf16.count)
         return regex.firstMatch(in: urlString, options: [], range: range) != nil
     }
+    
+    public func emptyAsNil() -> String? {
+        return self.isEmpty ? nil : self
+    }
 }
 
 

--- a/TodoCalendarApp/Sources/AppEnvironment.swift
+++ b/TodoCalendarApp/Sources/AppEnvironment.swift
@@ -52,5 +52,5 @@ struct AppEnvironment {
         return [googleCalendarService]
     }
     
-    static let dbVersion: Int32 = 3
+    static let dbVersion: Int32 = 4
 }


### PR DESCRIPTION
- GoogleCalendar.EventOrigin summary optional로 변경 및 summaryText 추가 ㄴ 서머리 있으면(빈값이 아니라면) 해당값 반환
ㄴ 존재하지 않고, visibility가 private이라면 비공개 로 반환
ㄴ 그 외의 경우는 알수없음으로 반환
- GoogleCalendarEventOriginTable visibility 칼럼 추가 ㄴ 디비 버전 4로 상향