### PR TITLE
[#563] ExternalCalendarService에 isSingleAccountService 프로토콜 요구사항 추가

### DIFF
--- a/Domain/Sources/Usecases/Account/ExternalServiceIntegration/ExternalService.swift
+++ b/Domain/Sources/Usecases/Account/ExternalServiceIntegration/ExternalService.swift
@@ -12,8 +12,9 @@ import UIKit
 // MARK: - ExternalCalendarService
 
 public protocol ExternalCalendarService: Sendable {
-    
+
     var identifier: String { get }
+    var isSingleAccountService: Bool { get }
 }
 
 
@@ -61,6 +62,7 @@ public final class ExternalCalendarOAuthUsecaseProviderImple: ExternalCalendarOA
 public struct AppleCalendarService: ExternalCalendarService {
 
     public let identifier: String = AppleCalendarService.id
+    public let isSingleAccountService: Bool = true
 
     public static var id: String { "apple" }
     /// Apple Calendar은 OAuth 계정이 없으므로 기기 로컬 계정을 나타내는 고정 ID
@@ -79,6 +81,7 @@ public struct GoogleCalendarService: ExternalCalendarService {
     }
     
     public let identifier: String = GoogleCalendarService.id
+    public let isSingleAccountService: Bool = false
     public let scopes: [Scope]
     
     public static var id: String {

--- a/Presentations/SettingScene/Sources/Event/EventSettingViewModel.swift
+++ b/Presentations/SettingScene/Sources/Event/EventSettingViewModel.swift
@@ -68,12 +68,12 @@ struct ExternalCalanserServiceModel: Hashable {
     ) {
         self.serviceId = service.identifier
 
-        switch service {
-        case is GoogleCalendarService:
+        switch service.identifier {
+        case GoogleCalendarService.id:
             self.serviceName = "event_setting::external_calendar::google::serviceName".localized()
             self.serviceIconName = "google_calendar_icon"
             self.status = accountId.map { IntegrateStatus.integrated(accountId: $0) } ?? .notIntegrated
-        case is AppleCalendarService:
+        case AppleCalendarService.id:
             self.serviceName = "event_setting::external_calendar::apple::serviceName".localized()
             self.serviceIconName = "apple_calendar_icon"
             self.status = accountId.map { IntegrateStatus.integrated(accountId: $0) } ?? .notIntegrated
@@ -366,7 +366,7 @@ extension EventSettingViewModelImple {
             return supporServices.flatMap { service -> [ExternalCalanserServiceModel] in
                 let integrated = (accounts[service.identifier] ?? [])
                     .compactMap { ExternalCalanserServiceModel(service, accountId: $0.email) }
-                let isSingleAccountService = service is AppleCalendarService
+                let isSingleAccountService = service.isSingleAccountService
                 if isSingleAccountService && !integrated.isEmpty {
                     return integrated
                 }


### PR DESCRIPTION
## Summary
- `ExternalCalendarService` 프로토콜에 `isSingleAccountService` 요구사항 추가
- `AppleCalendarService`는 `true`, `GoogleCalendarService`는 `false` 반환
- `EventSettingViewModel`에서 `service is AppleCalendarService` 대신 `service.isSingleAccountService`로 변경
- `ExternalCalanserServiceModel` 초기화에서 `service.identifier` 기반 분기로 변경

## Test plan
- [x] SettingScene 빌드 성공
- [x] EventSettingViewModelImpleTests 18개 전체 통과