### PR TITLE
[#636] AICommandRepository 구현체 추가

### DIFF
--- a/Domain/Sources/Models/AI/AICommand+Job.swift
+++ b/Domain/Sources/Models/AI/AICommand+Job.swift
@@ -16,7 +16,7 @@ public struct ProcessingAICommand: Sendable {
     public let jobId: String
     public let isConfirmJob: Bool
     
-    init(jobId: String, isConfirmJob: Bool) {
+    public init(jobId: String, isConfirmJob: Bool) {
         self.jobId = jobId
         self.isConfirmJob = isConfirmJob
     }

--- a/Domain/Sources/Usecases/Common/PlaceSuggestUsecase.swift
+++ b/Domain/Sources/Usecases/Common/PlaceSuggestUsecase.swift
@@ -129,16 +129,19 @@ public protocol PlaceSuggestUsecase: AnyObject, Sendable {
     var suggestPlaces: AnyPublisher<[Place], Never> { get }
 }
 
-public final class PlaceSuggestUsecaseImple: PlaceSuggestUsecase, @unchecked Sendable {
-    
+public final class PlaceSuggestUsecaseImple<Scheduler: Combine.Scheduler>: PlaceSuggestUsecase, @unchecked Sendable {
+
     private let suggestEngine: any PlaceSuggestEngine
-    private let throttleTime: RunLoop.SchedulerTimeType.Stride
+    private let throttleTime: Scheduler.SchedulerTimeType.Stride
+    private let scheduler: Scheduler
     public init(
         suggestEngine: any PlaceSuggestEngine,
-        throttleTime: RunLoop.SchedulerTimeType.Stride = .milliseconds(1200)
+        throttleTime: Scheduler.SchedulerTimeType.Stride = .milliseconds(1200),
+        scheduler: Scheduler
     ) {
         self.suggestEngine = suggestEngine
         self.throttleTime = throttleTime
+        self.scheduler = scheduler
         self.bindSuggest()
     }
     
@@ -176,7 +179,7 @@ extension PlaceSuggestUsecaseImple {
         }
         
         self.subject.query
-            .throttle(for: self.throttleTime, scheduler: RunLoop.main, latest: true)
+            .throttle(for: self.throttleTime, scheduler: self.scheduler, latest: true)
             .compactMap(suggestOrNot)
             .switchToLatest()
             .sink(receiveValue: { [weak self] places in

--- a/Domain/Tests/Usecases/PlaceSuggestUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/PlaceSuggestUsecaseImpleTests.swift
@@ -20,12 +20,13 @@ class PlaceSuggestUsecaseImpleTests: PublisherWaitable {
     
     private func makeUsecase(
         mocking: PassthroughSubject<[Place], Never>? = nil
-    ) -> PlaceSuggestUsecaseImple {
+    ) -> PlaceSuggestUsecaseImple<ImmediateScheduler> {
         let suggestEngine = StubPlaceSuggestEngine()
         suggestEngine.mocking = mocking
         return .init(
             suggestEngine: suggestEngine,
-            throttleTime: .milliseconds(0)
+            throttleTime: .milliseconds(0),
+            scheduler: .shared
         )
     }
 }

--- a/Repository/Sources/Remote/Endpoint.swift
+++ b/Repository/Sources/Remote/Endpoint.swift
@@ -263,6 +263,25 @@ public enum AppEndpoints: Endpoint {
 }
 
 
+// MARK: - AI
+
+enum AIAPIEndpoints: Endpoint {
+    case command
+    case confirmCommand
+    case job(id: String)
+    case usage
+
+    var subPath: String {
+        switch self {
+        case .command: return "command"
+        case .confirmCommand: return "command/confirm"
+        case .job(let id): return "jobs/\(id)"
+        case .usage: return "usage"
+        }
+    }
+}
+
+
 // MARK: - google account endpoint
 
 enum GoogleAuthEndpoint: Endpoint {
@@ -383,6 +402,10 @@ public struct RemoteEnvironment: Sendable {
         case let app as AppEndpoints:
             let prefix = "https://raw.githubusercontent.com/sudopark/TodoCalendar/develop/app-config"
             return appendSubpathIfNotEmpty(prefix, app.subPath)
+
+        case let ai as AIAPIEndpoints:
+            let prefix = "\(calendarAPIHost)/v1/ai"
+            return appendSubpathIfNotEmpty(prefix, ai.subPath)
 
         default: return nil
         }

--- a/Repository/Sources/Repository+Imple/AI/AICommand+Mapping.swift
+++ b/Repository/Sources/Repository+Imple/AI/AICommand+Mapping.swift
@@ -1,0 +1,182 @@
+//
+//  AICommand+Mapping.swift
+//  Repository
+//
+//  Created by sudo.park on 6/1/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Prelude
+import Optics
+import Domain
+import Extensions
+
+
+// MARK: - request body
+
+extension AIConfirmCommandAction {
+
+    func asJson(timeZone: String) -> [String: Any] {
+        var json: [String: Any] = [:]
+        json["tool"] = self.tool
+        json["confirm_token"] = self.confirmToken
+        json["timezone"] = timeZone
+        if let argsData = self.args,
+           let argsObject = try? JSONSerialization.jsonObject(with: argsData) {
+            json["args"] = argsObject
+        }
+        return json
+    }
+}
+
+
+// MARK: - response: jobId
+
+struct AIJobIdResponseMapper {
+
+    let jobId: String
+
+    init(json: [String: Any]) throws {
+        guard let jobId = json["job_id"] as? String
+        else { throw RuntimeError("invalid job_id response") }
+        self.jobId = jobId
+    }
+}
+
+
+// MARK: - response: AIJob
+
+struct AIJobMapper {
+
+    let job: AIJob
+
+    init(json: [String: Any]) throws {
+        guard let jobId = json["jobId"] as? String
+        else { throw RuntimeError("invalid AIJob response") }
+
+        let resultJson = json["result"] as? [String: Any]
+        let result = resultJson.flatMap { try? AIJobResultMapper(json: $0).result }
+
+        self.job = AIJob(jobId: jobId)
+            |> \.command .~ (json["commandText"] as? String)
+            |> \.status .~ (json["status"] as? String).flatMap { AIJob.Status(rawValue: $0) }
+            |> \.mode .~ (json["mode"] as? String).flatMap { AIJob.Mode(rawValue: $0) }
+            |> \.result .~ result
+            |> \.createAt .~ AICommandDateParser.parse(json["createdAt"])
+            |> \.updatedAt .~ AICommandDateParser.parse(json["updatedAt"])
+    }
+}
+
+
+// MARK: - AIJobResult
+
+struct AIJobResultMapper {
+
+    let result: AIJobResult?
+
+    init(json: [String: Any]) throws {
+        let type = json["type"] as? String
+        let mutations = (json["mutations"] as? [[String: Any]] ?? [])
+            .compactMap { try? AIJobDataMutationMapper(json: $0).mutation }
+
+        switch type {
+        case "DONE":
+            self.result = .done(
+                AIJobResult.DoneResult()
+                |> \.text .~ (json["text"] as? String)
+                |> \.mutations .~ mutations
+            )
+
+        case "CONFIRM":
+            let action = (json["action"] as? [String: Any])
+                .map { AIConfirmCommandActionMapper(json: $0).action }
+            self.result = .confirm(
+                AIJobResult.ConfirmResult()
+                |> \.text .~ (json["text"] as? String)
+                |> \.action .~ action
+                |> \.mutations .~ mutations
+            )
+
+        case "FAILED":
+            self.result = .failed(
+                AIJobResult.FailResult()
+                |> \.reason .~ (json["reason"] as? String)
+                |> \.errorCode .~ (json["errorCode"] as? String).flatMap { ServerErrorModel.ErrorCode(rawValue: $0) }
+                |> \.mutations .~ mutations
+            )
+
+        default:
+            self.result = nil
+        }
+    }
+}
+
+
+// MARK: - AIConfirmCommandAction (response)
+
+struct AIConfirmCommandActionMapper {
+
+    let action: AIConfirmCommandAction
+
+    init(json: [String: Any]) {
+        let argsData = json["args"].flatMap { try? JSONSerialization.data(withJSONObject: $0) }
+        self.action = AIConfirmCommandAction()
+            |> \.tool .~ (json["tool"] as? String)
+            |> \.confirmToken .~ (json["confirmToken"] as? String)
+            |> \.args .~ argsData
+    }
+}
+
+
+// MARK: - AIJobDataMutation
+
+struct AIJobDataMutationMapper {
+
+    let mutation: AIJobDataMutation?
+
+    init(json: [String: Any]) {
+        let dataTypeRaw = json["dataType"] as? String
+        let opRaw = json["op"] as? String
+        guard let dataTypeRaw, let opRaw,
+              let dataType = AIJobDataMutation.DataType(rawValue: dataTypeRaw),
+              let op = AIJobDataMutation.Operation(rawValue: opRaw)
+        else {
+            self.mutation = nil
+            return
+        }
+        self.mutation = AIJobDataMutation(dataType: dataType, operation: op)
+    }
+}
+
+
+// MARK: - response: AIAgentUsage
+
+struct AIAgentUsageMapper {
+
+    let usage: AIAgentUsage
+
+    init(json: [String: Any]) throws {
+        guard let input = json["input_tokens"] as? Int,
+              let output = json["output_tokens"] as? Int,
+              let limit = json["daily_limit"] as? Int
+        else { throw RuntimeError("invalid usage response") }
+
+        self.usage = AIAgentUsage(input: input, output: output, limit: limit)
+            |> \.date .~ (json["date"] as? String)
+            |> \.updatedAt .~ AICommandDateParser.parse(json["updated_at"])
+    }
+}
+
+
+// MARK: - date parser
+
+enum AICommandDateParser {
+
+    static func parse(_ value: Any?) -> Date? {
+        guard let iso = value as? String else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.date(from: iso)
+    }
+}

--- a/Repository/Sources/Repository+Imple/AI/AICommandRepositoryImple.swift
+++ b/Repository/Sources/Repository+Imple/AI/AICommandRepositoryImple.swift
@@ -1,0 +1,109 @@
+//
+//  AICommandRepositoryImple.swift
+//  Repository
+//
+//  Created by sudo.park on 6/1/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Domain
+import Extensions
+
+
+public final class AICommandRepositoryImple: AICommandRepository {
+
+    private let remote: any RemoteAPI
+    private let localStorage: any AICommandLocalStorage
+
+    public init(
+        remote: any RemoteAPI,
+        localStorage: any AICommandLocalStorage
+    ) {
+        self.remote = remote
+        self.localStorage = localStorage
+    }
+}
+
+
+// MARK: - command processing (remote)
+
+extension AICommandRepositoryImple {
+
+    public func processCommand(
+        _ commandText: String,
+        timeZone: String
+    ) async throws -> String {
+        let body: [String: Any] = [
+            "command_text": commandText,
+            "timezone": timeZone
+        ]
+        let json = try await self.requestJson(.post, AIAPIEndpoints.command, parameters: body)
+        return try AIJobIdResponseMapper(json: json).jobId
+    }
+
+    public func processConfirmCommand(
+        _ action: AIConfirmCommandAction,
+        timeZone: String
+    ) async throws -> String {
+        let json = try await self.requestJson(
+            .post,
+            AIAPIEndpoints.confirmCommand,
+            parameters: action.asJson(timeZone: timeZone)
+        )
+        return try AIJobIdResponseMapper(json: json).jobId
+    }
+
+    public func loadJob(_ jobId: String) async throws -> AIJob {
+        let json = try await self.requestJson(.get, AIAPIEndpoints.job(id: jobId))
+        return try AIJobMapper(json: json).job
+    }
+}
+
+
+// MARK: - processing command persistence (local)
+
+extension AICommandRepositoryImple {
+
+    public func updateProcessingAICommand(_ cmd: ProcessingAICommand) async throws {
+        try await self.localStorage.updateProcessingAICommand(cmd)
+    }
+
+    public func loadProcessingAICommand() async throws -> ProcessingAICommand? {
+        return try await self.localStorage.loadProcessingAICommand()
+    }
+
+    public func clearProcessingAICommand() async throws {
+        try await self.localStorage.clearProcessingAICommand()
+    }
+}
+
+
+// MARK: - usage (remote)
+
+extension AICommandRepositoryImple {
+
+    public func loadUsage() async throws -> AIAgentUsage {
+        let json = try await self.requestJson(.get, AIAPIEndpoints.usage)
+        return try AIAgentUsageMapper(json: json).usage
+    }
+}
+
+
+// MARK: - helpers
+
+private extension AICommandRepositoryImple {
+
+    func requestJson(
+        _ method: RemoteAPIMethod,
+        _ endpoint: any Endpoint,
+        parameters: [String: Any] = [:]
+    ) async throws -> [String: Any] {
+        let data = try await self.remote.request(method, endpoint, with: nil, parameters: parameters)
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            throw RuntimeError("invalid AI API response")
+        }
+        return json
+    }
+}

--- a/Repository/Sources/Repository+Imple/AI/Local/AICommandLocalStorage.swift
+++ b/Repository/Sources/Repository+Imple/AI/Local/AICommandLocalStorage.swift
@@ -1,0 +1,56 @@
+//
+//  AICommandLocalStorage.swift
+//  Repository
+//
+//  Created by sudo.park on 6/1/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import SQLiteService
+import Domain
+
+
+public protocol AICommandLocalStorage: AnyObject, Sendable {
+
+    func loadProcessingAICommand() async throws -> ProcessingAICommand?
+    func updateProcessingAICommand(_ cmd: ProcessingAICommand) async throws
+    func clearProcessingAICommand() async throws
+}
+
+
+public final class AICommandLocalStorageImple: AICommandLocalStorage {
+
+    private let sqliteService: SQLiteService
+
+    public init(sqliteService: SQLiteService) {
+        self.sqliteService = sqliteService
+    }
+}
+
+
+extension AICommandLocalStorageImple {
+
+    public func loadProcessingAICommand() async throws -> ProcessingAICommand? {
+        return try await self.sqliteService.async.run { db -> ProcessingAICommand? in
+            try? db.createTableOrNot(ProcessingAICommandTable.self)
+            let query = ProcessingAICommandTable.selectAll()
+            return try db.loadOne(ProcessingAICommandTable.self, query: query)
+        }
+    }
+
+    public func updateProcessingAICommand(_ cmd: ProcessingAICommand) async throws {
+        try await self.sqliteService.async.run { db in
+            try? db.createTableOrNot(ProcessingAICommandTable.self)
+            try db.delete(ProcessingAICommandTable.self, query: ProcessingAICommandTable.delete())
+            try db.insert(ProcessingAICommandTable.self, entities: [cmd])
+        }
+    }
+
+    public func clearProcessingAICommand() async throws {
+        try await self.sqliteService.async.run { db in
+            try? db.createTableOrNot(ProcessingAICommandTable.self)
+            try db.delete(ProcessingAICommandTable.self, query: ProcessingAICommandTable.delete())
+        }
+    }
+}

--- a/Repository/Sources/Repository+Imple/AI/Local/ProcessingAICommandTable.swift
+++ b/Repository/Sources/Repository+Imple/AI/Local/ProcessingAICommandTable.swift
@@ -1,0 +1,49 @@
+//
+//  ProcessingAICommandTable.swift
+//  Repository
+//
+//  Created by sudo.park on 6/1/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import SQLiteService
+import Domain
+
+
+struct ProcessingAICommandTable: Table {
+
+    enum Columns: String, TableColumn {
+        case jobId = "job_id"
+        case isConfirmJob = "is_confirm_job"
+
+        var dataType: ColumnDataType {
+            switch self {
+            case .jobId: return .text([.primaryKey(autoIncrement: false), .unique, .notNull])
+            case .isConfirmJob: return .integer([.notNull])
+            }
+        }
+    }
+
+    typealias ColumnType = Columns
+    typealias EntityType = ProcessingAICommand
+    static var tableName: String { "ProcessingAICommand" }
+
+    static func scalar(_ entity: ProcessingAICommand, for column: Columns) -> (any ScalarType)? {
+        switch column {
+        case .jobId: return entity.jobId
+        case .isConfirmJob: return entity.isConfirmJob
+        }
+    }
+}
+
+
+extension ProcessingAICommand: @retroactive RowValueType {
+
+    public init(_ cursor: CursorIterator) throws {
+        self.init(
+            jobId: try cursor.next().unwrap(),
+            isConfirmJob: try cursor.next().unwrap()
+        )
+    }
+}

--- a/Repository/Sources/Repository+Imple/Setting/Migration/AppDataMigrationImple.swift
+++ b/Repository/Sources/Repository+Imple/Setting/Migration/AppDataMigrationImple.swift
@@ -72,6 +72,7 @@ public final class AppDataMigrationImple: @unchecked Sendable {
             try? db.createTableOrNot(TodoToggleStateTable.self)
             try? db.createTableOrNot(EventUploadPendingQueueTable.self)
             try? db.createTableOrNot(EventNotificationIdTable.self)
+            try? db.createTableOrNot(ProcessingAICommandTable.self)
         }
     }
 }

--- a/Repository/Tests/AI/AICommandRepositoryImpleTests.swift
+++ b/Repository/Tests/AI/AICommandRepositoryImpleTests.swift
@@ -1,0 +1,415 @@
+//
+//  AICommandRepositoryImpleTests.swift
+//  RepositoryTests
+//
+//  Created by sudo.park on 6/2/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import XCTest
+import Domain
+import Extensions
+import UnitTestHelpKit
+
+@testable import Repository
+
+
+class AICommandRepositoryImpleTests: BaseLocalTests {
+
+    private var stubRemote: StubRemoteAPI!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        self.fileName = "ai_command_test"
+        self.stubRemote = .init(responses: DummyResponse().responses)
+    }
+
+    override func tearDownWithError() throws {
+        self.stubRemote = nil
+        try super.tearDownWithError()
+    }
+
+    private func makeRepository(
+        shouldFailRemote: Bool = false
+    ) -> AICommandRepositoryImple {
+        self.stubRemote.shouldFailRequest = shouldFailRemote
+        let localStorage = AICommandLocalStorageImple(
+            sqliteService: self.sqliteService
+        )
+        return AICommandRepositoryImple(
+            remote: self.stubRemote,
+            localStorage: localStorage
+        )
+    }
+}
+
+
+// MARK: - processCommand
+
+extension AICommandRepositoryImpleTests {
+
+    func testRepository_processCommand_returnsJobId() async throws {
+        // given
+        let repository = self.makeRepository()
+
+        // when
+        let jobId = try await repository.processCommand("내일 오후 3시 회의", timeZone: "Asia/Seoul")
+
+        // then
+        XCTAssertEqual(jobId, "new_job_id")
+        XCTAssertEqual(self.stubRemote.didRequestedMethod, .post)
+
+        let params = self.stubRemote.didRequestedParams
+        XCTAssertEqual(params?["command_text"] as? String, "내일 오후 3시 회의")
+        XCTAssertEqual(params?["timezone"] as? String, "Asia/Seoul")
+    }
+
+    func testRepository_whenProcessCommandFail_throwError() async {
+        // given
+        let repository = self.makeRepository(shouldFailRemote: true)
+
+        // when + then
+        do {
+            _ = try await repository.processCommand("x", timeZone: "Asia/Seoul")
+            XCTFail("must throw")
+        } catch {
+            // expected
+        }
+    }
+}
+
+
+// MARK: - processConfirmCommand
+
+extension AICommandRepositoryImpleTests {
+
+    func testRepository_processConfirmCommand_returnsJobId() async throws {
+        // given
+        let repository = self.makeRepository()
+        let args = try JSONSerialization.data(withJSONObject: ["schedule_id": "abc"])
+        let action = AIConfirmCommandAction()
+            |> \.tool .~ "delete_schedule"
+            |> \.confirmToken .~ "tok"
+            |> \.args .~ args
+
+        // when
+        let jobId = try await repository.processConfirmCommand(action, timeZone: "Asia/Seoul")
+
+        // then
+        XCTAssertEqual(jobId, "confirm_job_id")
+        XCTAssertEqual(self.stubRemote.didRequestedMethod, .post)
+
+        let params = self.stubRemote.didRequestedParams
+        XCTAssertEqual(params?["tool"] as? String, "delete_schedule")
+        XCTAssertEqual(params?["confirm_token"] as? String, "tok")
+        XCTAssertEqual(params?["timezone"] as? String, "Asia/Seoul")
+        let argsParam = params?["args"] as? [String: Any]
+        XCTAssertEqual(argsParam?["schedule_id"] as? String, "abc")
+    }
+}
+
+
+// MARK: - loadJob
+
+extension AICommandRepositoryImpleTests {
+
+    func testRepository_loadJob_done() async throws {
+        // given
+        let repository = self.makeRepository()
+
+        // when
+        let job = try await repository.loadJob("done_job")
+
+        // then
+        XCTAssertEqual(job.jobId, "done_job")
+        XCTAssertEqual(job.status, .done)
+        XCTAssertEqual(job.mode, .command)
+        XCTAssertEqual(job.command, "내일 오후 3시")
+        guard case .done(let result) = job.result else {
+            XCTFail("expect done result"); return
+        }
+        XCTAssertEqual(result.text, "일정 등록했어요")
+        XCTAssertEqual(result.mutations.map { $0.dataType }, [.schedule])
+        XCTAssertEqual(result.mutations.map { $0.operation }, [.created])
+        XCTAssertNotNil(job.createAt)
+        XCTAssertNotNil(job.updatedAt)
+    }
+
+    func testRepository_loadJob_confirm_keepsArgsAsRawData() async throws {
+        // given
+        let repository = self.makeRepository()
+
+        // when
+        let job = try await repository.loadJob("confirm_job")
+
+        // then
+        XCTAssertEqual(job.status, .confirm)
+        guard case .confirm(let result) = job.result else {
+            XCTFail("expect confirm result"); return
+        }
+        XCTAssertEqual(result.text, "정말 삭제할까요")
+        XCTAssertEqual(result.action?.tool, "delete_schedule")
+        XCTAssertEqual(result.action?.confirmToken, "tok-confirm")
+
+        let argsObject = try result.action?.args
+            .flatMap { try JSONSerialization.jsonObject(with: $0) as? [String: Any] }
+        XCTAssertEqual(argsObject?["schedule_id"] as? String, "abc")
+    }
+
+    func testRepository_loadJob_failed() async throws {
+        // given
+        let repository = self.makeRepository()
+
+        // when
+        let job = try await repository.loadJob("failed_job")
+
+        // then
+        XCTAssertEqual(job.status, .failed)
+        guard case .failed(let result) = job.result else {
+            XCTFail("expect failed result"); return
+        }
+        XCTAssertEqual(result.reason, "한도 소진")
+        XCTAssertEqual(result.errorCode, .dailyLimitExceeded)
+    }
+
+    func testRepository_loadJob_running() async throws {
+        // given
+        let repository = self.makeRepository()
+
+        // when
+        let job = try await repository.loadJob("running_job")
+
+        // then
+        XCTAssertEqual(job.status, .running)
+        XCTAssertFalse(job.isFinish)
+        XCTAssertNil(job.result)
+    }
+}
+
+
+// MARK: - loadUsage
+
+extension AICommandRepositoryImpleTests {
+
+    func testRepository_loadUsage() async throws {
+        // given
+        let repository = self.makeRepository()
+
+        // when
+        let usage = try await repository.loadUsage()
+
+        // then
+        XCTAssertEqual(usage.date, "2026-06-01")
+        XCTAssertEqual(usage.inputTokens, 1250)
+        XCTAssertEqual(usage.outputTokens, 320)
+        XCTAssertEqual(usage.dailyLimit, 5000)
+        XCTAssertNotNil(usage.updatedAt)
+    }
+}
+
+
+// MARK: - ProcessingAICommand persistence
+
+extension AICommandRepositoryImpleTests {
+
+    func testRepository_loadProcessingCommand_whenNotExists_isNil() async throws {
+        // given
+        let repository = self.makeRepository()
+
+        // when
+        let loaded = try await repository.loadProcessingAICommand()
+
+        // then
+        XCTAssertNil(loaded)
+    }
+
+    func testRepository_updateProcessingCommand_andLoad() async throws {
+        // given
+        let repository = self.makeRepository()
+        let cmd = ProcessingAICommand(jobId: "saved", isConfirmJob: false)
+
+        // when
+        try await repository.updateProcessingAICommand(cmd)
+        let loaded = try await repository.loadProcessingAICommand()
+
+        // then
+        XCTAssertEqual(loaded?.jobId, "saved")
+        XCTAssertEqual(loaded?.isConfirmJob, false)
+    }
+
+    func testRepository_updateProcessingCommand_isConfirmJobTrue_roundTrip() async throws {
+        // given
+        let repository = self.makeRepository()
+        let cmd = ProcessingAICommand(jobId: "confirm_cmd", isConfirmJob: true)
+
+        // when
+        try await repository.updateProcessingAICommand(cmd)
+        let loaded = try await repository.loadProcessingAICommand()
+
+        // then
+        XCTAssertEqual(loaded?.jobId, "confirm_cmd")
+        XCTAssertEqual(loaded?.isConfirmJob, true)
+    }
+
+    func testRepository_updateProcessingCommand_replacesPrevious() async throws {
+        // given
+        let repository = self.makeRepository()
+
+        // when
+        try await repository.updateProcessingAICommand(.init(jobId: "first", isConfirmJob: false))
+        try await repository.updateProcessingAICommand(.init(jobId: "second", isConfirmJob: true))
+        let loaded = try await repository.loadProcessingAICommand()
+
+        // then
+        XCTAssertEqual(loaded?.jobId, "second")
+        XCTAssertEqual(loaded?.isConfirmJob, true)
+    }
+
+    func testRepository_clearProcessingCommand() async throws {
+        // given
+        let repository = self.makeRepository()
+        try await repository.updateProcessingAICommand(.init(jobId: "to_clear", isConfirmJob: false))
+
+        // when
+        try await repository.clearProcessingAICommand()
+        let loaded = try await repository.loadProcessingAICommand()
+
+        // then
+        XCTAssertNil(loaded)
+    }
+}
+
+
+// MARK: - DummyResponse
+
+import Prelude
+import Optics
+
+private struct DummyResponse {
+
+    var responses: [StubRemoteAPI.Response] {
+        return [
+            .init(
+                method: .post,
+                endpoint: AIAPIEndpoints.command,
+                resultJsonString: .success(self.commandJobIdJson)
+            ),
+            .init(
+                method: .post,
+                endpoint: AIAPIEndpoints.confirmCommand,
+                resultJsonString: .success(self.confirmJobIdJson)
+            ),
+            .init(
+                method: .get,
+                endpoint: AIAPIEndpoints.job(id: "done_job"),
+                resultJsonString: .success(self.doneJobJson)
+            ),
+            .init(
+                method: .get,
+                endpoint: AIAPIEndpoints.job(id: "confirm_job"),
+                resultJsonString: .success(self.confirmJobJson)
+            ),
+            .init(
+                method: .get,
+                endpoint: AIAPIEndpoints.job(id: "failed_job"),
+                resultJsonString: .success(self.failedJobJson)
+            ),
+            .init(
+                method: .get,
+                endpoint: AIAPIEndpoints.job(id: "running_job"),
+                resultJsonString: .success(self.runningJobJson)
+            ),
+            .init(
+                method: .get,
+                endpoint: AIAPIEndpoints.usage,
+                resultJsonString: .success(self.usageJson)
+            )
+        ]
+    }
+
+    private var commandJobIdJson: String {
+        return #"{ "job_id": "new_job_id" }"#
+    }
+
+    private var confirmJobIdJson: String {
+        return #"{ "job_id": "confirm_job_id" }"#
+    }
+
+    private var doneJobJson: String {
+        return """
+        {
+            "jobId": "done_job",
+            "commandText": "내일 오후 3시",
+            "status": "DONE",
+            "mode": "command",
+            "createdAt": "2026-06-01T10:00:00.000Z",
+            "updatedAt": "2026-06-01T10:00:05.000Z",
+            "result": {
+                "type": "DONE",
+                "text": "일정 등록했어요",
+                "mutations": [
+                    { "dataType": "schedule", "op": "created" }
+                ]
+            }
+        }
+        """
+    }
+
+    private var confirmJobJson: String {
+        return """
+        {
+            "jobId": "confirm_job",
+            "status": "CONFIRM",
+            "mode": "command",
+            "result": {
+                "type": "CONFIRM",
+                "text": "정말 삭제할까요",
+                "action": {
+                    "tool": "delete_schedule",
+                    "args": { "schedule_id": "abc" },
+                    "confirmToken": "tok-confirm"
+                },
+                "mutations": []
+            }
+        }
+        """
+    }
+
+    private var failedJobJson: String {
+        return """
+        {
+            "jobId": "failed_job",
+            "status": "FAILED",
+            "mode": "command",
+            "result": {
+                "type": "FAILED",
+                "reason": "한도 소진",
+                "errorCode": "DailyLimitExceeded",
+                "mutations": []
+            }
+        }
+        """
+    }
+
+    private var runningJobJson: String {
+        return """
+        {
+            "jobId": "running_job",
+            "status": "RUNNING",
+            "mode": "command"
+        }
+        """
+    }
+
+    private var usageJson: String {
+        return """
+        {
+            "date": "2026-06-01",
+            "input_tokens": 1250,
+            "output_tokens": 320,
+            "daily_limit": 5000,
+            "updated_at": "2026-06-01T10:00:00.000Z"
+        }
+        """
+    }
+}

--- a/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
+++ b/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
@@ -276,7 +276,8 @@ extension NonLoginUsecaseFactoryImple {
     
     func makePlaceSuggestUsecase() -> any PlaceSuggestUsecase {
         return PlaceSuggestUsecaseImple(
-            suggestEngine: MapKitBasePlaceSuggestEngineImple()
+            suggestEngine: MapKitBasePlaceSuggestEngineImple(),
+            scheduler: RunLoop.main
         )
     }
     
@@ -691,7 +692,8 @@ extension LoginUsecaseFactoryImple {
     
     func makePlaceSuggestUsecase() -> any PlaceSuggestUsecase {
         return PlaceSuggestUsecaseImple(
-            suggestEngine: MapKitBasePlaceSuggestEngineImple()
+            suggestEngine: MapKitBasePlaceSuggestEngineImple(),
+            scheduler: RunLoop.main
         )
     }
     


### PR DESCRIPTION
## Summary
- `AICommandRepositoryImple` — `RemoteAPI(/v1/ai/* 4 endpoint)` + `AICommandLocalStorage` 단일 Imple. `ProcessingAICommand` 는 SQLite 에 영속 (db file 이 이미 user-scope 라 별도 user 컬럼 없이 single-row 로 관리)
- args 는 raw `Data` 로 보관해 서버 재전송 그대로 통과 (디코딩 거치지 않음). 매퍼는 `JSONSerialization` 기반 dict 매핑 채택
- 신규 테이블만 추가라 `AppEnvironment.dbVersion` bump 없이 `AppDataMigrationImple.prepareTables` 에 등록만
- `ProcessingAICommand.init` 만 internal → public 으로 노출 (Repository 매핑 진입점에서 외부 모듈 호출 필요)

## Notes
- 본 PR 의 base 는 `features/636-restore-job` 이고, 그쪽 `AICommandUsecaseImple` 가 사용하는 `AICommandRepository` 의 구체 구현을 분리해 올림
- composition root (UsecaseFactory wiring) 는 본 PR 범위 밖 — 별도 작업

## Test plan
- [x] `./scripts/run-all-tests.sh Repository` (262/262 — 신규 AI 13 케이스 포함)
- [x] Repository scheme 빌드 (iOS Simulator)
- [ ] base 브랜치 머지 후 composition root wiring 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)