### PR TITLE
[#625] AICommandUsecase 추가 및 필요 관련 데이터 모델 추가

### DIFF
--- a/Domain/Sources/Models/AI/AIAgentUsage.swift
+++ b/Domain/Sources/Models/AI/AIAgentUsage.swift
@@ -1,0 +1,27 @@
+//
+//  AIAgentUsage.swift
+//  Domain
+//
+//  Created by sudo.park on 5/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+
+public struct AIAgentUsage: Sendable {
+    
+    public var date: String?
+    public let inputTokens: Int
+    public let outputTokens: Int
+    public let dailyLimit: Int
+    public var updatedAt: Date?
+    
+    public init(
+        input: Int, output: Int, limit: Int
+    ) {
+        self.inputTokens = input
+        self.outputTokens = output
+        self.dailyLimit = limit
+    }
+}

--- a/Domain/Sources/Models/AI/AICommand+Job.swift
+++ b/Domain/Sources/Models/AI/AICommand+Job.swift
@@ -1,0 +1,114 @@
+//
+//  AICommand+Job.swift
+//  Domain
+//
+//  Created by sudo.park on 5/28/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+
+// MARK: - AIJob
+
+public struct AIJob: Sendable {
+    
+    public enum Status: String, Sendable {
+        case pending = "PENDING"
+        case running = "RUNNING"
+        case done = "DONE"
+        case confirm = "CONFIRM"
+        case failed = "FAILED"
+    }
+    
+    public enum Mode: String, Sendable {
+        case command
+        case confirm
+    }
+    
+    public let jobId: String
+    public var status: Status?
+    public var mode: Mode?
+    public var result: AIJobResult?
+    public var createAt: Date?
+    public var updatedAt: Date?
+    
+    public var isFinish: Bool {
+        return self.status == .done
+            || self.status == .confirm
+            || self.status == .failed
+    }
+    
+    public init(jobId: String) {
+        self.jobId = jobId
+    }
+}
+
+// MARK: - AIJobResult
+
+public enum AIJobResult: Sendable {
+    
+    case done(DoneResult)
+    case confirm(ConfirmResult)
+    case failed(FailResult)
+}
+
+extension AIJobResult {
+    
+    public struct DoneResult: Sendable {
+        public var text: String?
+        public var mutations: [AIJobDataMutation] = []
+        
+        public init() { }
+    }
+    
+    public struct ConfirmResult: Sendable {
+        
+        public var text: String?
+        public var action: AIConfirmCommandAction?
+        public var mutations: [AIJobDataMutation] = []
+        
+        public init() { }
+    }
+    
+    public struct FailResult: Sendable {
+        public var reason: String?
+        public var mutations: [AIJobDataMutation] = []
+        public var errorCode: ServerErrorModel.ErrorCode?
+        
+        public init() { }
+    }
+}
+
+public struct AIConfirmCommandAction: Sendable {
+    public var tool: String?
+    public var args: Data?
+    public var confirmToken: String?
+    
+    public init() { }
+}
+
+public struct AIJobDataMutation: Sendable {
+    
+    public enum DataType: String, Sendable {
+        case todo
+        case doneTodo = "done"
+        case schedule
+        case tag
+        case eventDetail = "event_detail"
+    }
+    
+    public enum Operation: String, Sendable {
+        case created
+        case updated
+        case deleted
+    }
+    
+    public let dataType: DataType
+    public let operation: Operation
+    
+    public init(dataType: DataType, operation: Operation) {
+        self.dataType = dataType
+        self.operation = operation
+    }
+}

--- a/Domain/Sources/Models/Common/ServerErrorModel.swift
+++ b/Domain/Sources/Models/Common/ServerErrorModel.swift
@@ -20,7 +20,20 @@ public struct ServerErrorModel: Error, @unchecked Sendable, Decodable {
     public enum ErrorCode: String, Sendable, Decodable {
         case unauthorized = "Unauthorized"
         case invalidAccessKey = "InvalidAccessKey"
+        case forbidden = "Forbidden"
+        case notFound = "NotFound"
         case cancelled
+        case tokenCapExceeded = "TokenCapExceeded"
+        case loopCapExceeded = "LoopCapExceeded"
+        case dailyLimitExceeded = "DailyLimitExceeded"
+        case noToolUse = "NoToolUse"
+        case multipleToolUses = "MultipleToolUses"
+        case unknownFinalize = "UnknownFinalize"
+        case confirmExpired = "ConfirmExpired"
+        case confirmArgsMismatch = "ConfirmArgsMismatch"
+        case unexpectedConfirmRequired = "UnexpectedConfirmRequired"
+        case agentLoopThrow = "AgentLoopThrow"
+        case agentError = "AgentError"
     }
     
     public var code: ErrorCode?

--- a/Domain/Sources/Repositories/AI/AICommandRepository.swift
+++ b/Domain/Sources/Repositories/AI/AICommandRepository.swift
@@ -1,0 +1,27 @@
+//
+//  AICommandRepository.swift
+//  Domain
+//
+//  Created by sudo.park on 5/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+
+public protocol AICommandRepository: AnyObject, Sendable {
+    
+    func processCommand(
+        _ commandText: String,
+        timeZone: String
+    ) async throws -> String
+    
+    func processConfirmCommand(
+        _ action: AIConfirmCommandAction,
+        timeZone: String
+    ) async throws -> String
+    
+    func loadJob(_ jobId: String) async throws -> AIJob
+    
+    func loadUsage() async throws -> AIAgentUsage
+}

--- a/Domain/Sources/Usecases/AI/AICommandUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AICommandUsecase.swift
@@ -1,0 +1,164 @@
+//
+//  AICommandUsecase.swift
+//  Domain
+//
+//  Created by sudo.park on 5/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Combine
+import Prelude
+import Optics
+import Extensions
+
+
+public protocol AICommandUsecase: AnyObject, Sendable {
+    
+    func processCommand(_ commandText: String) -> AnyPublisher<AIJob, any Error>
+    
+    func processConfirmCommand(_ action: AIConfirmCommandAction) -> AnyPublisher<AIJob, any Error>
+
+    func handleJobFinishNotification(_ jobId: String)
+}
+
+
+// MARK: - AICommandUsecaseImple
+
+public final class AICommandUsecaseImple: AICommandUsecase, @unchecked Sendable {
+    
+    public struct PollingPolicy {
+        let checkInterval: TimeInterval
+        let totalTimeout: TimeInterval
+        
+        public static var `default`: PollingPolicy {
+            return .init(checkInterval: 10, totalTimeout: 10*60)
+        }
+        
+        var totalTimeoutMsInt: Int { (totalTimeout * 1000) |> Int.init }
+    }
+    
+    private let repository: any AICommandRepository
+    private let calendarSettingUsecase: any CalendarSettingUsecase
+    private let pollingPolicy: PollingPolicy
+    public init(
+        repository: any AICommandRepository,
+        calendarSettingUsecase: any CalendarSettingUsecase,
+        pollingPolicy: PollingPolicy = .default
+    ) {
+        self.repository = repository
+        self.calendarSettingUsecase = calendarSettingUsecase
+        self.pollingPolicy = pollingPolicy
+        
+        self.internalBind()
+    }
+    
+    private struct Subject {
+        let timeZone = CurrentValueSubject<TimeZone?, Never>(nil)
+        let jobFinishEvent = PassthroughSubject<String, Never>()
+    }
+    private let subject = Subject()
+    private var cancelBag = Set<AnyCancellable>()
+
+    private func internalBind() {
+        self.calendarSettingUsecase.currentTimeZone
+            .sink(receiveValue: { [weak self] timeZone in
+                self?.subject.timeZone.send(timeZone)
+            })
+            .store(in: &self.cancelBag)
+    }
+}
+
+extension AICommandUsecaseImple {
+    
+    public func processCommand(_ commandText: String) -> AnyPublisher<AIJob, any Error> {
+        
+        let timeZone = self.currentIANATimeZone(); let repository = self.repository
+
+        let makeJob: some Publisher<String, any Error> = Publishers.create(do: {
+            return try await repository.processCommand(commandText, timeZone: timeZone)
+        })
+        
+        let waitJobUntilFinish = makeJob.flatMap { [weak self] jobId in
+            return self?.checkJob(jobId) ?? Empty().eraseToAnyPublisher()
+        }
+        
+        return waitJobUntilFinish
+            .eraseToAnyPublisher()
+    }
+    
+    public func processConfirmCommand(_ action: AIConfirmCommandAction) -> AnyPublisher<AIJob, any Error> {
+
+        let timeZone = self.currentIANATimeZone(); let repository = self.repository
+
+        let makeConfirmJob: some Publisher<String, any Error> = Publishers.create(do: {
+            return try await repository.processConfirmCommand(action, timeZone: timeZone)
+        })
+        
+        let waitUntilFinish = makeConfirmJob.flatMap { [weak self] jobId in
+            return self?.checkJob(jobId) ?? Empty().eraseToAnyPublisher()
+        }
+        
+        return waitUntilFinish
+            .eraseToAnyPublisher()
+    }
+    
+    public func handleJobFinishNotification(_ jobId: String) {
+        self.subject.jobFinishEvent.send(jobId)
+    }
+    
+    private func checkJob(_ jobId: String) -> AnyPublisher<AIJob, any Error> {
+        
+        let refreshWithPolling = self.polling()
+        let refreshAfterPushReceive = self.subject.jobFinishEvent
+            .filter { $0 == jobId }
+            .map { _ in }
+        
+        let refreshTrigger = Publishers.Merge(refreshWithPolling, refreshAfterPushReceive)
+        let refreshJob = refreshTrigger.map { [weak self] in
+            guard let self = self else { return Empty<AIJob, any Error>().eraseToAnyPublisher() }
+            return self.loadJobWithFilterError(jobId).eraseToAnyPublisher()
+        }
+        .switchToLatest()
+        
+        return refreshJob
+            .first(where: { $0.isFinish })
+            .timeout(
+                .milliseconds(self.pollingPolicy.totalTimeoutMsInt),
+                scheduler: DispatchQueue.main,
+                customError: { RuntimeError(key: "timeout", "process command timeout") }
+            )
+            .eraseToAnyPublisher()
+    }
+    
+    private func loadJobWithFilterError(_ jobId: String) -> AnyPublisher<AIJob, any Error> {
+        let repository = self.repository
+        return Publishers.create(do: {
+            return try await repository.loadJob(jobId)
+        })
+        .catch { (error: any Error) in
+            switch (error as? ServerErrorModel)?.code {
+            case .forbidden, .notFound:
+                return Fail<AIJob, any Error>(error: error).eraseToAnyPublisher()
+            default:
+                return Empty<AIJob, any Error>().eraseToAnyPublisher()
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+}
+
+
+extension AICommandUsecaseImple {
+    
+    private func currentIANATimeZone() -> String {
+        return (self.subject.timeZone.value ?? .current).identifier
+    }
+    
+    private func polling() -> some Publisher<Void, Never> {
+        return Timer
+            .publish(every: self.pollingPolicy.checkInterval, on: RunLoop.main, in: .common)
+            .autoconnect()
+            .map { _ in }
+    }
+}

--- a/Domain/Tests/Usecases/AICommandUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AICommandUsecaseImpleTests.swift
@@ -1,0 +1,443 @@
+//
+//  AICommandUsecaseImpleTests.swift
+//  Domain
+//
+//  Created by sudo.park on 5/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Testing
+import Combine
+import Prelude
+import Optics
+import Extensions
+import UnitTestHelpKit
+import TestDoubles
+
+@testable import Domain
+
+
+final class AICommandUsecaseImpleTests: PublisherWaitable {
+    
+    var cancelBag: Set<AnyCancellable>! = []
+    private var stubRepository = PrivateStubRepository()
+    
+    private func makeUsecase(
+        shouldFailMakeJob: Bool = false,
+        shouldFailMakeConfirmJob: Bool = false,
+        customStubLoadJobs: [AIJob]? = nil,
+        customStubLoadJobAsResult: [Result<AIJob, any Error>]? = nil,
+        shouldFailLoadJobWithError: ServerErrorModel? = nil,
+        customPollingPolicy: AICommandUsecaseImple.PollingPolicy? = nil
+    ) -> AICommandUsecaseImple {
+
+        stubRepository.shouldFailProcessCommand = shouldFailMakeJob
+        stubRepository.shouldFailProcessConfirmCommand = shouldFailMakeConfirmJob
+        let jobs = customStubLoadJobs ?? [
+            .dummyPendingJob, .dummyRunningJob, .dummyRunningJob, .dummyDoneJob
+        ]
+        stubRepository.stubLoadJobs = customStubLoadJobAsResult
+        ?? jobs.map { .success($0) }
+        
+        let calendarSettingUsecase = StubCalendarSettingUsecase()
+        calendarSettingUsecase.selectTimeZone(TimeZone(abbreviation: "KST")!)
+        
+        let policy = AICommandUsecaseImple.PollingPolicy(
+            checkInterval: 0.1,
+            totalTimeout: 3
+        )
+        
+        return AICommandUsecaseImple(
+            repository: stubRepository,
+            calendarSettingUsecase: calendarSettingUsecase,
+            pollingPolicy: customPollingPolicy ?? policy
+        )
+    }
+}
+
+
+// MARK: - process commmand
+
+extension AICommandUsecaseImpleTests {
+    
+    @Test(arguments: [AIJob.dummyDoneJob, .dummyFailJob, .dummyConfirmJob])
+    func usecase_processCommand(_ finalJob: AIJob) async throws {
+        // given
+        let expect = expectConfirm("커맨드 처리 정상케이스 동선: 작업 생성, 대기 이후 결과 반환 - \(String(describing: finalJob.status))")
+        expect.timeout = .seconds(5)
+        let usecase = self.makeUsecase(customStubLoadJobs: [
+            .dummyPendingJob, .dummyPendingJob,
+            .dummyRunningJob, .dummyRunningJob,
+            finalJob
+        ])
+        
+        // when
+        let processing = usecase.processCommand("cmd")
+        let job = try await self.firstOutput(expect, for: processing)
+        
+        // then
+        #expect(job?.isFinish == true)
+        #expect(job?.status == finalJob.status)
+    }
+
+    @Test func usecase_whenProcessCommand_checkIsFinishWithPolling() async throws {
+        // given
+        let expect = expectConfirm("커맨드 처리시 주기적으로 작업상태 폴링해서 완료 여부 판단")
+        expect.timeout = .seconds(5)
+        let usecase = self.makeUsecase()
+        
+        // when
+        let processing = usecase.processCommand("cmd")
+        let job = try await self.firstOutput(expect, for: processing)
+        
+        // then
+        #expect(job?.isFinish == true)
+    }
+    
+    // 커맨드 처리시 fcm 메세지 받으면 작업상태 확인해서 완료 정보 반환
+    @Test func usecase_whenReceiveJobFinishNotification_loadFinishedJob() async throws {
+        // given
+        let expect = expectConfirm("커맨드 처리시 fcm 메세지 받으면 작업상태 확인해서 완료 정보 반환")
+        expect.timeout = .seconds(5)
+        let policy = AICommandUsecaseImple.PollingPolicy(
+            checkInterval: 1,
+            totalTimeout: 10
+        )
+        let usecase = self.makeUsecase(customPollingPolicy: policy)
+        self.stubRepository.loadJobMocking = .dummyRunningJob
+        
+        // when
+        let processing = usecase.processCommand("cmd")
+        let job = try await self.firstOutput(expect, for: processing) {
+            
+            try await Task.sleep(for: .milliseconds(10))
+            self.stubRepository.loadJobMocking = .dummyConfirmJob
+            
+            usecase.handleJobFinishNotification("some_job")
+        }
+        
+        // then
+        #expect(job?.isFinish == true)
+    }
+    
+    // 커맨드 처리시 에러 발생해도 폴링 유지
+    @Test func usecase_whenProcessCommand_ignoreErrorDuringLoad() async throws {
+        // given
+        let expect = expectConfirm("커맨드 처리시 에러 발생해도 폴링 유지")
+        expect.timeout = .seconds(5)
+        let usecase = self.makeUsecase(
+            customStubLoadJobAsResult: [
+                .success(.dummyPendingJob),
+                .success(.dummyRunningJob),
+                .failure(RuntimeError("failed")),
+                .failure(RuntimeError("failed")),
+                .success(.dummyDoneJob)
+            ]
+        )
+        
+        // when
+        let processing = usecase.processCommand("cmd")
+        let job = try await self.firstOutput(expect, for: processing)
+        
+        // then
+        #expect(job?.isFinish == true)
+    }
+    
+    // 커맨드 처리시 forbidden, notFound 에러 수신시 폴링 중지
+    @Test(arguments: [ServerErrorModel.dummy(.forbidden), .dummy(.notFound)])
+    func usecase_whenProcessCommand_stopCheckAndThrowError(_ reason: ServerErrorModel) async throws {
+        // given
+        let expect = expectConfirm("커맨드 처리시 forbidden, notFound 에러 수신시 폴링 중지")
+        expect.timeout = .seconds(5)
+        let usecase = self.makeUsecase(
+            customStubLoadJobAsResult: [
+                .success(.dummyPendingJob),
+                .success(.dummyRunningJob),
+                .failure(reason),
+            ]
+        )
+        
+        // when
+        let processing = usecase.processCommand("cmd")
+        let fail = try await self.failure(expect, for: processing)
+        
+        // then
+        #expect(fail != nil)
+    }
+    
+    // 커맨드 처리 - 완료여부 폴링 작업 전체 타임아웃 초과시 에러 처리
+    @Test func usecase_whenProcessCommandTakeTooLong_timeout() async throws {
+        // given
+        let expect = expectConfirm("커맨드 처리 - 완료여부 폴링 작업 전체 타임아웃 초과시 에러 처리")
+        expect.timeout = .seconds(5)
+        let usecase = self.makeUsecase(
+            customStubLoadJobs: Array(repeating: .dummyRunningJob, count: 4000)
+        )
+        
+        // when
+        let processing = usecase.processCommand("cmd")
+        let fail = try await self.failure(expect, for: processing)
+        
+        // then
+        #expect(fail != nil)
+        #expect((fail as? RuntimeError)?.key == "timeout")
+    }
+    
+    // 커맨드 요청부터 실패한경우 -> 에러
+    @Test func usecase_processCommandFail() async throws {
+        // given
+        let expect = expectConfirm("커맨드 요청부터 실패한경우 -> 에러")
+        expect.timeout = .seconds(5)
+        let usecase = self.makeUsecase(shouldFailMakeJob: true)
+        
+        // when
+        let processing = usecase.processCommand("cmd")
+        let fail = try await self.failure(expect, for: processing)
+        
+        // then
+        #expect(fail != nil)
+    }
+}
+
+
+// MARK: - process confirm command
+
+extension AICommandUsecaseImpleTests {
+
+    @Test(arguments: [AIJob.dummyDoneJob, .dummyFailJob, .dummyConfirmJob])
+    func usecase_processConfirmCommand(_ finalJob: AIJob) async throws {
+        // given
+        let expect = expectConfirm("컨펌 커맨드 처리 정상케이스 동선: 작업 생성, 대기 이후 결과 반환 - \(String(describing: finalJob.status))")
+        expect.timeout = .seconds(5)
+        let usecase = self.makeUsecase(customStubLoadJobs: [
+            .dummyPendingJob, .dummyPendingJob,
+            .dummyRunningJob, .dummyRunningJob,
+            finalJob
+        ])
+
+        // when
+        let processing = usecase.processConfirmCommand(.init())
+        let job = try await self.firstOutput(expect, for: processing)
+
+        // then
+        #expect(job?.isFinish == true)
+        #expect(job?.status == finalJob.status)
+    }
+
+    @Test func usecase_whenProcessConfirmCommand_checkIsFinishWithPolling() async throws {
+        // given
+        let expect = expectConfirm("컨펌 커맨드 처리시 주기적으로 작업상태 폴링해서 완료 여부 판단")
+        expect.timeout = .seconds(5)
+        let usecase = self.makeUsecase()
+
+        // when
+        let processing = usecase.processConfirmCommand(.init())
+        let job = try await self.firstOutput(expect, for: processing)
+
+        // then
+        #expect(job?.isFinish == true)
+    }
+
+    // 컨펌 커맨드 처리시 fcm 메세지 받으면 작업상태 확인해서 완료 정보 반환
+    @Test func usecase_whenReceiveJobFinishNotification_loadFinishedConfirmJob() async throws {
+        // given
+        let expect = expectConfirm("컨펌 커맨드 처리시 fcm 메세지 받으면 작업상태 확인해서 완료 정보 반환")
+        expect.timeout = .seconds(5)
+        let policy = AICommandUsecaseImple.PollingPolicy(
+            checkInterval: 1,
+            totalTimeout: 10
+        )
+        let usecase = self.makeUsecase(customPollingPolicy: policy)
+        self.stubRepository.loadJobMocking = .dummyRunningJob
+
+        // when
+        let processing = usecase.processConfirmCommand(.init())
+        let job = try await self.firstOutput(expect, for: processing) {
+
+            try await Task.sleep(for: .milliseconds(10))
+            self.stubRepository.loadJobMocking = .dummyDoneJob
+
+            usecase.handleJobFinishNotification("some_job")
+        }
+
+        // then
+        #expect(job?.isFinish == true)
+    }
+
+    // 컨펌 커맨드 처리시 에러 발생해도 폴링 유지
+    @Test func usecase_whenProcessConfirmCommand_ignoreErrorDuringLoad() async throws {
+        // given
+        let expect = expectConfirm("컨펌 커맨드 처리시 에러 발생해도 폴링 유지")
+        expect.timeout = .seconds(5)
+        let usecase = self.makeUsecase(
+            customStubLoadJobAsResult: [
+                .success(.dummyPendingJob),
+                .success(.dummyRunningJob),
+                .failure(RuntimeError("failed")),
+                .failure(RuntimeError("failed")),
+                .success(.dummyDoneJob)
+            ]
+        )
+
+        // when
+        let processing = usecase.processConfirmCommand(.init())
+        let job = try await self.firstOutput(expect, for: processing)
+
+        // then
+        #expect(job?.isFinish == true)
+    }
+
+    // 컨펌 커맨드 처리시 forbidden, notFound 에러 수신시 폴링 중지
+    @Test(arguments: [ServerErrorModel.dummy(.forbidden), .dummy(.notFound)])
+    func usecase_whenProcessConfirmCommand_stopCheckAndThrowError(_ reason: ServerErrorModel) async throws {
+        // given
+        let expect = expectConfirm("컨펌 커맨드 처리시 forbidden, notFound 에러 수신시 폴링 중지")
+        expect.timeout = .seconds(5)
+        let usecase = self.makeUsecase(
+            customStubLoadJobAsResult: [
+                .success(.dummyPendingJob),
+                .success(.dummyRunningJob),
+                .failure(reason),
+            ]
+        )
+
+        // when
+        let processing = usecase.processConfirmCommand(.init())
+        let fail = try await self.failure(expect, for: processing)
+
+        // then
+        #expect(fail != nil)
+    }
+
+    // 컨펌 커맨드 처리 - 완료여부 폴링 작업 전체 타임아웃 초과시 에러 처리
+    @Test func usecase_whenProcessConfirmCommandTakeTooLong_timeout() async throws {
+        // given
+        let expect = expectConfirm("컨펌 커맨드 처리 - 완료여부 폴링 작업 전체 타임아웃 초과시 에러 처리")
+        expect.timeout = .seconds(5)
+        let usecase = self.makeUsecase(
+            customStubLoadJobs: Array(repeating: .dummyRunningJob, count: 4000)
+        )
+
+        // when
+        let processing = usecase.processConfirmCommand(.init())
+        let fail = try await self.failure(expect, for: processing)
+
+        // then
+        #expect(fail != nil)
+        #expect((fail as? RuntimeError)?.key == "timeout")
+    }
+
+    // 컨펌 커맨드 요청부터 실패한경우 -> 에러
+    @Test func usecase_processConfirmCommandFail() async throws {
+        // given
+        let expect = expectConfirm("컨펌 커맨드 요청부터 실패한경우 -> 에러")
+        expect.timeout = .seconds(5)
+        let usecase = self.makeUsecase(shouldFailMakeConfirmJob: true)
+
+        // when
+        let processing = usecase.processConfirmCommand(.init())
+        let fail = try await self.failure(expect, for: processing)
+
+        // then
+        #expect(fail != nil)
+    }
+}
+
+private extension AIJob {
+ 
+    static var dummyPendingJob: AIJob {
+        
+        let job = AIJob(jobId: "some_job")
+            |> \.status .~ .pending
+        return job
+    }
+
+    static var dummyRunningJob: AIJob {
+        return dummyPendingJob
+            |> \.status .~ .running
+    }
+
+    static var dummyDoneJob: AIJob {
+        let result = AIJobResult.DoneResult()
+            |> \.text .~ "done"
+            |> \.mutations .~ [
+                .init(dataType: .todo, operation: .created)
+            ]
+        return dummyRunningJob
+            |> \.status .~ .done
+            |> \.result .~ .done(result)
+    }
+
+    static var dummyFailJob: AIJob {
+        let result = AIJobResult.FailResult()
+            |> \.reason .~ "failed"
+            |> \.errorCode .~ .agentError
+        return dummyRunningJob
+            |> \.status .~ .failed
+            |> \.result .~ .failed(result)
+    }
+
+    static var dummyConfirmJob: AIJob {
+        let result = AIJobResult.ConfirmResult()
+            |> \.text .~ "confirm need"
+            |> \.action .~ .init()
+        return dummyRunningJob
+            |> \.status .~ .confirm
+            |> \.result .~ .confirm(result)
+    }
+    
+}
+
+private extension ServerErrorModel {
+    
+    static func dummy(_ code: ServerErrorModel.ErrorCode) -> ServerErrorModel {
+        return .init()
+            |> \.code .~ code
+    }
+}
+
+private final class PrivateStubRepository: AICommandRepository, @unchecked Sendable {
+    
+    var shouldFailProcessCommand: Bool = false
+    func processCommand(_ commandText: String, timeZone: String) async throws -> String {
+        guard !self.shouldFailProcessCommand
+        else {
+            throw RuntimeError("not imple")
+        }
+        return "some_job"
+    }
+
+    var shouldFailProcessConfirmCommand: Bool = false
+    func processConfirmCommand(_ action: AIConfirmCommandAction, timeZone: String) async throws -> String {
+        guard !self.shouldFailProcessConfirmCommand
+        else {
+            throw RuntimeError("not imple")
+        }
+        return "some_job"
+    }
+    
+    
+    var stubLoadJobs: [Result<AIJob, any Error>] = []
+    var loadJobMocking: AIJob?
+    func loadJob(_ jobId: String) async throws -> AIJob {
+        
+        if let mocking = self.loadJobMocking {
+            return mocking
+        }
+        
+        if self.stubLoadJobs.isEmpty {
+            throw RuntimeError("failed")
+        }
+        
+        let first = self.stubLoadJobs.removeFirst()
+        switch first {
+        case .success(let job): return job
+        case .failure(let error): throw error
+        }
+    }
+    
+    func loadUsage() async throws -> AIAgentUsage {
+        throw RuntimeError("not imple")
+    }
+}


### PR DESCRIPTION
서버 스펙: https://github.com/sudopark/TodoCalendar-Functions/blob/develop/docs/spec/aiFront.md

- 사용자 자연어 요청시 aiFrontAPI를 사용해서, 지시를 처리하고 처리 결과를 받아오는 AICommandUsecase 추가
- processCommand시 발급된 jobId를 사용해서 usecase 내부에서 폴링하여 상태 체크 -> 완료되면 AIJob 데이터 반환
  - 또한 fcm 메세지를 받은 경우도 상태 조회 트리거로 사용
- 폴링 주기는 10초, 총 폴링 타임아웃은 10분으로 설정
- 서버 에러 모델 ErrorCode 케이스 추가