### PR TITLE
[#628] 음성 → 텍스트 변환 모듈 (SpeechRecognizeUsecase)

### DIFF
--- a/Domain/Sources/Usecases/Speech/SpeechRecognizePermissionChecker.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizePermissionChecker.swift
@@ -1,0 +1,31 @@
+//
+//  SpeechRecognizePermissionChecker.swift
+//  Domain
+//
+//  Created by sudo.park on 6/7/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+
+// MARK: - SpeechRecognizeAuthStatus
+
+public enum SpeechRecognizeAuthStatus: Sendable {
+    case notDetermined
+    case denied
+    case restricted
+    case authorized
+}
+
+
+// MARK: - SpeechRecognizePermissionChecker
+
+public protocol SpeechRecognizePermissionChecker: Sendable {
+
+    // mic + speech recognition 권한을 함께 확인 (가장 보수적인 상태 반환)
+    func checkAuthorizationStatus() async -> SpeechRecognizeAuthStatus
+
+    // mic → speech 순차 요청. 둘 다 grant되어야 true
+    func requestAccess() async throws -> Bool
+}

--- a/Domain/Sources/Usecases/Speech/SpeechRecognizePermissionCheckerImple.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizePermissionCheckerImple.swift
@@ -1,0 +1,55 @@
+//
+//  SpeechRecognizePermissionCheckerImple.swift
+//  Domain
+//
+//  Created by sudo.park on 6/7/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Speech
+import AVFoundation
+
+
+public final class SpeechRecognizePermissionCheckerImple: SpeechRecognizePermissionChecker, @unchecked Sendable {
+
+    public init() {}
+
+    public func checkAuthorizationStatus() async -> SpeechRecognizeAuthStatus {
+        let speech = SFSpeechRecognizer.authorizationStatus()
+        let mic = AVAudioApplication.shared.recordPermission
+        return Self.combine(speech: speech, mic: mic)
+    }
+
+    public func requestAccess() async throws -> Bool {
+        let micGranted = await withCheckedContinuation { continuation in
+            AVAudioApplication.requestRecordPermission { granted in
+                continuation.resume(returning: granted)
+            }
+        }
+        guard micGranted else { return false }
+
+        let speechStatus = await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                continuation.resume(returning: status)
+            }
+        }
+        return speechStatus == .authorized
+    }
+
+    private static func combine(
+        speech: SFSpeechRecognizerAuthorizationStatus,
+        mic: AVAudioApplication.recordPermission
+    ) -> SpeechRecognizeAuthStatus {
+        if speech == .denied || mic == .denied {
+            return .denied
+        }
+        if speech == .restricted {
+            return .restricted
+        }
+        if speech == .authorized && mic == .granted {
+            return .authorized
+        }
+        return .notDetermined
+    }
+}

--- a/Domain/Sources/Usecases/Speech/SpeechRecognizeService.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizeService.swift
@@ -1,0 +1,37 @@
+//
+//  SpeechRecognizeService.swift
+//  Domain
+//
+//  Created by sudo.park on 6/7/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+
+// MARK: - SpeechRecognizeFragment
+
+public struct SpeechRecognizeFragment: Sendable, Equatable {
+    public let text: String
+    public let isFinal: Bool
+
+    public init(text: String, isFinal: Bool) {
+        self.text = text
+        self.isFinal = isFinal
+    }
+}
+
+
+// MARK: - SpeechRecognizeService
+
+public protocol SpeechRecognizeService: Sendable {
+
+    var recognized: AnyPublisher<SpeechRecognizeFragment, any Error> { get }
+
+    // raw 오디오 발화 감지 (voice activity)
+    var isVoiceActive: AnyPublisher<Bool, Never> { get }
+
+    func start() throws
+    func stop()
+}

