### PR TITLE
[#601] 위젯 이벤트 타입 선택에 애플 캘린더 태그 지원

### DIFF
--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Base+Factory/EventTypeSelectIntentFactory.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Base+Factory/EventTypeSelectIntentFactory.swift
@@ -73,4 +73,10 @@ extension EventTypeSelectIntentFactory {
             accountRepository: makeExternalCalendarAcountRepository()
         )
     }
+
+    func makeAppleCalendarRepository() -> any AppleCalendarRepository {
+        return AppleCalendarLocalAggregatedRepositoryImple(
+            connectionPool: base.externalCalendarDBConnectionPool
+        )
+    }
 }

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Intents/EventTypeSelectIntent.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Intents/EventTypeSelectIntent.swift
@@ -76,9 +76,10 @@ struct EventTypeQuery: EntityQuery, @unchecked Sendable {
         let baseTags = try await tagRepository.loadAllCustomTags()
             .values.first(where: { _ in true })?
             .map { Tags.custom($0) } ?? []
-        let externalTags = try await self.loadOnGoogleCalendarTags()
-        
-        return [.defaultTag] + baseTags + externalTags
+        let googleTags = (try? await self.loadOnGoogleCalendarTags()) ?? []
+        let appleTags = (try? await self.loadOnAppleCalendarTags()) ?? []
+
+        return [.defaultTag] + baseTags + googleTags + appleTags
     }
     
     private func asEntity(_ tag: Tags) -> EventTypeEntity {
@@ -96,9 +97,30 @@ struct EventTypeQuery: EntityQuery, @unchecked Sendable {
             return EventTypeEntity(id: tag.id, name: tag.name)
             |> \.externalServiceId .~ serviceId
             |> \.externalServiceName .~ "external_service.name::google".localized()
+
+        case .apple(let serviceId, let tag):
+            return EventTypeEntity(id: tag.id, name: tag.name)
+            |> \.externalServiceId .~ serviceId
+            |> \.externalServiceName .~ "event_setting::external_calendar::apple::serviceName".localized()
         }
     }
     
+    private func loadOnAppleCalendarTags() async throws -> [Tags] {
+
+        let externalCalendarRepository = factory.makeExternalCalendarAcountRepository()
+        let appleRepository = factory.makeAppleCalendarRepository()
+
+        let serviceId = AppleCalendarService.id
+        let externalAccounts = try await externalCalendarRepository.loadIntegratedAccounts()
+            .asDictionary { $0.serviceIdentifier }
+        guard externalAccounts[serviceId] != nil else { return [] }
+
+        let tags = try await appleRepository.loadCalendarTags()
+            .values.first(where: { _ in true })?
+            .map { Tags.apple(serviceId, $0) }
+        return tags ?? []
+    }
+
     private func loadOnGoogleCalendarTags() async throws -> [Tags] {
         
         let externalCalendarRepository = factory.makeExternalCalendarAcountRepository()
@@ -120,6 +142,7 @@ private enum Tags {
     case defaultTag
     case custom(CustomEventTag)
     case google(String, GoogleCalendar.Tag)
+    case apple(String, AppleCalendar.Tag)
 }
 
 


### PR DESCRIPTION
## Summary
closes #601

- `EventTypeQuery`에서 애플 캘린더 연동 시 태그 목록을 로드하여 위젯 설정에 노출
- `EventTypeSelectIntentFactory`에 `makeAppleCalendarRepository()` 팩토리 메서드 추가
- 외부 캘린더(Google·Apple) 태그 로딩 실패 시 `try?`로 격리하여 기본 태그는 정상 노출
- `EventTypeSelectIntent`와 `EventListComponentSelectIntent`가 동일한 `EventTypeQuery`를 공유하므로 두 위젯 모두 수정됨

## Test plan
- [ ] 애플 캘린더 연동 상태에서 EventListWidget 설정 → 애플 캘린더 태그 목록 노출 확인
- [ ] 애플 캘린더 연동 상태에서 TodayAndNext 위젯 설정 → 애플 캘린더 태그 목록 노출 확인
- [ ] 애플 캘린더 미연동 상태에서 태그 목록에 애플 캘린더 미노출 확인
- [ ] 구글 캘린더 태그도 기존처럼 정상 노출 확인