### PR TITLE
[#559] 위젯 구글 캘린더 이벤트 accountId 빈 문자열 크래쉬 수정

### DIFF
--- a/Domain/Sources/Models/Events/ExternalCalendar/GoogleCalendarEvent.swift
+++ b/Domain/Sources/Models/Events/ExternalCalendar/GoogleCalendarEvent.swift
@@ -245,7 +245,7 @@ extension GoogleCalendar {
     public struct Event: Sendable {
         public let eventId: String
         public let calendarId: String
-        public var accountId: String = ""
+        public let accountId: String
         public let name: String
         public var eventTagId: EventTagId?
         public var colorId: String?
@@ -259,6 +259,7 @@ extension GoogleCalendar {
         
         public init(
             _ eventId: String, _ calendarId: String,
+            accountId: String,
             name: String,
             colorId: String?,
             htmlLink: String? = nil,
@@ -267,6 +268,7 @@ extension GoogleCalendar {
         ) {
             self.eventId = eventId
             self.calendarId = calendarId
+            self.accountId = accountId
             self.eventTagId = .externalCalendar(
                 serviceId: GoogleCalendarService.id, id: calendarId
             )
@@ -278,10 +280,11 @@ extension GoogleCalendar {
         }
         
         public init?(
-            _ origin: EventOrigin, _ calendarId: String, _ defaultTimeZone: String?
+            _ origin: EventOrigin, _ calendarId: String, accountId: String, _ defaultTimeZone: String?
         ) {
             self.eventId = origin.id
             self.calendarId = calendarId
+            self.accountId = accountId
             
             self.name = origin.summaryText
             self.eventTagId = .externalCalendar(

--- a/Domain/Sources/Usecases/Events/ExternalCalendar/GoogleCalendarUsecase.swift
+++ b/Domain/Sources/Usecases/Events/ExternalCalendar/GoogleCalendarUsecase.swift
@@ -264,7 +264,6 @@ extension GoogleCalendarUsecaseImple {
     ) {
         let repository = self.repositoryPool.repository(for: accountId)
         let updateEvents: ([GoogleCalendar.Event]) -> Void = { [weak self] refreshed in
-            let eventsWithAccount = refreshed.map { $0 |> \.accountId .~ accountId }
             self?.sharedDataStore.update(
                 [String: GoogleCalendar.Event].self,
                 key: ShareDataKeys.googleCalendarEvents.rawValue
@@ -272,12 +271,12 @@ extension GoogleCalendarUsecaseImple {
                 let cachedInRange = (old ?? [:]).filter {
                     $0.value.eventTime.isRoughlyOverlap(with: period)
                 }
-                let newMap = eventsWithAccount.asDictionary { $0.eventId }
+                let newMap = refreshed.asDictionary { $0.eventId }
                 let removed = cachedInRange.filter {
                     $0.value.calendarId == calendarId && newMap[$0.key] == nil
                 }
                 let eventWithoutRemoved = (old ?? [:]).filter { removed[$0.key] == nil }
-                return eventsWithAccount.reduce(into: eventWithoutRemoved) { $0[$1.eventId] = $1 }
+                return refreshed.reduce(into: eventWithoutRemoved) { $0[$1.eventId] = $1 }
             }
         }
 

--- a/Domain/Tests/Usecases/GoogleCalendarUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/GoogleCalendarUsecaseImpleTests.swift
@@ -340,7 +340,7 @@ extension GoogleCalendarUsecaseImpleTests {
         usecase.prepare()
 
         let dummyEvents = (0..<5).map { i -> GoogleCalendar.Event in
-            .init("\(i)-tag1", "tag1", name: "event", colorId: "c", time: .period(0..<10))
+            .init("\(i)-tag1", "tag1", accountId: "stub@gmail.com", name: "event", colorId: "c", time: .period(0..<10))
         }
 
         let eventLists = try await outputs(expect, for: usecase.events(in: 0..<20)) {
@@ -460,7 +460,7 @@ extension GoogleCalendarUsecaseImpleTests {
     }
 
     @Test func convertEventRawValue_whenTimeIsAllDay_convertsToEvent() {
-        let event = GoogleCalendar.Event(dummyAllDayEventOrigin, "calendar_id", "Asia/Seoul")
+        let event = GoogleCalendar.Event(dummyAllDayEventOrigin, "calendar_id", accountId: "stub@gmail.com", "Asia/Seoul")
 
         #expect(event?.eventId == "id")
         #expect(event?.name == "summary")
@@ -473,7 +473,7 @@ extension GoogleCalendarUsecaseImpleTests {
     }
 
     @Test func convertEventRawValue_whenTimeIsPeriod_convertsToEvent() {
-        let event = GoogleCalendar.Event(dummyPeriodEventOrigin, "calendar_id", "Asia/Seoul")
+        let event = GoogleCalendar.Event(dummyPeriodEventOrigin, "calendar_id", accountId: "stub@gmail.com", "Asia/Seoul")
 
         #expect(event?.eventId == "id")
         #expect(event?.name == "summary")
@@ -597,6 +597,7 @@ private final class PrivateStubRepository: GoogleCalendarRepository, @unchecked 
         let events = (0..<10).map { i -> GoogleCalendar.Event in
             .init(
                 "event:\(i)-\(calendarId)", calendarId,
+                accountId: "stub@gmail.com",
                 name: "some name", colorId: "color",
                 time: .period(period.lowerBound..<period.lowerBound + TimeInterval(i + 1))
             )

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListView.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListView.swift
@@ -560,7 +560,7 @@ struct DayEventListViewPreviewProvider: PreviewProvider {
             HolidayCalendarEvent(.init(uuid: "hd", dateString: "2023-09-30", name: "추석"), in: TimeZone.current)!
         )
         
-        let google = GoogleCalendar.Event("some", "cal", name: "google event", colorId: "colorId", time: .at(100))
+        let google = GoogleCalendar.Event("some", "cal", accountId: "preview@gmail.com", name: "google event", colorId: "colorId", time: .at(100))
         let googleEvent = GoogleCalendarEvent(google, in: TimeZone.current)
         let googleCell = GoogleCalendarEventCellViewModel(googleEvent, in: 0..<200, TimeZone.current, true)
         

--- a/Presentations/CalendarScenes/Tests/Common/CalendarEventListhUsecaseImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Common/CalendarEventListhUsecaseImpleTests.swift
@@ -37,7 +37,7 @@ final class CalendarEventListhUsecaseImpleTests: PublisherWaitable {
         }
         let googles = (0..<4).map { int in
             return GoogleCalendar.Event(
-                "g:\(int)", "google", name: "g", colorId: "color", time: .at(0)
+                "g:\(int)", "google", accountId: "stub@gmail.com", name: "g", colorId: "color", time: .at(0)
             )
             |> \.eventTagId .~ .externalCalendar(serviceId: GoogleCalendarService.id, id: "google")
             |> \.status .~ (int == 3 ? .cancelled : .confirmed)
@@ -87,7 +87,7 @@ extension CalendarEventListhUsecaseImpleTests {
     
     @Test func googleCalendarEvent_whenTimeIsAllDay_eventTimeOnCalendarUpperboundIsMinus1Second() {
         // given
-        let event = GoogleCalendar.Event("id", "calendar", name: "name", colorId: "color", time: .allDay(0..<100, secondsFromGMT: 0))
+        let event = GoogleCalendar.Event("id", "calendar", accountId: "stub@gmail.com", name: "name", colorId: "color", time: .allDay(0..<100, secondsFromGMT: 0))
         
         // when
         let calendarEvent = GoogleCalendarEvent(event, in: TimeZone(abbreviation: "UTC")!)

--- a/Presentations/CalendarScenes/Tests/Common/EventListCellEventHanleViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Common/EventListCellEventHanleViewModelImpleTests.swift
@@ -561,7 +561,8 @@ extension GoogleCalendarEventCellViewModel {
     
     static func dummy(_ link: String? = "link") -> GoogleCalendarEventCellViewModel {
         let google = GoogleCalendar.Event(
-            "google", "calendar", name: "name",
+            "google", "calendar", accountId: "stub@gmail.com",
+            name: "name",
             colorId: "id", htmlLink: link,
             time: .at(1)
         )

--- a/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
@@ -659,7 +659,7 @@ extension DayEventListViewModelImpleTests {
             isRepeating: false
         ) |> \.turn .~ 1
         let google = GoogleCalendar.Event(
-            "google", "calendarId", name: "google", colorId: "color", time: .at(self.todayRange.lowerBound + 200)
+            "google", "calendarId", accountId: "stub@gmail.com", name: "google", colorId: "color", time: .at(self.todayRange.lowerBound + 200)
         )
         let googleEvent = GoogleCalendarEvent(google, in: timeZone)
         return [

--- a/Presentations/CalendarScenes/Tests/Month/WeekEventStackBuilderTests.swift
+++ b/Presentations/CalendarScenes/Tests/Month/WeekEventStackBuilderTests.swift
@@ -245,6 +245,7 @@ extension WeekEventStackBuilderTests {
         let timeStamps = start.timeIntervalSince1970..<end.timeIntervalSince1970
         let event = GoogleCalendar.Event(
             "\(daysRange)", calendarId,
+            accountId: "stub@gmail.com",
             name: "google",
             colorId: colorId,
             time: .period(timeStamps)

--- a/Presentations/EventDetailScene/Tests/GoogleCalendarEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/GoogleCalendarEventDetailViewModelImpleTests.swift
@@ -41,7 +41,7 @@ final class GoogleCalendarEventDetailViewModelImpleTests: PublisherWaitable {
         calendarUsecase.refreshGoogleCalendarEventTags()
         
         let viewModel = GoogleCalendarEventDetailViewModelImple(
-            calenadrId: "g:7", accountId: "", eventId: "id",
+            calenadrId: "g:7", accountId: "stub@gmail.com", eventId: "id",
             googleCalendarUsecase: calendarUsecase,
             calendarSettingUsecase: settingUsecase,
             daysIntervalCountUsecase: StubDaysIntervalCountUsecase()

--- a/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Google/GoogleCalendarRepositoryImple.swift
+++ b/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Google/GoogleCalendarRepositoryImple.swift
@@ -104,7 +104,7 @@ extension GoogleCalendarRepositoryImple {
                     let refreshedList = try await self.loadEventOriginListFromRemote(calendarId, in: period)
 
                     let events = refreshedList.items.compactMap {
-                        return GoogleCalendar.Event($0, calendarId, refreshedList.timeZone)
+                        return GoogleCalendar.Event($0, calendarId, accountId: self.accountId, refreshedList.timeZone)
                     }
                     if let cached {
                         try? await self.cacheStorage.removeEvents(cached.map { $0.eventId }, accountId: self.accountId)

--- a/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Google/Local/GoogleCalendarLocalStorage.swift
+++ b/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Google/Local/GoogleCalendarLocalStorage.swift
@@ -154,6 +154,7 @@ extension GoogleCalendarLocalStorageImple {
             return .init(
                 eventId,
                 calendarId,
+                accountId: accountId,
                 name: GoogleCalendar.EventOrigin.summaryText(
                     summary,
                     visibility: visibilityText.flatMap { .init(rawValue: $0) }
@@ -228,7 +229,7 @@ extension GoogleCalendarLocalStorageImple {
             let entity = Events.Entity(accountId: accountId, calendarId, defaultTimeZone, origin)
             try db.insert(Events.self, entities: [entity])
 
-            if let event = GoogleCalendar.Event(origin, calendarId, defaultTimeZone) {
+            if let event = GoogleCalendar.Event(origin, calendarId, accountId: accountId, defaultTimeZone) {
                 let timeEntity = Times.Entity(event.eventId, event.eventTime, nil)
                 try db.insert(Times.self, entities: [timeEntity])
             }

--- a/Repository/Tests/Event/ExternalCalendar/GoogleCalendarLocalAggregatedRepositoryImpleTests.swift
+++ b/Repository/Tests/Event/ExternalCalendar/GoogleCalendarLocalAggregatedRepositoryImpleTests.swift
@@ -8,6 +8,8 @@
 
 import Testing
 import Combine
+import Prelude
+import Optics
 import Domain
 import Extensions
 import UnitTestHelpKit
@@ -156,6 +158,25 @@ extension GoogleCalendarLocalAggregatedRepositoryImpleTests {
         #expect(tags?.map(\.id).sorted() == ["tag1", "tag2"])
     }
 
+    @Test func loadEvents_withSingleAccount_returnsEventsWithAccountId() async throws {
+        defer { cleanup() }
+        let pool = try await makePool()
+        defer { Task { try? await pool.close(serviceId: googleServiceId) } }
+
+        let storage = localStorage(pool: pool)
+        let event = GoogleCalendar.Event("ev1", "cal1", accountId: account1, name: "event", colorId: nil, time: .at(50))
+        let origin = GoogleCalendar.EventOrigin(id: "ev1", summary: "event")
+        let list = GoogleCalendar.EventOriginValueList() |> \.items .~ [origin]
+        try await storage.updateEvents("cal1", list, [event], accountId: account1)
+
+        let repo = makeRepository(accountEmails: [account1], pool: pool)
+        let events = try await repo.loadEvents("cal1", in: 0..<100).values.first(where: { _ in true })
+
+        #expect(events?.count == 1)
+        #expect(events?.first?.eventId == "ev1")
+        #expect(events?.first?.accountId == account1)
+    }
+
     @Test func loadEventDetail_withSingleAccount_returnsDetail() async throws {
         defer { cleanup() }
         let pool = try await makePool()
@@ -219,6 +240,34 @@ extension GoogleCalendarLocalAggregatedRepositoryImpleTests {
         let tags = try await repo.loadCalendarTags().values.first(where: { _ in true })
 
         #expect(tags?.map(\.id).sorted() == ["tag1", "tag2", "tag3"])
+    }
+
+    @Test func loadEvents_withMultipleAccounts_returnsEventsWithCorrectAccountId() async throws {
+        defer { cleanup() }
+        let pool = try await makePool()
+        defer { Task { try? await pool.close(serviceId: googleServiceId) } }
+
+        let storage = localStorage(pool: pool)
+        // account1에 이벤트 저장
+        let event1 = GoogleCalendar.Event("ev1", "cal1", accountId: account1, name: "e1", colorId: nil, time: .at(50))
+        let origin1 = GoogleCalendar.EventOrigin(id: "ev1", summary: "e1")
+        let list1 = GoogleCalendar.EventOriginValueList() |> \.items .~ [origin1]
+        try await storage.updateEvents("cal1", list1, [event1], accountId: account1)
+        // account2에 이벤트 저장
+        let event2 = GoogleCalendar.Event("ev2", "cal1", accountId: account2, name: "e2", colorId: nil, time: .at(60))
+        let origin2 = GoogleCalendar.EventOrigin(id: "ev2", summary: "e2")
+        let list2 = GoogleCalendar.EventOriginValueList() |> \.items .~ [origin2]
+        try await storage.updateEvents("cal1", list2, [event2], accountId: account2)
+
+        let repo = makeRepository(accountEmails: [account1, account2], pool: pool)
+        let events = try await repo.loadEvents("cal1", in: 0..<100).values.first(where: { _ in true })
+
+        let sorted = events?.sorted(by: { $0.eventId < $1.eventId })
+        #expect(sorted?.count == 2)
+        #expect(sorted?[0].eventId == "ev1")
+        #expect(sorted?[0].accountId == account1)
+        #expect(sorted?[1].eventId == "ev2")
+        #expect(sorted?[1].accountId == account2)
     }
 
     @Test func loadEventDetail_withMultipleAccounts_findsAcrossAccounts() async throws {

--- a/Repository/Tests/Event/ExternalCalendar/GoogleCalendarRepositoryImple+Tests.swift
+++ b/Repository/Tests/Event/ExternalCalendar/GoogleCalendarRepositoryImple+Tests.swift
@@ -219,6 +219,7 @@ extension GoogleCalendarRepositoryImple_Tests {
             #expect(ids == [
                 "time_is_date", "out_of_period", "time_is_dateTime", "second_page_event"
             ])
+            #expect(eventFromRemote?.allSatisfy { $0.accountId == self.testAccountId } == true)
             self.assertEventTimeIsDate(eventFromRemote?.first)
         }
     }
@@ -246,11 +247,13 @@ extension GoogleCalendarRepositoryImple_Tests {
             #expect(eventFromCache?.map { $0.location } == [
                 "Hangang Kukdong Apartments, 38-6 Toseong-ro, Songpa District, Seoul, South Korea"
             ])
-            
+            #expect(eventFromCache?.allSatisfy { $0.accountId == self.testAccountId } == true)
+
             let eventFromRemote = eventLists.last
             #expect(eventFromRemote?.map { $0.eventId } == [
                 "time_is_date", "out_of_period", "time_is_dateTime", "second_page_event"
             ])
+            #expect(eventFromRemote?.allSatisfy { $0.accountId == self.testAccountId } == true)
             let name = eventFromRemote?.first(where: { $0.eventId == "time_is_date" })?.name
             #expect(name == "하루죙일")
         }
@@ -420,7 +423,7 @@ extension GoogleCalendarRepositoryImple_Tests {
             |> \.htmlLink .~ "link"
             |> \.location .~ "Hangang Kukdong Apartments, 38-6 Toseong-ro, Songpa District, Seoul, South Korea"
         let timeZone = "Asia/Seoul"
-        let originEvent = GoogleCalendar.Event(origin, "c_id", timeZone)!
+        let originEvent = GoogleCalendar.Event(origin, "c_id", accountId: self.testAccountId, timeZone)!
         let list = GoogleCalendar.EventOriginValueList()
             |> \.timeZone .~ timeZone
             |> \.items .~ [origin]

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/Doubles/StubRepositories.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/Doubles/StubRepositories.swift
@@ -56,7 +56,7 @@ final class StubGoogleCalendarRepository: GoogleCalendarRepository, @unchecked S
             return Just(eventMocking).mapAsAnyError().eraseToAnyPublisher()
         }
         let event = GoogleCalendar.Event(
-            "e1", calendarId, name: "google", colorId: "e1", time: .period(period)
+            "e1", calendarId, accountId: "stub@gmail.com", name: "google", colorId: "e1", time: .period(period)
         )
         return Just([event]).mapAsAnyError().eraseToAnyPublisher()
     }

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/Usecases/CalendarEventFetchUsecaseImpleTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/Usecases/CalendarEventFetchUsecaseImpleTests.swift
@@ -364,7 +364,7 @@ extension CalendarEventFetchUsecaseImpleTests {
         try await parameterizeTest(.schedule(schedule, nil), expectLocation: nil)
         try await parameterizeTest(.schedule(schedule, detail), expectLocation: "schedule place")
         
-        var google = GoogleCalendar.Event("e1", "", name: "", colorId: "", time: .at(refDate.timeIntervalSince1970 + 10))
+        var google = GoogleCalendar.Event("e1", "", accountId: "stub@gmail.com", name: "", colorId: "", time: .at(refDate.timeIntervalSince1970 + 10))
         try await parameterizeTest(.google(google), expectLocation: nil)
         
         google = google |> \.location .~ "google location"

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/EventCellViewModel+WdigetURL+Tests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/EventCellViewModel+WdigetURL+Tests.swift
@@ -33,8 +33,7 @@ struct EventCellViewModelWidgetURL_Tests {
     }
     
     func makeGoogleModel() -> GoogleCalendarEventCellViewModel {
-        var google = GoogleCalendar.Event("event", "calendar", name: "some", colorId: nil, time: .at(100))
-        google.accountId = "test@gmail.com"
+        let google = GoogleCalendar.Event("event", "calendar", accountId: "test@gmail.com", name: "some", colorId: nil, time: .at(100))
         let event = GoogleCalendarEvent(google, in: .current)
         return .init(event, in: 0..<10, .current, true)!
     }

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/NextEventWidgetViewModelProviderTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/NextEventWidgetViewModelProviderTests.swift
@@ -77,7 +77,8 @@ extension NextEventWidgetViewModelProviderTests {
     
     private var nextGoogleCalendarEvent: TodayNextEvent {
         let google = GoogleCalendar.Event(
-            "some", "cal", name: "google", colorId: nil,
+            "some", "cal", accountId: "stub@gmail.com",
+            name: "google", colorId: nil,
             location: "location",
             time: .period(1000..<2000)
         )


### PR DESCRIPTION
## Summary
- `GoogleCalendar.Event.accountId`를 `var` (기본값 `""`) → `let` (init 필수)로 변경하여 컴파일 타임에 누락을 방지
- `GoogleCalendarLocalStorageImple`, `GoogleCalendarRepositoryImple`에서 Event 생성 시 accountId를 전달하도록 수정
- `GoogleCalendarUsecase`에서 불필요해진 optics 후처리 (`\.accountId .~ accountId`) 제거
- `GoogleCalendarLocalAggregatedRepositoryImple`의 단일/복수 계정 loadEvents 테스트 추가

## Test plan
- [x] Domain `GoogleCalendarUsecaseImpleTests` 21개 통과
- [x] Repository `GoogleCalendarLocalAggregatedRepositoryImpleTests` 12개 통과 (새 테스트 2개 포함)
- [x] CalendarScenes 관련 테스트 스위트 통과

Closes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)