### PR TITLE
강업 체크 기능 추가

### DIFF
--- a/Domain/Sources/Models/AppUpdateInfo.swift
+++ b/Domain/Sources/Models/AppUpdateInfo.swift
@@ -1,0 +1,18 @@
+//
+//  AppUpdateInfo.swift
+//  Domain
+//
+
+import Foundation
+
+public struct AppUpdateInfo: Sendable {
+    public var forceUpdateVersion: String?
+    public var recommendUpdateVersion: String?
+
+    public init() { }
+}
+
+public enum AppUpdateRequirement: Sendable, Equatable {
+    case forceRequired
+    case recommended
+}

--- a/Domain/Sources/Repositories/AppRepository.swift
+++ b/Domain/Sources/Repositories/AppRepository.swift
@@ -1,0 +1,10 @@
+//
+//  AppRepository.swift
+//  Domain
+//
+
+import Foundation
+
+public protocol AppRepository: Sendable {
+    func loadUpdateInfo() async throws -> AppUpdateInfo
+}

--- a/Domain/Sources/Usecases/Support/AppUpdateCheckUsecase.swift
+++ b/Domain/Sources/Usecases/Support/AppUpdateCheckUsecase.swift
@@ -1,0 +1,125 @@
+//
+//  AppUpdateCheckUsecase.swift
+//  Domain
+//
+
+import Foundation
+import Combine
+import CombineExt
+import AsyncFlatMap
+import Extensions
+
+
+// MARK: - AppUpdateCheckUsecase
+
+public protocol AppUpdateCheckUsecase: Sendable {
+    func checkUpdateIsNeed()
+    var updateRequirement: AnyPublisher<AppUpdateRequirement, Never> { get }
+}
+
+
+// MARK: - AppUpdateCheckUsecaseImple
+
+public final class AppUpdateCheckUsecaseImple: AppUpdateCheckUsecase, @unchecked Sendable {
+
+    private let appRepository: any AppRepository
+
+    public init(
+        appRepository: any AppRepository,
+        deviceInfoFetchService: any DeviceInfoFetchService
+    ) {
+        self.appRepository = appRepository
+
+        guard let appVersion = deviceInfoFetchService.fetchAppVersion()
+        else { return }
+        self.bindCheckTrigger(appVersion)
+    }
+
+    private struct Subject {
+        let checkTrigger = PassthroughSubject<Void, Never>()
+        let appUpdateRequirement = PassthroughSubject<AppUpdateRequirement, Never>()
+    }
+    private let subject = Subject()
+    private var cancellables: Set<AnyCancellable> = []
+}
+
+
+extension AppUpdateCheckUsecaseImple {
+
+    public func checkUpdateIsNeed() {
+        self.subject.checkTrigger.send(())
+    }
+
+    private func bindCheckTrigger(_ currentAppVersion: String) {
+
+        self.subject.checkTrigger
+            .mapAsAnyError()
+            .flatMapLatest { [weak self] in
+                return self?.loadUpdateInfoWithoutError() ?? Empty().eraseToAnyPublisher()
+            }
+            .compactMap { [weak self] info in
+                return self?.checkAppVersion(currentAppVersion, updateInfo: info)
+            }
+            .sink(receiveValue: { [weak self] requirement in
+                self?.subject.appUpdateRequirement.send(requirement)
+            })
+            .store(in: &self.cancellables)
+    }
+
+    private func loadUpdateInfoWithoutError() -> AnyPublisher<AppUpdateInfo?, any Error> {
+        let repository = self.appRepository
+        return Publishers.create(do: {
+            do {
+                return try await repository.loadUpdateInfo()
+            } catch {
+                return nil
+            }
+        })
+        .eraseToAnyPublisher()
+    }
+
+    private func checkAppVersion(_ current: String, updateInfo: AppUpdateInfo?) -> AppUpdateRequirement? {
+        return updateInfo.flatMap { AppUpdateRequirement(current: current, appUpdateInfo: $0) }
+    }
+}
+
+extension AppUpdateCheckUsecaseImple {
+
+    public var updateRequirement: AnyPublisher<AppUpdateRequirement, Never> {
+        return self.subject.appUpdateRequirement
+            .eraseToAnyPublisher()
+    }
+}
+
+
+extension AppUpdateRequirement {
+
+    public init?(current: String, appUpdateInfo: AppUpdateInfo) {
+        if let forceVersion = appUpdateInfo.forceUpdateVersion,
+           current.isVersionLessThan(forceVersion) {
+            self = .forceRequired
+            return
+        }
+        if let recommendVersion = appUpdateInfo.recommendUpdateVersion,
+           current.isVersionLessThan(recommendVersion) {
+            self = .recommended
+            return
+        }
+        return nil
+    }
+}
+
+
+private extension String {
+
+    func isVersionLessThan(_ target: String) -> Bool {
+        let currentParts = self.split(separator: ".")
+        let targetParts = target.split(separator: ".")
+        let maxCount = max(currentParts.count, targetParts.count)
+        let pad: ([Substring]) -> String = { parts in
+            let filled = parts.map(String.init) + Array(repeating: "0", count: maxCount - parts.count)
+            return filled.joined(separator: ".")
+        }
+        return pad(currentParts).compare(pad(targetParts), options: .numeric) == .orderedAscending
+    }
+}

