### PR TITLE
[#627] API 호출 시 Accept-Language 헤더 추가

### DIFF
--- a/Repository/Sources/Remote/AcceptLanguage.swift
+++ b/Repository/Sources/Remote/AcceptLanguage.swift
@@ -1,0 +1,24 @@
+//
+//  AcceptLanguage.swift
+//  Repository
+//
+//  Created by sudo.park on 5/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+
+public enum AcceptLanguage {
+
+    public static func headerValue(from preferredLanguages: [String]) -> String {
+        guard !preferredLanguages.isEmpty else { return "en" }
+        return preferredLanguages.enumerated()
+            .map { index, language in
+                guard index > 0 else { return language }
+                let quality = max(0.1, 1.0 - Double(index) * 0.1)
+                return "\(language);q=\(String(format: "%.1f", quality))"
+            }
+            .joined(separator: ",")
+    }
+}

--- a/Repository/Sources/Remote/Endpoint.swift
+++ b/Repository/Sources/Remote/Endpoint.swift
@@ -305,14 +305,17 @@ public struct RemoteEnvironment: Sendable {
     let calendarAPIHost: String
     private let csAPI: String
     let deviceId: String
+    let acceptLanguage: @Sendable () -> String
     public init(
         calendarAPIHost: String,
         csAPI: String,
-        deviceId: String
+        deviceId: String,
+        acceptLanguage: @escaping @Sendable () -> String
     ) {
         self.calendarAPIHost = calendarAPIHost
         self.csAPI = csAPI
         self.deviceId = deviceId
+        self.acceptLanguage = acceptLanguage
     }
     
     func path(_ endpoint: any Endpoint) -> String? {

--- a/Repository/Sources/Remote/RemoteAPI.swift
+++ b/Repository/Sources/Remote/RemoteAPI.swift
@@ -143,7 +143,8 @@ extension RemoteAPIImple {
     
     private func defaultHeader() -> [String: String] {
         return [
-            "device_id": self.environment.deviceId
+            "device_id": self.environment.deviceId,
+            "Accept-Language": self.environment.acceptLanguage()
         ]
     }
 }

--- a/Repository/Tests/Auth/CalendarAPIAutenticatorTests.swift
+++ b/Repository/Tests/Auth/CalendarAPIAutenticatorTests.swift
@@ -25,7 +25,7 @@ class CalendarAPIAutenticatorTests: BaseTestCase {
     private var spyListener: SpyAutenticatorTokenRefreshListener?
     
     override func setUpWithError() throws {
-        self.remoteEnvironment = .init(calendarAPIHost: "https://calendar.come", csAPI: "cs_api", deviceId: "device_id")
+        self.remoteEnvironment = .init(calendarAPIHost: "https://calendar.come", csAPI: "cs_api", deviceId: "device_id", acceptLanguage: { "en" })
         self.spyAuthStore = .init()
         self.stubFirebaseService = .init()
         self.spyListener = .init()

--- a/Repository/Tests/Doubles/StubRemoteAPI.swift
+++ b/Repository/Tests/Doubles/StubRemoteAPI.swift
@@ -46,7 +46,8 @@ final class StubRemoteAPI: RemoteAPI, @unchecked Sendable {
     let environment: RemoteEnvironment = .init(
         calendarAPIHost: "dummy_calendar_api_host",
         csAPI: "cs_channel_api",
-        deviceId: "device_id"
+        deviceId: "device_id",
+        acceptLanguage: { "en" }
     )
     var didRequestedMethod: RemoteAPIMethod?
     var didRequestedPath: String?

--- a/Repository/Tests/Remote/AcceptLanguageTests.swift
+++ b/Repository/Tests/Remote/AcceptLanguageTests.swift
@@ -1,0 +1,43 @@
+//
+//  AcceptLanguageTests.swift
+//  RepositoryTests
+//
+//  Created by sudo.park on 5/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+
+@testable import Repository
+
+
+struct AcceptLanguageTests {
+
+    @Test func headerValue_singleLanguage_hasNoQuality() {
+        // given + when
+        let value = AcceptLanguage.headerValue(from: ["en"])
+        // then
+        #expect(value == "en")
+    }
+
+    @Test func headerValue_multipleLanguages_appendsDescendingQuality() {
+        // given + when
+        let value = AcceptLanguage.headerValue(from: ["ko-KR", "en-US"])
+        // then
+        #expect(value == "ko-KR,en-US;q=0.9")
+    }
+
+    @Test func headerValue_threeLanguages_decreasesQualityByIndex() {
+        // given + when
+        let value = AcceptLanguage.headerValue(from: ["ko-KR", "en-US", "ja-JP"])
+        // then
+        #expect(value == "ko-KR,en-US;q=0.9,ja-JP;q=0.8")
+    }
+
+    @Test func headerValue_empty_fallsBackToEnglish() {
+        // given + when
+        let value = AcceptLanguage.headerValue(from: [])
+        // then
+        #expect(value == "en")
+    }
+}

--- a/Repository/Tests/Remote/RemoteAPIImpleTests.swift
+++ b/Repository/Tests/Remote/RemoteAPIImpleTests.swift
@@ -16,9 +16,16 @@ import UnitTestHelpKit
 
 class RemoteAPIImpleTests {
     
-    private func makeRemote() -> RemoteAPIImple {
-        let env = RemoteEnvironment(calendarAPIHost: "https://fake.com", csAPI: "some", deviceId: "device_id")
-        let session = FakeSession()
+    private func makeRemote(
+        session: FakeSession = FakeSession(),
+        acceptLanguage: @escaping @Sendable () -> String = { "en" }
+    ) -> RemoteAPIImple {
+        let env = RemoteEnvironment(
+            calendarAPIHost: "https://fake.com",
+            csAPI: "some",
+            deviceId: "device_id",
+            acceptLanguage: acceptLanguage
+        )
         return RemoteAPIImple(session: session, environment: env, interceptor: nil)
     }
 }
@@ -50,7 +57,7 @@ extension RemoteAPIImpleTests {
     @Test func remote_whenCancel_beforePerform() async throws {
         // given
         let remote = self.makeRemote()
-        
+
         // when
         let endpoint = EventSyncEndPoints.check
         let task = Task {
@@ -58,14 +65,33 @@ extension RemoteAPIImpleTests {
             return data
         }
         task.cancel()
-        
+
         // then
         let result = await task.result
         #expect(result.failure is CancellationError)
     }
+
+    @Test func remote_request_attachesAcceptLanguageHeaderFromEnvironment() async throws {
+        // given
+        let session = FakeSession()
+        let remote = self.makeRemote(session: session, acceptLanguage: { "ko-KR,en-US;q=0.9" })
+
+        // when
+        let task = Task {
+            try await remote.request(.get, EventSyncEndPoints.check, with: [:], parameters: [:])
+        }
+        try await Task.sleep(for: .milliseconds(10))
+        task.cancel()
+        _ = await task.result
+
+        // then
+        #expect(session.didRequestedHeaders?["Accept-Language"] == "ko-KR,en-US;q=0.9")
+    }
 }
 
-private class FakeSession: Session {
+private final class FakeSession: Session, @unchecked Sendable {
+
+    var didRequestedHeaders: HTTPHeaders?
 
     override func request(
         _ convertible: any URLConvertible,
@@ -76,7 +102,8 @@ private class FakeSession: Session {
         interceptor: (any RequestInterceptor)? = nil,
         requestModifier: Session.RequestModifier? = nil
     ) -> DataRequest {
-        
+
+        self.didRequestedHeaders = headers
         let req = RequestConvertible(url: convertible, method: method, parameters: parameters, encoding: encoding, headers: headers, requestModifier: requestModifier)
         
         let request = DataRequest(

--- a/Repository/Tests/Remote/RemoteEnvironmentPathTests.swift
+++ b/Repository/Tests/Remote/RemoteEnvironmentPathTests.swift
@@ -19,7 +19,8 @@ struct RemoteEnvironmentPathTests {
     private let env = RemoteEnvironment(
         calendarAPIHost: "https://api.example.com",
         csAPI: "https://cs.example.com",
-        deviceId: "device_id"
+        deviceId: "device_id",
+        acceptLanguage: { "en" }
     )
 }
 

--- a/TodoCalendarApp/AppExtensions/Base/AppExtensionBase.swift
+++ b/TodoCalendarApp/AppExtensions/Base/AppExtensionBase.swift
@@ -94,7 +94,8 @@ final class AppExtensionBase {
         let environment = RemoteEnvironment(
             calendarAPIHost: host ?? "https://dummy.com",
             csAPI: csAPi ?? "https://dummy.com",
-            deviceId: AppEnvironment.deviceId(self.userDefaultEnvironmentStorage)
+            deviceId: AppEnvironment.deviceId(self.userDefaultEnvironmentStorage),
+            acceptLanguage: { AcceptLanguage.headerValue(from: Locale.preferredLanguages) }
         )
         return environment
     }()

--- a/TodoCalendarApp/Sources/Factories/ApplicationBase.swift
+++ b/TodoCalendarApp/Sources/Factories/ApplicationBase.swift
@@ -89,7 +89,8 @@ final class ApplicationBase {
         let environment = RemoteEnvironment(
             calendarAPIHost: host ?? "https://dummy.com",
             csAPI: csAPi ?? "https://dummy.com",
-            deviceId: AppEnvironment.deviceId(userDefaultEnvironmentStorage)
+            deviceId: AppEnvironment.deviceId(userDefaultEnvironmentStorage),
+            acceptLanguage: { AcceptLanguage.headerValue(from: Locale.preferredLanguages) }
         )
         return environment
     }()


### PR DESCRIPTION
## 배경
서버가 클라이언트 언어에 맞춰 응답(에러 메시지 등)을 내려줄 수 있도록, 모든 Remote API 요청에 `Accept-Language` 헤더를 추가한다. (closes #627)

## 접근
- 헤더 값은 **요청 시점마다** 현재 시스템 언어 기준으로 계산한다. iOS 앱별 언어 설정 등 런타임 변경을 반영하기 위해 정적 주입이 아닌 provider 클로저로 처리.
- `RemoteAPIImple`은 자체 백엔드와 Google 캘린더가 같은 인스턴스를 공유하므로, 공통 `defaultHeader()`에서 부착 → 양쪽 모두 적용.
- 환경 인지(`Locale`)는 composition root에만 두고 Repository 레이어는 `Locale`에 무지하도록 유지.

## 변경
- **`AcceptLanguage.headerValue(from:)`** (신규) — `preferredLanguages`를 BCP-47 + q-value 문자열로 변환. 인덱스별 q 내림차순(`ko-KR,en-US;q=0.9`), 빈 배열은 `"en"` fallback.
- **`RemoteEnvironment.acceptLanguage`** — 언어 문자열을 매 호출 계산하는 `@Sendable () -> String` provider 필드 추가.
- **`RemoteAPIImple.defaultHeader`** — `device_id` 옆에 `Accept-Language` 부착, 요청마다 provider 평가.
- **`ApplicationBase` / `AppExtensionBase`** — `{ AcceptLanguage.headerValue(from: Locale.preferredLanguages) }` 주입.

## 검증
- 순수 변환 로직 TDD (단일/복수/3개/빈 배열 케이스).
- 회귀 테스트: 헤더가 실제 요청에 실리는지 검증 (헤더 제거 시 RED 확인까지 거침).
- Repository 테스트 통과 + 앱 타겟 빌드 SUCCEEDED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)