--- a/Domain/Sources/Usecases/Speech/SpeechRecognizeServiceImple.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizeServiceImple.swift
@@ -1,0 +1,108 @@
+//
+//  SpeechRecognizeServiceImple.swift
+//  Domain
+//
+//  Created by sudo.park on 6/7/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Combine
+import Speech
+import AVFoundation
+
+
+public final class SpeechRecognizeServiceImple: SpeechRecognizeService, @unchecked Sendable {
+
+    private let recognizer: SFSpeechRecognizer?
+    private let audioEngine = AVAudioEngine()
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var task: SFSpeechRecognitionTask?
+
+    private let recognizedSubject = PassthroughSubject<SpeechRecognizeFragment, any Error>()
+    private let voiceActiveSubject = CurrentValueSubject<Bool, Never>(false)
+
+    // 입력 레벨이 이 dBFS 이상이면 발화 중으로 간주
+    private let voiceActivityThreshold: Float = -35.0
+
+    public init(locale: Locale = .current) {
+        self.recognizer = SFSpeechRecognizer(locale: locale)
+    }
+
+    public var recognized: AnyPublisher<SpeechRecognizeFragment, any Error> {
+        return self.recognizedSubject.eraseToAnyPublisher()
+    }
+    public var isVoiceActive: AnyPublisher<Bool, Never> {
+        return self.voiceActiveSubject.removeDuplicates().eraseToAnyPublisher()
+    }
+
+    public func start() throws {
+        guard let recognizer, recognizer.isAvailable else {
+            throw SpeechRecognizeFailReason.recognizerUnavailable
+        }
+
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
+        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        self.request = request
+
+        let inputNode = self.audioEngine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
+            self?.request?.append(buffer)
+            self?.updateVoiceActivity(buffer)
+        }
+
+        self.task = recognizer.recognitionTask(with: request) { [weak self] result, error in
+            guard let self else { return }
+            if let result {
+                let fragment = SpeechRecognizeFragment(
+                    text: result.bestTranscription.formattedString,
+                    isFinal: result.isFinal
+                )
+                self.recognizedSubject.send(fragment)
+            }
+            if let error {
+                self.recognizedSubject.send(completion: .failure(error))
+                self.teardownAudio()
+            }
+        }
+
+        self.audioEngine.prepare()
+        try self.audioEngine.start()
+    }
+
+    public func stop() {
+        self.request?.endAudio()
+        self.task?.cancel()
+        self.teardownAudio()
+    }
+
+    private func teardownAudio() {
+        if self.audioEngine.isRunning {
+            self.audioEngine.stop()
+            self.audioEngine.inputNode.removeTap(onBus: 0)
+        }
+        self.request = nil
+        self.task = nil
+        self.voiceActiveSubject.send(false)
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
+    private func updateVoiceActivity(_ buffer: AVAudioPCMBuffer) {
+        guard let channelData = buffer.floatChannelData?[0] else { return }
+        let frameLength = Int(buffer.frameLength)
+        guard frameLength > 0 else { return }
+        var sumSquares: Float = 0
+        for i in 0..<frameLength {
+            let sample = channelData[i]
+            sumSquares += sample * sample
+        }
+        let rms = sqrt(sumSquares / Float(frameLength))
+        let dbfs = 20 * log10(max(rms, .leastNonzeroMagnitude))
+        self.voiceActiveSubject.send(dbfs >= self.voiceActivityThreshold)
+    }
+}

--- a/Domain/Sources/Usecases/Speech/SpeechRecognizeUsecase.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizeUsecase.swift
@@ -29,3 +29,161 @@ public protocol SpeechRecognizeUsecase: Sendable {
     func startListening(autoStopAfterSilence: TimeInterval?)
     func stopListening()
 }
