### PR TITLE
[#616] 설정 화면에 업데이트 진입점 추가

### DIFF
--- a/Domain/Sources/Models/AppUpdateInfo.swift
+++ b/Domain/Sources/Models/AppUpdateInfo.swift
@@ -8,7 +8,7 @@ import Foundation
 public struct AppUpdateInfo: Sendable {
     public var forceUpdateVersion: String?
     public var recommendUpdateVersion: String?
-
+    public var latestVersion: String?
     public init() { }
 }
 

--- a/Domain/Sources/Usecases/Support/AppUpdateCheckUsecase.swift
+++ b/Domain/Sources/Usecases/Support/AppUpdateCheckUsecase.swift
@@ -15,6 +15,7 @@ import Extensions
 public protocol AppUpdateCheckUsecase: Sendable {
     func checkUpdateIsNeed()
     var updateRequirement: AnyPublisher<AppUpdateRequirement, Never> { get }
+    var isUpdateAvailable: AnyPublisher<Bool, Never> { get }
 }
 
 
@@ -23,14 +24,16 @@ public protocol AppUpdateCheckUsecase: Sendable {
 public final class AppUpdateCheckUsecaseImple: AppUpdateCheckUsecase, @unchecked Sendable {
 
     private let appRepository: any AppRepository
+    private let currentAppVersion: String?
 
     public init(
         appRepository: any AppRepository,
         deviceInfoFetchService: any DeviceInfoFetchService
     ) {
         self.appRepository = appRepository
+        self.currentAppVersion = deviceInfoFetchService.fetchAppVersion()
 
-        guard let appVersion = deviceInfoFetchService.fetchAppVersion()
+        guard let appVersion = self.currentAppVersion
         else { return }
         self.bindCheckTrigger(appVersion)
     }
@@ -38,6 +41,7 @@ public final class AppUpdateCheckUsecaseImple: AppUpdateCheckUsecase, @unchecked
     private struct Subject {
         let checkTrigger = PassthroughSubject<Void, Never>()
         let appUpdateRequirement = PassthroughSubject<AppUpdateRequirement, Never>()
+        let currentUpdateInfo = CurrentValueSubject<AppUpdateInfo?, Never>(nil)
     }
     private let subject = Subject()
     private var cancellables: Set<AnyCancellable> = []
@@ -57,6 +61,9 @@ extension AppUpdateCheckUsecaseImple {
             .flatMapLatest { [weak self] in
                 return self?.loadUpdateInfoWithoutError() ?? Empty().eraseToAnyPublisher()
             }
+            .handleEvents(receiveOutput: { [weak self] info in
+                self?.subject.currentUpdateInfo.send(info)
+            })
             .compactMap { [weak self] info in
                 return self?.checkAppVersion(currentAppVersion, updateInfo: info)
             }
@@ -87,6 +94,18 @@ extension AppUpdateCheckUsecaseImple {
 
     public var updateRequirement: AnyPublisher<AppUpdateRequirement, Never> {
         return self.subject.appUpdateRequirement
+            .eraseToAnyPublisher()
+    }
+
+    public var isUpdateAvailable: AnyPublisher<Bool, Never> {
+        let currentAppVersion = self.currentAppVersion
+        return self.subject.currentUpdateInfo
+            .map { info -> Bool in
+                guard let current = currentAppVersion,
+                      let latest = info?.latestVersion
+                else { return false }
+                return current.isVersionLessThan(latest)
+            }
             .eraseToAnyPublisher()
     }
 }

--- a/Domain/Tests/Usecases/AppUpdateCheckUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AppUpdateCheckUsecaseImpleTests.swift
@@ -185,11 +185,13 @@ class AppUpdateCheckUsecaseImpleTests: BaseTestCase, PublisherWaitable {
         currentAppVersion: String = "2.0.0",
         forceVersion: String? = nil,
         recommendVersion: String? = nil,
+        latestVersion: String? = nil,
         shouldFail: Bool = false
     ) -> AppUpdateCheckUsecaseImple {
         let stubRepository = StubAppRepository(
             forceVersion: forceVersion,
             recommendVersion: recommendVersion,
+            latestVersion: latestVersion,
             shouldFail: shouldFail
         )
         var stubDeviceInfo = StubDeviceInfoFetchService()
@@ -335,21 +337,137 @@ extension AppUpdateCheckUsecaseImpleTests {
 }
 
 
+// MARK: - isUpdateAvailable 판정 (latest_version 단독 축)
+
+extension AppUpdateCheckUsecaseImpleTests {
+
+    func test_whenLatestVersionHigherThanCurrent_isUpdateAvailableIsTrue() {
+        // given
+        let expect = expectation(description: "최신 버전이 높으면 true")
+        expect.expectedFulfillmentCount = 2
+        let usecase = self.makeUsecase(
+            currentAppVersion: "1.0.0",
+            latestVersion: "1.1.0"
+        )
+
+        // when
+        let values = self.waitOutputs(expect, for: usecase.isUpdateAvailable, timeout: 1.0) {
+            usecase.checkUpdateIsNeed()
+        }
+
+        // then
+        XCTAssertEqual(values, [false, true])
+    }
+
+    func test_whenLatestVersionEqualsCurrent_isUpdateAvailableIsFalse() {
+        // given
+        let expect = expectation(description: "동일하면 false")
+        expect.expectedFulfillmentCount = 2
+        let usecase = self.makeUsecase(
+            currentAppVersion: "2.0.0",
+            latestVersion: "2.0.0"
+        )
+
+        // when
+        let values = self.waitOutputs(expect, for: usecase.isUpdateAvailable, timeout: 1.0) {
+            usecase.checkUpdateIsNeed()
+        }
+
+        // then
+        XCTAssertEqual(values, [false, false])
+    }
+
+    func test_whenLatestVersionLowerThanCurrent_isUpdateAvailableIsFalse() {
+        // given
+        let expect = expectation(description: "최신 버전이 낮으면 false")
+        expect.expectedFulfillmentCount = 2
+        let usecase = self.makeUsecase(
+            currentAppVersion: "3.0.0",
+            latestVersion: "2.9.0"
+        )
+
+        // when
+        let values = self.waitOutputs(expect, for: usecase.isUpdateAvailable, timeout: 1.0) {
+            usecase.checkUpdateIsNeed()
+        }
+
+        // then
+        XCTAssertEqual(values, [false, false])
+    }
+
+    func test_whenLatestVersionMissing_isUpdateAvailableIsFalse() {
+        // given
+        let expect = expectation(description: "latest nil이면 false")
+        expect.expectedFulfillmentCount = 2
+        let usecase = self.makeUsecase(
+            currentAppVersion: "1.0.0",
+            forceVersion: "2.0.0",
+            recommendVersion: "1.5.0",
+            latestVersion: nil
+        )
+
+        // when
+        let values = self.waitOutputs(expect, for: usecase.isUpdateAvailable, timeout: 1.0) {
+            usecase.checkUpdateIsNeed()
+        }
+
+        // then
+        XCTAssertEqual(values, [false, false])
+    }
+
+    func test_whenForceAppliesButLatestAlsoHigher_isUpdateAvailableIsTrueIndependently() {
+        // given
+        let expect = expectation(description: "force와 독립적으로 latest 기준 판정")
+        expect.expectedFulfillmentCount = 2
+        let usecase = self.makeUsecase(
+            currentAppVersion: "1.0.0",
+            forceVersion: "2.0.0",
+            latestVersion: "2.0.0"
+        )
+
+        // when
+        let values = self.waitOutputs(expect, for: usecase.isUpdateAvailable, timeout: 1.0) {
+            usecase.checkUpdateIsNeed()
+        }
+
+        // then
+        XCTAssertEqual(values, [false, true])
+    }
+
+    func test_whenLoadFails_isUpdateAvailableStaysFalse() {
+        // given
+        let expect = expectation(description: "로드 실패 시 false 유지")
+        let usecase = self.makeUsecase(shouldFail: true)
+
+        // when
+        let values = self.waitOutputs(expect, for: usecase.isUpdateAvailable, timeout: 1.0) {
+            usecase.checkUpdateIsNeed()
+        }
+
+        // then
+        XCTAssertEqual(values, [false])
+    }
+}
+
+
 // MARK: - Stubs
 
 private class StubAppRepository: AppRepository, @unchecked Sendable {
 
     private let forceVersion: String?
     private let recommendVersion: String?
+    private let latestVersion: String?
     private let shouldFail: Bool
 
     init(
         forceVersion: String? = nil,
         recommendVersion: String? = nil,
+        latestVersion: String? = nil,
         shouldFail: Bool = false
     ) {
         self.forceVersion = forceVersion
         self.recommendVersion = recommendVersion
+        self.latestVersion = latestVersion
         self.shouldFail = shouldFail
     }
 
@@ -358,6 +476,7 @@ private class StubAppRepository: AppRepository, @unchecked Sendable {
         var info = AppUpdateInfo()
         info.forceUpdateVersion = self.forceVersion
         info.recommendUpdateVersion = self.recommendVersion
+        info.latestVersion = self.latestVersion
         return info
     }
 }

--- a/Presentations/Scenes/Sources/Factories.swift
+++ b/Presentations/Scenes/Sources/Factories.swift
@@ -60,8 +60,9 @@ public protocol CommonUsecaseFactory {
 }
 
 public protocol SupportUsecaseFactory {
-    
+
     func makeFeedbackUsecase() -> any FeedbackUsecase
+    var appUpdateCheckUsecase: any AppUpdateCheckUsecase { get }
 }
 
 public protocol ExternalCalendarUsecaseFactory {

--- a/Presentations/SettingScene/Sources/Setting/SettingItemListBuilderImple.swift
+++ b/Presentations/SettingScene/Sources/Setting/SettingItemListBuilderImple.swift
@@ -56,7 +56,8 @@ extension SettingItemListSceneBuilerImple: SettingItemListSceneBuiler {
             appstoreLinkPath: self.appstoreLinkPath,
             accountUsecase: self.usecaseFactory.accountUescase,
             uiSettingUsecase: self.usecaseFactory.makeUISettingUsecase(),
-            deviceInfoFetchService: self.usecaseFactory.deviceInfoFetchService()
+            deviceInfoFetchService: self.usecaseFactory.deviceInfoFetchService(),
+            appUpdateCheckUsecase: self.usecaseFactory.appUpdateCheckUsecase
         )
         
         let viewController = SettingItemListViewController(

--- a/Presentations/SettingScene/Sources/Setting/SettingItemListView.swift
+++ b/Presentations/SettingScene/Sources/Setting/SettingItemListView.swift
@@ -40,16 +40,18 @@ import CommonPresentation
 // MARK: - SettingItemListViewEventHandler
 
 final class SettingItemListViewEventHandler: Observable {
-    
+
     var onAppear: () -> Void = { }
     var selectItem: (any SettingItemModelType) -> Void = { _ in }
     var close: () -> Void = { }
-    
+    var openAppUpdate: () -> Void = { }
+
     func bind(_ viewModel: any SettingItemListViewModel) {
-        
+
         self.onAppear = viewModel.prepare
         self.selectItem = viewModel.selectItem
         self.close = viewModel.close
+        self.openAppUpdate = viewModel.openAppUpdate
     }
 }
 
@@ -124,13 +126,18 @@ struct SettingItemListView: View {
                         .font(self.appearance.fontSet.size(16, weight: .semibold).asFont)
                         .foregroundStyle(self.appearance.colorSet.text0.asColor)
                     
-                    if let appVersion = (section as? AppInfoSectionModel)?.version {
-                        
+                    if let appInfoSection = section as? AppInfoSectionModel,
+                       let appVersion = appInfoSection.version {
+
                         Spacer()
-                        
+
                         Text(appVersion)
                             .font(self.appearance.fontSet.size(14, weight: .semibold).asFont)
                             .foregroundStyle(self.appearance.colorSet.text2.asColor)
+
+                        if appInfoSection.isUpdateAvailable {
+                            self.updateBadge
+                        }
                     }
                 }
                 .padding(.top, 8)
@@ -152,6 +159,25 @@ struct SettingItemListView: View {
     
     private var itemFont: Font {
         return self.appearance.fontSet.subNormal.asFont
+    }
+
+    private var updateBadge: some View {
+        HStack(spacing: 2) {
+            Text("new")
+                .font(self.appearance.fontSet.size(12, weight: .semibold).asFont)
+            Image(systemName: "chevron.right")
+                .font(self.appearance.fontSet.size(10, weight: .semibold).asFont)
+        }
+        .foregroundStyle(self.appearance.colorSet.primaryBtnText.asColor)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(self.appearance.colorSet.primaryBtnBackground.asColor)
+        )
+        .onTapGesture {
+            self.eventHandlers.openAppUpdate()
+        }
     }
     
     private func normalItemView(_ item: SettingItemModel) -> some View {
@@ -271,11 +297,37 @@ struct SettingItemListViewPreviewProvider: PreviewProvider {
         let viewAppearance = ViewAppearance(setting: setting, isSystemDarkTheme: false)
         let state = SettingItemListViewState()
         let eventHandlers = SettingItemListViewEventHandler()
-        state.sections = [
-            SettingSectionModel(headerText: "section", items: [
-                AccountSettingItemModel(.init("some"))
-            ])
-        ]
+        let baseSection = SettingSectionModel(
+            headerText: nil,
+            items: [
+                SettingItemModel(.appearance),
+                SettingItemModel(.editEvent),
+                SettingItemModel(.holidaySetting),
+                AccountSettingItemModel(nil)
+            ]
+        )
+        let supportSection = SettingSectionModel(
+            headerText: "setting.section.support::name".localized(),
+            items: [
+                SettingItemModel(.feedback),
+                SettingItemModel(.help)
+            ]
+        )
+        let appInfoSection = AppInfoSectionModel(
+            headerText: "setting.section.app::name".localized(),
+            version: "v2.9.2",
+            isUpdateAvailable: true,
+            items: [
+                SettingItemModel(.shareApp),
+                SettingItemModel(.addReview),
+                SettingItemModel(.sourceCode)
+            ]
+        )
+        let suggestSection = SettingSectionModel(
+            headerText: "setting.section.suggest::name".localized(),
+            items: [SuggestAppItemModel.readmind()]
+        )
+        state.sections = [baseSection, supportSection, appInfoSection, suggestSection]
         
         let view = SettingItemListView()
             .environment(state)

--- a/Presentations/SettingScene/Sources/Setting/SettingItemListViewModel.swift
+++ b/Presentations/SettingScene/Sources/Setting/SettingItemListViewModel.swift
@@ -125,6 +125,7 @@ struct SettingSectionModel: SettingSectionModelType {
 struct AppInfoSectionModel: SettingSectionModelType {
     let headerText: String?
     var version: String?
+    var isUpdateAvailable: Bool = false
     let items: [any SettingItemModelType]
 }
 
@@ -136,8 +137,9 @@ protocol SettingItemListViewModel: AnyObject, Sendable, SettingItemListSceneInte
     // interactor
     func prepare()
     func selectItem(_ model: any SettingItemModelType)
+    func openAppUpdate()
     func close()
-    
+
     // presenter
     var sectionModels: AnyPublisher<[any SettingSectionModelType], Never> { get }
 }
@@ -146,23 +148,26 @@ protocol SettingItemListViewModel: AnyObject, Sendable, SettingItemListSceneInte
 // MARK: - SettingItemListViewModelImple
 
 final class SettingItemListViewModelImple: SettingItemListViewModel, @unchecked Sendable {
-    
+
     private let appstoreLinkPath: String
     private let accountUsecase: any AccountUsecase
     private let uiSettingUsecase: any UISettingUsecase
     private let deviceInfoFetchService: any DeviceInfoFetchService
+    private let appUpdateCheckUsecase: any AppUpdateCheckUsecase
     var router: (any SettingItemListRouting)?
-    
+
     init(
         appstoreLinkPath: String,
         accountUsecase: any AccountUsecase,
         uiSettingUsecase: any UISettingUsecase,
-        deviceInfoFetchService: any DeviceInfoFetchService
+        deviceInfoFetchService: any DeviceInfoFetchService,
+        appUpdateCheckUsecase: any AppUpdateCheckUsecase
     ) {
         self.appstoreLinkPath = appstoreLinkPath
         self.accountUsecase = accountUsecase
         self.uiSettingUsecase = uiSettingUsecase
         self.deviceInfoFetchService = deviceInfoFetchService
+        self.appUpdateCheckUsecase = appUpdateCheckUsecase
     }
     
     
@@ -207,6 +212,10 @@ extension SettingItemListViewModelImple {
         }
     }
     
+    func openAppUpdate() {
+        self.router?.openSafari(self.appstoreLinkPath)
+    }
+
     func close() {
         self.router?.closeScene()
     }
@@ -263,8 +272,8 @@ extension SettingItemListViewModelImple {
 extension SettingItemListViewModelImple {
     
     var sectionModels: AnyPublisher<[any SettingSectionModelType], Never> {
-        
-        let transform: (AccountInfo?, DeviceInfo?) -> [any SettingSectionModelType] = { account, device in
+
+        let transform: (AccountInfo?, DeviceInfo?, Bool) -> [any SettingSectionModelType] = { account, device, isUpdateAvailable in
             let baseSectionItems: [SettingItemModel] = [
                 .init(.appearance),
                 .init(.editEvent),
@@ -272,16 +281,16 @@ extension SettingItemListViewModelImple {
             ]
             let accountItem = AccountSettingItemModel(account)
             let baseSection = SettingSectionModel(
-                headerText: nil, 
+                headerText: nil,
                 items: baseSectionItems + [accountItem]
             )
-            
+
             let supportSectionItems: [SettingItemModel] = [
                 .init(.feedback),
                 .init(.help)
             ]
             let supportSection = SettingSectionModel(headerText: "setting.section.support::name".localized(), items: supportSectionItems)
-            
+
             let appInfoSectionItems: [SettingItemModel] = [
                 .init(.shareApp),
                 .init(.addReview),
@@ -290,22 +299,24 @@ extension SettingItemListViewModelImple {
             let appInfoSection = AppInfoSectionModel(
                 headerText: "setting.section.app::name".localized(),
                 version: device?.appVersion.map { "v\($0)"},
+                isUpdateAvailable: isUpdateAvailable,
                 items: appInfoSectionItems
             )
-            
+
             let suggestItem = SuggestAppItemModel.readmind()
             let suggestSection = SettingSectionModel(headerText: "setting.section.suggest::name".localized(), items: [suggestItem])
-            
+
             let sections: [any SettingSectionModelType] = [
                 baseSection, supportSection, appInfoSection, suggestSection
             ]
             return sections
         }
-        
+
         return Publishers
-            .CombineLatest(
+            .CombineLatest3(
                 self.accountUsecase.currentAccountInfo,
-                self.subject.deviceInfo
+                self.subject.deviceInfo,
+                self.appUpdateCheckUsecase.isUpdateAvailable
             )
             .map(transform)
             .eraseToAnyPublisher()

--- a/Presentations/SettingScene/Tests/Setting/SettingItemListViewModelImpleTests.swift
+++ b/Presentations/SettingScene/Tests/Setting/SettingItemListViewModelImpleTests.swift
@@ -17,29 +17,51 @@ import TestDoubles
 
 
 class SettingItemListViewModelImpleTests: BaseTestCase, PublisherWaitable {
-    
+
     var cancelBag: Set<AnyCancellable>!
     private var spyRouter: SpyRouter!
-    
+    private var stubAppUpdateCheckUsecase: StubAppUpdateCheckUsecase!
+
     override func setUpWithError() throws {
         self.cancelBag = .init()
         self.spyRouter = .init()
+        self.stubAppUpdateCheckUsecase = StubAppUpdateCheckUsecase()
     }
-    
+
     override func tearDownWithError() throws {
         self.cancelBag = nil
         self.spyRouter = nil
+        self.stubAppUpdateCheckUsecase = nil
     }
-    
-    private func makeViewModel(_ account: AccountInfo? = nil) -> SettingItemListViewModelImple {
+
+    private func makeViewModel(
+        _ account: AccountInfo? = nil,
+        isUpdateAvailable: Bool = false
+    ) -> SettingItemListViewModelImple {
+        self.stubAppUpdateCheckUsecase.isUpdateAvailableSubject.send(isUpdateAvailable)
         let accountUsecase = StubAccountUsecase(account)
         let viewModel = SettingItemListViewModelImple(
             appstoreLinkPath: "some",
             accountUsecase: accountUsecase,
             uiSettingUsecase: StubUISettingUsecase(),
-            deviceInfoFetchService: StubDeviceInfoFetchService()
+            deviceInfoFetchService: StubDeviceInfoFetchService(),
+            appUpdateCheckUsecase: self.stubAppUpdateCheckUsecase
         )
         viewModel.router = self.spyRouter
+        return viewModel
+    }
+
+    private func makeViewModelWithInitialLoaded(
+        isUpdateAvailable: Bool = false
+    ) -> SettingItemListViewModelImple {
+        let expect = expectation(description: "wait initial section models")
+        expect.assertForOverFulfill = false
+        let viewModel = self.makeViewModel(isUpdateAvailable: isUpdateAvailable)
+
+        let _ = self.waitFirstOutput(expect, for: viewModel.sectionModels) {
+            viewModel.prepare()
+        }
+
         return viewModel
     }
 }
@@ -360,5 +382,93 @@ private struct StubDeviceInfoFetchService: DeviceInfoFetchService {
 
     func fetchAppVersion() -> String? {
         return "1.0.0"
+    }
+}
+
+private final class StubAppUpdateCheckUsecase: AppUpdateCheckUsecase, @unchecked Sendable {
+
+    let isUpdateAvailableSubject = CurrentValueSubject<Bool, Never>(false)
+    let updateRequirementSubject = PassthroughSubject<AppUpdateRequirement, Never>()
+    var didCheckUpdateIsNeed: Bool = false
+
+    func checkUpdateIsNeed() {
+        self.didCheckUpdateIsNeed = true
+    }
+
+    var updateRequirement: AnyPublisher<AppUpdateRequirement, Never> {
+        return self.updateRequirementSubject.eraseToAnyPublisher()
+    }
+
+    var isUpdateAvailable: AnyPublisher<Bool, Never> {
+        return self.isUpdateAvailableSubject.eraseToAnyPublisher()
+    }
+}
+
+
+// MARK: - AppInfoSectionModel의 isUpdateAvailable 반영
+
+extension SettingItemListViewModelImpleTests {
+
+    func test_whenIsUpdateAvailableFalse_appInfoSectionReflectsFalse() {
+        // given
+        let expect = expectation(description: "false 반영")
+        let viewModel = self.makeViewModelWithInitialLoaded(isUpdateAvailable: false)
+
+        // when
+        let sections = self.waitFirstOutput(expect, for: viewModel.sectionModels)
+
+        // then
+        let appInfo = sections?.compactMap { $0 as? AppInfoSectionModel }.first
+        XCTAssertEqual(appInfo?.isUpdateAvailable, false)
+    }
+
+    func test_whenIsUpdateAvailableChangesToTrue_appInfoSectionReflectsTrue() {
+        // given
+        let expect = expectation(description: "true로 변경 시 반영")
+        expect.expectedFulfillmentCount = 2
+        let viewModel = self.makeViewModelWithInitialLoaded(isUpdateAvailable: false)
+
+        // when
+        let sectionsList = self.waitOutputs(expect, for: viewModel.sectionModels) {
+            self.stubAppUpdateCheckUsecase.isUpdateAvailableSubject.send(true)
+        }
+
+        // then — 마지막 방출에서 true
+        let lastAppInfo = sectionsList.last?.compactMap { $0 as? AppInfoSectionModel }.first
+        XCTAssertEqual(lastAppInfo?.isUpdateAvailable, true)
+    }
+}
+
+
+// MARK: - openAppUpdate 동작
+
+extension SettingItemListViewModelImpleTests {
+
+    func test_openAppUpdate_invokesOpenSafariWithAppstoreLinkPath() {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        viewModel.openAppUpdate()
+
+        // then
+        XCTAssertEqual(self.spyRouter.didOpenSafariPath, "some")
+    }
+}
+
+
+// MARK: - 체크 트리거 호출 안함 정책
+
+extension SettingItemListViewModelImpleTests {
+
+    func test_prepare_doesNotTriggerCheckUpdate() {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        viewModel.prepare()
+
+        // then — Setting 화면은 구독만, checkUpdateIsNeed 호출 안 함
+        XCTAssertFalse(self.stubAppUpdateCheckUsecase.didCheckUpdateIsNeed)
     }
 }

--- a/Repository/Sources/Repository+Imple/Support/AppUpdateInfo+Mapping.swift
+++ b/Repository/Sources/Repository+Imple/Support/AppUpdateInfo+Mapping.swift
@@ -14,6 +14,7 @@ struct AppUpdateInfoMapper: Decodable {
     private enum CodingKeys: String, CodingKey {
         case forceUpdateVersion = "force_update_version"
         case recommendUpdateVersion = "recommend_update_version"
+        case latestVersion = "latest_version"
     }
 
     init(from decoder: any Decoder) throws {
@@ -21,6 +22,7 @@ struct AppUpdateInfoMapper: Decodable {
         var info = AppUpdateInfo()
         info.forceUpdateVersion = try container.decodeIfPresent(String.self, forKey: .forceUpdateVersion)
         info.recommendUpdateVersion = try container.decodeIfPresent(String.self, forKey: .recommendUpdateVersion)
+        info.latestVersion = try container.decodeIfPresent(String.self, forKey: .latestVersion)
         self.info = info
     }
 }

--- a/Repository/Tests/Supports/AppRemoteRepositoryImpleTests.swift
+++ b/Repository/Tests/Supports/AppRemoteRepositoryImpleTests.swift
@@ -45,6 +45,7 @@ extension AppRemoteRepositoryImpleTests {
         // then
         XCTAssertEqual(info.forceUpdateVersion, "3.0.0")
         XCTAssertEqual(info.recommendUpdateVersion, "2.5.0")
+        XCTAssertEqual(info.latestVersion, "2.8.0")
     }
 
     func test_whenFetchFails_throwError() async {
@@ -68,7 +69,8 @@ private struct DummyResponse {
         return """
         {
             "force_update_version": "3.0.0",
-            "recommend_update_version": "2.5.0"
+            "recommend_update_version": "2.5.0",
+            "latest_version": "2.8.0"
         }
         """
     }

--- a/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
+++ b/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
@@ -14,26 +14,29 @@ import Scenes
 // MARK: - NonLoginUsecaseFactoryImple
 
 struct NonLoginUsecaseFactoryImple: UsecaseFactory {
-    
+
     let authUsecase: any AuthUsecase
     let accountUescase: any AccountUsecase
     let externalCalenarIntegrationUsecase: any ExternalCalendarIntegrationUsecase
     let viewAppearanceStore: ApplicationViewAppearanceStoreImple
     let eventSyncUsecase: any EventSyncUsecase
     let eventUploadService: any EventUploadService = NotNeedEventUploadService()
+    let appUpdateCheckUsecase: any AppUpdateCheckUsecase
     private let applicationBase: ApplicationBase
-    
+
     init(
         authUsecase: any AuthUsecase,
         accountUescase: any AccountUsecase,
         externalCalenarIntegrationUsecase: any ExternalCalendarIntegrationUsecase,
         viewAppearanceStore: ApplicationViewAppearanceStoreImple,
+        appUpdateCheckUsecase: any AppUpdateCheckUsecase,
         applicationBase: ApplicationBase
     ) {
         self.authUsecase = authUsecase
         self.accountUescase = accountUescase
         self.externalCalenarIntegrationUsecase = externalCalenarIntegrationUsecase
         self.viewAppearanceStore = viewAppearanceStore
+        self.appUpdateCheckUsecase = appUpdateCheckUsecase
         self.eventSyncUsecase = NotNeedEventSyncUsecase()
         self.applicationBase = applicationBase
     }
@@ -324,7 +327,7 @@ extension NonLoginUsecaseFactoryImple {
 
 
 struct LoginUsecaseFactoryImple: UsecaseFactory {
-    
+
     let userId: String
     let authUsecase: any AuthUsecase
     let accountUescase: any AccountUsecase
@@ -333,14 +336,16 @@ struct LoginUsecaseFactoryImple: UsecaseFactory {
     let temporaryUserDataMigrationUsecase: any TemporaryUserDataMigrationUescase
     let eventSyncUsecase: any EventSyncUsecase
     let eventUploadService: any EventUploadService
+    let appUpdateCheckUsecase: any AppUpdateCheckUsecase
     private let applicationBase: ApplicationBase
-    
+
     init(
         userId: String,
         authUsecase: any AuthUsecase,
         accountUescase: any AccountUsecase,
         externalCalenarIntegrationUsecase: any ExternalCalendarIntegrationUsecase,
         viewAppearanceStore: ApplicationViewAppearanceStoreImple,
+        appUpdateCheckUsecase: any AppUpdateCheckUsecase,
         temporaryUserDataFilePath: String,
         applicationBase: ApplicationBase
     ) {
@@ -349,8 +354,9 @@ struct LoginUsecaseFactoryImple: UsecaseFactory {
         self.accountUescase = accountUescase
         self.externalCalenarIntegrationUsecase = externalCalenarIntegrationUsecase
         self.viewAppearanceStore = viewAppearanceStore
+        self.appUpdateCheckUsecase = appUpdateCheckUsecase
         self.applicationBase = applicationBase
-        
+
         let migrationRepository = TemporaryUserDataMigrationRepositoryImple(
             tempUserDBPath: temporaryUserDataFilePath, 
             remoteAPI: applicationBase.remoteAPI,

--- a/TodoCalendarApp/Sources/Root/ApplicationRootBuilder.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootBuilder.swift
@@ -83,7 +83,8 @@ final class ApplicationRootBuilder {
             externalCalenarIntegrationUsecase: externalCalendarIntegrationUsecase,
             backgroundEventSyncUsecase: backgroundEventSyncUsecase,
             applicationBase: applicationBase,
-            deepLinkHandler: deepLinkHandler
+            deepLinkHandler: deepLinkHandler,
+            appUpdateCheckUsecase: appUpdateCheckUsecase
         )
         rootViewModel.router = rootRouter
         deepLinkHandler.appRouter = rootRouter

--- a/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
@@ -218,6 +218,7 @@ final class ApplicationRootRouter: ApplicationRouting, @unchecked Sendable {
     private let backgroundEventSyncUsecase: any BackgroundEventSyncUsecase
     private let applicationBase: ApplicationBase
     private let deepLinkHandler: ApplicationDeepLinkHandlerImple
+    private let appUpdateCheckUsecase: any AppUpdateCheckUsecase
     private var usecaseFactory: (any UsecaseFactory)!
 
     init(
@@ -226,7 +227,8 @@ final class ApplicationRootRouter: ApplicationRouting, @unchecked Sendable {
         externalCalenarIntegrationUsecase: any ExternalCalendarIntegrationUsecase,
         backgroundEventSyncUsecase: any BackgroundEventSyncUsecase,
         applicationBase: ApplicationBase,
-        deepLinkHandler: ApplicationDeepLinkHandlerImple
+        deepLinkHandler: ApplicationDeepLinkHandlerImple,
+        appUpdateCheckUsecase: any AppUpdateCheckUsecase
     ) {
         self.authUsecase = authUsecase
         self.accountUsecase = accountUsecase
@@ -234,6 +236,7 @@ final class ApplicationRootRouter: ApplicationRouting, @unchecked Sendable {
         self.backgroundEventSyncUsecase = backgroundEventSyncUsecase
         self.applicationBase = applicationBase
         self.deepLinkHandler = deepLinkHandler
+        self.appUpdateCheckUsecase = appUpdateCheckUsecase
     }
     
     func showError(_ error: any Error) {
@@ -351,6 +354,7 @@ extension ApplicationRootRouter {
                 accountUescase: self.accountUsecase,
                 externalCalenarIntegrationUsecase: self.externalCalenarIntegrationUsecase,
                 viewAppearanceStore: self.viewAppearanceStore,
+                appUpdateCheckUsecase: self.appUpdateCheckUsecase,
                 temporaryUserDataFilePath: AppEnvironment.dbFilePath(for: nil),
                 applicationBase: self.applicationBase
             )
@@ -360,6 +364,7 @@ extension ApplicationRootRouter {
                 accountUescase: self.accountUsecase,
                 externalCalenarIntegrationUsecase: self.externalCalenarIntegrationUsecase,
                 viewAppearanceStore: self.viewAppearanceStore,
+                appUpdateCheckUsecase: self.appUpdateCheckUsecase,
                 applicationBase: applicationBase
             )
         }

--- a/app-config/update-info.json
+++ b/app-config/update-info.json
@@ -1,4 +1,5 @@
 {
   "force_update_version": null,
-  "recommend_update_version": null
+  "recommend_update_version": null,
+  "latest_version": null
 }

--- a/docs/spec/infrastructure.md
+++ b/docs/spec/infrastructure.md
@@ -324,11 +324,14 @@ ApplicationDeepLinkHandlerImple:
 ```json
 {
   "force_update_version": "2.0.0",
-  "recommend_update_version": "1.9.0"
+  "recommend_update_version": "1.9.0",
+  "latest_version": "2.1.0"
 }
 ```
 
-- 두 필드 모두 선택적. null이면 해당 등급 비활성.
+- 세 필드 모두 선택적. null이면 해당 판정 비활성.
+- `force_update_version` / `recommend_update_version` — 업데이트 **강제·권장 하한선**. 팝업 트리거용.
+- `latest_version` — **스토어에 올라간 최신 배포 버전**. 설정 화면의 "업데이트 가능" 안내(비강제) 판정용.
 - 디코딩은 Repository 레이어의 `AppUpdateInfoMapper`가 담당. Domain 모델 `AppUpdateInfo`는 Decodable 채택하지 않음.
 
 ### 7.2 판정 알고리즘
@@ -353,6 +356,20 @@ ApplicationDeepLinkHandlerImple:
 - `2.0 == 2.0.0` 동일 취급 (zero-padding)
 - `major.minor.patch` 순수 숫자 포맷만 가정 — `1.0-beta` 같은 semver pre-release는 미대응
 
+#### 7.2.1 업데이트 가능 여부 판정 (`isUpdateAvailable`)
+
+`AppUpdateCheckUsecase.isUpdateAvailable: AnyPublisher<Bool, Never>` — 설정 화면의 비강제 안내용 판정:
+
+```
+1. latest_version이 없으면 → false
+2. current < latest_version → true
+3. 그 외 → false
+```
+
+`force_update_version` / `recommend_update_version`과 **독립**으로 판정. 두 축은 "업데이트 강제·권장 하한선"을 표현하고, `latest_version`은 "스토어에 올라간 최신 배포 버전"을 표현하는 서로 다른 축이다. 세 값이 동시에 존재해도 각자 독립적으로 평가된다.
+
+내부 구현: `AppUpdateCheckUsecaseImple.Subject.currentUpdateInfo: CurrentValueSubject<AppUpdateInfo?, Never>`에 `loadUpdateInfo` 결과를 사이드이펙트로 저장하고, 여기서 `map`으로 파생. `String.isVersionLessThan` extension은 force/recommended 판정과 공유.
+
 ### 7.3 체크 트리거
 
 `AppUpdateCheckUsecase.checkUpdateIsNeed()` 호출 시점:
@@ -363,6 +380,8 @@ ApplicationDeepLinkHandlerImple:
 | 포그라운드 복귀 | `UIApplication.willEnterForegroundNotification` 구독 |
 
 `updateRequirement` Publisher가 `forceRequired` / `recommended`를 방출하면 `ApplicationRootViewModelImple.bindUpdateRequirement`의 sink가 `router?.showUpdatePopup(requirement)`를 호출.
+
+설정 화면(`SettingItemListViewModelImple`)은 `isUpdateAvailable`을 **구독만** 하고 `checkUpdateIsNeed()`를 호출하지 않는다. 앱 시작·포그라운드 복귀에서 이미 트리거되며, `currentUpdateInfo` CurrentValueSubject가 마지막 값을 보관해 Setting 진입 즉시 현재값을 받을 수 있다. Setting에서 추가 트리거하면 force/recommended 팝업이 설정 화면 위로 겹쳐 뜰 여지가 있어 기존 팝업 흐름 간섭을 피하기 위한 정책.
 
 ### 7.4 팝업 동작
 
@@ -394,6 +413,8 @@ ApplicationDeepLinkHandlerImple:
 | Root View | `TodoCalendarApp/Sources/Root/ForceUpdatePopupView.swift` |
 | Root Router | `TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift`의 `showUpdatePopup` |
 | Root VM | `TodoCalendarApp/Sources/Root/ApplicationRootViewModel.swift`의 `bindUpdateRequirement` + `handleWillEnterForeground` |
+| Setting VM | `Presentations/SettingScene/Sources/Setting/SettingItemListViewModel.swift`의 `isUpdateAvailable` 구독 + `openAppUpdate()` |
+| Factory | `Presentations/Scenes/Sources/Factories.swift` `SupportUsecaseFactory.appUpdateCheckUsecase` (단일 인스턴스 공유 계약) |
 | 원격 설정 | `app-config/update-info.json` |
 
 ### 7.6 한계 / 후속 과제


### PR DESCRIPTION
## Summary

설정 화면에서 사용자가 새 버전 배포를 인지하고 App Store로 이동할 수 있는 진입점을 추가. 기존 강제·권장 업데이트 팝업 흐름과는 독립된 "단순 안내" 축을 도입한다.

### 배경

기존 앱 버전 체크는 `force_update_version` / `recommend_update_version` 두 축으로 **강제·권장 업데이트 팝업**만 담당했다(스펙: `docs/spec/infrastructure.md §7`). 두 조건이 걸리지 않아도 스토어에 더 높은 버전이 있을 수 있는데, 이를 사용자에게 알릴 통로가 없었다. 이번 작업은 `latest_version` 필드를 신설해 "단순 업데이트 가능" 상태를 별도 축으로 표현하고, 설정 화면에 뱃지 진입점으로 노출한다.

### 설계 요약

- **독립 관심사 = 독립 Source**: 팝업 트리거(`updateRequirement: PassthroughSubject`, 이벤트 세만틱)와 단순 안내(`isUpdateAvailable: CurrentValueSubject` 파생, 상태 세만틱)를 별도 Publisher로 분리. 기존 `ApplicationRootViewModel.bindUpdateRequirement` 소비자 동작 불변.
- **판정 독립성**: `isUpdateAvailable`은 `latest_version` 단독으로 판정. force/recommended 값과 무관.
- **단일 인스턴스 공유**: `SupportUsecaseFactory.appUpdateCheckUsecase`를 `var` 프로퍼티로 노출해 ApplicationRoot와 Setting VM이 같은 Usecase 인스턴스를 공유. 실제 경로는 `ApplicationRootRouter`가 Factory 생성 책임을 가진 구조에 맞춰 Router 경유로 주입.
- **기존 로직 재사용**: 버전 비교는 기존 `String.isVersionLessThan(_:)` extension을 그대로 재사용.

### 주요 변경

- `AppUpdateInfo.latestVersion: String?` + `AppUpdateCheckUsecase.isUpdateAvailable: AnyPublisher<Bool, Never>`
- `AppUpdateInfoMapper`에 `latest_version` 디코딩 + 회귀 테스트
- `SupportUsecaseFactory.appUpdateCheckUsecase` 프로토콜 프로퍼티 + 두 Factory 구현체·Router·Builder 주입 경로
- `SettingItemListViewModel.openAppUpdate()` + `AppInfoSectionModel.isUpdateAvailable` + 구독 정책(Setting은 트리거 X, 구독만)
- `SettingItemListView` 헤더에 `new ›` 뱃지 렌더 (primary 색 rounded rect)
- `app-config/update-info.json`에 `latest_version: null` + `docs/spec/infrastructure.md §7` 업데이트

### 커밋 구성

1. `5081e801` Domain — 모델 필드 + Usecase 판정
2. `4cbdd828` Remote 디코딩·Factory 주입 경로
3. `19a65f00` Setting VM 연결 + View 뱃지
4. `c9f37785` update-info.json + 인프라 스펙

## Test plan

- [ ] 로컬에서 `app-config/update-info.json`의 `latest_version`을 현재 앱 버전보다 높은 값으로 세팅 → 설정 화면 헤더에 `new ›` 뱃지 노출 확인
- [ ] 뱃지 탭 → App Store(`appstoreLinkPath`) 이동 확인
- [ ] `latest_version`이 `null`이거나 현재 버전과 같/낮음 → 뱃지 비노출 확인
- [ ] `force_update_version`·`recommend_update_version`과 `latest_version` 동시 세팅 → 팝업 + 뱃지 각자 독립 동작 확인
- [ ] 라이트/다크 테마 모두 뱃지 가독성 확인
- [ ] 앱 포그라운드 복귀 시 뱃지 상태 갱신(값 바뀌면 반영)

### 후속 과제 (본 PR 범위 외)

- `latest_version` 값을 릴리즈 시 자동 갱신하는 파이프라인
- `TodoCalendar.xcworkspace` 이중 참조 경고(`[#617]` CI 커밋 영향) 별도 이슈로 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)