### PR TITLE
[#595] 애플캘린더 연동 시 기본 표시(on)로 변경

### DIFF
--- a/Domain/Sources/Usecases/Account/ExternalServiceIntegration/ExternalCalendarIntegrationUsecase.swift
+++ b/Domain/Sources/Usecases/Account/ExternalServiceIntegration/ExternalCalendarIntegrationUsecase.swift
@@ -56,6 +56,23 @@ extension ExternalCalendarIntegrationUsecase {
     public func currentIntegratedAccounts(for serviceId: String) -> [ExternalServiceAccountinfo] {
         return self.currentIntegratedAccounts().filter { $0.serviceIdentifier == serviceId }
     }
+
+    public func currentOrNewIntegratedAccount(
+        for serviceId: String
+    ) -> AnyPublisher<ExternalServiceAccountinfo, Never> {
+        let currents = Just(self.currentIntegratedAccounts(for: serviceId))
+            .flatMap { $0.publisher }
+        let newIntegrated = self.integrationStatusChanged
+            .compactMap { status -> ExternalServiceAccountinfo? in
+                switch status {
+                case .integrated(let sid, let account) where sid == serviceId:
+                    return account
+                default: return nil
+                }
+            }
+        return currents.append(newIntegrated)
+            .eraseToAnyPublisher()
+    }
 }
 
 

--- a/Domain/Sources/Usecases/Events/ExternalCalendar/AppleCalendarUsecase.swift
+++ b/Domain/Sources/Usecases/Events/ExternalCalendar/AppleCalendarUsecase.swift
@@ -157,14 +157,14 @@ extension AppleCalendarUsecaseImple {
         refreshEventBag.forEach { $0.cancel() }
         refreshEventBag = []
 
-        let accounts = integrationUsecase.currentIntegratedAccounts(for: appleService.identifier)
-        guard !accounts.isEmpty else { return }
-
-        repository.loadEvents(in: period)
-            .sink(
-                receiveCompletion: { _ in },
-                receiveValue: { [weak self] events in self?.updateStoredEvents(events, in: period) }
-            )
+        integrationUsecase.currentOrNewIntegratedAccount(for: appleService.identifier)
+            .flatMap { [weak self] _ -> AnyPublisher<[AppleCalendar.Event], Never> in
+                guard let self else { return Empty().eraseToAnyPublisher() }
+                return self.repository.loadEvents(in: period)
+                    .replaceError(with: [])
+                    .eraseToAnyPublisher()
+            }
+            .sink { [weak self] events in self?.updateStoredEvents(events, in: period) }
             .store(in: &refreshEventBag)
     }
 

--- a/Domain/Sources/Usecases/Events/ExternalCalendar/GoogleCalendarUsecase.swift
+++ b/Domain/Sources/Usecases/Events/ExternalCalendar/GoogleCalendarUsecase.swift
@@ -244,7 +244,7 @@ extension GoogleCalendarUsecaseImple {
     public func refreshEvents(in period: Range<TimeInterval>) {
         self.cancelRefresh()
 
-        let accounts = self.integrationUsecase.currentAndNewIntegratedGoogleAccounts()
+        let accounts = self.integrationUsecase.currentOrNewIntegratedAccount(for: googleService.identifier)
         let activeCalendarTagPerAccount = accounts
             .compactMap { $0.email }
             .flatMap(self.activeCalendars())
@@ -321,25 +321,3 @@ public extension GoogleCalendar.Tag {
 }
 
 
-private extension ExternalCalendarIntegrationUsecase {
-
-    func currentAndNewIntegratedGoogleAccounts() -> AnyPublisher<ExternalServiceAccountinfo, Never> {
-
-        let googleServiceId = GoogleCalendarService.id
-        let currents = self.integratedServiceAccounts
-            .map { $0[googleServiceId] ?? [] }
-            .flatMap { $0.publisher }
-        let newIntegrated = self.integrationStatusChanged
-            .compactMap { status in
-                switch status {
-                case .integrated(let serviceId, let account) where serviceId == googleServiceId:
-                    return account
-                default: return nil
-                }
-            }
-
-        return Publishers.Merge(currents, newIntegrated)
-            .removeAllDuplicates()
-            .eraseToAnyPublisher()
-    }
-}

--- a/Domain/Tests/Usecases/AppleCalendarUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AppleCalendarUsecaseImpleTests.swift
@@ -312,6 +312,25 @@ extension AppleCalendarUsecaseImpleTests {
         #expect(stubRepository.didLoadEvents == false)
     }
 
+    @Test func refreshEvents_whenIntegratedAfterRefreshCall_loadsEventsAutomatically() async throws {
+        // given
+        let period: Range<TimeInterval> = 0..<100
+        let stubEvents = makeStubEvents(count: 3)
+        let expect = expectConfirm("연동 후 자동으로 이벤트 로드")
+        expect.count = 2
+        let usecase = makeUsecase(isIntegrated: false, stubEvents: stubEvents)
+        usecase.prepare()
+
+        // when
+        let eventLists = try await outputs(expect, for: usecase.events(in: period)) {
+            usecase.refreshEvents(in: period)
+            self.sendIntegration(true)
+        }
+
+        // then
+        #expect(eventLists.last?.count == 3)
+    }
+
     @Test func refreshEvents_removesDeletedEventsInPeriod() async throws {
         // given - 0..<5 범위에 5개 이벤트 로드
         let initialEvents = makeStubEvents(count: 5)

--- a/Domain/Tests/Usecases/ExternalCalendarIntegrationUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/ExternalCalendarIntegrationUsecaseImpleTests.swift
@@ -312,6 +312,41 @@ extension ExternalCalendarIntegrationUsecaseImpleTests {
         #expect(account.email == AppleCalendarService.localAccountId)
     }
 
+    @Test func currentOrNewIntegratedAccount_whenAlreadyIntegrated_emitsCurrentThenStops() async throws {
+        // given
+        let service = GoogleCalendarService(scopes: [.readOnly])
+        let account = ExternalServiceAccountinfo(service.identifier, email: "google@email.com")
+        let usecase = self.makeUsecase(startWithIntegrated: [account])
+        try await usecase.prepareIntegratedAccounts()
+
+        // when
+        var emitted: [ExternalServiceAccountinfo] = []
+        let sub = usecase.currentOrNewIntegratedAccount(for: service.identifier)
+            .sink { emitted.append($0) }
+        try await Task.sleep(for: .milliseconds(100))
+        sub.cancel()
+
+        // then — 현재 연동 계정 1회만 방출, 중복 없음
+        #expect(emitted.count == 1)
+        #expect(emitted.first?.email == "google@email.com")
+    }
+
+    @Test func currentOrNewIntegratedAccount_whenNewIntegration_emitsOnceWithoutDuplicate() async throws {
+        // given
+        let service = GoogleCalendarService(scopes: [.readOnly])
+        let usecase = self.makeUsecase()
+        let expect = self.expectConfirm("신규 연동 시 계정 1회만 방출")
+
+        // when
+        let accounts = try await self.outputs(expect, for: usecase.currentOrNewIntegratedAccount(for: service.identifier)) {
+            _ = try await usecase.integrate(external: service)
+        }
+        try await Task.sleep(for: .milliseconds(100))
+
+        // then — 신규 연동 계정 1회만 방출, integratedServiceAccounts 업데이트에 의한 중복 없음
+        #expect(accounts.count == 1)
+        #expect(accounts.first?.email == "google@email.com")
+    }
 }
 
 


### PR DESCRIPTION
## Summary\n\n- 애플캘린더 연동 시 모든 캘린더가 기본 off로 설정되어 이벤트가 안 보이던 문제 수정\n- 구글캘린더와 달리 애플캘린더는 로컬 기기 캘린더이므로, 연동 즉시 표시(on)되도록 변경\n- `setInitialOffTagIds` 제거 — off 목록에 추가하지 않음\n\ncloses #595\n\n## Test plan\n\n- [x] `AppleCalendarUsecaseImpleTests` 15개 전체 통과\n- [ ] 실기기에서 애플캘린더 최초 연동 후 이벤트가 즉시 표시되는지 확인\n- [ ] 기존 연동 상태에서 앱 재시작 시 정상 동작 확인