+
+
+// MARK: - SpeechRecognizeUsecaseImple
+
+public final class SpeechRecognizeUsecaseImple<Scheduler: Combine.Scheduler>: SpeechRecognizeUsecase, @unchecked Sendable {
+
+    private let service: any SpeechRecognizeService
+    private let permissionChecker: any SpeechRecognizePermissionChecker
+    private let scheduler: Scheduler
+
+    public init(
+        service: any SpeechRecognizeService,
+        permissionChecker: any SpeechRecognizePermissionChecker,
+        scheduler: Scheduler
+    ) {
+        self.service = service
+        self.permissionChecker = permissionChecker
+        self.scheduler = scheduler
+    }
+
+    private let sessionSubject = CurrentValueSubject<PassthroughSubject<String, any Error>, Never>(.init())
+    private var currentSession: PassthroughSubject<String, any Error>?
+    private var serviceBag: Set<AnyCancellable> = []
+    private var silenceTimer: AnyCancellable?
+
+    private var isListening: Bool = false
+    private var latestText: String = ""
+    private var isVoiceActive: Bool = false
+    private var autoStopAfterSilence: TimeInterval?
+    private var waitingFragmentAfterSilence: Bool = false
+}
+
+extension SpeechRecognizeUsecaseImple {
+
+    public var result: AnyPublisher<String, any Error> {
+        return self.sessionSubject
+            .setFailureType(to: (any Error).self)
+            .map { $0.eraseToAnyPublisher() }
+            .switchToLatest()
+            .eraseToAnyPublisher()
+    }
+
+    public func startListening(autoStopAfterSilence: TimeInterval?) {
+        self.teardownSession()
+        let session = PassthroughSubject<String, any Error>()
+        self.currentSession = session
+        self.sessionSubject.send(session)
+        self.latestText = ""
+        self.isVoiceActive = false
+        self.waitingFragmentAfterSilence = false
+        self.autoStopAfterSilence = autoStopAfterSilence
+        self.isListening = true
+
+        Task { [weak self] in
+            guard let self else { return }
+            let status = await self.permissionChecker.checkAuthorizationStatus()
+            guard self.isListening else { return }
+            guard status == .authorized else {
+                session.send(completion: .failure(SpeechRecognizeFailReason.notAuthorized))
+                self.isListening = false
+                return
+            }
+            self.bindService()
+            do {
+                try self.service.start()
+                self.resetSilenceTimer()
+            } catch {
+                session.send(completion: .failure(error))
+                self.isListening = false
+            }
+        }
+    }
+
+    public func stopListening() {
+        guard self.isListening else { return }
+        self.finish(with: self.latestText)
+    }
+}
+
+extension SpeechRecognizeUsecaseImple {
+
+    private func bindService() {
+        self.service.recognized
+            .sink(receiveCompletion: { [weak self] completion in
+                guard case let .failure(error) = completion else { return }
+                guard let self, self.isListening else { return }
+                self.isListening = false
+                self.currentSession?.send(completion: .failure(error))
+            }, receiveValue: { [weak self] fragment in
+                self?.handle(fragment)
+            })
+            .store(in: &self.serviceBag)
+
+        self.service.isVoiceActive
+            .sink(receiveValue: { [weak self] active in
+                guard let self else { return }
+                self.isVoiceActive = active
+                if active == false, self.waitingFragmentAfterSilence {
+                    self.resetSilenceTimer()
+                }
+            })
+            .store(in: &self.serviceBag)
+    }
+
+    private func handle(_ fragment: SpeechRecognizeFragment) {
+        guard self.isListening else { return }
+        self.latestText = fragment.text
+        if self.waitingFragmentAfterSilence {
+            self.finish(with: fragment.text)
+            return
+        }
+        if fragment.isFinal {
+            self.finish(with: fragment.text)
+            return
+        }
+        self.resetSilenceTimer()
+    }
+
+    private func resetSilenceTimer() {
+        self.silenceTimer?.cancel()
+        self.silenceTimer = nil
+        self.waitingFragmentAfterSilence = false
+        guard let autoStop = self.autoStopAfterSilence else { return }
+        self.silenceTimer = Just(())
+            .delay(for: .seconds(autoStop), scheduler: self.scheduler)
+            .sink(receiveValue: { [weak self] in self?.onSilenceTimeout() })
+    }
+
+    private func onSilenceTimeout() {
+        guard self.isListening else { return }
+        if self.isVoiceActive {
+            self.waitingFragmentAfterSilence = true
+        } else {
+            self.finish(with: self.latestText)
+        }
+    }
+
+    private func finish(with text: String) {
+        guard self.isListening else { return }
+        self.isListening = false
+        self.teardownSessionResources()
+        self.service.stop()
+        self.currentSession?.send(text)
+        self.currentSession?.send(completion: .finished)
+    }
+
+    private func teardownSession() {
+        self.isListening = false
+        self.teardownSessionResources()
+    }
+
+    private func teardownSessionResources() {
+        self.silenceTimer?.cancel()
+        self.silenceTimer = nil
+        self.waitingFragmentAfterSilence = false
+        self.serviceBag = []
+    }
+}

