### PR TITLE
[#629] AI 자연어 입력 — Domain 백엔드 (Phase 1+2): 실시간 음성 인식·거부 seam·AIAgent orchestrator

### DIFF
--- a/Domain/Sources/Models/AI/AIAgentState.swift
+++ b/Domain/Sources/Models/AI/AIAgentState.swift
@@ -1,0 +1,21 @@
+//
+//  AIAgentState.swift
+//  Domain
+//
+//  Created by sudo.park on 6/14/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+
+// MARK: - AIAgentState
+
+public enum AIAgentState: Sendable {
+
+    case idle                                                       // command 없음 (초기/리셋)
+    case processing(command: String)                                // 서버 처리 중
+    case confirm(command: String, action: AIConfirmCommandAction)   // 확인 필요
+    case done(message: String?)                                     // 완료
+    case failed(reason: String?)                                    // 실패
+}

--- a/Domain/Sources/Models/AI/AICommand+Job.swift
+++ b/Domain/Sources/Models/AI/AICommand+Job.swift
@@ -33,6 +33,7 @@ public struct AIJob: Sendable {
         case done = "DONE"
         case confirm = "CONFIRM"
         case failed = "FAILED"
+        case rejected = "REJECTED"
     }
     
     public enum Mode: String, Sendable {
@@ -53,6 +54,7 @@ public struct AIJob: Sendable {
         return self.status == .done
             || self.status == .confirm
             || self.status == .failed
+            || self.status == .rejected
     }
     
     public init(jobId: String) {
@@ -100,7 +102,8 @@ public struct AIConfirmCommandAction: Sendable {
     public var tool: String?
     public var args: Data?
     public var confirmToken: String?
-    
+    public var parentJobId: String?
+
     public init() { }
 }
 

--- a/Domain/Sources/Repositories/AI/AICommandRepository.swift
+++ b/Domain/Sources/Repositories/AI/AICommandRepository.swift
@@ -20,7 +20,9 @@ public protocol AICommandRepository: AnyObject, Sendable {
         _ action: AIConfirmCommandAction,
         timeZone: String
     ) async throws -> String
-    
+
+    func rejectConfirmCommand(_ action: AIConfirmCommandAction) async throws
+
     func loadJob(_ jobId: String) async throws -> AIJob
     
     func updateProcessingAICommand(_ cmd: ProcessingAICommand) async throws

--- a/Domain/Sources/Usecases/AI/AIAgentUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentUsecase.swift
@@ -1,0 +1,145 @@
+//
+//  AIAgentUsecase.swift
+//  Domain
+//
+//  Created by sudo.park on 6/14/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Combine
+import Extensions
+
+
+// MARK: - AIAgentUsecase
+
+public protocol AIAgentUsecase: AnyObject, Sendable {
+
+    var state: AnyPublisher<AIAgentState, Never> { get }
+    var usage: AnyPublisher<AIAgentUsage, Never> { get }
+
+    func sendCommand(_ text: String)
+    func confirm()
+    func decline()
+
+    func reset()
+    func restoreIfNeeded()
+    func loadUsage()
+}
+
+
+// MARK: - AIAgentUsecaseImple
+
+public final class AIAgentUsecaseImple: AIAgentUsecase, @unchecked Sendable {
+
+    private let commandUsecase: any AICommandUsecase
+    private let usageUsecase: any AIAgentUsageUsecase
+
+    public init(
+        commandUsecase: any AICommandUsecase,
+        usageUsecase: any AIAgentUsageUsecase
+    ) {
+        self.commandUsecase = commandUsecase
+        self.usageUsecase = usageUsecase
+    }
+
+    private struct Subject {
+        let state = CurrentValueSubject<AIAgentState, Never>(.idle)
+    }
+    private let subject = Subject()
+    private var commandCancellable: AnyCancellable?
+
+    private func startProcessing(_ jobPublisher: AnyPublisher<AIJob, any Error>) {
+        self.commandCancellable?.cancel()
+        self.commandCancellable = jobPublisher
+            .sink(
+                receiveCompletion: { [weak self] completion in
+                    if case .failure = completion {
+                        self?.subject.state.send(.failed(reason: nil))
+                    }
+                },
+                receiveValue: { [weak self] job in
+                    self?.handleJobResult(job)
+                }
+            )
+    }
+
+    private func handleJobResult(_ job: AIJob) {
+        guard job.isFinish else { return }
+        // REJECTED는 result.type=CONFIRM이 남아도 status 우선 — confirm 재노출 금지 (복원 시 미동의=초기화)
+        if job.status == .rejected {
+            self.subject.state.send(.idle)
+            return
+        }
+        guard let result = job.result else { return }
+        switch result {
+        case .done(let done):
+            self.subject.state.send(.done(message: done.text))
+        case .confirm(let confirm):
+            guard let action = confirm.action else {
+                self.subject.state.send(.failed(reason: confirm.text))
+                return
+            }
+            self.subject.state.send(.confirm(command: job.command ?? "", action: action))
+        case .failed(let fail):
+            self.subject.state.send(.failed(reason: fail.reason))
+        }
+    }
+}
+
+
+// MARK: - actions
+
+extension AIAgentUsecaseImple {
+
+    public func sendCommand(_ text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        self.subject.state.send(.processing(command: trimmed))
+        self.startProcessing(self.commandUsecase.processCommand(trimmed))
+    }
+
+    public func confirm() {
+        guard case .confirm(let command, let action) = self.subject.state.value
+        else { return }
+        self.subject.state.send(.processing(command: command))
+        self.startProcessing(self.commandUsecase.processConfirmCommand(action))
+    }
+
+    public func decline() {
+        if case .confirm(_, let action) = self.subject.state.value {
+            self.commandUsecase.rejectConfirmCommand(action)
+        }
+        self.reset()
+    }
+
+    public func reset() {
+        self.commandCancellable?.cancel()
+        self.commandCancellable = nil
+        self.subject.state.send(.idle)
+    }
+
+    public func restoreIfNeeded() {
+        // 세션 종료 후 복귀 — 영속된 in-flight job에 재연결 (결과는 handleJobResult로 매핑).
+        // 영속 job이 없으면 restoreCommandifNeed가 무방출 → idle 유지.
+        self.startProcessing(self.commandUsecase.restoreCommandifNeed())
+    }
+
+    public func loadUsage() {
+        self.usageUsecase.refresh()
+    }
+}
+
+
+// MARK: - outputs
+
+extension AIAgentUsecaseImple {
+
+    public var state: AnyPublisher<AIAgentState, Never> {
+        return self.subject.state.eraseToAnyPublisher()
+    }
+
+    public var usage: AnyPublisher<AIAgentUsage, Never> {
+        return self.usageUsecase.currentUsage
+    }
+}

--- a/Domain/Sources/Usecases/AI/AICommandUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AICommandUsecase.swift
@@ -18,7 +18,9 @@ public protocol AICommandUsecase: AnyObject, Sendable {
     func processCommand(_ commandText: String) -> AnyPublisher<AIJob, any Error>
     
     func processConfirmCommand(_ action: AIConfirmCommandAction) -> AnyPublisher<AIJob, any Error>
-    
+
+    func rejectConfirmCommand(_ action: AIConfirmCommandAction)
+
     func restoreCommandifNeed() -> AnyPublisher<AIJob, any Error>
 
     func handleJobFinishNotification(_ jobId: String)
@@ -118,6 +120,12 @@ extension AICommandUsecaseImple {
             .eraseToAnyPublisher()
     }
     
+    public func rejectConfirmCommand(_ action: AIConfirmCommandAction) {
+        let repository = self.repository
+        // 서버 거부 API(Functions#243) 미구현 — 준비 전까지 fire-and-forget.
+        Task { try? await repository.rejectConfirmCommand(action) }
+    }
+
     public func handleJobFinishNotification(_ jobId: String) {
         self.subject.jobFinishEvent.send(jobId)
     }

--- a/Domain/Sources/Usecases/Speech/SpeechRecognizeUsecase.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizeUsecase.swift
@@ -16,8 +16,10 @@ public protocol SpeechRecognizeUsecase: Sendable {
 
     func startListening()
     func stopListening()
- 
+    func finishListening()
+
     var recognizeResult: AnyPublisher<Result<String, any Error>, Never> { get }
+    var recognizingText: AnyPublisher<String, Never> { get }
     var isRecognizingWithLevel: AnyPublisher<Float?, Never> { get }
 }
 
@@ -43,9 +45,10 @@ public final class SpeechRecognizeUsecaseImple: SpeechRecognizeUsecase, @uncheck
     private struct Subject {
         let isRecognizing = CurrentValueSubject<Bool, Never>(false)
         let result = PassthroughSubject<Result<String, any Error>, Never>()
+        let recognizingText = CurrentValueSubject<String, Never>("")
     }
     private let subject = Subject()
-    private var serviceBinding: AnyCancellable?
+    private var serviceBinding = Set<AnyCancellable>()
 }
 
 extension SpeechRecognizeUsecaseImple {
@@ -62,7 +65,7 @@ extension SpeechRecognizeUsecaseImple {
                 self.subject.isRecognizing.send(true)
                 
             } catch {
-                self.serviceBinding?.cancel()
+                self.serviceBinding = []
                 self.subject.isRecognizing.send(false)
                 self.subject.result.send(.failure(error))
             }
@@ -71,7 +74,7 @@ extension SpeechRecognizeUsecaseImple {
     
     public func stopListening() {
         self.service.stop()
-        self.serviceBinding?.cancel()
+        self.serviceBinding = []
         self.subject.isRecognizing.send(false)
     }
     
@@ -87,8 +90,10 @@ extension SpeechRecognizeUsecaseImple {
             }
         }
         
-        self.serviceBinding?.cancel()
-        self.serviceBinding = Publishers.CombineLatest(
+        self.subject.recognizingText.send("")
+        self.serviceBinding = []
+
+        Publishers.CombineLatest(
             self.service.recognized.mapAsOptional().prepend(nil),
             self.silenceTimeout.mapAsAnyError().mapAsOptional().prepend(nil)
         )
@@ -98,6 +103,17 @@ extension SpeechRecognizeUsecaseImple {
             receiveCompletion: self.handleCompletion(),
             receiveValue: self.handleRecognized()
         )
+        .store(in: &self.serviceBinding)
+
+        self.service.recognized
+            .map { $0.text }
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { [weak self] text in
+                    self?.subject.recognizingText.send(text)
+                }
+            )
+            .store(in: &self.serviceBinding)
     }
     
     private enum RecognizeResult {
@@ -149,7 +165,20 @@ extension SpeechRecognizeUsecaseImple {
         return self.subject.result
             .eraseToAnyPublisher()
     }
-    
+
+    public var recognizingText: AnyPublisher<String, Never> {
+        return self.subject.recognizingText
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
+
+    public func finishListening() {
+        guard self.subject.isRecognizing.value else { return }
+        let text = self.subject.recognizingText.value
+        self.stopListening()
+        self.subject.result.send(.success(text))
+    }
+
     public var isRecognizingWithLevel: AnyPublisher<Float?, Never> {
         let service = self.service
         return self.subject.isRecognizing

--- a/Domain/Tests/Doubles/StubAICommandRepository.swift
+++ b/Domain/Tests/Doubles/StubAICommandRepository.swift
@@ -35,6 +35,11 @@ class BaseStubAICommandRepository: AICommandRepository, @unchecked Sendable {
     }
     
     
+    var didRejectParentJobId: String?
+    func rejectConfirmCommand(_ action: AIConfirmCommandAction) async throws {
+        self.didRejectParentJobId = action.parentJobId
+    }
+
     var stubLoadJobs: [Result<AIJob, any Error>] = []
     var loadJobMocking: Result<AIJob, any Error>?
     func loadJob(_ jobId: String) async throws -> AIJob {

--- a/Domain/Tests/Usecases/AI/AIAgentUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AI/AIAgentUsecaseImpleTests.swift
@@ -1,0 +1,360 @@
+//
+//  AIAgentUsecaseImpleTests.swift
+//  Domain
+//
+//  Created by sudo.park on 6/14/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Combine
+import Prelude
+import Optics
+import UnitTestHelpKit
+import Extensions
+
+@testable import Domain
+
+
+class AIAgentUsecaseImpleTests: PublisherWaitable {
+
+    var cancelBag: Set<AnyCancellable>! = []
+    private var stubCommand: StubAICommandUsecase!
+    private var stubUsage: StubAIAgentUsageUsecase!
+
+    private func makeUsecase(shouldFail: Bool = false) -> AIAgentUsecaseImple {
+        self.stubCommand = .init()
+        self.stubCommand.shouldFail = shouldFail
+        self.stubUsage = .init()
+        return AIAgentUsecaseImple(
+            commandUsecase: self.stubCommand,
+            usageUsecase: self.stubUsage
+        )
+    }
+
+    private func makeUsecaseWithCommandJob(_ job: AIJob) -> AIAgentUsecaseImple {
+        let usecase = self.makeUsecase()
+        self.stubCommand.stubCommandJob = job
+        return usecase
+    }
+
+    private func makeUsecaseInConfirm(
+        token: String = "tk-1",
+        command: String = "내일 회의 잡아줘",
+        confirmedBy job: AIJob? = nil
+    ) -> AIAgentUsecaseImple {
+        var confirm = AIJobResult.ConfirmResult()
+        confirm.action = AIConfirmCommandAction()
+            |> \.confirmToken .~ token
+            |> \.parentJobId .~ "parent-job"
+        let usecase = self.makeUsecaseWithCommandJob(
+            self.dummyJob(.confirm(confirm), command: command)
+        )
+        self.stubCommand.stubConfirmJob = job
+        usecase.sendCommand(command)
+        return usecase
+    }
+
+    private func dummyJob(
+        _ result: AIJobResult,
+        command: String? = "회의 잡아줘",
+        status: AIJob.Status? = nil
+    ) -> AIJob {
+        return AIJob(jobId: "job-1")
+            |> \.command .~ command
+            |> \.status .~ (status ?? self.status(for: result))
+            |> \.result .~ result
+    }
+
+    private func status(for result: AIJobResult) -> AIJob.Status {
+        switch result {
+        case .done: return .done
+        case .confirm: return .confirm
+        case .failed: return .failed
+        }
+    }
+
+    private func stateName(_ state: AIAgentState) -> String {
+        switch state {
+        case .idle: return "idle"
+        case .processing: return "processing"
+        case .confirm: return "confirm"
+        case .done: return "done"
+        case .failed: return "failed"
+        }
+    }
+}
+
+
+// MARK: - 초기 상태 / usage
+
+extension AIAgentUsecaseImpleTests {
+
+    @Test func usecase_initialState_isIdle() async throws {
+        // given
+        let expect = expectConfirm("초기 상태 idle")
+        let usecase = self.makeUsecase()
+        // when
+        let state = try await self.firstOutput(expect, for: usecase.state)
+        // then
+        #expect(state.map(self.stateName) == "idle")
+    }
+
+    @Test func usecase_loadUsage_refreshesUsageUsecase() async throws {
+        // given
+        let usecase = self.makeUsecase()
+        // when
+        usecase.loadUsage()
+        // then
+        #expect(self.stubUsage.didRefresh == true)
+    }
+
+    @Test func usecase_usage_forwardsUsageUsecaseCurrentUsage() async throws {
+        // given
+        let expect = expectConfirm("usage 전달")
+        let usecase = self.makeUsecase()
+        let usage = AIAgentUsage(input: 10, output: 20, limit: 100)
+        // when
+        let output = try await self.firstOutput(expect, for: usecase.usage) {
+            self.stubUsage.usageSubject.send(usage)
+        }
+        // then
+        #expect(output?.dailyLimit == 100)
+        #expect(output?.inputTokens == 10)
+    }
+}
+
+
+// MARK: - 처리 시작 & 결과 분기
+
+extension AIAgentUsecaseImpleTests {
+
+    @Test func usecase_sendCommand_entersProcessingThenDone() async throws {
+        // given
+        let expect = expectConfirm("커맨드 전송 → processing → done")
+        expect.count = 3
+        var done = AIJobResult.DoneResult()
+        done.text = "할 일 추가 완료"
+        let usecase = self.makeUsecaseWithCommandJob(self.dummyJob(.done(done)))
+        // when
+        let states = try await self.outputs(expect, for: usecase.state) {
+            usecase.sendCommand("회의 잡아줘")
+        }
+        // then
+        #expect(states.map(self.stateName) == ["idle", "processing", "done"])
+        guard case .done(let message) = try #require(states.last) else { Issue.record("done 아님"); return }
+        #expect(message == "할 일 추가 완료")
+    }
+
+    @Test func usecase_sendCommand_empty_isIgnored() async throws {
+        // given
+        let expect = expectConfirm("공백 커맨드 무시")
+        let usecase = self.makeUsecase()
+        // when
+        let state = try await self.firstOutput(expect, for: usecase.state) {
+            usecase.sendCommand("   ")
+        }
+        // then
+        #expect(state.map(self.stateName) == "idle")
+    }
+
+    @Test func usecase_whenResultConfirm_entersConfirmWithCommand() async throws {
+        // given
+        let expect = expectConfirm("결과 confirm → confirm 상태")
+        expect.count = 3
+        var confirm = AIJobResult.ConfirmResult()
+        confirm.action = AIConfirmCommandAction() |> \.confirmToken .~ "tk-1"
+        let usecase = self.makeUsecaseWithCommandJob(
+            self.dummyJob(.confirm(confirm), command: "내일 회의 잡아줘")
+        )
+        // when
+        let states = try await self.outputs(expect, for: usecase.state) {
+            usecase.sendCommand("내일 회의 잡아줘")
+        }
+        // then
+        guard case .confirm(let command, let action) = try #require(states.last) else { Issue.record("confirm 아님"); return }
+        #expect(command == "내일 회의 잡아줘")
+        #expect(action.confirmToken == "tk-1")
+    }
+
+    @Test func usecase_whenResultFailed_entersFailed() async throws {
+        // given
+        let expect = expectConfirm("결과 failed → failed 상태")
+        expect.count = 3
+        var fail = AIJobResult.FailResult()
+        fail.reason = "이해하지 못했어요"
+        let usecase = self.makeUsecaseWithCommandJob(self.dummyJob(.failed(fail)))
+        // when
+        let states = try await self.outputs(expect, for: usecase.state) {
+            usecase.sendCommand("뭐라고")
+        }
+        // then
+        guard case .failed(let reason) = try #require(states.last) else { Issue.record("failed 아님"); return }
+        #expect(reason == "이해하지 못했어요")
+    }
+
+    @Test func usecase_whenProcessingFails_entersFailed() async throws {
+        // given
+        let expect = expectConfirm("처리 에러 → failed")
+        expect.count = 3
+        let usecase = self.makeUsecase(shouldFail: true)
+        // when
+        let states = try await self.outputs(expect, for: usecase.state) {
+            usecase.sendCommand("회의")
+        }
+        // then
+        #expect(states.map(self.stateName).last == "failed")
+    }
+}
+
+
+// MARK: - confirm / decline
+
+extension AIAgentUsecaseImpleTests {
+
+    @Test func usecase_confirm_processesConfirmJobToDone() async throws {
+        // given
+        let expect = expectConfirm("동의 → confirm job 처리 → done")
+        expect.count = 3
+        var done = AIJobResult.DoneResult()
+        done.text = "반영 완료"
+        let usecase = self.makeUsecaseInConfirm(confirmedBy: self.dummyJob(.done(done)))
+        try await Task.sleep(for: .milliseconds(30))
+        // when
+        let states = try await self.outputs(expect, for: usecase.state) {
+            usecase.confirm()
+        }
+        // then — 구독 시 confirm 재방출 + processing + done
+        #expect(states.map(self.stateName) == ["confirm", "processing", "done"])
+    }
+
+    @Test func usecase_decline_rejectsAndResetsToIdle() async throws {
+        // given
+        let expect = expectConfirm("미동의 → 거부 + idle 초기화")
+        expect.count = 2
+        let usecase = self.makeUsecaseInConfirm(token: "reject-tk")
+        try await Task.sleep(for: .milliseconds(30))
+        // when
+        let states = try await self.outputs(expect, for: usecase.state) {
+            usecase.decline()
+        }
+        // then
+        #expect(states.last.map(self.stateName) == "idle")
+        #expect(self.stubCommand.didRejectParentJobId == "parent-job")
+    }
+}
+
+
+// MARK: - 초기화 / 복원
+
+extension AIAgentUsecaseImpleTests {
+
+    @Test func usecase_reset_returnsToIdle() async throws {
+        // given
+        let expect = expectConfirm("초기화 → idle")
+        expect.count = 2
+        var done = AIJobResult.DoneResult()
+        done.text = "완료"
+        let usecase = self.makeUsecaseWithCommandJob(self.dummyJob(.done(done)))
+        usecase.sendCommand("회의")
+        try await Task.sleep(for: .milliseconds(30))
+        // when
+        let states = try await self.outputs(expect, for: usecase.state) {
+            usecase.reset()
+        }
+        // then
+        #expect(states.last.map(self.stateName) == "idle")
+    }
+
+    @Test func usecase_restoreIfNeeded_attachesToInflightCommandAndEmitsResult() async throws {
+        // given — 세션 종료 후 영속된 job이 done으로 끝나 있음 (서버 완료 + push 후 복귀)
+        let expect = expectConfirm("복원 → 영속 in-flight job 결과 수신")
+        expect.count = 2
+        var done = AIJobResult.DoneResult()
+        done.text = "완료"
+        let usecase = self.makeUsecase()
+        self.stubCommand.stubRestoreJob = self.dummyJob(.done(done))
+        // when
+        let states = try await self.outputs(expect, for: usecase.state) {
+            usecase.restoreIfNeeded()
+        }
+        // then
+        #expect(states.map(self.stateName) == ["idle", "done"])
+    }
+
+    @Test func usecase_restoreIfNeeded_whenNoInflightCommand_staysIdle() async throws {
+        // given — 영속 job 없음 (restoreCommandifNeed → 무방출)
+        let expect = expectConfirm("복원할 게 없으면 idle 유지")
+        let usecase = self.makeUsecase()
+        // when
+        let state = try await self.firstOutput(expect, for: usecase.state) {
+            usecase.restoreIfNeeded()
+        }
+        // then
+        #expect(state.map(self.stateName) == "idle")
+    }
+
+    @Test func usecase_restoreIfNeeded_whenRejectedJob_staysIdleNotConfirm() async throws {
+        // given — 이미 거부된 job (status=REJECTED, result.type=CONFIRM 보존) 복원
+        let expect = expectConfirm("REJECTED 복원 → confirm 재노출 금지, idle")
+        expect.count = 2
+        var confirm = AIJobResult.ConfirmResult()
+        confirm.action = AIConfirmCommandAction() |> \.confirmToken .~ "tk-1"
+        let rejectedJob = self.dummyJob(.confirm(confirm), status: .rejected)
+        let usecase = self.makeUsecase()
+        self.stubCommand.stubRestoreJob = rejectedJob
+        // when
+        let states = try await self.outputs(expect, for: usecase.state) {
+            usecase.restoreIfNeeded()
+        }
+        // then — status 우선 판정으로 confirm 아닌 idle
+        #expect(states.map(self.stateName) == ["idle", "idle"])
+    }
+}
+
+
+// MARK: - test doubles
+
+private final class StubAICommandUsecase: AICommandUsecase, @unchecked Sendable {
+
+    var stubCommandJob: AIJob?
+    var stubConfirmJob: AIJob?
+    var stubRestoreJob: AIJob?
+    var shouldFail: Bool = false
+    var didRejectParentJobId: String?
+
+    func processCommand(_ commandText: String) -> AnyPublisher<AIJob, any Error> {
+        return self.jobPublisher(self.stubCommandJob)
+    }
+    func processConfirmCommand(_ action: AIConfirmCommandAction) -> AnyPublisher<AIJob, any Error> {
+        return self.jobPublisher(self.stubConfirmJob)
+    }
+    func rejectConfirmCommand(_ action: AIConfirmCommandAction) {
+        self.didRejectParentJobId = action.parentJobId
+    }
+    func restoreCommandifNeed() -> AnyPublisher<AIJob, any Error> {
+        return self.jobPublisher(self.stubRestoreJob)
+    }
+    func handleJobFinishNotification(_ jobId: String) { }
+
+    private func jobPublisher(_ job: AIJob?) -> AnyPublisher<AIJob, any Error> {
+        if self.shouldFail {
+            return Fail(error: RuntimeError("stub fail")).eraseToAnyPublisher()
+        }
+        guard let job else { return Empty().eraseToAnyPublisher() }
+        return Just(job).setFailureType(to: (any Error).self).eraseToAnyPublisher()
+    }
+}
+
+private final class StubAIAgentUsageUsecase: AIAgentUsageUsecase, @unchecked Sendable {
+
+    let usageSubject = CurrentValueSubject<AIAgentUsage?, Never>(nil)
+    var didRefresh: Bool = false
+
+    func refresh() { self.didRefresh = true }
+    func loadUsage() async throws -> AIAgentUsage { throw RuntimeError("not imple") }
+    var currentUsage: AnyPublisher<AIAgentUsage, Never> {
+        return self.usageSubject.compactMap { $0 }.eraseToAnyPublisher()
+    }
+}

--- a/Domain/Tests/Usecases/AICommandUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AICommandUsecaseImpleTests.swift
@@ -57,6 +57,26 @@ final class AICommandUsecaseImpleTests: PublisherWaitable {
 }
 
 
+// MARK: - rejectConfirmCommand
+
+extension AICommandUsecaseImpleTests {
+
+    @Test func usecase_rejectConfirmCommand_delegatesToRepositoryFireAndForget() async throws {
+        // given
+        let usecase = self.makeUsecase()
+        var action = AIConfirmCommandAction()
+        action.parentJobId = "parent-job"
+
+        // when
+        usecase.rejectConfirmCommand(action)
+        try await Task.sleep(for: .milliseconds(50))
+
+        // then
+        #expect(self.stubRepository.didRejectParentJobId == "parent-job")
+    }
+}
+
+
 // MARK: - process commmand
 
 extension AICommandUsecaseImpleTests {

--- a/Domain/Tests/Usecases/Speech/SpeechRecognizeUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/Speech/SpeechRecognizeUsecaseImpleTests.swift
@@ -189,6 +189,73 @@ extension SpeechRecognizeUsecaseImpleTests {
 }
 
 
+// MARK: - 실시간 인식 텍스트 / 수동 완료
+
+extension SpeechRecognizeUsecaseImpleTests {
+
+    @Test func usecase_whileRecognizing_emitsPartialTextInRealtime() async throws {
+        // given
+        let expect = expectConfirm("부분 인식 텍스트 실시간 방출")
+        expect.count = 3
+        let (usecase, service) = self.makeUsecase()
+
+        // when
+        let texts = try await self.outputs(expect, for: usecase.recognizingText) {
+            usecase.startListening()
+            try await Task.sleep(for: .milliseconds(60))
+            service.emit(.init(text: "오늘", isFinal: false))
+            service.emit(.init(text: "오늘 회의", isFinal: false))
+            try await Task.sleep(for: .milliseconds(40))
+        }
+
+        // then
+        #expect(texts == ["", "오늘", "오늘 회의"])
+    }
+
+    @Test func usecase_whenFinishListening_emitsCurrentTextAsResult() async throws {
+        // given
+        let (usecase, service) = self.makeUsecase()
+
+        // when
+        let captured = try await self.captureResult(for: usecase) {
+            usecase.startListening()
+            try await Task.sleep(for: .milliseconds(60))
+            service.emit(.init(text: "회의 잡아줘", isFinal: false))
+            try await Task.sleep(for: .milliseconds(20))
+            usecase.finishListening()
+        }
+
+        // then
+        let result = try #require(captured)
+        guard case .success(let text) = result else {
+            Issue.record("성공 결과가 아님")
+            return
+        }
+        #expect(text == "회의 잡아줘")
+    }
+
+    @Test func usecase_whenFinishListeningWithoutSpeech_emitsEmptyText() async throws {
+        // given
+        let (usecase, _) = self.makeUsecase()
+
+        // when
+        let captured = try await self.captureResult(for: usecase) {
+            usecase.startListening()
+            try await Task.sleep(for: .milliseconds(60))
+            usecase.finishListening()
+        }
+
+        // then
+        let result = try #require(captured)
+        guard case .success(let text) = result else {
+            Issue.record("성공 결과가 아님")
+            return
+        }
+        #expect(text == "")
+    }
+}
+
+
 // MARK: - 듣기 상태와 입력 레벨
 
 extension SpeechRecognizeUsecaseImpleTests {

--- a/Repository/Sources/Remote/Endpoint.swift
+++ b/Repository/Sources/Remote/Endpoint.swift
@@ -268,6 +268,7 @@ public enum AppEndpoints: Endpoint {
 enum AIAPIEndpoints: Endpoint {
     case command
     case confirmCommand
+    case rejectCommand
     case job(id: String)
     case usage
 
@@ -275,6 +276,7 @@ enum AIAPIEndpoints: Endpoint {
         switch self {
         case .command: return "command"
         case .confirmCommand: return "command/confirm"
+        case .rejectCommand: return "command/reject"
         case .job(let id): return "jobs/\(id)"
         case .usage: return "usage"
         }

--- a/Repository/Sources/Repository+Imple/AI/AICommand+Mapping.swift
+++ b/Repository/Sources/Repository+Imple/AI/AICommand+Mapping.swift
@@ -124,6 +124,7 @@ struct AIConfirmCommandActionMapper {
         self.action = AIConfirmCommandAction()
             |> \.tool .~ (json["tool"] as? String)
             |> \.confirmToken .~ (json["confirmToken"] as? String)
+            |> \.parentJobId .~ (json["parentJobId"] as? String)
             |> \.args .~ argsData
     }
 }

--- a/Repository/Sources/Repository+Imple/AI/AICommandRepositoryImple.swift
+++ b/Repository/Sources/Repository+Imple/AI/AICommandRepositoryImple.swift
@@ -54,6 +54,12 @@ extension AICommandRepositoryImple {
         return try AIJobIdResponseMapper(json: json).jobId
     }
 
+    public func rejectConfirmCommand(_ action: AIConfirmCommandAction) async throws {
+        var body: [String: Any] = [:]
+        body["job_id"] = action.parentJobId
+        _ = try await self.requestJson(.post, AIAPIEndpoints.rejectCommand, parameters: body)
+    }
+
     public func loadJob(_ jobId: String) async throws -> AIJob {
         let json = try await self.requestJson(.get, AIAPIEndpoints.job(id: jobId))
         return try AIJobMapper(json: json).job

--- a/Repository/Tests/AI/AICommandRepositoryImpleTests.swift
+++ b/Repository/Tests/AI/AICommandRepositoryImpleTests.swift
@@ -106,6 +106,21 @@ extension AICommandRepositoryImpleTests {
         let argsParam = params?["args"] as? [String: Any]
         XCTAssertEqual(argsParam?["schedule_id"] as? String, "abc")
     }
+
+    func testRepository_rejectConfirmCommand_postsParentJobId() async throws {
+        // given
+        let repository = self.makeRepository()
+        let action = AIConfirmCommandAction()
+            |> \.parentJobId .~ "parent-123"
+
+        // when
+        try await repository.rejectConfirmCommand(action)
+
+        // then
+        XCTAssertEqual(self.stubRemote.didRequestedMethod, .post)
+        XCTAssertEqual(self.stubRemote.didRequestedPath?.contains("command/reject"), true)
+        XCTAssertEqual(self.stubRemote.didRequestedParams?["job_id"] as? String, "parent-123")
+    }
 }
 
 
@@ -298,6 +313,11 @@ private struct DummyResponse {
                 method: .post,
                 endpoint: AIAPIEndpoints.confirmCommand,
                 resultJsonString: .success(self.confirmJobIdJson)
+            ),
+            .init(
+                method: .post,
+                endpoint: AIAPIEndpoints.rejectCommand,
+                resultJsonString: .success(#"{ "ok": true }"#)
             ),
             .init(
                 method: .get,


### PR DESCRIPTION
## 배경

메인 할일 입력 우측 진입점에서 시작할 **AI 음성·텍스트 자연어 입력 바텀시트**(#629)의 Domain 백엔드. **Phase 1+2 (Domain only)** — UI(`AIAgentScene`)·진입점 연결·holder 구현은 후속.

## 책임 경계 (재모델링 — 이전 PR 리뷰 반영)

- **입력 modality(음성/키보드) + 입력 단계 UI + 권한** → **Presentation(VM, 후속 Phase 4)**. VM이 `SpeechRecognizeUsecase`를 직접 써서 확정 텍스트를 만든다.
- **command 처리 라이프사이클** → **Domain `AIAgentUsecase`**. 확정 텍스트를 받아 처리하고 결과 상태만 추적·보관. 입력 modality는 모른다.

> 설계: `docs/superpowers/specs/2026-06-13-aiagent-voice-input-design.md`

## 변경 (커밋 단위)

**C1 — `SpeechRecognizeUsecase` 실시간 인식 + 수동 완료**
- `recognizingText` — 인식 중 partial transcript 실시간 노출(`.removeDuplicates()`). partial 포워딩은 별도 cancellable 없이 `serviceBinding`에 `handleEvents`로 통합(CQS).
- `finishListening()` — 자동 종료 미작동 대비, 현재 누적 텍스트를 `recognizeResult`로 방출하고 종료.

**C2 — 미동의 거부 seam + REJECTED status (서버 #248)**
- `AICommandRepository.rejectConfirmCommand` — `command/reject`로 **`job_id`(parentJobId)** POST. confirmToken 불필요, `device_id`는 `RemoteAPI` 전역 주입.
- `AICommandUsecase.rejectConfirmCommand` — fire-and-forget. 기존 흐름 미변경 additive.
- `AIConfirmCommandAction.parentJobId` 추가 + Mapper 파싱 (reject job_id 출처).
- `AIJob.Status.rejected("REJECTED")` + `isFinish` 포함(폴링 terminal). status=REJECTED는 result.type=CONFIRM 남아도 **status 우선** 판정.
- `AIAgentState` — command 라이프사이클 enum(idle/processing/confirm/done/failed).

**C3 — `AIAgentUsecase` orchestrator**
- `AICommandUsecase` + `AIAgentUsageUsecase`만 조합 (**speech 없음**). 단일 `AIAgentState` + usage 노출.
- `sendCommand(text)` → processing → 결과 분기. `confirm()` 동의 재처리, `decline()` 미동의 거부 f&f + reset.
- `restoreIfNeeded()` → **`restoreCommandifNeed` 위임** — 세션 종료 후 복귀(서버 완료+push) 시 영속 in-flight job 재연결해 결과 처리. REJECTED 복원은 confirm 재노출 않고 idle.

## 닫기/복원
입력 단계 = VM(시트 수명) → 휘발. command 단계 = holder 보관. (a) 같은 세션은 `state`(`CurrentValueSubject`) 자동 replay, (b) 세션 종료 후 복귀는 `restoreIfNeeded → restoreCommandifNeed`로 영속 job 재연결. (엣지: `isFinish`에서 영속 clear → confirm 재복원 1회 한정, 허용.)

## 테스트
TDD(RED→GREEN). Speech 13 + AIAgent orchestrator 14 + reject(Domain/Repository) 통과. Stub은 기록만, 시나리오는 `make...` 팩토리 주입. (전체 Domain 회귀 통과; `EventNotification`·AICommand 폴링 일부는 병렬 부하성 flaky로 단독 실행 시 통과 — 본 변경 무관.)

## 스코프 밖 (후속)
- `AIAgentScene.framework` 6파일 — VM이 speech 입력단계머신 + `AIAgentUsecase` 합성 (Phase 4)
- 진입점 connect, `AIAgentHolder` 구현, holder가 `restoreIfNeeded`/push 호출 연결
- Limit/Upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)