### PR TITLE
[#628] 음성 → 텍스트 변환 모듈 (SpeechRecognizeUsecase)

### DIFF
--- a/Domain/Sources/Usecases/Speech/SpeechRecognizePermissionChecker.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizePermissionChecker.swift
@@ -1,0 +1,33 @@
+//
+//  SpeechRecognizePermissionChecker.swift
+//  Domain
+//
+//  Created by sudo.park on 6/7/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+
+// MARK: - SpeechRecognizeAuthStatus
+
+public struct SpeechRecognizeAuthError: Error {
+    public enum Reason: Sendable {
+        case restricted
+        case denied
+    }
+    public let micNotAvail: Reason?
+    public let speechNotAvail: Reason?
+    public init(micNotAvail: Reason? = nil, speechNotAvail: Reason? = nil) {
+        self.micNotAvail = micNotAvail
+        self.speechNotAvail = speechNotAvail
+    }
+}
+
+
+// MARK: - SpeechRecognizePermissionChecker
+
+public protocol SpeechRecognizePermissionChecker: Sendable {
+
+    func requestAccess() async throws
+}

--- a/Domain/Sources/Usecases/Speech/SpeechRecognizePermissionCheckerImple.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizePermissionCheckerImple.swift
@@ -1,0 +1,76 @@
+//
+//  SpeechRecognizePermissionCheckerImple.swift
+//  Domain
+//
+//  Created by sudo.park on 6/7/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Speech
+import AVFoundation
+
+
+public final class SpeechRecognizePermissionCheckerImple: SpeechRecognizePermissionChecker, @unchecked Sendable {
+
+    public init() {}
+
+    public func requestAccess() async throws {
+        let mic = await self.requestMicAccessIfNeed()
+        let speech = await self.requestSpeechAccessIfNeed()
+        
+        switch (mic, speech) {
+        case (.grant, .grant):
+            return
+        case (_, .restricted):
+            throw SpeechRecognizeAuthError(speechNotAvail: .restricted)
+        default:
+            throw SpeechRecognizeAuthError(
+                micNotAvail: mic == .denied ? .denied : nil,
+                speechNotAvail: speech == .denied ? .denied : nil
+            )
+        }
+    }
+    
+    private enum AuthorizationStatus {
+        case restricted
+        case grant
+        case denied
+    }
+    
+    private func requestMicAccessIfNeed() async -> AuthorizationStatus {
+        
+        let mic = AVAudioApplication.shared.recordPermission
+        switch mic {
+        case .denied: return .denied
+        case .granted: return .grant
+        case .undetermined:
+            let isGrant = await withCheckedContinuation { continuation in
+                AVAudioApplication.requestRecordPermission { granted in
+                    continuation.resume(returning: granted)
+                }
+            }
+            return isGrant ? .grant : .denied
+        @unknown default:
+            return .denied
+        }
+    }
+    
+    private func requestSpeechAccessIfNeed() async -> AuthorizationStatus {
+        let speech = SFSpeechRecognizer.authorizationStatus()
+        switch speech {
+        case .restricted: return .restricted
+        case .denied: return .denied
+        case .authorized: return .grant
+        case .notDetermined:
+            let status  = await withCheckedContinuation { continuation in
+                SFSpeechRecognizer.requestAuthorization { status in
+                    continuation.resume(returning: status)
+                }
+            }
+            return status == .authorized ? .grant : .denied
+        @unknown default:
+            return .denied
+        }
+    }
+}

--- a/Domain/Sources/Usecases/Speech/SpeechRecognizeService.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizeService.swift
@@ -1,0 +1,37 @@
+//
+//  SpeechRecognizeService.swift
+//  Domain
+//
+//  Created by sudo.park on 6/7/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+
+// MARK: - SpeechRecognizeFragment
+
+public struct SpeechRecognizeFragment: Sendable, Equatable {
+    public let text: String
+    public let isFinal: Bool
+
+    public init(text: String, isFinal: Bool) {
+        self.text = text
+        self.isFinal = isFinal
+    }
+}
+
+
+// MARK: - SpeechRecognizeService
+
+public protocol SpeechRecognizeService: Sendable {
+    
+    func start() throws
+    func stop()
+
+    var recognized: AnyPublisher<SpeechRecognizeFragment, any Error> { get }
+
+    // raw 오디오 입력 세기 (0...1 정규화 레벨)
+    var voiceLevel: AnyPublisher<Float, Never> { get }
+}

--- a/Domain/Sources/Usecases/Speech/SpeechRecognizeServiceImple.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizeServiceImple.swift
@@ -1,0 +1,158 @@
+//
+//  SpeechRecognizeServiceImple.swift
+//  Domain
+//
+//  Created by sudo.park on 6/7/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Combine
+import Speech
+import AVFoundation
+import Extensions
+
+
+public final class SpeechRecognizeServiceImple: SpeechRecognizeService, @unchecked Sendable {
+
+    private let recognizer: SFSpeechRecognizer?
+    private let audioEngine = AVAudioEngine()
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var task: SFSpeechRecognitionTask?
+
+    private struct Subject {
+        let recognizedResult = PassthroughSubject<
+            Result<SpeechRecognizeFragment, any Error>, Never
+        >()
+        let voiceLevel = CurrentValueSubject<Float, Never>(0)
+    }
+    private let subject = Subject()
+
+    // 이 dBFS 이하를 0(무음)으로, 0dBFS를 1로 매핑하는 노이즈 플로어
+    private let noiseFloor: Float = -50.0
+
+    public init(locale: Locale = .current) {
+        self.recognizer = SFSpeechRecognizer(locale: locale)
+    }
+}
+
+
+extension SpeechRecognizeServiceImple {
+    
+    public func start() throws {
+        do {
+            guard let recognizer, recognizer.isAvailable else {
+                throw RuntimeError(key: "recognizerUnavailable", "speech recognizer unavailable")
+            }
+            try self.configureAudioSession()
+            let request = self.makeRequest()
+            self.installInputTap()
+            self.task = self.makeRecognitionTask(recognizer: recognizer, request: request)
+            try self.startEngine()
+        } catch {
+            // start 도중 실패하면 설치된 tap/세션을 되돌려 완전 초기 상태로 리셋 후 전파
+            self.teardownAudio()
+            throw error
+        }
+    }
+
+    private func configureAudioSession() throws {
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
+        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+    }
+
+    private func makeRequest() -> SFSpeechAudioBufferRecognitionRequest {
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        self.request = request
+        return request
+    }
+
+    private func installInputTap() {
+        let inputNode = self.audioEngine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
+            self?.request?.append(buffer)
+            self?.updateVoiceLevel(buffer)
+        }
+    }
+
+    private func makeRecognitionTask(
+        recognizer: SFSpeechRecognizer,
+        request: SFSpeechAudioBufferRecognitionRequest
+    ) -> SFSpeechRecognitionTask {
+        return recognizer.recognitionTask(with: request) { [weak self] result, error in
+            self?.handleRecognition(result: result, error: error)
+        }
+    }
+
+    private func handleRecognition(result: SFSpeechRecognitionResult?, error: (any Error)?) {
+        if let result {
+            let fragment = SpeechRecognizeFragment(
+                text: result.bestTranscription.formattedString,
+                isFinal: result.isFinal
+            )
+            self.subject.recognizedResult.send(.success(fragment))
+        }
+        if let error {
+            self.subject.recognizedResult.send(.failure(error))
+            self.teardownAudio()
+        }
+    }
+
+    private func startEngine() throws {
+        self.audioEngine.prepare()
+        try self.audioEngine.start()
+    }
+
+    public func stop() {
+        self.request?.endAudio()
+        self.teardownAudio()
+    }
+
+    // 무조건 호출해도 안전(idempotent): stop/cancel/removeTap 모두 미동작·미설치 상태에서 호출해도 무해.
+    // start 실패 cleanup, 중복 stop, 에러 분기 self-teardown 모두 이 한 경로로 처리.
+    private func teardownAudio() {
+        self.task?.cancel()
+        self.audioEngine.stop()
+        self.audioEngine.inputNode.removeTap(onBus: 0)
+        self.request = nil
+        self.task = nil
+        self.subject.voiceLevel.send(0)
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
+    private func updateVoiceLevel(_ buffer: AVAudioPCMBuffer) {
+        guard let channelData = buffer.floatChannelData?[0] else { return }
+        let frameLength = Int(buffer.frameLength)
+        guard frameLength > 0 else { return }
+        var sumSquares: Float = 0
+        for i in 0..<frameLength {
+            let sample = channelData[i]
+            sumSquares += sample * sample
+        }
+        let rms = sqrt(sumSquares / Float(frameLength))
+        let dbfs = 20 * log10(max(rms, .leastNonzeroMagnitude))
+        let level = max(0, min(1, (dbfs - self.noiseFloor) / -self.noiseFloor))
+        self.subject.voiceLevel.send(level)
+    }
+}
+
+extension SpeechRecognizeServiceImple {
+
+    public var recognized: AnyPublisher<SpeechRecognizeFragment, any Error> {
+        return self.subject.recognizedResult
+            .setFailureType(to: (any Error).self)
+            .tryMap { result in
+                switch result {
+                case .success(let fragment): return fragment
+                case .failure(let error): throw error
+                }
+            }
+            .eraseToAnyPublisher()
+    }
+    public var voiceLevel: AnyPublisher<Float, Never> {
+        return self.subject.voiceLevel.eraseToAnyPublisher()
+    }
+}

--- a/Domain/Sources/Usecases/Speech/SpeechRecognizeUsecase.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizeUsecase.swift
@@ -1,0 +1,168 @@
+//
+//  SpeechRecognizeUsecase.swift
+//  Domain
+//
+//  Created by sudo.park on 6/7/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+
+// MARK: - SpeechRecognizeUsecase
+
+public protocol SpeechRecognizeUsecase: Sendable {
+
+    func startListening()
+    func stopListening()
+ 
+    var recognizeResult: AnyPublisher<Result<String, any Error>, Never> { get }
+    var isRecognizingWithLevel: AnyPublisher<Float?, Never> { get }
+}
+
+
+// MARK: - SpeechRecognizeUsecaseImple
+
+public final class SpeechRecognizeUsecaseImple: SpeechRecognizeUsecase, @unchecked Sendable {
+
+    private let service: any SpeechRecognizeService
+    private let permissionChecker: any SpeechRecognizePermissionChecker
+    private let autoStopAfterSilence: TimeInterval
+
+    public init(
+        service: any SpeechRecognizeService,
+        permissionChecker: any SpeechRecognizePermissionChecker,
+        autoStopAfterSilence: TimeInterval = 3
+    ) {
+        self.service = service
+        self.permissionChecker = permissionChecker
+        self.autoStopAfterSilence = autoStopAfterSilence
+    }
+
+    private struct Subject {
+        let isRecognizing = CurrentValueSubject<Bool, Never>(false)
+        let result = PassthroughSubject<Result<String, any Error>, Never>()
+    }
+    private let subject = Subject()
+    private var serviceBinding: AnyCancellable?
+}
+
+extension SpeechRecognizeUsecaseImple {
+    
+    public func startListening() {
+       
+        guard !self.subject.isRecognizing.value else { return }
+        
+        Task {
+            do {
+                try await self.permissionChecker.requestAccess()
+                self.bindService()
+                try self.service.start()
+                self.subject.isRecognizing.send(true)
+                
+            } catch {
+                self.serviceBinding?.cancel()
+                self.subject.isRecognizing.send(false)
+                self.subject.result.send(.failure(error))
+            }
+        }
+    }
+    
+    public func stopListening() {
+        self.service.stop()
+        self.serviceBinding?.cancel()
+        self.subject.isRecognizing.send(false)
+    }
+    
+    private func bindService() {
+        
+        let selectText: (SpeechRecognizeFragment?, Void?) -> RecognizeResult? = { fragment, timeout in
+            
+            switch (fragment, timeout) {
+            case (.some(let frg), _) where frg.isFinal: return .recognized(frg.text)
+            case (.some(let frg), .some): return .recognized(frg.text)
+            case (.none, .some): return .timeout
+            default: return nil
+            }
+        }
+        
+        self.serviceBinding?.cancel()
+        self.serviceBinding = Publishers.CombineLatest(
+            self.service.recognized.mapAsOptional().prepend(nil),
+            self.silenceTimeout.mapAsAnyError().mapAsOptional().prepend(nil)
+        )
+        .compactMap(selectText)
+        .first()
+        .sink(
+            receiveCompletion: self.handleCompletion(),
+            receiveValue: self.handleRecognized()
+        )
+    }
+    
+    private enum RecognizeResult {
+        case recognized(String)
+        case timeout
+    }
+    
+    private func handleCompletion() -> (Subscribers.Completion<any Error>) -> Void  {
+        return  { [weak self] completion in
+            guard let self, case .failure(let error) = completion
+            else { return }
+            
+            self.stopListening()
+            self.subject.result.send(.failure(error))
+        }
+    }
+    
+    private func handleRecognized() -> (RecognizeResult) -> Void {
+        return { [weak self] result in
+            self?.stopListening()
+            guard case .recognized(let text) = result else { return }
+            self?.subject.result.send(.success(text))
+        }
+    }
+    
+    private var silenceTimeout: AnyPublisher<Void, Never> {
+        let interval = Int(self.autoStopAfterSilence * 1000)
+        return self.service.voiceLevel
+            .map { $0 == 0 }
+            .removeDuplicates()
+            .map { isSilence in
+                guard isSilence
+                else { return Empty<Void, Never>().eraseToAnyPublisher() }
+                
+                return  Just(()).delay(
+                    for: .milliseconds(interval),
+                    scheduler: DispatchQueue.main
+                )
+                .eraseToAnyPublisher()
+            }
+            .switchToLatest()
+            .eraseToAnyPublisher()
+    }
+}
+
+extension SpeechRecognizeUsecaseImple {
+    
+    public var recognizeResult: AnyPublisher<Result<String, any Error>, Never> {
+        return self.subject.result
+            .eraseToAnyPublisher()
+    }
+    
+    public var isRecognizingWithLevel: AnyPublisher<Float?, Never> {
+        let service = self.service
+        return self.subject.isRecognizing
+            .map { flag in
+                guard flag
+                else {
+                    return Just<Float?>(nil).eraseToAnyPublisher()
+                }
+                return service.voiceLevel
+                    .mapAsOptional()
+                    .eraseToAnyPublisher()
+            }
+            .switchToLatest()
+            .eraseToAnyPublisher()
+    }
+}

--- a/Domain/Tests/Usecases/Speech/SpeechRecognizeUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/Speech/SpeechRecognizeUsecaseImpleTests.swift
@@ -1,0 +1,319 @@
+//
+//  SpeechRecognizeUsecaseImpleTests.swift
+//  Domain
+//
+//  Created by sudo.park on 6/7/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Combine
+import UnitTestHelpKit
+import Extensions
+
+@testable import Domain
+
+
+class SpeechRecognizeUsecaseImpleTests: PublisherWaitable {
+
+    var cancelBag: Set<AnyCancellable>! = []
+
+    private func makeUsecase(
+        autoStopAfterSilence: TimeInterval = 3,
+        accessError: (any Error)? = nil,
+        startError: (any Error)? = nil
+    ) -> (SpeechRecognizeUsecaseImple, StubSpeechRecognizeService) {
+        let service = StubSpeechRecognizeService()
+        service.startError = startError
+        let permission = StubSpeechRecognizePermissionChecker()
+        permission.accessError = accessError
+        let usecase = SpeechRecognizeUsecaseImple(
+            service: service,
+            permissionChecker: permission,
+            autoStopAfterSilence: autoStopAfterSilence
+        )
+        return (usecase, service)
+    }
+
+    private func captureResult(
+        for usecase: SpeechRecognizeUsecaseImple,
+        timeout: Duration = .milliseconds(150),
+        _ action: () async throws -> Void
+    ) async throws -> Result<String, any Error>? {
+        let box = ResultBox()
+        usecase.recognizeResult
+            .sink { box.value = $0 }
+            .store(in: &self.cancelBag)
+        try await action()
+        try await Task.sleep(for: timeout)
+        return box.value
+    }
+}
+
+
+// MARK: - 음성 인식 결과
+
+extension SpeechRecognizeUsecaseImpleTests {
+
+    @Test func usecase_whenUserFinishesSpeaking_emitsRecognizedText() async throws {
+        // given
+        let (usecase, service) = self.makeUsecase()
+
+        // when
+        let captured = try await self.captureResult(for: usecase) {
+            usecase.startListening()
+            try await Task.sleep(for: .milliseconds(50))
+            service.emit(.init(text: "안녕하세요", isFinal: true))
+        }
+
+        // then
+        let result = try #require(captured)
+        guard case .success(let text) = result else {
+            Issue.record("성공 결과가 아님")
+            return
+        }
+        #expect(text == "안녕하세요")
+    }
+
+    @Test func usecase_whenUserKeepsSpeaking_emitsFinalText() async throws {
+        // given
+        let (usecase, service) = self.makeUsecase()
+
+        // when
+        let captured = try await self.captureResult(for: usecase) {
+            usecase.startListening()
+            try await Task.sleep(for: .milliseconds(50))
+            service.emit(.init(text: "오늘", isFinal: false))
+            service.emit(.init(text: "오늘 일정", isFinal: false))
+            service.emit(.init(text: "오늘 일정 추가", isFinal: false))
+            service.emit(.init(text: "오늘 일정 추가해줘", isFinal: true))
+        }
+
+        // then
+        let result = try #require(captured)
+        guard case .success(let text) = result else {
+            Issue.record("성공 결과가 아님")
+            return
+        }
+        #expect(text == "오늘 일정 추가해줘")
+    }
+
+    @Test func usecase_whenUserPausesAfterSpeaking_emitsRecognizedTextSoFar() async throws {
+        // given
+        let (usecase, service) = self.makeUsecase(autoStopAfterSilence: 0.1)
+
+        // when
+        let captured = try await self.captureResult(for: usecase) {
+            usecase.startListening()
+            try await Task.sleep(for: .milliseconds(50))
+            service.emit(.init(text: "오늘 일정", isFinal: false))
+            try await Task.sleep(for: .milliseconds(200))
+        }
+
+        // then
+        let result = try #require(captured)
+        guard case .success(let text) = result else {
+            Issue.record("성공 결과가 아님")
+            return
+        }
+        #expect(text == "오늘 일정")
+    }
+
+    @Test func usecase_whenPermissionDenied_emitsFailure() async throws {
+        // given
+        let (usecase, _) = self.makeUsecase(
+            accessError: SpeechRecognizeAuthError(micNotAvail: .denied)
+        )
+
+        // when
+        let captured = try await self.captureResult(for: usecase) {
+            usecase.startListening()
+            try await Task.sleep(for: .milliseconds(80))
+        }
+
+        // then
+        let result = try #require(captured)
+        guard case .failure(let error) = result else {
+            Issue.record("실패 결과가 아님")
+            return
+        }
+        let authError = try #require(error as? SpeechRecognizeAuthError)
+        guard case .denied? = authError.micNotAvail else {
+            Issue.record("micNotAvail이 denied가 아님")
+            return
+        }
+        #expect(authError.speechNotAvail == nil)
+    }
+
+    @Test func usecase_whenListeningCannotStart_emitsFailure() async throws {
+        // given
+        let startError = RuntimeError(key: "engineStartFail", "audio engine could not start")
+        let (usecase, _) = self.makeUsecase(startError: startError)
+
+        // when
+        let captured = try await self.captureResult(for: usecase) {
+            usecase.startListening()
+            try await Task.sleep(for: .milliseconds(80))
+        }
+
+        // then
+        let result = try #require(captured)
+        guard case .failure(let error) = result else {
+            Issue.record("실패 결과가 아님")
+            return
+        }
+        let runtimeError = try #require(error as? RuntimeError)
+        #expect(runtimeError.key == "engineStartFail")
+        #expect(runtimeError.message == "audio engine could not start")
+    }
+
+    @Test func usecase_whenRecognitionFails_emitsFailure() async throws {
+        // given
+        let (usecase, service) = self.makeUsecase()
+
+        // when
+        let captured = try await self.captureResult(for: usecase) {
+            usecase.startListening()
+            try await Task.sleep(for: .milliseconds(50))
+            service.emitError(RuntimeError("recognition interrupted"))
+        }
+
+        // then
+        let result = try #require(captured)
+        guard case .failure = result else {
+            Issue.record("실패 결과가 아님")
+            return
+        }
+    }
+}
+
+
+// MARK: - 듣기 상태와 입력 레벨
+
+extension SpeechRecognizeUsecaseImpleTests {
+
+    @Test func usecase_whenNotListening_hasNoInputLevel() async throws {
+        // given
+        let (usecase, _) = self.makeUsecase()
+
+        // when
+        let value = try await self.firstOutput(
+            expectConfirm("듣고 있지 않을 때"), for: usecase.isRecognizingWithLevel
+        )
+
+        // then
+        guard case .some(let level) = value else {
+            Issue.record("방출이 없었음")
+            return
+        }
+        #expect(level == nil)
+    }
+
+    @Test func usecase_whileListening_providesInputLevels() async throws {
+        // given
+        let expect = expectConfirm("듣는 동안 입력 레벨")
+        expect.count = 5
+        let (usecase, service) = self.makeUsecase()
+
+        // when
+        let levels = try await self.outputs(expect, for: usecase.isRecognizingWithLevel) {
+            usecase.startListening()
+            try await Task.sleep(for: .milliseconds(60))
+            service.sendLevel(0.3)
+            service.sendLevel(0.6)
+            service.sendLevel(0.9)
+            try await Task.sleep(for: .milliseconds(40))
+        }
+
+        // then
+        #expect(levels == [nil, 0.0, 0.3, 0.6, 0.9])
+    }
+
+    @Test func usecase_whenSilentWithoutSpeech_stopsListening() async throws {
+        // given
+        let expect = expectConfirm("발화 없이 침묵이 지속될 때")
+        expect.count = 3
+        let (usecase, _) = self.makeUsecase(autoStopAfterSilence: 0.1)
+
+        // when
+        let levels = try await self.outputs(expect, for: usecase.isRecognizingWithLevel) {
+            usecase.startListening()
+            try await Task.sleep(for: .milliseconds(250))
+        }
+
+        // then
+        #expect(levels.last == .some(nil))
+    }
+}
+
+
+// MARK: - 중복 시작 방지
+
+extension SpeechRecognizeUsecaseImpleTests {
+
+    @Test func usecase_whenAlreadyListening_ignoresStart() async throws {
+        // given
+        let expect = expectConfirm("이미 듣는 중에 다시 시작")
+        expect.count = 3
+        let (usecase, service) = self.makeUsecase()
+
+        // when
+        let levels = try await self.outputs(expect, for: usecase.isRecognizingWithLevel) {
+            usecase.startListening()
+            try await Task.sleep(for: .milliseconds(60))
+            service.sendLevel(0.5)
+            try await Task.sleep(for: .milliseconds(30))
+            usecase.startListening()
+            try await Task.sleep(for: .milliseconds(40))
+        }
+
+        // then
+        #expect(levels == [nil, 0.0, 0.5])
+    }
+}
+
+
+// MARK: - test doubles
+
+private final class ResultBox: @unchecked Sendable {
+    var value: Result<String, any Error>?
+}
+
+private final class StubSpeechRecognizeService: SpeechRecognizeService, @unchecked Sendable {
+
+    private let recognizedSubject = PassthroughSubject<SpeechRecognizeFragment, any Error>()
+    private let voiceLevelSubject = CurrentValueSubject<Float, Never>(0)
+
+    var startError: (any Error)?
+
+    var recognized: AnyPublisher<SpeechRecognizeFragment, any Error> {
+        return self.recognizedSubject.eraseToAnyPublisher()
+    }
+    var voiceLevel: AnyPublisher<Float, Never> {
+        return self.voiceLevelSubject.eraseToAnyPublisher()
+    }
+    func start() throws {
+        if let startError { throw startError }
+    }
+    func stop() { }
+
+    func emit(_ fragment: SpeechRecognizeFragment) {
+        self.recognizedSubject.send(fragment)
+    }
+    func emitError(_ error: any Error) {
+        self.recognizedSubject.send(completion: .failure(error))
+    }
+    func sendLevel(_ level: Float) {
+        self.voiceLevelSubject.send(level)
+    }
+}
+
+private final class StubSpeechRecognizePermissionChecker: SpeechRecognizePermissionChecker, @unchecked Sendable {
+
+    var accessError: (any Error)?
+
+    func requestAccess() async throws {
+        if let accessError { throw accessError }
+    }
+}


### PR DESCRIPTION
## 배경

#629(음성 입력 → AICommand 생성 플로우)의 **입력원**으로 쓸, 유저 음성을 받아 최종 인식 텍스트를 내보내는 Domain 모듈. 순수 모듈만 다루고 DI 조립·UI·AICommand 연결·Info.plist(Tuist) 권한 키는 #629로 분리.

## 구성

2-layer seam. 테스트되는 로직(`SpeechRecognizeUsecase`)이 플랫폼 seam(`SpeechRecognizeService`, `SpeechRecognizePermissionChecker`) 위에 올라간다. system-capability 서비스라 concrete 구현도 Domain에 둠(`LocalNotificationServiceImple` 선례).

- **`SpeechRecognizeUsecase`**
  - `recognizeResult: AnyPublisher<Result<String, any Error>, Never>` — 권한/시작/인식 실패는 `failure`, final fragment 또는 침묵 타임아웃 시 인식 텍스트를 `success`로 방출.
  - **침묵 자동 종료** — `voiceLevel`이 0으로 전환된 뒤 `autoStopAfterSilence`(기본 3s) 경과 시 그때까지의 인식 텍스트로 마무리. 발화가 재개되면 진행 중 타이머를 취소(`switchToLatest` + 무음 전환 감지).
  - `isRecognizingWithLevel: AnyPublisher<Float?, Never>` — 듣는 중에는 입력 레벨(0~1), 아닐 땐 nil.
  - 중복 `startListening`은 무시.
- **`SpeechRecognizeServiceImple`** — SFSpeechRecognizer + AVAudioEngine. recognitionTask partial 결과를 fragment로, audio tap RMS dBFS를 0~1로 정규화해 voiceLevel로. start 중 실패 시 self-teardown으로 완전 리셋, stop은 idempotent.
- **`SpeechRecognizePermissionCheckerImple`** — mic→speech 순차 권한 요청, 거부·제한 사유별 `SpeechRecognizeAuthError`.

## 테스트

`SpeechRecognizeUsecaseImpleTests` 10종 (Swift Testing) — 발화 종료/연속 fragment→final/침묵 마무리 성공, 권한·시작·인식 실패, 입력 레벨 전달, 무음 시 자동 종료, 중복 시작 방지. 전부 stub seam으로 검증. concrete 2개는 실기기 의존이라 빌드 보증까지(실동작은 #629 통합 시).

## 남은 과제 (#629)

- `ApplicationBase`/`UsecaseFactory` 조립, `recognizeResult` → `AICommandUsecase.processCommand` 연결
- 음성 입력 UI (권한 분기 + 레벨 시각화)
- Tuist 앱 타깃 Info.plist에 `NSMicrophoneUsageDescription`·`NSSpeechRecognitionUsageDescription`

🤖 Generated with [Claude Code](https://claude.com/claude-code)