### PR TITLE
[#591] 애플 캘린더 연동 시 계정 정보 미노출 처리

### DIFF
--- a/Presentations/SettingScene/Sources/Event/EventSettingView.swift
+++ b/Presentations/SettingScene/Sources/Event/EventSettingView.swift
@@ -468,7 +468,14 @@ private extension ExternalCalanserServiceModel {
     
     var accountName: String? {
         guard case .integrated(let accountId) = self.status else { return nil }
-        return accountId
+        switch self.serviceId {
+        case AppleCalendarService.id:
+            return nil
+        case GoogleCalendarService.id:
+            return accountId
+        default:
+            return accountId
+        }
     }
     
     var compareKey: String {


### PR DESCRIPTION
## Summary\n- closes #591\n- 외부 캘린더 설정 화면에서 애플 캘린더 연동 시 무의미한 계정 정보(\"device\")가 노출되던 문제 수정\n- `accountName` computed property에 서비스별 switch 분기를 추가하여 애플 캘린더는 계정 정보 미노출, 구글 캘린더는 기존대로 표시\n\n## Test plan\n- [ ] 애플 캘린더 연동 후 설정 > 외부 캘린더 화면에서 계정 정보가 표시되지 않는지 확인\n- [ ] 구글 캘린더 연동 후 동일 화면에서 계정 이메일이 정상 표시되는지 확인