### PR TITLE
[#650] 외부캘린더 credential 만료되 삭제된 경우 remote 세팅이 안되어 발생하는 크래쉬 수정

### DIFF
--- a/Repository/Sources/Repository+Imple/Account/ExternalCalendarIntegrateRepositoryImple.swift
+++ b/Repository/Sources/Repository+Imple/Account/ExternalCalendarIntegrateRepositoryImple.swift
@@ -98,26 +98,58 @@ extension ExternalCalendarIntegrateRepositoryImple {
             }
         }
         
-        let activeAccounts = accounts.filter(self.checkIsNotExpired(_:))
+        let activeAccountAndCredentials = accounts
+            .compactMap(self.checkActiveAccountInfo(_:))
         
-        activeAccounts.forEach { account in
-            guard let accountId = account.email,
-                  let credential = credentialStore.loadCredential(for: account.serviceIdentifier, accountId: accountId)
-            else { return }
-            remotePool.setup(for: account.serviceIdentifier, accountId: accountId, credential: credential)
+        activeAccountAndCredentials.forEach { info in
+            guard case .api(let credential) = info.credential else { return }
+            self.remotePool.setup(
+                for: info.account.serviceIdentifier,
+                accountId: info.accountId,
+                credential: credential
+            )
         }
 
-        return activeAccounts
+        return activeAccountAndCredentials.map { $0.account }
     }
     
-    private func checkIsNotExpired(_ account: ExternalServiceAccountinfo) -> Bool {
+    struct ActiveAccountInfo {
+        enum Credential {
+            case api(APICredential)
+            case apple
+        }
+        let accountId: String
+        let account: ExternalServiceAccountinfo
+        let credential: Credential
+    }
+    private func checkActiveAccountInfo(_ account: ExternalServiceAccountinfo) -> ActiveAccountInfo? {
+        guard let accountId = account.email else { return nil }
         
-        guard account.serviceIdentifier == AppleCalendarService.id
-        else { return true }
+        switch account.serviceIdentifier {
+        case AppleCalendarService.id:
+            guard self.checkAppleCalendarIsNotExpired(accountId)
+            else { return nil }
+            return .init(
+                accountId: accountId, account: account, credential: .apple
+            )
+            
+        default:
+            guard let credential = credentialStore.loadCredential(for: account.serviceIdentifier, accountId: accountId)
+            else { return nil }
+            
+            return .init(
+                accountId: accountId, account: account, credential: .api(credential)
+            )
+        }
+    }
+    
+    private func checkAppleCalendarIsNotExpired(
+        _ accountId: String
+    ) -> Bool {
         
         let hasPermission = self.appleCalendarPermissionChecker.isAuthorized()
-        if !hasPermission, let email = account.email {
-            self.removingAccountAction(account.serviceIdentifier, accountId: email)
+        if !hasPermission {
+            self.removingAccountAction(AppleCalendarService.id, accountId: accountId)
          }
         return hasPermission
     }

--- a/Repository/Tests/Auth/ExternalCalendarIntegrateRepositoryImpleTests.swift
+++ b/Repository/Tests/Auth/ExternalCalendarIntegrateRepositoryImpleTests.swift
@@ -25,7 +25,7 @@ struct ExternalCalendarIntegrateRepositoryImpleTests {
     private let spyKeyChain = SpyKeyChainStorage()
 
     private func makeReposiotry(
-        _ accounts: [(ExternalServiceAccountinfo, APICredential)] = [],
+        _ accounts: [(ExternalServiceAccountinfo, APICredential?)] = [],
         appleAccountOnly: [ExternalServiceAccountinfo] = [],
         applePermissionGranted: Bool = true
     ) -> ExternalCalendarIntegrateRepositoryImple {
@@ -37,7 +37,9 @@ struct ExternalCalendarIntegrateRepositoryImpleTests {
             accountIds.append(accountId)
             spyKeyChain.update("\(serviceId)-accounts", accountIds)
             spyKeyChain.update("\(serviceId)-\(accountId)-account", ExternalServiceAccountMapper(account: pair.0))
-            spyKeyChain.update("\(serviceId)-\(accountId)-credential", APICredentialMapper(credential: pair.1))
+            if let credential = pair.1 {
+                spyKeyChain.update("\(serviceId)-\(accountId)-credential", APICredentialMapper(credential: credential))
+            }
         }
 
         appleAccountOnly.forEach { account in
@@ -63,6 +65,10 @@ struct ExternalCalendarIntegrateRepositoryImpleTests {
 
     private var dummyGoogleAccount: ExternalServiceAccountinfo {
         return .init(googleService.identifier, email: "old-email")
+    }
+    
+    private var dummyNoCredentialAccount: ExternalServiceAccountinfo {
+        return .init(googleService.identifier, email: "no-credential")
     }
 
     private var googleCredential: APICredential {
@@ -300,6 +306,47 @@ extension ExternalCalendarIntegrateRepositoryImpleTests {
     }
 }
 
+// MARK: - load accounts with credential
+
+extension ExternalCalendarIntegrateRepositoryImpleTests {
+    
+    // 연동된 외부 캘린더 로드 중 credentail이 무효한 경우 제외하고 로드 + remote setup
+    @Test func repository_whenLoadIntegratedAccount_filterIsNotExpired() async throws {
+        // given
+        let repository = self.makeReposiotry(
+            [
+                (dummyGoogleAccount, googleCredential),
+                (dummyNoCredentialAccount, nil),
+                (dummyAppleAccount, nil)
+            ]
+        )
+        
+        // when
+        let accounts = try await repository.loadIntegratedAccounts()
+        
+        // then
+        #expect(accounts.map { $0.email } == ["old-email", AppleCalendarService.localAccountId])
+    }
+    
+    @Test func repository_whenAfterLoadIntegratedAccount_setupRemoteCredentialIfNeed() async throws {
+        // given
+        let repository = self.makeReposiotry(
+            [
+                (dummyGoogleAccount, googleCredential),
+                (dummyNoCredentialAccount, nil),
+                (dummyAppleAccount, nil)
+            ]
+        )
+        
+        // when
+        let _ = try await repository.loadIntegratedAccounts()
+        
+        // then
+        #expect(spyPool.setupCredentials == [
+            "\(googleService.identifier)-old-email": "old-google-access"
+        ])
+    }
+}
 
 // MARK: - Spy
 


### PR DESCRIPTION
원인
- 외부캘린더 api 토큰 만료 + 갱신 실패시 로컬에 저장된 credential 삭제
- 이후 앱 시작시 로컬에 account는 계속 저장되어있음 + credential은 만료된 상태
- 이때 credential이 없는 account는 remote 세팅 안됨 -> 이후 account는 credential 존재 여부와 상관없이 연동된것으로 판단
- 이후 만료된 계정(credential 없는 경우) 데이터 조회하려는 경우 repository가 세팅 안되어 있어 크래쉬

수정
- 저장된 account 준 credential이 세팅된 계정만 연동된것으로 판정