### PR TITLE
[#582] 위젯에서 외부 캘린더 조회 실패 시 graceful 처리

### DIFF
--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Usecases/CalendarEventFetchUsecase.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Usecases/CalendarEventFetchUsecase.swift
@@ -206,20 +206,20 @@ extension CalendarEventFetchUsecaseImple {
         events.customTagMap = customTagMap
         
         if await self.checkGoogleCalendarIntegrated() {
-            events.googleCalendarColors = try await self.googleCalendarColors()
-            let tags = try await self.googleCalendarTags()
-            events.googleCalendarTags = tags
-
-            let allTagIds = Array(tags.keys)
-            let googleEvents = try await self.googleCalendarEvents(allTagIds, in: range, timeZone)
-            eventsWithTime += googleEvents
+            events.googleCalendarColors = try? await self.googleCalendarColors()
+            if let tags = try? await self.googleCalendarTags() {
+                events.googleCalendarTags = tags
+                let allTagIds = Array(tags.keys)
+                let googleEvents = (try? await self.googleCalendarEvents(allTagIds, in: range, timeZone)) ?? []
+                eventsWithTime += googleEvents
+            }
         }
 
         if await self.checkAppleCalendarIntegrated() {
-            let tags = try await self.appleCalendarTags()
-            events.appleCalendarTags = tags
-
-            let appleEvents = try await self.appleCalendarEvents(in: range, timeZone)
+            if let tags = try? await self.appleCalendarTags() {
+                events.appleCalendarTags = tags
+            }
+            let appleEvents = (try? await self.appleCalendarEvents(in: range, timeZone)) ?? []
             eventsWithTime += appleEvents
         }
 

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/Doubles/StubRepositories.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/Doubles/StubRepositories.swift
@@ -43,24 +43,35 @@ final class StubExternalCalendarRepository: ExternalCalendarIntegrateRepository,
 }
 
 final class StubGoogleCalendarRepository: GoogleCalendarRepository, @unchecked Sendable {
-    
+
+    var shouldFail: Bool = false
+
     func loadColors() -> AnyPublisher<GoogleCalendar.Colors, any Error> {
+        guard !shouldFail else {
+            return Fail(error: RuntimeError("read db cannot write")).eraseToAnyPublisher()
+        }
         let colorSet = GoogleCalendar.Colors.ColorSet(foregroundHex: "for", backgroudHex: "back")
         let colors = GoogleCalendar.Colors(
             ownerId: "stub@google.com", calendars: ["c1": colorSet], events: ["e1": colorSet]
         )
         return Just(colors).mapAsAnyError().eraseToAnyPublisher()
     }
-    
+
     func loadCalendarTags() -> AnyPublisher<[GoogleCalendar.Tag], any Error> {
+        guard !shouldFail else {
+            return Fail(error: RuntimeError("read db cannot write")).eraseToAnyPublisher()
+        }
         let tags: [GoogleCalendar.Tag] = [
             .init(id: "c1", name: "c1"), .init(id: "c2", name: "c2")
         ]
         return Just(tags).mapAsAnyError().eraseToAnyPublisher()
     }
-    
+
     var eventMocking: [GoogleCalendar.Event]?
     func loadEvents(_ calendarId: String, in period: Range<TimeInterval>) -> AnyPublisher<[GoogleCalendar.Event], any Error> {
+        guard !shouldFail else {
+            return Fail(error: RuntimeError("read db cannot write")).eraseToAnyPublisher()
+        }
         if let eventMocking {
             return Just(eventMocking).mapAsAnyError().eraseToAnyPublisher()
         }
@@ -78,13 +89,13 @@ final class StubGoogleCalendarRepository: GoogleCalendarRepository, @unchecked S
 }
 
 final class PrivateStubAppleCalendarRepository: AppleCalendarRepository, @unchecked Sendable {
-    
-    func loadEvent(id: String) -> AnyPublisher<Domain.AppleCalendar.Event?, Never> {
-        return Empty().eraseToAnyPublisher()
-    }
-    
+
+    var shouldFail: Bool = false
 
     func loadCalendarTags() -> AnyPublisher<[AppleCalendar.Tag], any Error> {
+        guard !shouldFail else {
+            return Fail(error: RuntimeError("read db cannot write")).eraseToAnyPublisher()
+        }
         let tags: [AppleCalendar.Tag] = [
             .init(id: "a:1", name: "Work", colorHex: "#FF0000"),
             .init(id: "a:2", name: "Personal", colorHex: "#00FF00")
@@ -94,6 +105,9 @@ final class PrivateStubAppleCalendarRepository: AppleCalendarRepository, @unchec
 
     var eventMocking: [AppleCalendar.Event]?
     func loadEvents(in period: Range<TimeInterval>) -> AnyPublisher<[AppleCalendar.Event], any Error> {
+        guard !shouldFail else {
+            return Fail(error: RuntimeError("read db cannot write")).eraseToAnyPublisher()
+        }
         if let eventMocking {
             return Just(eventMocking).mapAsAnyError().eraseToAnyPublisher()
         }

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/Usecases/CalendarEventFetchUsecaseImpleTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/Usecases/CalendarEventFetchUsecaseImpleTests.swift
@@ -43,6 +43,8 @@ class CalendarEventFetchUsecaseImpleTests: BaseTestCase {
         hasForemost: Bool = true,
         isGoogleAccountIntegrated: Bool = false,
         isAppleCalendarIntegrated: Bool = false,
+        shouldFailGoogleCalendar: Bool = false,
+        shouldFailAppleCalendar: Bool = false,
         eventDetail: EventDetailData? = nil
     ) -> CalendarEventFetchUsecaseImple {
 
@@ -63,6 +65,9 @@ class CalendarEventFetchUsecaseImpleTests: BaseTestCase {
             isGoogleAccountIntegrated: isGoogleAccountIntegrated,
             isAppleCalendarIntegrated: isAppleCalendarIntegrated
         )
+
+        self.stubGoogleCalendarRepository.shouldFail = shouldFailGoogleCalendar
+        self.stubAppleCalendarRepository.shouldFail = shouldFailAppleCalendar
 
         let detailRepository = StubEventDetailRepository()
         detailRepository.stubDetail = eventDetail
@@ -201,6 +206,43 @@ extension CalendarEventFetchUsecaseImpleTests {
         XCTAssertEqual(events.googleCalendarColors?.calendars.count, 1)
     }
     
+    // 애플캘린더 조회 실패 시에도 나머지 이벤트는 정상 반환
+    func testUsecase_whenAppleCalendarFailed_stillReturnOtherEvents() async throws {
+        // given
+        let usecase = self.makeUsecase(
+            isAppleCalendarIntegrated: true,
+            shouldFailAppleCalendar: true
+        )
+        let range = self.dummyRange
+
+        // when
+        let events = try await usecase.fetchEvents(in: range, kst)
+
+        // then
+        XCTAssertEqual(events.currentTodos.count, 1)
+        XCTAssertEqual(events.eventWithTimes.count, 3)
+        XCTAssertEqual(events.appleCalendarTags.isEmpty, true)
+    }
+
+    // 구글캘린더 조회 실패 시에도 나머지 이벤트는 정상 반환
+    func testUsecase_whenGoogleCalendarFailed_stillReturnOtherEvents() async throws {
+        // given
+        let usecase = self.makeUsecase(
+            isGoogleAccountIntegrated: true,
+            shouldFailGoogleCalendar: true
+        )
+        let range = self.dummyRange
+
+        // when
+        let events = try await usecase.fetchEvents(in: range, kst)
+
+        // then
+        XCTAssertEqual(events.currentTodos.count, 1)
+        XCTAssertEqual(events.eventWithTimes.count, 3)
+        XCTAssertEqual(events.googleCalendarTags.isEmpty, true)
+        XCTAssertNil(events.googleCalendarColors)
+    }
+
     // 해당시간에 해당하는 이벤트 정보 반환시에 시간순 정렬
     func testUsecase_whenFetchEvents_sortByTime() async throws {
         // given


### PR DESCRIPTION
## Summary

closes #582

위젯의 `CalendarEventFetchUsecaseImple.fetchEvents()`에서 Apple/Google Calendar DB 조회가 실패하면 전체 `fetchEvents()`가 throw되어 위젯이 에러 상태로 빠지던 문제 수정.

## 원인 분석

- 위젯은 외부 캘린더 DB를 `openWithReadOnly: true`로 열음
- `AppleCalendarLocalStorageImple`의 read 메서드가 `createTableOrNot`(DDL)을 호출하는데, 테이블이 아직 없는 경우 read-only DB에서 `CREATE TABLE` 실행 실패
- Google Calendar은 메인 앱에서 미리 테이블이 생성되어 문제가 드러나지 않았으나, 원론적으로 같은 이슈 존재
- `fetchEvents()`에서 외부 캘린더 조회를 `try await`으로 호출하여, 실패 시 전체가 throw됨

## 변경 내용

- `fetchEvents()`의 Google/Apple Calendar 조회를 `try?`로 변경하여, 실패 시에도 나머지 이벤트(Todo, Schedule, Holiday)는 정상 반환
- Stub에 `shouldFail` 파라미터 추가, 실패 시에도 정상 동작하는 테스트 2건 추가

## Test plan

- [x] `testUsecase_whenAppleCalendarFailed_stillReturnOtherEvents` — Apple Calendar 실패 시 나머지 이벤트 정상 반환
- [x] `testUsecase_whenGoogleCalendarFailed_stillReturnOtherEvents` — Google Calendar 실패 시 나머지 이벤트 정상 반환
- [x] 기존 CalendarEventFetchUsecaseImple 테스트 15개 포함 전체 17개 통과