--- a/Domain/Sources/Usecases/Support/FeedbackUsecase.swift
+++ b/Domain/Sources/Usecases/Support/FeedbackUsecase.swift
@@ -20,6 +20,7 @@ public protocol FeedbackUsecase: Sendable {
 public protocol DeviceInfoFetchService: Sendable {
     @MainActor
     func fetchDeviceInfo() async -> DeviceInfo
+    func fetchAppVersion() -> String?
 }
 
 public final class FeedbackUsecaseImple: FeedbackUsecase, @unchecked Sendable {

--- a/Domain/Tests/Doubles/StubDeviceInfoFetchService.swift
+++ b/Domain/Tests/Doubles/StubDeviceInfoFetchService.swift
@@ -14,12 +14,18 @@ import Optics
 
 
 struct StubDeviceInfoFetchService: DeviceInfoFetchService {
-    
+
+    var stubAppVersion: String? = "1.0.0"
+
     @MainActor
     func fetchDeviceInfo() async -> DeviceInfo {
         return DeviceInfo()
             |> \.appVersion .~ "app"
             |> \.osVersion .~ "os"
             |> \.deviceModel .~ "model"
+    }
+
+    func fetchAppVersion() -> String? {
+        return self.stubAppVersion
     }
 }

--- a/Domain/Tests/Usecases/AppUpdateCheckUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AppUpdateCheckUsecaseImpleTests.swift
@@ -1,0 +1,363 @@
+//
+//  AppUpdateCheckUsecaseImpleTests.swift
+//  DomainTests
+//
+
+import XCTest
+import Combine
+import Prelude
+import Optics
+import Extensions
+import UnitTestHelpKit
+import TestDoubles
+
+@testable import Domain
+
+
+// MARK: - AppUpdateRequirement init 테스트 (버전 문자열 비교)
+
+class AppUpdateRequirementTests: BaseTestCase {
+
+    private func requirement(current: String, target: String) -> AppUpdateRequirement? {
+        var info = AppUpdateInfo()
+        info.forceUpdateVersion = target
+        return AppUpdateRequirement(current: current, appUpdateInfo: info)
+    }
+}
+
+
+// MARK: - major / minor / patch 단위 비교
+
+extension AppUpdateRequirementTests {
+
+    func test_whenMajorVersionIsLess_treatAsOutdated() {
+        // given / when
+        let result = self.requirement(current: "1.0.0", target: "2.0.0")
+
+        // then
+        XCTAssertEqual(result, .forceRequired)
+    }
+
+    func test_whenMinorVersionIsLess_treatAsOutdated() {
+        // given / when
+        let result = self.requirement(current: "2.0.0", target: "2.1.0")
+
+        // then
+        XCTAssertEqual(result, .forceRequired)
+    }
+
+    func test_whenPatchVersionIsLess_treatAsOutdated() {
+        // given / when
+        let result = self.requirement(current: "2.0.0", target: "2.0.1")
+
+        // then
+        XCTAssertEqual(result, .forceRequired)
+    }
+
+    func test_whenCurrentIsHigher_treatAsUpToDate() {
+        // given / when
+        let result = self.requirement(current: "3.0.0", target: "2.0.0")
+
+        // then
+        XCTAssertNil(result)
+    }
+
+    func test_whenCurrentEqualsTarget_treatAsUpToDate() {
+        // given / when
+        let result = self.requirement(current: "2.0.0", target: "2.0.0")
+
+        // then
+        XCTAssertNil(result)
+    }
+}
+
+
+// MARK: - 컴포넌트 개수가 다른 경우 zero-padding
+
+extension AppUpdateRequirementTests {
+
+    func test_whenCurrentHasFewerComponents_padWithZeroAndOutdated() {
+        // given — "2.0"은 "2.0.0"으로 패딩되어 "2.0.1"보다 낮음
+        // when
+        let result = self.requirement(current: "2.0", target: "2.0.1")
+
+        // then
+        XCTAssertEqual(result, .forceRequired)
+    }
+
+    func test_whenTargetHasFewerComponents_padWithZeroAndOutdated() {
+        // given — target "2.0"은 "2.0.0"으로 패딩되고, current "1.9.9"는 그보다 낮음
+        // when
+        let result = self.requirement(current: "1.9.9", target: "2.0")
+
+        // then
+        XCTAssertEqual(result, .forceRequired)
+    }
+
+    func test_whenTargetHasFewerComponents_currentIsHigher_treatAsUpToDate() {
+        // given — current "2.0.1"은 target "2.0"(="2.0.0")보다 높음
+        // when
+        let result = self.requirement(current: "2.0.1", target: "2.0")
+
+        // then
+        XCTAssertNil(result)
+    }
+
+    func test_whenPaddedValuesAreEqual_treatAsUpToDate() {
+        // given — "2.0.0" vs "2.0" → 둘 다 "2.0.0"으로 정렬되어 동일
+        // when
+        let result = self.requirement(current: "2.0.0", target: "2.0")
+
+        // then
+        XCTAssertNil(result)
+    }
+
+    func test_whenSingleComponent_padBothAndCompare() {
+        // given — "1"은 "1.0.0"으로, "2.0.0"은 그대로 유지. 1 < 2이므로 outdated
+        // when
+        let result = self.requirement(current: "1", target: "2.0.0")
+
+        // then
+        XCTAssertEqual(result, .forceRequired)
+    }
+
+    func test_whenSingleComponentTarget_currentIsLower_outdated() {
+        // given — target "3"은 "3.0.0"으로 패딩되고, current "2.9.9"는 그보다 낮음
+        // when
+        let result = self.requirement(current: "2.9.9", target: "3")
+
+        // then
+        XCTAssertEqual(result, .forceRequired)
+    }
+
+    func test_whenComponentCountDiffersByMoreThanOne_padWithZero() {
+        // given — current "1"은 "1.0.0.0"으로 패딩되어 "1.0.0.1"보다 낮음
+        // when
+        let result = self.requirement(current: "1", target: "1.0.0.1")
+
+        // then
+        XCTAssertEqual(result, .forceRequired)
+    }
+
+    func test_whenShorterCurrentIsActuallyHigher_treatAsUpToDate() {
+        // given — current "2.1"(="2.1.0")은 target "2.0.99"보다 높음.
+        //         짧다고 무조건 낮은 게 아님을 확인.
+        // when
+        let result = self.requirement(current: "2.1", target: "2.0.99")
+
+        // then
+        XCTAssertNil(result)
+    }
+}
+
+
+// MARK: - 렉시코그라피 아닌 숫자 비교
+
+extension AppUpdateRequirementTests {
+
+    func test_whenComponentHasTwoDigits_compareNumerically() {
+        // given — "1.10.0"은 "1.9.0"보다 높은 버전.
+        //         문자열 비교만 하면 "10" < "9"로 뒤집히지만 numeric 옵션으로 올바르게 비교됨.
+        // when
+        let result = self.requirement(current: "1.10.0", target: "1.9.0")
+
+        // then
+        XCTAssertNil(result)
+    }
+}
+
+
+// MARK: - AppUpdateCheckUsecaseImple 테스트
+
+class AppUpdateCheckUsecaseImpleTests: BaseTestCase, PublisherWaitable {
+
+    var cancelBag: Set<AnyCancellable>!
+
+    override func setUpWithError() throws {
+        self.cancelBag = .init()
+    }
+
+    override func tearDownWithError() throws {
+        self.cancelBag = nil
+    }
+
+    private func makeUsecase(
+        currentAppVersion: String = "2.0.0",
+        forceVersion: String? = nil,
+        recommendVersion: String? = nil,
+        shouldFail: Bool = false
+    ) -> AppUpdateCheckUsecaseImple {
+        let stubRepository = StubAppRepository(
+            forceVersion: forceVersion,
+            recommendVersion: recommendVersion,
+            shouldFail: shouldFail
+        )
+        var stubDeviceInfo = StubDeviceInfoFetchService()
+        stubDeviceInfo.stubAppVersion = currentAppVersion
+        return AppUpdateCheckUsecaseImple(
+            appRepository: stubRepository,
+            deviceInfoFetchService: stubDeviceInfo
+        )
+    }
+}
+
+
+// MARK: - current / force / recommend 조합 결정 로직
+
+extension AppUpdateCheckUsecaseImpleTests {
+
+    func test_whenCurrentBelowForceVersion_emitForceRequired() {
+        // given
+        let expect = expectation(description: "강업 버전 미만이면 forceRequired 방출")
+        let usecase = self.makeUsecase(
+            currentAppVersion: "1.0.0",
+            forceVersion: "2.0.0"
+        )
+
+        // when
+        let requirements = self.waitOutputs(expect, for: usecase.updateRequirement) {
+            usecase.checkUpdateIsNeed()
+        }
+
+        // then
+        XCTAssertEqual(requirements, [.forceRequired])
+    }
+
+    func test_whenCurrentBelowRecommendVersionOnly_emitRecommended() {
+        // given
+        let expect = expectation(description: "권장 버전만 미만이면 recommended 방출")
+        let usecase = self.makeUsecase(
+            currentAppVersion: "1.0.0",
+            recommendVersion: "2.0.0"
+        )
+
+        // when
+        let requirements = self.waitOutputs(expect, for: usecase.updateRequirement) {
+            usecase.checkUpdateIsNeed()
+        }
+
+        // then
+        XCTAssertEqual(requirements, [.recommended])
+    }
+
+    func test_whenBothForceAndRecommendApply_forceTakesPriority() {
+        // given — current가 force·recommend 둘 다에 걸려도 force가 우선
+        let expect = expectation(description: "강업·권장 모두 해당하면 force 우선")
+        let usecase = self.makeUsecase(
+            currentAppVersion: "1.0.0",
+            forceVersion: "2.0.0",
+            recommendVersion: "1.5.0"
+        )
+
+        // when
+        let requirements = self.waitOutputs(expect, for: usecase.updateRequirement) {
+            usecase.checkUpdateIsNeed()
+        }
+
+        // then
+        XCTAssertEqual(requirements, [.forceRequired])
+    }
+
+    func test_whenForceNotMetButRecommendMet_emitRecommended() {
+        // given — current가 force는 넘었지만 recommend에는 걸리는 경우
+        let expect = expectation(description: "강업 미충족·권장 충족 시 recommended")
+        let usecase = self.makeUsecase(
+            currentAppVersion: "2.5.0",
+            forceVersion: "2.0.0",
+            recommendVersion: "3.0.0"
+        )
+
+        // when
+        let requirements = self.waitOutputs(expect, for: usecase.updateRequirement) {
+            usecase.checkUpdateIsNeed()
+        }
+
+        // then
+        XCTAssertEqual(requirements, [.recommended])
+    }
+
+    func test_whenCurrentAboveBoth_emitNothing() {
+        // given
+        let expect = expectation(description: "강업·권장 모두 넘으면 방출 없음")
+        expect.isInverted = true
+        let usecase = self.makeUsecase(
+            currentAppVersion: "3.0.0",
+            forceVersion: "2.0.0",
+            recommendVersion: "2.5.0"
+        )
+
+        // when
+        let requirements = self.waitOutputs(expect, for: usecase.updateRequirement, timeout: 0.5) {
+            usecase.checkUpdateIsNeed()
+        }
+
+        // then
+        XCTAssertTrue(requirements.isEmpty)
+    }
+
+    func test_whenForceAndRecommendBothMissing_emitNothing() {
+        // given — 서버 응답에 버전 정보가 하나도 없는 경우
+        let expect = expectation(description: "강업·권장 버전 모두 nil이면 방출 없음")
+        expect.isInverted = true
+        let usecase = self.makeUsecase(
+            currentAppVersion: "2.0.0"
+        )
+
+        // when
+        let requirements = self.waitOutputs(expect, for: usecase.updateRequirement, timeout: 0.5) {
+            usecase.checkUpdateIsNeed()
+        }
+
+        // then
+        XCTAssertTrue(requirements.isEmpty)
+    }
+}
+
+
+// MARK: - 조회 실패 대응
+
+extension AppUpdateCheckUsecaseImpleTests {
+
+    func test_whenFetchFails_emitNothing() {
+        // given
+        let expect = expectation(description: "조회 실패 시 방출 없음")
+        expect.isInverted = true
+        let usecase = self.makeUsecase(shouldFail: true)
+
+        // when
+        let requirements = self.waitOutputs(expect, for: usecase.updateRequirement, timeout: 0.5) {
+            usecase.checkUpdateIsNeed()
+        }
+
+        // then
+        XCTAssertTrue(requirements.isEmpty)
+    }
+}
+
+
+// MARK: - Stubs
+
+private class StubAppRepository: AppRepository, @unchecked Sendable {
+
+    private let forceVersion: String?
+    private let recommendVersion: String?
+    private let shouldFail: Bool
+
+    init(
+        forceVersion: String? = nil,
+        recommendVersion: String? = nil,
+        shouldFail: Bool = false
+    ) {
+        self.forceVersion = forceVersion
+        self.recommendVersion = recommendVersion
+        self.shouldFail = shouldFail
+    }
+
+    func loadUpdateInfo() async throws -> AppUpdateInfo {
+        if shouldFail { throw RuntimeError("load failed") }
+        var info = AppUpdateInfo()
+        info.forceUpdateVersion = self.forceVersion
+        info.recommendUpdateVersion = self.recommendVersion
+        return info
+    }
+}

--- a/Presentations/SettingScene/Tests/Setting/SettingItemListViewModelImpleTests.swift
+++ b/Presentations/SettingScene/Tests/Setting/SettingItemListViewModelImpleTests.swift
@@ -349,12 +349,16 @@ private class SpyRouter: BaseSpyRouter, SettingItemListRouting, @unchecked Senda
 
 
 private struct StubDeviceInfoFetchService: DeviceInfoFetchService {
-    
+
     @MainActor
     func fetchDeviceInfo() async -> DeviceInfo {
         return DeviceInfo()
             |> \.appVersion .~ "app"
             |> \.osVersion .~ "os"
             |> \.deviceModel .~ "model"
+    }
+
+    func fetchAppVersion() -> String? {
+        return "1.0.0"
     }
 }

--- a/Repository/Sources/Remote/Endpoint.swift
+++ b/Repository/Sources/Remote/Endpoint.swift
@@ -249,6 +249,20 @@ enum EventSyncEndPoints: Endpoint {
     }
 }
 
+// MARK: - App
+
+public enum AppEndpoints: Endpoint {
+    case updateInfo
+
+    public var subPath: String {
+        switch self {
+        case .updateInfo:
+            return "update-info.json"
+        }
+    }
+}
+
+
 // MARK: - google account endpoint
 
 enum GoogleAuthEndpoint: Endpoint {
@@ -362,7 +376,11 @@ public struct RemoteEnvironment: Sendable {
         case let googleCalendar as GoogleCalendarEndpoint:
             let prefix = "https://www.googleapis.com/calendar/v3"
             return appendSubpathIfNotEmpty(prefix, googleCalendar.subPath)
-            
+
+        case let app as AppEndpoints:
+            let prefix = "https://github.com/sudopark/TodoCalendar/app-config"
+            return appendSubpathIfNotEmpty(prefix, app.subPath)
+
         default: return nil
         }
     }

--- a/Repository/Sources/Remote/Endpoint.swift
+++ b/Repository/Sources/Remote/Endpoint.swift
@@ -378,7 +378,7 @@ public struct RemoteEnvironment: Sendable {
             return appendSubpathIfNotEmpty(prefix, googleCalendar.subPath)
 
         case let app as AppEndpoints:
-            let prefix = "https://github.com/sudopark/TodoCalendar/app-config"
+            let prefix = "https://raw.githubusercontent.com/sudopark/TodoCalendar/develop/app-config"
             return appendSubpathIfNotEmpty(prefix, app.subPath)
 
         default: return nil

--- a/Repository/Sources/Repository+Imple/Support/AppRemoteRepositoryImple.swift
+++ b/Repository/Sources/Repository+Imple/Support/AppRemoteRepositoryImple.swift
@@ -1,0 +1,23 @@
+//
+//  AppRemoteRepositoryImple.swift
+//  Repository
+//
+
+import Foundation
+import Domain
+
+public final class AppRemoteRepositoryImple: AppRepository, @unchecked Sendable {
+
+    private let remoteAPI: any RemoteAPI
+
+    public init(remoteAPI: any RemoteAPI) {
+        self.remoteAPI = remoteAPI
+    }
+
+    public func loadUpdateInfo() async throws -> AppUpdateInfo {
+        let mapper: AppUpdateInfoMapper = try await self.remoteAPI.request(
+            .get, AppEndpoints.updateInfo
+        )
+        return mapper.info
+    }
+}

--- a/Repository/Sources/Repository+Imple/Support/AppUpdateInfo+Mapping.swift
+++ b/Repository/Sources/Repository+Imple/Support/AppUpdateInfo+Mapping.swift
@@ -1,0 +1,26 @@
+//
+//  AppUpdateInfo+Mapping.swift
+//  Repository
+//
+
+import Foundation
+import Domain
+
+
+struct AppUpdateInfoMapper: Decodable {
+
+    let info: AppUpdateInfo
+
+    private enum CodingKeys: String, CodingKey {
+        case forceUpdateVersion = "force_update_version"
+        case recommendUpdateVersion = "recommend_update_version"
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        var info = AppUpdateInfo()
+        info.forceUpdateVersion = try container.decodeIfPresent(String.self, forKey: .forceUpdateVersion)
+        info.recommendUpdateVersion = try container.decodeIfPresent(String.self, forKey: .recommendUpdateVersion)
+        self.info = info
+    }
+}

--- a/Repository/Tests/Supports/AppRemoteRepositoryImpleTests.swift
+++ b/Repository/Tests/Supports/AppRemoteRepositoryImpleTests.swift
@@ -1,0 +1,85 @@
+//
+//  AppRemoteRepositoryImpleTests.swift
+//  RepositoryTests
+//
+
+import XCTest
+import UnitTestHelpKit
+
+@testable import Domain
+@testable import Repository
+
+
+class AppRemoteRepositoryImpleTests: BaseTestCase {
+
+    private var stubRemote: StubRemoteAPI!
+
+    override func setUpWithError() throws {
+        self.stubRemote = .init(responses: DummyResponse().responses)
+    }
+
+    override func tearDownWithError() throws {
+        self.stubRemote = nil
+    }
+
+    private func makeRepository(
+        shouldFail: Bool = false
+    ) -> AppRemoteRepositoryImple {
+        if shouldFail {
+            self.stubRemote.shouldFailRequest = true
+        }
+        return AppRemoteRepositoryImple(remoteAPI: self.stubRemote)
+    }
+}
+
+
+extension AppRemoteRepositoryImpleTests {
+
+    func test_loadUpdateInfo() async throws {
+        // given
+        let repository = self.makeRepository()
+
+        // when
+        let info = try await repository.loadUpdateInfo()
+
+        // then
+        XCTAssertEqual(info.forceUpdateVersion, "3.0.0")
+        XCTAssertEqual(info.recommendUpdateVersion, "2.5.0")
+    }
+
+    func test_whenFetchFails_throwError() async {
+        // given
+        let repository = self.makeRepository(shouldFail: true)
+
+        // when + then
+        do {
+            let _ = try await repository.loadUpdateInfo()
+            XCTFail("should fail")
+        } catch {
+            // expected
+        }
+    }
+}
+
+
+private struct DummyResponse {
+
+    private var updateInfoResponse: String {
+        return """
+        {
+            "force_update_version": "3.0.0",
+            "recommend_update_version": "2.5.0"
+        }
+        """
+    }
+
+    var responses: [StubRemoteAPI.Response] {
+        return [
+            .init(
+                method: .get,
+                endpoint: AppEndpoints.updateInfo,
+                resultJsonString: .success(self.updateInfoResponse)
+            )
+        ]
+    }
+}

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -499,3 +499,10 @@
 // MARK: - link
 
 "deeplink::invalid_link_message" = "This link format is not supported.\nPlease update the app to the latest version.";
+
+// MARK: - force update
+
+"force_update.title" = "Update Required";
+"force_update.message" = "A new version is available.\nPlease update to continue using the app.";
+"recommend_update.title" = "Update Recommended";
+"recommend_update.message" = "A new version is available.\nWe recommend updating for a better experience.";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -499,3 +499,10 @@
 // MARK: - link
 
 "deeplink::invalid_link_message" = "지원하지 않는 형식의 링크입니다.\n앱을 최신 버전으로 업데이트 해주세요.";
+
+// MARK: - force update
+
+"force_update.title" = "업데이트 필요";
+"force_update.message" = "새로운 버전이 출시되었습니다.\n앱을 사용하려면 업데이트가 필요합니다.";
+"recommend_update.title" = "업데이트 권장";
+"recommend_update.message" = "새로운 버전이 출시되었습니다.\n더 나은 경험을 위해 업데이트를 권장합니다.";

--- a/TodoCalendarApp/Sources/Factories/ApplicationBase.swift
+++ b/TodoCalendarApp/Sources/Factories/ApplicationBase.swift
@@ -248,6 +248,10 @@ struct DeviceInfoFetchServiceImple: DeviceInfoFetchService {
             return "\($0)(\(buildNumber ?? "0"))"
         }
     }
+
+    func fetchAppVersion() -> String? {
+        return self.markettingVersion()
+    }
     
     @MainActor
     private func osVersion() -> String {

--- a/TodoCalendarApp/Sources/Root/ApplicationRootBuilder.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootBuilder.swift
@@ -57,6 +57,12 @@ final class ApplicationRootBuilder {
             appDataMigration: appDataMigration
         )
         
+        let appRepository = AppRemoteRepositoryImple(remoteAPI: applicationBase.remoteAPI)
+        let appUpdateCheckUsecase = AppUpdateCheckUsecaseImple(
+            appRepository: appRepository,
+            deviceInfoFetchService: DeviceInfoFetchServiceImple()
+        )
+
         let backgroundEventSyncUsecase = BackgroundEventSyncUsecaseImple()
         let deepLinkHandler = ApplicationDeepLinkHandlerImple()
         let rootViewModel = ApplicationRootViewModelImple(
@@ -66,7 +72,8 @@ final class ApplicationRootBuilder {
             deepLinkHandler: deepLinkHandler,
             externalCalendarServiceUsecase: externalCalendarIntegrationUsecase,
             userNotificationUsecase: userNotificationUsecase,
-            backgroundEventSyncUsecase: backgroundEventSyncUsecase
+            backgroundEventSyncUsecase: backgroundEventSyncUsecase,
+            appUpdateCheckUsecase: appUpdateCheckUsecase
         )
         remote.attach(listener: rootViewModel)
         applicationBase.externalCalendarAccountRemotePool.attach(listener: rootViewModel)

--- a/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
@@ -203,7 +203,7 @@ protocol ApplicationRouting: Routing {
 
     func setupInitialScene(_ prepareResult: ApplicationPrepareResult)
     func changeRootSceneAfter(signIn auth: Auth?)
-    func showForceUpdatePopup(_ requirement: AppUpdateRequirement)
+    func showUpdatePopup(_ requirement: AppUpdateRequirement)
 }
 
 final class ApplicationRootRouter: ApplicationRouting, @unchecked Sendable {
@@ -309,7 +309,7 @@ extension ApplicationRootRouter {
         }
     }
 
-    func showForceUpdatePopup(_ requirement: AppUpdateRequirement) {
+    func showUpdatePopup(_ requirement: AppUpdateRequirement) {
         Task { @MainActor in
             guard self.updatePopupViewController == nil else { return }
             guard let topViewController = self.window.rootViewController?.topPresentedViewController()

--- a/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SwiftUI
 import Domain
 import Extensions
 import Scenes
@@ -199,15 +200,17 @@ extension ApplicationViewAppearanceStoreImple: AppleCalendarViewAppearanceStore 
 // MARK: - ApplicationRootRouter
 
 protocol ApplicationRouting: Routing {
-    
+
     func setupInitialScene(_ prepareResult: ApplicationPrepareResult)
     func changeRootSceneAfter(signIn auth: Auth?)
+    func showForceUpdatePopup(_ requirement: AppUpdateRequirement)
 }
 
 final class ApplicationRootRouter: ApplicationRouting, @unchecked Sendable {
     
     
     @MainActor var window: UIWindow!
+    @MainActor private weak var updatePopupViewController: UIViewController?
     var viewAppearanceStore: ApplicationViewAppearanceStoreImple!
     private let authUsecase: any AuthUsecase
     private let accountUsecase: any AccountUsecase
@@ -300,9 +303,41 @@ extension ApplicationRootRouter {
         Task { @MainActor in
             guard let topViewController = self.window.rootViewController?.topPresentedViewController()
             else { return }
-            
+
             let alertController = info.asAlertViewController()
             topViewController.present(alertController, animated: true)
+        }
+    }
+
+    func showForceUpdatePopup(_ requirement: AppUpdateRequirement) {
+        Task { @MainActor in
+            guard self.updatePopupViewController == nil else { return }
+            guard let topViewController = self.window.rootViewController?.topPresentedViewController()
+            else { return }
+
+            let onUpdate: () -> Void = {
+                if let url = URL(string: AppEnvironment.appstoreLinkPath) {
+                    UIApplication.shared.open(url)
+                }
+            }
+            let onClose: (() -> Void)? = requirement == .recommended ? { [weak self] in
+                self?.updatePopupViewController?.dismiss(animated: false)
+                self?.updatePopupViewController = nil
+            } : nil
+
+            let view = ForceUpdatePopupView(
+                requirement: requirement,
+                onUpdate: onUpdate,
+                onClose: onClose
+            )
+            .environment(self.viewAppearanceStore.appearance)
+            let hostingVC = UIHostingController(rootView: view)
+            hostingVC.modalPresentationStyle = .overFullScreen
+            hostingVC.isModalInPresentation = true
+            hostingVC.view.backgroundColor = .clear
+
+            self.updatePopupViewController = hostingVC
+            topViewController.present(hostingVC, animated: false)
         }
     }
     

--- a/TodoCalendarApp/Sources/Root/ApplicationRootViewModel.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootViewModel.swift
@@ -197,7 +197,7 @@ extension ApplicationRootViewModelImple {
         self.appUpdateCheckUsecase.updateRequirement
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] requirement in
-                self?.router?.showForceUpdatePopup(requirement)
+                self?.router?.showUpdatePopup(requirement)
             })
             .store(in: &self.cancellables)
     }

--- a/TodoCalendarApp/Sources/Root/ApplicationRootViewModel.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootViewModel.swift
@@ -25,6 +25,7 @@ final class ApplicationRootViewModelImple: @unchecked Sendable {
     private let externalCalendarServiceUsecase: any ExternalCalendarIntegrationUsecase
     private let userNotificationUsecase: any UserNotificationUsecase
     private let backgroundEventSyncUsecase: any BackgroundEventSyncUsecase
+    private let appUpdateCheckUsecase: any AppUpdateCheckUsecase
     var router: ApplicationRootRouter?
 
     init(
@@ -34,7 +35,8 @@ final class ApplicationRootViewModelImple: @unchecked Sendable {
         deepLinkHandler: ApplicationDeepLinkHandlerImple,
         externalCalendarServiceUsecase: any ExternalCalendarIntegrationUsecase,
         userNotificationUsecase: any UserNotificationUsecase,
-        backgroundEventSyncUsecase: any BackgroundEventSyncUsecase
+        backgroundEventSyncUsecase: any BackgroundEventSyncUsecase,
+        appUpdateCheckUsecase: any AppUpdateCheckUsecase
     ) {
         self.authUsecase = authUsecase
         self.accountUsecase = accountUsecase
@@ -43,10 +45,12 @@ final class ApplicationRootViewModelImple: @unchecked Sendable {
         self.externalCalendarServiceUsecase = externalCalendarServiceUsecase
         self.userNotificationUsecase = userNotificationUsecase
         self.backgroundEventSyncUsecase = backgroundEventSyncUsecase
-        
+        self.appUpdateCheckUsecase = appUpdateCheckUsecase
+
         self.bindAccountStatusChanged()
         self.bindApplicationStatusChanged()
         self.bindExternalCalenarIntegratedStatus()
+        self.bindUpdateRequirement()
     }
     
     private struct Subject {
@@ -72,6 +76,7 @@ extension ApplicationRootViewModelImple: AutenticatorTokenRefreshListener {
             self.router?.setupInitialScene(result)
             self.subject.isSignIn.send(result.latestLoginAcount != nil)
             self.registerTokenIfNeed()
+            self.appUpdateCheckUsecase.checkUpdateIsNeed()
         }
     }
     
@@ -170,12 +175,31 @@ extension ApplicationRootViewModelImple {
                 self?.handleDidEnterBackground()
             })
             .store(in: &self.cancellables)
+
+        NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
+            .sink(receiveValue: { [weak self] _ in
+                self?.handleWillEnterForeground()
+            })
+            .store(in: &self.cancellables)
     }
     
     private func handleDidEnterBackground() {
         self.prepareUsecase.prepareEnterBackground()
         self.backgroundEventSyncUsecase.scheduleTask()
         WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    private func handleWillEnterForeground() {
+        self.appUpdateCheckUsecase.checkUpdateIsNeed()
+    }
+
+    private func bindUpdateRequirement() {
+        self.appUpdateCheckUsecase.updateRequirement
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self] requirement in
+                self?.router?.showForceUpdatePopup(requirement)
+            })
+            .store(in: &self.cancellables)
     }
 }
 

--- a/TodoCalendarApp/Sources/Root/ForceUpdatePopupView.swift
+++ b/TodoCalendarApp/Sources/Root/ForceUpdatePopupView.swift
@@ -35,32 +35,52 @@ struct ForceUpdatePopupView: View {
         }
     }
 
+    @ViewBuilder
     private var popupContent: some View {
-        VStack(spacing: 20) {
-            Text(titleText)
+        switch requirement {
+        case .forceRequired:
+            forceRequiredContent
+        case .recommended:
+            recommendedContent
+        }
+    }
+
+    private var forceRequiredContent: some View {
+        popupCard {
+            Text("force_update.title".localized())
                 .font(appearance.fontSet.bigBold.asFont)
                 .foregroundStyle(appearance.colorSet.text0.asColor)
                 .multilineTextAlignment(.center)
 
-            Text(messageText)
+            Text("force_update.message".localized())
                 .font(appearance.fontSet.normal.asFont)
                 .foregroundStyle(appearance.colorSet.text1.asColor)
                 .multilineTextAlignment(.center)
 
-            actionButtons
+            ConfirmButton(
+                title: "common.update".localized(),
+                textColor: appearance.colorSet.primaryBtnText.asColor,
+                backgroundColor: appearance.colorSet.primaryBtnBackground.asColor
+            )
+            .eventHandler(\.onTap) {
+                self.onUpdate()
+            }
         }
-        .padding(24)
-        .background(
-            RoundedRectangle(cornerRadius: 16)
-                .fill(Color(.systemBackground))
-        )
     }
 
-    @ViewBuilder
-    private var actionButtons: some View {
-        HStack(spacing: 12) {
-            
-            if self.requirement == .recommended {
+    private var recommendedContent: some View {
+        popupCard {
+            Text("recommend_update.title".localized())
+                .font(appearance.fontSet.bigBold.asFont)
+                .foregroundStyle(appearance.colorSet.text0.asColor)
+                .multilineTextAlignment(.center)
+
+            Text("recommend_update.message".localized())
+                .font(appearance.fontSet.normal.asFont)
+                .foregroundStyle(appearance.colorSet.text1.asColor)
+                .multilineTextAlignment(.center)
+
+            HStack(spacing: 12) {
                 ConfirmButton(
                     title: "common.close".localized(),
                     textColor: appearance.colorSet.secondaryBtnText.asColor,
@@ -69,17 +89,30 @@ struct ForceUpdatePopupView: View {
                 .eventHandler(\.onTap) {
                     self.closePopup { self.onClose?() }
                 }
-            }
-            
-            ConfirmButton(
-                title: "common.update".localized(),
-                textColor: appearance.colorSet.primaryBtnText.asColor,
-                backgroundColor: appearance.colorSet.primaryBtnBackground.asColor
-            )
-            .eventHandler(\.onTap) {
-                self.closePopup { self.onUpdate() }
+
+                ConfirmButton(
+                    title: "common.update".localized(),
+                    textColor: appearance.colorSet.primaryBtnText.asColor,
+                    backgroundColor: appearance.colorSet.primaryBtnBackground.asColor
+                )
+                .eventHandler(\.onTap) {
+                    self.closePopup { self.onUpdate() }
+                }
             }
         }
+    }
+
+    private func popupCard<Content: View>(
+        @ViewBuilder _ content: () -> Content
+    ) -> some View {
+        VStack(spacing: 20) {
+            content()
+        }
+        .padding(24)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(appearance.colorSet.bg0.asColor)
+        )
     }
 
     private func closePopup(_ handler: @escaping () -> Void) {
@@ -87,24 +120,6 @@ struct ForceUpdatePopupView: View {
         backgroundShown = false
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
             handler()
-        }
-    }
-
-    private var titleText: String {
-        switch requirement {
-        case .forceRequired:
-            return "force_update.title".localized()
-        case .recommended:
-            return "recommend_update.title".localized()
-        }
-    }
-
-    private var messageText: String {
-        switch requirement {
-        case .forceRequired:
-            return "force_update.message".localized()
-        case .recommended:
-            return "recommend_update.message".localized()
         }
     }
 }

--- a/TodoCalendarApp/Sources/Root/ForceUpdatePopupView.swift
+++ b/TodoCalendarApp/Sources/Root/ForceUpdatePopupView.swift
@@ -1,0 +1,110 @@
+//
+//  ForceUpdatePopupView.swift
+//  TodoCalendarApp
+//
+
+import SwiftUI
+import Domain
+import CommonPresentation
+import Extensions
+
+struct ForceUpdatePopupView: View {
+
+    let requirement: AppUpdateRequirement
+    let onUpdate: () -> Void
+    let onClose: (() -> Void)?
+
+    @State private var popupShown: Bool = false
+    @State private var backgroundShown: Bool = false
+    @Environment(ViewAppearance.self) private var appearance
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(backgroundShown ? 0.5 : 0)
+                .ignoresSafeArea()
+                .animation(.easeInOut(duration: 0.25), value: backgroundShown)
+
+            popupContent
+                .padding(.horizontal, 40)
+                .opacity(popupShown ? 1 : 0)
+                .animation(.easeInOut(duration: 0.25), value: popupShown)
+        }
+        .onAppear {
+            popupShown = true
+            backgroundShown = true
+        }
+    }
+
+    private var popupContent: some View {
+        VStack(spacing: 20) {
+            Text(titleText)
+                .font(appearance.fontSet.bigBold.asFont)
+                .foregroundStyle(appearance.colorSet.text0.asColor)
+                .multilineTextAlignment(.center)
+
+            Text(messageText)
+                .font(appearance.fontSet.normal.asFont)
+                .foregroundStyle(appearance.colorSet.text1.asColor)
+                .multilineTextAlignment(.center)
+
+            actionButtons
+        }
+        .padding(24)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color(.systemBackground))
+        )
+    }
+
+    @ViewBuilder
+    private var actionButtons: some View {
+        HStack(spacing: 12) {
+            
+            if self.requirement == .recommended {
+                ConfirmButton(
+                    title: "common.close".localized(),
+                    textColor: appearance.colorSet.secondaryBtnText.asColor,
+                    backgroundColor: appearance.colorSet.secondaryBtnBackground.asColor
+                )
+                .eventHandler(\.onTap) {
+                    self.closePopup { self.onClose?() }
+                }
+            }
+            
+            ConfirmButton(
+                title: "common.update".localized(),
+                textColor: appearance.colorSet.primaryBtnText.asColor,
+                backgroundColor: appearance.colorSet.primaryBtnBackground.asColor
+            )
+            .eventHandler(\.onTap) {
+                self.closePopup { self.onUpdate() }
+            }
+        }
+    }
+
+    private func closePopup(_ handler: @escaping () -> Void) {
+        popupShown = false
+        backgroundShown = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+            handler()
+        }
+    }
+
+    private var titleText: String {
+        switch requirement {
+        case .forceRequired:
+            return "force_update.title".localized()
+        case .recommended:
+            return "recommend_update.title".localized()
+        }
+    }
+
+    private var messageText: String {
+        switch requirement {
+        case .forceRequired:
+            return "force_update.message".localized()
+        case .recommended:
+            return "recommend_update.message".localized()
+        }
+    }
+}

