### PR TITLE
[#599] 애플 캘린더 이벤트 URL·메모 정보 표시

### DIFF
--- a/Domain/Sources/Models/Events/ExternalCalendar/AppleCalendarEvent.swift
+++ b/Domain/Sources/Models/Events/ExternalCalendar/AppleCalendarEvent.swift
@@ -47,13 +47,17 @@ extension AppleCalendar {
         public let eventTagId: EventTagId
         public let eventTime: EventTime
         public let location: String?
+        public let url: String?
+        public let notes: String?
 
         public init(
             eventId: String,
             calendarId: String,
             name: String,
             eventTime: EventTime,
-            location: String? = nil
+            location: String? = nil,
+            url: String? = nil,
+            notes: String? = nil
         ) {
             self.eventId = eventId
             self.calendarId = calendarId
@@ -61,6 +65,8 @@ extension AppleCalendar {
             self.eventTagId = .externalCalendar(serviceId: AppleCalendarService.id, id: calendarId)
             self.eventTime = eventTime
             self.location = location
+            self.url = url
+            self.notes = notes
         }
     }
 }

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailRouter.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailRouter.swift
@@ -15,6 +15,7 @@ import CommonPresentation
 
 protocol AppleCalendarEventDetailRouting: Routing, Sendable {
     func routeToAppleCalendarApp(at interval: TimeInterval)
+    func openURL(_ urlString: String)
 }
 
 // MARK: - Router
@@ -32,6 +33,11 @@ extension AppleCalendarEventDetailRouter {
         // calshow: scheme uses seconds since 2001-01-01 (Core Data reference date)
         let referenceInterval = interval - 978307200
         guard let url = URL(string: "calshow:\(referenceInterval)") else { return }
+        UIApplication.shared.open(url)
+    }
+
+    func openURL(_ urlString: String) {
+        guard let url = URL(string: urlString) else { return }
         UIApplication.shared.open(url)
     }
 }

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailView.swift
@@ -23,6 +23,8 @@ import CommonPresentation
     var timeText: SelectedTime?
     var ddayText: String = ""
     var location: String?
+    var url: String?
+    var notes: String?
     var tagModel: AppleCalendarTagModel?
 
     func bind(_ viewModel: any AppleCalendarEventDetailViewModel) {
@@ -58,6 +60,20 @@ import CommonPresentation
             })
             .store(in: &self.cancellables)
 
+        viewModel.url
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self] text in
+                self?.url = text
+            })
+            .store(in: &self.cancellables)
+
+        viewModel.notes
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self] text in
+                self?.notes = text
+            })
+            .store(in: &self.cancellables)
+
         viewModel.tagModel
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] model in
@@ -74,11 +90,13 @@ final class AppleCalendarEventDetailViewEventHandler: Observable {
 
     var onAppear: () -> Void = { }
     var openInAppleCalendar: () -> Void = { }
+    var openURL: (String) -> Void = { _ in }
     var close: () -> Void = { }
 
     func bind(_ viewModel: any AppleCalendarEventDetailViewModel) {
         self.onAppear = viewModel.refresh
         self.openInAppleCalendar = viewModel.openInAppleCalendar
+        self.openURL = viewModel.openURL(_:)
         self.close = viewModel.close
     }
 }
