### PR TITLE
[#622] API v2 단일화 — v1-only 8개 엔드포인트 v2 전환 (1·2단계)

### DIFF
--- a/Repository/Sources/Remote/Endpoint.swift
+++ b/Repository/Sources/Remote/Endpoint.swift
@@ -326,48 +326,48 @@ public struct RemoteEnvironment: Sendable {
             return "https://gist.githubusercontent.com/sudopark/\(endpoint.subPath)"
             
         case let holiday as HolidayAPIEndpoints:
-            let prefix = "\(calendarAPIHost)/v1/holiday"
+            let prefix = "\(calendarAPIHost)/v2/holiday"
             return appendSubpathIfNotEmpty(prefix, holiday.subPath)
-            
+
         case let account as AccountAPIEndpoints:
-            return "\(calendarAPIHost)/v1/accounts/\(account.subPath)"
-            
+            return "\(calendarAPIHost)/v2/accounts/\(account.subPath)"
+
         case let user as UserAPIEndpoints:
-            return "\(calendarAPIHost)/v1/user/\(user.subPath)"
-            
+            return "\(calendarAPIHost)/v2/user/\(user.subPath)"
+
         case let todo as TodoAPIEndpoints:
             let prefix = "\(calendarAPIHost)/v2/todos"
             return appendSubpathIfNotEmpty(prefix, todo.subPath)
-            
+
         case let schedule as ScheduleEventEndpoints:
             let prefix = "\(calendarAPIHost)/v2/schedules"
             return appendSubpathIfNotEmpty(prefix, schedule.subPath)
-            
+
         case let foremost as ForemostEventEndpoints:
-            let prefix = "\(calendarAPIHost)/v1/foremost"
+            let prefix = "\(calendarAPIHost)/v2/foremost"
             return appendSubpathIfNotEmpty(prefix, foremost.subPath)
-            
+
         case let eventTag as EventTagEndpoints:
             let prefix = "\(calendarAPIHost)/v2/tags"
             return appendSubpathIfNotEmpty(prefix, eventTag.subPath)
-            
+
         case let detail as EventDetailEndpoints:
-            let prefix = "\(calendarAPIHost)/v1/event_details"
+            let prefix = "\(calendarAPIHost)/v2/event_details"
             return appendSubpathIfNotEmpty(prefix, detail.subPath)
-            
+
         case let setting as AppSettingEndpoints:
-            let prefix = "\(calendarAPIHost)/v1/setting"
+            let prefix = "\(calendarAPIHost)/v2/setting"
             return appendSubpathIfNotEmpty(prefix, setting.subPath)
-            
+
         case let migration as MigrationEndpoints:
-            let prefix = "\(calendarAPIHost)/v1/migration"
+            let prefix = "\(calendarAPIHost)/v2/migration"
             return appendSubpathIfNotEmpty(prefix, migration.subPath)
-            
+
         case let feedback as FeedbackEndpoints:
             return appendSubpathIfNotEmpty(self.csAPI, feedback.subPath)
-            
+
         case let sync as EventSyncEndPoints:
-            let prefix = "\(calendarAPIHost)/v1/sync"
+            let prefix = "\(calendarAPIHost)/v2/sync"
             return appendSubpathIfNotEmpty(prefix, sync.subPath)
             
         case let googleAuth as GoogleAuthEndpoint:

--- a/Repository/Tests/Notification/UserNotificationRepositoryImpleTests.swift
+++ b/Repository/Tests/Notification/UserNotificationRepositoryImpleTests.swift
@@ -72,7 +72,7 @@ extension UserNotificationRepositoryImpleTests {
             )
             
             // then
-            #expect(self.stubRemote.didRequestedPath == "dummy_calendar_api_host/v1/user/notification")
+            #expect(self.stubRemote.didRequestedPath == "dummy_calendar_api_host/v2/user/notification")
             let params = self.stubRemote.didRequestedParams ?? [:]
             #expect(params["fcm_token"] as? String == "token")
             #expect(params["device_model"] as? String == "model")

--- a/Repository/Tests/Remote/RemoteEnvironmentPathTests.swift
+++ b/Repository/Tests/Remote/RemoteEnvironmentPathTests.swift
@@ -1,0 +1,69 @@
+//
+//  RemoteEnvironmentPathTests.swift
+//  RepositoryTests
+//
+//  Created by sudo.park on 5/10/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Domain
+
+@testable import Repository
+
+
+// MARK: - calendarAPIHost 기반 엔드포인트 v2 prefix 매핑 검증
+
+struct RemoteEnvironmentPathTests {
+
+    private let env = RemoteEnvironment(
+        calendarAPIHost: "https://api.example.com",
+        csAPI: "https://cs.example.com",
+        deviceId: "device_id"
+    )
+}
+
+extension RemoteEnvironmentPathTests {
+
+    @Test func path_holidaysEndpoint_returnsV2HolidayURL() {
+        // when
+        let path = self.env.path(HolidayAPIEndpoints.holidays)
+        // then
+        #expect(path == "https://api.example.com/v2/holiday")
+    }
+
+    @Test func path_accountInfoEndpoint_returnsV2AccountsInfoURL() {
+        // when
+        let path = self.env.path(AccountAPIEndpoints.info)
+        // then
+        #expect(path == "https://api.example.com/v2/accounts/info")
+    }
+
+    @Test func path_foremostEventEndpoint_returnsV2ForemostEventURL() {
+        // when
+        let path = self.env.path(ForemostEventEndpoints.event)
+        // then
+        #expect(path == "https://api.example.com/v2/foremost/event")
+    }
+
+    @Test func path_eventDetailEndpoint_returnsV2EventDetailsURL() {
+        // when
+        let path = self.env.path(EventDetailEndpoints.detail(eventId: "id"))
+        // then
+        #expect(path == "https://api.example.com/v2/event_details/id")
+    }
+
+    @Test func path_appSettingDefaultColorEndpoint_returnsV2SettingURL() {
+        // when
+        let path = self.env.path(AppSettingEndpoints.defaultEventTagColor)
+        // then
+        #expect(path == "https://api.example.com/v2/setting/event/tag/default/color")
+    }
+
+    @Test func path_eventSyncCheckEndpoint_returnsV2SyncCheckURL() {
+        // when
+        let path = self.env.path(EventSyncEndPoints.check)
+        // then
+        #expect(path == "https://api.example.com/v2/sync/check")
+    }
+}

--- a/Repository/Tests/Setting/TemporaryUserDataMigrationRepositoryImpleTests.swift
+++ b/Repository/Tests/Setting/TemporaryUserDataMigrationRepositoryImpleTests.swift
@@ -191,8 +191,8 @@ extension TemporaryUserDataMigrationRepositoryImpleTests {
         // then
         let paths = self.stubRemote.didRequestedPaths
         XCTAssertEqual(paths, [
-            "dummy_calendar_api_host/v1/migration/todos/done",
-            "dummy_calendar_api_host/v1/migration/todos/done/details"
+            "dummy_calendar_api_host/v2/migration/todos/done",
+            "dummy_calendar_api_host/v2/migration/todos/done/details"
         ])
     }
     

--- a/docs/spec/sync.md
+++ b/docs/spec/sync.md
@@ -43,9 +43,9 @@
 
 | 단계 | 메서드 | 경로 | 파라미터 |
 |---|---|---|---|
-| 체크 | GET | `/v1/sync/check` | `dataType`, `timestamp` (optional) |
-| 시작 | GET | `/v1/sync/start` | `dataType`, `timestamp` (optional), `size` (30) |
-| 계속 | GET | `/v1/sync/continue` | `dataType`, `cursor`, `size` |
+| 체크 | GET | `/v2/sync/check` | `dataType`, `timestamp` (optional) |
+| 시작 | GET | `/v2/sync/start` | `dataType`, `timestamp` (optional), `size` (30) |
+| 계속 | GET | `/v2/sync/continue` | `dataType`, `cursor`, `size` |
 
 **동기화 체크 응답** (`EventSyncCheckRespose`)
 
@@ -118,7 +118,7 @@ struct EventSyncResponse<T: Sendable> {
 | EventTag | `PUT /v2/tags/{tagId}` | `DELETE /v2/tags/{tagId}` |
 | Todo | `POST/PUT /v2/todos/{todoId}` | `DELETE /v2/todos/{todoId}` |
 | Schedule | `PUT /v2/schedules/{eventId}` | `DELETE /v2/schedules/{eventId}` |
-| EventDetail | `POST /v1/event_details/{eventId}` | `DELETE /v1/event_details/{eventId}` |
+| EventDetail | `POST /v2/event_details/{eventId}` | `DELETE /v2/event_details/{eventId}` |
 
 ### 4. 백그라운드 동기화
 


### PR DESCRIPTION
## 배경

서버 측 v1 라우터 일몰(sudopark/TodoCalendar-Functions#175)의 클라 연동.
서버 1단계(v1-only 8개 엔드포인트 v2 미러링) prod 배포 완료된 시점에 클라 1·2단계 진행.

> 클라 작업 정의: #622

## 변경 요약

`RemoteEnvironment.path()`에서 v1로 호출되던 8개 엔드포인트의 prefix를 v2로 단일화. 응답 형태는 서버 1단계 미러링이 v1 그대로 유지하므로 매퍼는 손대지 않음.

- `RemoteEnvironment.path` — `holiday` / `accounts` / `user` / `foremost` / `event_details` / `setting` / `migration` / `sync` 8개 case의 calendarAPIHost prefix `v1` → `v2`
- `TemporaryUserDataMigrationRepositoryImpleTests.testRespository_migrateDoneTodoEvents` — `didRequestedPaths` 검증 v2로 갱신
- `UserNotificationRepositoryImpleTests.repository_register` — `didRequestedPath` 검증 v2로 갱신

> revertDoneTodo의 v2 응답 차이(`{todo, detail}`)는 `RevertTodoResultMapper`가 이미 v2 형태로 작성돼 있어 별도 작업 불필요.
> `TodoAPIEndpoints` / `ScheduleEventEndpoints` / `EventTagEndpoints`는 이전부터 v2 사용 중.

## 검증

- [x] `Repository/` 내 `/v1/` 잔여 0건
- [x] `./scripts/run-all-tests.sh Repository` 통과 (123/123)

## 남은 과제

- **3단계(강제 업데이트 트리거)** — 코드 변경 없는 운영 작업. 이번 빌드 배포 + 사용자 업데이트 수신 기간 확보 후, `app-config/update-info.json`의 `force_update_version`을 신버전 미만으로 설정. 서버 측 4단계(v1 트래픽 0 확인) 게이트와 동기화.
- **docs/spec/sync.md stale** — `/v1/sync/...`, `/v1/event_details/...` 표기가 남아있음. 이번 PR 범위 외(Repository/ 한정)라 미포함. 별도 작업 권장.
- **path 검증 보강** — 8개 엔드포인트 중 `migration`/`user/notification`만 `didRequestedPath` 명시 검증 보유. 나머지 6개는 동작 결과만 검증 중. 이슈의 "있으면 추가" 항목으로 별도 트랙.

## 관련

- Closes #622 (1·2단계)
- 서버: sudopark/TodoCalendar-Functions#175