### PR TITLE
[#543] 공휴일 조회 실패시 캘린더 안그려질수있는 이슈 수정

### DIFF
--- a/Domain/Sources/Usecases/Calendar/CalendarUsecase.swift
+++ b/Domain/Sources/Usecases/Calendar/CalendarUsecase.swift
@@ -79,6 +79,7 @@ extension CalendarUsecaseImple {
         
         let baseComponents = self.baseCalendarComponents(year, month)
         let holidaysGivenYear = self.holidayUsecase.holidays()
+            .prepend([:])
             .map(selectHolidays)
         return Publishers.CombineLatest(baseComponents, holidaysGivenYear)
             .map { $0.update(holidays: $1)}

--- a/Domain/Tests/Usecases/CalendarUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/CalendarUsecaseImpleTests.swift
@@ -94,7 +94,7 @@ extension CalendarUsecaseImpleTests {
         let usecase = self.makeUsecaseWithStub()
         
         // when
-        let source = usecase.components(for: 01, of: 2023)
+        let source = usecase.components(for: 01, of: 2023).dropFirst()
         let components = self.waitFirstOutput(expect, for: source)
         
         // then
@@ -113,7 +113,7 @@ extension CalendarUsecaseImpleTests {
         let usecase = self.makeUsecaseWithStub()
         
         // when
-        let source = usecase.components(for: 02, of: 2023)
+        let source = usecase.components(for: 02, of: 2023).dropFirst()
         let components = self.waitFirstOutput(expect, for: source)
         
         // then
@@ -132,7 +132,7 @@ extension CalendarUsecaseImpleTests {
         let usecase = self.makeUsecaseWithStub()
         
         // when
-        let source = usecase.components(for: 04, of: 2023)
+        let source = usecase.components(for: 04, of: 2023).dropFirst()
         let components = self.waitFirstOutput(expect, for: source)
         
         // then
@@ -152,7 +152,7 @@ extension CalendarUsecaseImpleTests {
         let usecase = self.makeUsecaseWithStub()
         
         // when
-        let source = usecase.components(for: 05, of: 2023)
+        let source = usecase.components(for: 05, of: 2023).dropFirst()
         let components = self.waitFirstOutput(expect, for: source)
         
         // then
@@ -171,7 +171,7 @@ extension CalendarUsecaseImpleTests {
         let usecase = self.makeUsecaseWithStub()
         
         // when
-        let source = usecase.components(for: 05, of: 2023)
+        let source = usecase.components(for: 05, of: 2023).dropFirst()
         let components = self.waitFirstOutput(expect, for: source.dropFirst()) {
             self.changeWeekFirstDay(.monday)
         }
@@ -192,7 +192,7 @@ extension CalendarUsecaseImpleTests {
         let usecase = self.makeUsecaseWithStub()
         
         // when
-        let source = usecase.components(for: 12, of: 2023)
+        let source = usecase.components(for: 12, of: 2023).dropFirst()
         let components = self.waitFirstOutput(expect, for: source.dropFirst()) {
             self.changeWeekFirstDay(.monday)
         }
@@ -213,7 +213,7 @@ extension CalendarUsecaseImpleTests {
         let usecase = self.makeUsecaseWithStub()
         
         // when
-        let source = usecase.components(for: 12, of: 2023)
+        let source = usecase.components(for: 12, of: 2023).dropFirst()
         let components = self.waitFirstOutput(expect, for: source.dropFirst()) {
             self.changeWeekFirstDay(.saturday)
         }
@@ -238,7 +238,7 @@ extension CalendarUsecaseImpleTests {
         let usecase = self.makeUsecaseWithStub()
         
         // when
-        let source = usecase.components(for: 09, of: 2023)
+        let source = usecase.components(for: 09, of: 2023).dropFirst()
         let components = self.waitFirstOutput(expect, for: source.dropFirst()) {
             self.changeWeekFirstDay(.saturday)
         }
@@ -263,7 +263,7 @@ extension CalendarUsecaseImpleTests {
         let usecase = self.makeUsecaseWithStub()
         
         // when
-        let source = usecase.components(for: 12, of: 2023)
+        let source = usecase.components(for: 12, of: 2023).dropFirst()
         let components = self.waitFirstOutput(expect, for: source)
         
         // then
@@ -282,7 +282,7 @@ extension CalendarUsecaseImpleTests {
         let usecase = self.makeUsecaseWithStub()
         
         // when
-        let source = usecase.components(for: 1, of: 2024)
+        let source = usecase.components(for: 1, of: 2024).dropFirst()
         let components = self.waitFirstOutput(expect, for: source)
         
         // then


### PR DESCRIPTION
- CalendarUsecaseImple 캘린더 정보 조회시에 당장 캘린더 정보 없더라도 빈값으로 간주하고 시작하도록 설정