@@ -140,6 +158,14 @@ struct AppleCalendarEventDetailView: View {
 
                         if let location = self.state.location {
                             self.locationView(location)
+                        }
+
+                        if let url = self.state.url {
+                            self.urlView(url)
+                        }
+
+                        if let notes = self.state.notes {
+                            self.notesView(notes)
                         }
 
                         if let tagModel = self.state.tagModel {
@@ -266,6 +292,37 @@ struct AppleCalendarEventDetailView: View {
                 .foregroundStyle(self.appearance.colorSet.text1.asColor)
 
             Text(location)
+                .font(appearance.fontSet.normal.asFont)
+                .foregroundStyle(appearance.colorSet.text0.asColor)
+
+            Spacer()
+        }
+    }
+
+    private func urlView(_ urlString: String) -> some View {
+        HStack(spacing: 16) {
+            Image(systemName: "link")
+                .font(.system(size: 16, weight: .light))
+                .foregroundStyle(self.appearance.colorSet.text1.asColor)
+
+            Text(urlString)
+                .font(appearance.fontSet.normal.asFont)
+                .foregroundStyle(appearance.colorSet.accent.asColor)
+                .onTapGesture {
+                    self.eventHandlers.openURL(urlString)
+                }
+
+            Spacer()
+        }
+    }
+
+    private func notesView(_ notes: String) -> some View {
+        HStack(alignment: .top, spacing: 16) {
+            Image(systemName: "doc.text")
+                .font(.system(size: 16, weight: .light))
+                .foregroundStyle(self.appearance.colorSet.text1.asColor)
+
+            Text(notes)
                 .font(appearance.fontSet.normal.asFont)
                 .foregroundStyle(appearance.colorSet.text0.asColor)
 

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewModel.swift
@@ -29,6 +29,7 @@ protocol AppleCalendarEventDetailViewModel: AnyObject, Sendable, AppleCalendarEv
     // interactor
     func refresh()
     func openInAppleCalendar()
+    func openURL(_ urlString: String)
     func close()
 
     // presenter
@@ -36,6 +37,8 @@ protocol AppleCalendarEventDetailViewModel: AnyObject, Sendable, AppleCalendarEv
     var timeText: AnyPublisher<SelectedTime?, Never> { get }
     var ddayText: AnyPublisher<String, Never> { get }
     var location: AnyPublisher<String?, Never> { get }
+    var url: AnyPublisher<String?, Never> { get }
+    var notes: AnyPublisher<String?, Never> { get }
     var tagModel: AnyPublisher<AppleCalendarTagModel?, Never> { get }
 }
 
@@ -114,6 +117,10 @@ extension AppleCalendarEventDetailViewModelImple {
         self.router?.routeToAppleCalendarApp(at: startInterval)
     }
 
+    func openURL(_ urlString: String) {
+        self.router?.openURL(urlString)
+    }
+
     func close() {
         self.router?.closeScene()
     }
@@ -165,6 +172,22 @@ extension AppleCalendarEventDetailViewModelImple {
         return self.subject.event
             .compactMap { $0 }
             .map { $0.location }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
+
+    var url: AnyPublisher<String?, Never> {
+        return self.subject.event
+            .compactMap { $0 }
+            .map { $0.url }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
+
+    var notes: AnyPublisher<String?, Never> {
+        return self.subject.event
+            .compactMap { $0 }
+            .map { $0.notes }
             .removeDuplicates()
             .eraseToAnyPublisher()
     }

--- a/Presentations/EventDetailScene/Tests/AppleCalendarEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/AppleCalendarEventDetailViewModelImpleTests.swift
@@ -59,6 +59,33 @@ final class AppleCalendarEventDetailViewModelImpleTests: PublisherWaitable {
         return viewModel
     }
 
+    private func makeViewModelWithURLAndNotes() -> AppleCalendarEventDetailViewModelImple {
+        let settingUsecase = StubCalendarSettingUsecase()
+        settingUsecase.prepare()
+        let appleUsecase = StubAppleCalendarUsecase()
+        appleUsecase.stubCalendarTags = [.init(id: stubCalendarId, name: "Work", colorHex: nil)]
+        appleUsecase.refreshCalendarTags()
+        appleUsecase.stubEvents = [
+            AppleCalendar.Event(
+                eventId: stubEventId,
+                calendarId: stubCalendarId,
+                name: "Meeting",
+                eventTime: .at(Date().timeIntervalSince1970),
+                url: "https://example.com",
+                notes: "Meeting notes"
+            )
+        ]
+        let viewModel = AppleCalendarEventDetailViewModelImple(
+            calendarId: stubCalendarId,
+            eventId: stubEventId,
+            appleCalendarUsecase: appleUsecase,
+            calendarSettingUsecase: settingUsecase,
+            daysIntervalCountUsecase: StubDaysIntervalCountUsecase()
+        )
+        viewModel.router = self.spyRouter
+        return viewModel
+    }
+
     private func makeViewModelWithNoLocation() -> AppleCalendarEventDetailViewModelImple {
         let settingUsecase = StubCalendarSettingUsecase()
         settingUsecase.prepare()
@@ -165,6 +192,36 @@ extension AppleCalendarEventDetailViewModelImpleTests {
         #expect(locationValue == nil)
     }
 
+    @Test func viewModel_provideURL() async throws {
+        // given
+        let expect = expectConfirm("URL 정보 제공")
+        let viewModel = self.makeViewModelWithURLAndNotes()
+
+        // when
+        let url = try await self.firstOutput(expect, for: viewModel.url) {
+            viewModel.refresh()
+        }
+
+        // then
+        let urlValue = try #require(url)
+        #expect(urlValue == "https://example.com")
+    }
+
+    @Test func viewModel_provideNotes() async throws {
+        // given
+        let expect = expectConfirm("메모 정보 제공")
+        let viewModel = self.makeViewModelWithURLAndNotes()
+
+        // when
+        let notes = try await self.firstOutput(expect, for: viewModel.notes) {
+            viewModel.refresh()
+        }
+
+        // then
+        let notesValue = try #require(notes)
+        #expect(notesValue == "Meeting notes")
+    }
+
     @Test func viewModel_close() {
         // given
         let viewModel = self.makeViewModel()
@@ -179,4 +236,5 @@ extension AppleCalendarEventDetailViewModelImpleTests {
 
 private final class SpyRouter: BaseSpyRouter, AppleCalendarEventDetailRouting, @unchecked Sendable {
     func routeToAppleCalendarApp(at interval: TimeInterval) { }
+    func openURL(_ urlString: String) { }
 }

--- a/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Apple/AppleCalendar+EventKit.swift
+++ b/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Apple/AppleCalendar+EventKit.swift
@@ -120,7 +120,9 @@ private extension EKEvent {
             calendarId: calendarId,
             name: title ?? "",
             eventTime: eventTime,
-            location: location
+            location: location,
+            url: url?.absoluteString,
+            notes: notes
         )
     }
 

--- a/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Apple/Local/AppleCalendarLocalStorage.swift
+++ b/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Apple/Local/AppleCalendarLocalStorage.swift
@@ -113,7 +113,9 @@ extension AppleCalendarLocalStorageImple {
                 calendarId: event.calendarId,
                 name: event.name,
                 eventTime: time,
-                location: event.location
+                location: event.location,
+                url: event.url,
+                notes: event.notes
             )
         }
 
@@ -138,7 +140,9 @@ extension AppleCalendarLocalStorageImple {
                 calendarId: event.calendarId,
                 name: event.name,
                 eventTime: time,
-                location: event.location
+                location: event.location,
+                url: event.url,
+                notes: event.notes
             )
         }
 

--- a/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Apple/Local/AppleCalendarTables.swift
+++ b/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Apple/Local/AppleCalendarTables.swift
@@ -63,12 +63,16 @@ struct AppleCalendarEventTable: Table {
         let calendarId: String
         let name: String
         let location: String?
+        let url: String?
+        let notes: String?
 
         init(_ event: AppleCalendar.Event) {
             self.eventId = event.eventId
             self.calendarId = event.calendarId
             self.name = event.name
             self.location = event.location
+            self.url = event.url
+            self.notes = event.notes
         }
 
         init(_ cursor: CursorIterator) throws {
@@ -76,6 +80,8 @@ struct AppleCalendarEventTable: Table {
             self.calendarId = try cursor.next().unwrap()
             self.name = try cursor.next().unwrap()
             self.location = cursor.next()
+            self.url = cursor.next()
+            self.notes = cursor.next()
         }
     }
 
@@ -84,6 +90,8 @@ struct AppleCalendarEventTable: Table {
         case calendarId = "calendar_id"
         case name
         case location
+        case url
+        case notes
 
         var dataType: ColumnDataType {
             switch self {
@@ -91,6 +99,8 @@ struct AppleCalendarEventTable: Table {
             case .calendarId: return .text([.notNull])
             case .name: return .text([.notNull])
             case .location: return .text([])
+            case .url: return .text([])
+            case .notes: return .text([])
             }
         }
     }
@@ -105,6 +115,9 @@ struct AppleCalendarEventTable: Table {
         case .calendarId: return entity.calendarId
         case .name: return entity.name
         case .location: return entity.location
+        case .url: return entity.url
+        case .notes: return entity.notes
         }
     }
+
 }


### PR DESCRIPTION
## Summary
closes #599

- `EKEvent`의 `url`/`notes`를 `AppleCalendar.Event` 도메인 모델부터 DB 테이블, 뷰모델, 뷰까지 전 레이어에 매핑
- 이벤트 상세 화면에서 URL(탭 시 Safari 열기)과 메모를 location과 동일한 패턴으로 노출

## 변경 범위
- **Domain**: `AppleCalendar.Event`에 `url: String?`, `notes: String?` 추가
- **Repository**: EKEvent 변환, DB 테이블, LocalStorage에 url/notes 매핑
- **Presentation**: ViewModel에 publisher 추가, View에 URL·메모 UI 추가, Router에 URL 열기 지원

## Test plan
- [x] `AppleCalendarEventDetailViewModelImpleTests` — 8개 테스트 통과 (url/notes 포함)