--- a/app-config/update-info.json
+++ b/app-config/update-info.json
@@ -1,0 +1,4 @@
+{
+  "force_update_version": null,
+  "recommend_update_version": null
+}


### PR DESCRIPTION
## 배경

서버 API 브레이킹 체인지나 치명적 결함이 발견됐을 때 구버전 사용자를 새 버전으로 강제 이전시킬 수 있는 통로가 필요했다. 반대로 "새 버전이 있으니 업데이트를 권장한다" 수준의 완화된 안내도 같은 채널로 가능해야 하고, 이 조건을 앱 재배포 없이 즉시 조정할 수 있어야 한다.

## 접근

- **조건 외부화**: 최소 지원 버전을 담은 정적 JSON을 저장소에 올리고 GitHub raw로 서빙. 파일만 갱신하면 이미 배포된 앱들이 다음 체크 시 새 기준을 따른다.
- **자연스러운 버전 비교**: 버전 문자열을 자리수별 zero-padding 후 `.numeric` 옵션으로 비교해 `1.10`을 `1.9`보다 높게 취급. 자리수가 달라도(`2.0` vs `2.0.1`) 올바르게 정렬된다.
- **요구 수준의 이넘 모델링**: 판정 결과는 `AppUpdateRequirement`(`forceRequired` / `recommended`) 이넘으로 표현. "업데이트 불필요"는 방출을 생략해 호출부가 별도 분기 없이 "필요한 때만 반응"할 수 있도록 했다.
- **전송 포맷 격리**: 원격 JSON 디코딩 책임은 Repository 레이어의 `AppUpdateInfoMapper`에만 두고 Domain 모델은 전송 포맷을 알지 않도록 분리.
- **강제 모달 보장**: 강제 요구일 때 `isModalInPresentation` + 버튼/제스처 dismiss 봉쇄로 사용자가 업데이트 외 경로로 앱에 진입하지 못하게 차단. 권장 팝업은 "나중에"/"업데이트" 선택 가능.
- **체크 트리거**: 앱 시작과 포그라운드 복귀 두 시점에 체크를 재실행. 사용자가 장시간 백그라운드에 둔 뒤 돌아와도 최신 조건이 반영된다.
- **연출**: 팝업 등장·퇴장은 SwiftUI 내부에서 `.opacity`로 제어하고 모달 전환은 `animated:false`로 띄워 배경 딤과 팝업이 동일한 페이드로 사라지도록 통일.