--- a/Domain/Sources/Usecases/Speech/SpeechRecognizeUsecase.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizeUsecase.swift
@@ -89,6 +89,7 @@ extension SpeechRecognizeUsecaseImple {
             guard status == .authorized else {
                 session.send(completion: .failure(SpeechRecognizeFailReason.notAuthorized))
                 self.isListening = false
+                self.resetSessionStream()
                 return
             }
             self.bindService()
@@ -98,6 +99,7 @@ extension SpeechRecognizeUsecaseImple {
             } catch {
                 session.send(completion: .failure(error))
                 self.isListening = false
+                self.resetSessionStream()
             }
         }
     }
@@ -117,6 +119,7 @@ extension SpeechRecognizeUsecaseImple {
                 guard let self, self.isListening else { return }
                 self.isListening = false
                 self.currentSession?.send(completion: .failure(error))
+                self.resetSessionStream()
             }, receiveValue: { [weak self] fragment in
                 self?.handle(fragment)
             })
@@ -178,6 +181,13 @@ extension SpeechRecognizeUsecaseImple {
     private func teardownSession() {
         self.isListening = false
         self.teardownSessionResources()
+    }
+
+    // 에러로 끝난 세션은 Combine 상 terminal이라, sessionSubject의 현재값을
+    // fresh placeholder로 교체해 다음 구독자가 옛 실패를 재생받지 않게 한다.
+    private func resetSessionStream() {
+        self.currentSession = nil
+        self.sessionSubject.send(.init())
     }
 
     private func teardownSessionResources() {

--- a/Domain/Sources/Usecases/Speech/SpeechRecognizeUsecase.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizeUsecase.swift
@@ -1,0 +1,31 @@
+//
+//  SpeechRecognizeUsecase.swift
+//  Domain
+//
+//  Created by sudo.park on 6/7/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+
+// MARK: - SpeechRecognizeFailReason
+
+public enum SpeechRecognizeFailReason: Error, Sendable, Equatable {
+    case notAuthorized
+    case recognizerUnavailable
+    case recognitionFailed
+}
+
+
+// MARK: - SpeechRecognizeUsecase
+
+public protocol SpeechRecognizeUsecase: Sendable {
+
+    // 세션당 최종 텍스트 1회 방출. 에러 종료 후엔 다음 startListening이 fresh 스트림으로 교체
+    var result: AnyPublisher<String, any Error> { get }
+
+    func startListening(autoStopAfterSilence: TimeInterval?)
+    func stopListening()
+}

--- a/Domain/Tests/Usecases/Speech/SpeechRecognizeUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/Speech/SpeechRecognizeUsecaseImpleTests.swift
@@ -58,6 +58,145 @@ extension SpeechRecognizeUsecaseImpleTests {
         #expect(texts == ["안녕하세요"])
         #expect(service.didStop == true)
     }
+
+    // 권한 denied → notAuthorized 에러 방출, service.start 미호출
+    @Test func usecase_whenNotAuthorized_emitNotAuthorizedError() async throws {
+        // given
+        let expect = expectConfirm("권한 거부 시 notAuthorized 에러")
+        let (usecase, service) = self.makeUsecase(authStatus: .denied)
+
+        // when
+        let error = try await self.failure(expect, for: usecase.result) {
+            usecase.startListening(autoStopAfterSilence: nil)
+            try await Task.sleep(for: .milliseconds(30))
+        }
+
+        // then
+        #expect(error as? SpeechRecognizeFailReason == .notAuthorized)
+        #expect(service.didStart == false)
+    }
+
+    // service.start가 throw → 해당 에러 전파
+    @Test func usecase_whenServiceStartThrows_propagateError() async throws {
+        // given
+        let expect = expectConfirm("service.start 실패 시 에러 전파")
+        let (usecase, _) = self.makeUsecase(startError: RuntimeError("start failed"))
+
+        // when
+        let error = try await self.failure(expect, for: usecase.result) {
+            usecase.startListening(autoStopAfterSilence: nil)
+            try await Task.sleep(for: .milliseconds(30))
+        }
+
+        // then
+        #expect(error is RuntimeError)
+    }
+
+    // service가 isFinal=true fragment 방출 → 자동 종료 + 해당 text
+    @Test func usecase_whenServiceEmitsFinalFragment_finishWithThatText() async throws {
+        // given
+        let expect = expectConfirm("isFinal fragment 시 자동 종료")
+        let (usecase, service) = self.makeUsecase()
+
+        // when
+        let texts = try await self.outputs(expect, for: usecase.result) {
+            usecase.startListening(autoStopAfterSilence: nil)
+            try await Task.sleep(for: .milliseconds(20))
+            service.emit(.init(text: "최종 텍스트", isFinal: true))
+        }
+
+        // then
+        #expect(texts == ["최종 텍스트"])
+        #expect(service.didStop == true)
+    }
+
+    // fragment 한 번도 안 온 채 stop → 빈 문자열
+    @Test func usecase_whenStopWithoutFragment_emitEmptyString() async throws {
+        // given
+        let expect = expectConfirm("입력 없이 stop 시 빈 문자열")
+        let (usecase, _) = self.makeUsecase()
+
+        // when
+        let texts = try await self.outputs(expect, for: usecase.result) {
+            usecase.startListening(autoStopAfterSilence: nil)
+            try await Task.sleep(for: .milliseconds(20))
+            usecase.stopListening()
+        }
+
+        // then
+        #expect(texts == [""])
+    }
+
+    // autoStop 경과 + voice inactive → 마지막 text로 즉시 종료
+    @Test func usecase_whenSilenceTimeoutAndVoiceInactive_finishWithLatestText() async throws {
+        // given
+        let expect = expectConfirm("침묵 타임아웃 + 소리 없음 → 즉시 종료")
+        let (usecase, service) = self.makeUsecase()
+        service.setVoiceActive(false)
+
+        // when
+        let texts = try await self.outputs(expect, for: usecase.result) {
+            usecase.startListening(autoStopAfterSilence: 0.05)
+            try await Task.sleep(for: .milliseconds(20))
+            service.emit(.init(text: "타임아웃 텍스트", isFinal: false))
+            try await Task.sleep(for: .milliseconds(120))   // 50ms 침묵 경과
+        }
+
+        // then
+        #expect(texts == ["타임아웃 텍스트"])
+        #expect(service.didStop == true)
+    }
+
+    // autoStop 경과 + voice active → 즉시 종료 안 함, 이후 fragment로 종료
+    @Test func usecase_whenSilenceTimeoutButVoiceActive_waitNextFragment() async throws {
+        // given
+        let expect = expectConfirm("침묵 타임아웃이지만 발화 중 → 다음 fragment로 종료")
+        let (usecase, service) = self.makeUsecase()
+        service.setVoiceActive(true)   // 아직 발화 중
+
+        // when
+        let texts = try await self.outputs(expect, for: usecase.result) {
+            usecase.startListening(autoStopAfterSilence: 0.05)
+            try await Task.sleep(for: .milliseconds(20))
+            service.emit(.init(text: "중간", isFinal: false))
+            try await Task.sleep(for: .milliseconds(120))   // 타임아웃 떴지만 voiceActive라 대기
+            service.emit(.init(text: "중간 그리고 끝", isFinal: false))   // 이게 종료 신호
+            try await Task.sleep(for: .milliseconds(20))
+        }
+
+        // then
+        #expect(texts == ["중간 그리고 끝"])
+        #expect(service.didStop == true)
+    }
+
+    // 에러 종료된 세션 후 재 startListening → fresh result 스트림으로 정상 동작
+    @Test func usecase_afterErrorSession_restartWorksWithFreshStream() async throws {
+        // given
+        let (usecase, service) = self.makeUsecase()
+
+        // when: 1st 세션 — start 에러로 종료
+        let errExpect = expectConfirm("1차 세션 에러")
+        let error = try await self.failure(errExpect, for: usecase.result) {
+            service.startError = RuntimeError("first fail")
+            usecase.startListening(autoStopAfterSilence: nil)
+            try await Task.sleep(for: .milliseconds(30))
+        }
+        #expect(error is RuntimeError)
+
+        // when: 2nd 세션 — 정상 동작
+        service.startError = nil
+        let okExpect = expectConfirm("2차 세션 정상 텍스트")
+        let texts = try await self.outputs(okExpect, for: usecase.result) {
+            usecase.startListening(autoStopAfterSilence: nil)
+            try await Task.sleep(for: .milliseconds(20))
+            service.emit(.init(text: "재시작 텍스트", isFinal: false))
+            try await Task.sleep(for: .milliseconds(20))
+            usecase.stopListening()
+        }
+
+        // then
+        #expect(texts == ["재시작 텍스트"])
+    }
 }
 
 

--- a/Domain/Tests/Usecases/Speech/SpeechRecognizeUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/Speech/SpeechRecognizeUsecaseImpleTests.swift
@@ -1,0 +1,112 @@
+//
+//  SpeechRecognizeUsecaseImpleTests.swift
+//  Domain
+//
+//  Created by sudo.park on 6/7/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Combine
+import UnitTestHelpKit
+import Extensions
+
+@testable import Domain
+
+
+class SpeechRecognizeUsecaseImpleTests: PublisherWaitable {
+
+    var cancelBag: Set<AnyCancellable>! = []
+
+    private func makeUsecase(
+        authStatus: SpeechRecognizeAuthStatus = .authorized,
+        startError: (any Error)? = nil
+    ) -> (SpeechRecognizeUsecaseImple<DispatchQueue>, StubSpeechRecognizeService) {
+        let service = StubSpeechRecognizeService()
+        service.startError = startError
+        let permission = StubSpeechRecognizePermissionChecker()
+        permission.status = authStatus
+        let usecase = SpeechRecognizeUsecaseImple(
+            service: service,
+            permissionChecker: permission,
+            scheduler: DispatchQueue.main
+        )
+        return (usecase, service)
+    }
+}
+
+extension SpeechRecognizeUsecaseImpleTests {
+
+    // 권한 OK + 명시적 stop → 마지막 fragment text 방출
+    @Test func usecase_whenStopListening_emitLatestRecognizedText() async throws {
+        // given
+        let expect = expectConfirm("stop 시 마지막 인식 텍스트 방출")
+        let (usecase, service) = self.makeUsecase()
+
+        // when
+        let texts = try await self.outputs(expect, for: usecase.result) {
+            usecase.startListening(autoStopAfterSilence: nil)
+            try await Task.sleep(for: .milliseconds(20))
+            service.emit(.init(text: "안녕", isFinal: false))
+            service.emit(.init(text: "안녕하세요", isFinal: false))
+            try await Task.sleep(for: .milliseconds(20))
+            usecase.stopListening()
+        }
+
+        // then
+        #expect(texts == ["안녕하세요"])
+        #expect(service.didStop == true)
+    }
+}
+
+
+// MARK: - Stubs
+
+private final class StubSpeechRecognizeService: SpeechRecognizeService, @unchecked Sendable {
+
+    private let recognizedSubject = PassthroughSubject<SpeechRecognizeFragment, any Error>()
+    private let voiceActiveSubject = CurrentValueSubject<Bool, Never>(false)
+
+    var startError: (any Error)?
+    private(set) var didStart: Bool = false
+    private(set) var didStop: Bool = false
+
+    var recognized: AnyPublisher<SpeechRecognizeFragment, any Error> {
+        return self.recognizedSubject.eraseToAnyPublisher()
+    }
+    var isVoiceActive: AnyPublisher<Bool, Never> {
+        return self.voiceActiveSubject.eraseToAnyPublisher()
+    }
+    func start() throws {
+        if let startError { throw startError }
+        self.didStart = true
+    }
+    func stop() {
+        self.didStop = true
+    }
+
+    // test control
+    func emit(_ fragment: SpeechRecognizeFragment) {
+        self.recognizedSubject.send(fragment)
+    }
+    func emitError(_ error: any Error) {
+        self.recognizedSubject.send(completion: .failure(error))
+    }
+    func setVoiceActive(_ active: Bool) {
+        self.voiceActiveSubject.send(active)
+    }
+}
+
+private final class StubSpeechRecognizePermissionChecker: SpeechRecognizePermissionChecker, @unchecked Sendable {
+
+    var status: SpeechRecognizeAuthStatus = .authorized
+    var grantAccess: Bool = true
+
+    func checkAuthorizationStatus() async -> SpeechRecognizeAuthStatus {
+        return self.status
+    }
+    func requestAccess() async throws -> Bool {
+        return self.grantAccess
+    }
+}


### PR DESCRIPTION
## 배경

#629(앱에서 음성 입력 → AICommand 생성 플로우)의 **입력원**으로 쓸, 유저 음성을 받아 최종 인식 텍스트(`String`)를 방출하는 Domain 모듈. 이 PR은 순수 모듈만 다루고 DI 조립·UI·AICommand 연결은 #629로 분리.

## 접근

2-layer seam 구조. 테스트 대상 로직(`SpeechRecognizeUsecase`)이 플랫폼 seam(`SpeechRecognizeService`, `SpeechRecognizePermissionChecker`) 위에 올라간다. system-capability 서비스이므로 concrete 구현도 Domain에 둠 (`LocalNotificationServiceImple` 선례).

- **`SpeechRecognizeUsecase`** — 세션당 최종 텍스트 1회 방출. 권한 게이팅 → `service.start` → recognized fragment 구독으로 최신 text 보관.
  - `startListening(autoStopAfterSilence:)` — on/off 명시 종료 + 침묵 자동종료 옵션 둘 다 지원.
  - **autoStop voice-activity 분기**: 침묵 타임아웃 시 현재 발화 상태로 분기. inactive면 즉시 종료, active(인식 lag)면 대기 후 다음 fragment를 종료 신호로 판단.
  - **세션 재사용 수명**: Combine `failure`는 terminal이라, 에러로 끝난 세션이 `sessionSubject` 현재값으로 남아 재구독 시 옛 실패를 재생하는 문제 → `resetSessionStream`으로 fresh placeholder 교체. `result`는 세션별 subject를 `switchToLatest`로 노출.
- **`SpeechRecognizeServiceImple`** — SFSpeechRecognizer + AVAudioEngine. recognitionTask partial 결과를 fragment로, audio tap RMS dBFS(-35) 임계로 voice activity 판정.
- **`SpeechRecognizePermissionCheckerImple`** — mic(AVAudioApplication) + speech(SFSpeechRecognizer) 권한 통합. mic→speech 순차 요청, 둘 다 grant 시에만 true.

## 테스트

`SpeechRecognizeUsecaseImpleTests` 8 케이스 (Swift Testing) — 기본 stop 방출 / 권한거부 / start실패 전파 / isFinal 자동종료 / 빈입력 / 침묵+무음 즉시종료 / 침묵+발화중 대기 / 에러 후 재시작 fresh 스트림. 전부 stub service·permission으로 검증. concrete 2개는 실기기 의존이라 빌드 보증까지만 — 실 동작 검증은 #629 통합 시.

## 남은 과제 (#629)

- `ApplicationBase`/`UsecaseFactory`에 조립, AICommand 플로우 연결(`result` → `AICommandUsecase.processCommand`)
- 음성 입력 UI (권한 분기)
- Tuist 앱 타깃 Info.plist에 `NSMicrophoneUsageDescription`·`NSSpeechRecognitionUsageDescription` 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)