### PR TITLE
[#617] CI 실패 전파 정확성 + DerivedData 공유로 속도 개선

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -135,6 +135,9 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.schemes != ''
     runs-on: Maggie-m1
+    defaults:
+      run:
+        shell: bash -eo pipefail {0}
     env:
       DESTINATION: 'platform=iOS Simulator,name=iPhone 16,OS=18.1'
     steps:
@@ -168,6 +171,7 @@ jobs:
       - name: Test Domain
         if: contains(needs.detect-changes.outputs.schemes, ' Domain ')
         run: |
+          set -euo pipefail
           xcodebuild clean test \
             -workspace TodoCalendar.xcworkspace \
             -scheme Domain \
@@ -178,6 +182,7 @@ jobs:
       - name: Test Repository
         if: contains(needs.detect-changes.outputs.schemes, ' Repository ')
         run: |
+          set -euo pipefail
           xcodebuild clean test \
             -workspace TodoCalendar.xcworkspace \
             -scheme Repository \
@@ -188,6 +193,7 @@ jobs:
       - name: Test CalendarScenes
         if: contains(needs.detect-changes.outputs.schemes, ' CalendarScenes ')
         run: |
+          set -euo pipefail
           xcodebuild clean test \
             -workspace TodoCalendar.xcworkspace \
             -scheme CalendarScenes \
@@ -198,6 +204,7 @@ jobs:
       - name: Test EventDetailScene
         if: contains(needs.detect-changes.outputs.schemes, ' EventDetailScene ')
         run: |
+          set -euo pipefail
           xcodebuild clean test \
             -workspace TodoCalendar.xcworkspace \
             -scheme EventDetailScene \
@@ -208,6 +215,7 @@ jobs:
       - name: Test EventListScenes
         if: contains(needs.detect-changes.outputs.schemes, ' EventListScenes ')
         run: |
+          set -euo pipefail
           xcodebuild clean test \
             -workspace TodoCalendar.xcworkspace \
             -scheme EventListScenes \
@@ -218,6 +226,7 @@ jobs:
       - name: Test SettingScene
         if: contains(needs.detect-changes.outputs.schemes, ' SettingScene ')
         run: |
+          set -euo pipefail
           xcodebuild clean test \
             -workspace TodoCalendar.xcworkspace \
             -scheme SettingScene \
@@ -228,6 +237,7 @@ jobs:
       - name: Test MemberScenes
         if: contains(needs.detect-changes.outputs.schemes, ' MemberScenes ')
         run: |
+          set -euo pipefail
           xcodebuild clean test \
             -workspace TodoCalendar.xcworkspace \
             -scheme MemberScenes \
@@ -238,6 +248,7 @@ jobs:
       - name: Test TodoCalendarApp
         if: contains(needs.detect-changes.outputs.schemes, ' TodoCalendarApp ')
         run: |
+          set -euo pipefail
           xcodebuild clean test \
             -workspace TodoCalendar.xcworkspace \
             -scheme TodoCalendarApp \
@@ -248,6 +259,7 @@ jobs:
       - name: Test TodoCalendarAppWidget
         if: contains(needs.detect-changes.outputs.schemes, ' TodoCalendarAppWidget ')
         run: |
+          set -euo pipefail
           xcodebuild clean test \
             -workspace TodoCalendar.xcworkspace \
             -scheme TodoCalendarAppWidget \

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -168,13 +168,19 @@ jobs:
       - name: Generate project
         run: tuist generate --no-open
 
+      - name: Reset DerivedData
+        run: |
+          set -euo pipefail
+          rm -rf ./DerivedData
+
       - name: Test Domain
         if: contains(needs.detect-changes.outputs.schemes, ' Domain ')
         run: |
           set -euo pipefail
-          xcodebuild clean test \
+          xcodebuild test \
             -workspace TodoCalendar.xcworkspace \
             -scheme Domain \
+            -derivedDataPath ./DerivedData \
             -destination "$DESTINATION" \
             -testLanguage en -testRegion en_US \
             | xcpretty
@@ -183,9 +189,10 @@ jobs:
         if: contains(needs.detect-changes.outputs.schemes, ' Repository ')
         run: |
           set -euo pipefail
-          xcodebuild clean test \
+          xcodebuild test \
             -workspace TodoCalendar.xcworkspace \
             -scheme Repository \
+            -derivedDataPath ./DerivedData \
             -destination "$DESTINATION" \
             -testLanguage en -testRegion en_US \
             | xcpretty
@@ -194,9 +201,10 @@ jobs:
         if: contains(needs.detect-changes.outputs.schemes, ' CalendarScenes ')
         run: |
           set -euo pipefail
-          xcodebuild clean test \
+          xcodebuild test \
             -workspace TodoCalendar.xcworkspace \
             -scheme CalendarScenes \
+            -derivedDataPath ./DerivedData \
             -destination "$DESTINATION" \
             -testLanguage en -testRegion en_US \
             | xcpretty
@@ -205,9 +213,10 @@ jobs:
         if: contains(needs.detect-changes.outputs.schemes, ' EventDetailScene ')
         run: |
           set -euo pipefail
-          xcodebuild clean test \
+          xcodebuild test \
             -workspace TodoCalendar.xcworkspace \
             -scheme EventDetailScene \
+            -derivedDataPath ./DerivedData \
             -destination "$DESTINATION" \
             -testLanguage en -testRegion en_US \
             | xcpretty
@@ -216,9 +225,10 @@ jobs:
         if: contains(needs.detect-changes.outputs.schemes, ' EventListScenes ')
         run: |
           set -euo pipefail
-          xcodebuild clean test \
+          xcodebuild test \
             -workspace TodoCalendar.xcworkspace \
             -scheme EventListScenes \
+            -derivedDataPath ./DerivedData \
             -destination "$DESTINATION" \
             -testLanguage en -testRegion en_US \
             | xcpretty
@@ -227,9 +237,10 @@ jobs:
         if: contains(needs.detect-changes.outputs.schemes, ' SettingScene ')
         run: |
           set -euo pipefail
-          xcodebuild clean test \
+          xcodebuild test \
             -workspace TodoCalendar.xcworkspace \
             -scheme SettingScene \
+            -derivedDataPath ./DerivedData \
             -destination "$DESTINATION" \
             -testLanguage en -testRegion en_US \
             | xcpretty
@@ -238,9 +249,10 @@ jobs:
         if: contains(needs.detect-changes.outputs.schemes, ' MemberScenes ')
         run: |
           set -euo pipefail
-          xcodebuild clean test \
+          xcodebuild test \
             -workspace TodoCalendar.xcworkspace \
             -scheme MemberScenes \
+            -derivedDataPath ./DerivedData \
             -destination "$DESTINATION" \
             -testLanguage en -testRegion en_US \
             | xcpretty
@@ -249,9 +261,10 @@ jobs:
         if: contains(needs.detect-changes.outputs.schemes, ' TodoCalendarApp ')
         run: |
           set -euo pipefail
-          xcodebuild clean test \
+          xcodebuild test \
             -workspace TodoCalendar.xcworkspace \
             -scheme TodoCalendarApp \
+            -derivedDataPath ./DerivedData \
             -destination "$DESTINATION" \
             -testLanguage en -testRegion en_US \
             | xcpretty
@@ -260,9 +273,10 @@ jobs:
         if: contains(needs.detect-changes.outputs.schemes, ' TodoCalendarAppWidget ')
         run: |
           set -euo pipefail
-          xcodebuild clean test \
+          xcodebuild test \
             -workspace TodoCalendar.xcworkspace \
             -scheme TodoCalendarAppWidget \
+            -derivedDataPath ./DerivedData \
             -destination "$DESTINATION" \
             -testLanguage en -testRegion en_US \
             | xcpretty


### PR DESCRIPTION
## Summary
- **#617 수정**: `xcodebuild ... | xcpretty` 파이프라인에서 xcodebuild 실패가 CI 스텝 성공으로 가려지던 문제를 `pipefail` 적용으로 해결. 테스트 실패·빌드 실패·시뮬레이터 실패 모두 스텝 실패로 올바르게 전파.
- **CI 속도 개선**: 스킴마다 `clean`으로 DerivedData를 통째 비우고 처음부터 재컴파일하던 구조를 걷어냄. 워크스페이스 로컬 `./DerivedData`를 `-derivedDataPath`로 고정하고 run 시작 시 1회만 초기화해, 두 번째 스킴부터 공통 모듈(Domain·Repository·Supports/*·Scenes·CommonPresentation)을 재사용.

## 변경 지점
`.github/workflows/pr_test.yml`
- `jobs.test.defaults.run.shell: bash -eo pipefail {0}` 신설 (job 전체 기본값 — 새 스텝 추가 시 누락 방지)
- 9개 Test 스텝 `run:` 첫 줄 `set -euo pipefail` 명시 (의도 가시화 + 이중 방어)
- `Reset DerivedData` 스텝 신설 (`tuist generate` 직후, `rm -rf ./DerivedData`)
- 9개 `xcodebuild clean test` → `xcodebuild test`
- 9개 xcodebuild에 `-derivedDataPath ./DerivedData` 일관 적용

## Out of scope
- 프레임워크 선별 로직(`detect-changes`) 정밀화는 Phase 1·2 효과 측정 후 별도 과제로 분리.
- `.xcresult` 아티팩트 업로드, `actions/cache` DerivedData 캐싱, matrix 병렬화는 본 PR 범위 외.

## Test plan
- [ ] PR 생성 후 CI가 초록으로 통과하는지 확인
- [ ] (선택) 일시적으로 failing test 1건을 심은 draft PR로 CI가 빨간색으로 표시되는지 검증
- [ ] 머지 후 후속 PR에서 전체 스킴 빌드 시 소요 시간 단축 체감 여부 확인

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)