## 커밋 구성

1. 강업 체크용 최소 지원 버전 JSON 추가
2. 앱 버전과 서버 최소 버전 비교로 업데이트 요구 수준 판정하는 Domain 흐름 도입
3. AppRepository 원격 구현과 JSON→도메인 매퍼 추가
4. 업데이트 안내 팝업 뷰 추가
5. 업데이트 체크 흐름을 루트에 연결하고 팝업 노출 경로 구성

## 한계 · 후속 과제

- 권장 팝업은 포그라운드 복귀마다 재노출된다. 사용자가 "나중에"를 선택했을 때 일정 기간 억제하는 정책은 아직 없음 — 필요해지면 마지막 dismiss 시점을 로컬에 저장해 억제 기간을 둘 수 있다.
- 버전 비교는 `major.minor.patch` 순수 숫자 포맷만 가정. `1.0-beta` 같은 semver pre-release 표기는 고려하지 않았다.

## Test plan

- [x] `AppUpdateRequirement` 버전 비교 엣지 케이스 (major/minor/patch, 자리수 불일치, 숫자 비교)
- [x] `AppUpdateCheckUsecaseImple` 결정 로직 (force 우선, 단일 버전만 존재, 조회 실패, 버전 정보 부재)
- [x] `AppRemoteRepositoryImple` JSON 디코딩 / 실패 전파
- [x] 시뮬레이터에서 팝업 노출·닫힘 애니메이션 확인

Closes #614