### PR TITLE
[#629] AI 자연어 입력 진입점 미로그인 게이팅 — 탭 시 로그인 유도

### DIFF
--- a/Presentations/CalendarScenes/Sources/CalendarSceneBuilderImple.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarSceneBuilderImple.swift
@@ -16,6 +16,8 @@ public struct CalendarSceneBuilderImple {
     private let viewAppearance: ViewAppearance
     private let eventDetailSceneBuilder: any EventDetailSceneBuilder
     private let eventListSceneBuilder: any EventListSceneBuiler
+    private let accountUsecase: any AccountUsecase
+    private let memberSceneBuilder: any MemberSceneBuilder
     private let aiAgentSceneBuilder: (any AIAgentSceneBuilder)?
     private let pendingCompleteTodoState: PendingCompleteTodoState = .init()
     public let calendarDeepLinkHandler = CalendarDeepLinkHandlerImple()
@@ -26,12 +28,16 @@ public struct CalendarSceneBuilderImple {
         viewAppearance: ViewAppearance,
         eventDetailSceneBuilder: any EventDetailSceneBuilder,
         eventListSceneBuilder: any EventListSceneBuiler,
+        accountUsecase: any AccountUsecase,
+        memberSceneBuilder: any MemberSceneBuilder,
         aiAgentSceneBuilder: (any AIAgentSceneBuilder)? = nil
     ) {
         self.usecaseFactory = usecaseFactory
         self.viewAppearance = viewAppearance
         self.eventDetailSceneBuilder = eventDetailSceneBuilder
         self.eventListSceneBuilder = eventListSceneBuilder
+        self.accountUsecase = accountUsecase
+        self.memberSceneBuilder = memberSceneBuilder
         self.aiAgentSceneBuilder = aiAgentSceneBuilder
     }
 
@@ -75,6 +81,8 @@ extension CalendarSceneBuilderImple: CalendarSceneBuilder {
             viewAppearance: self.viewAppearance,
             eventDetailSceneBuilder: self.eventDetailSceneBuilder,
             eventListSceneBuilder: self.eventListSceneBuilder,
+            accountUsecase: self.accountUsecase,
+            memberSceneBuilder: self.memberSceneBuilder,
             aiAgentSceneBuilder: self.aiAgentSceneBuilder
         )
         

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListBuilderImple.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListBuilderImple.swift
@@ -8,6 +8,7 @@
 //
 
 import UIKit
+import Domain
 import Scenes
 import CommonPresentation
 
@@ -20,6 +21,8 @@ final class DayEventListSceneBuilerImple {
     private let viewAppearance: ViewAppearance
     private let eventDetailSceneBuilder: any EventDetailSceneBuilder
     private let eventListSceneBuilder: any EventListSceneBuiler
+    private let accountUsecase: any AccountUsecase
+    private let memberSceneBuilder: any MemberSceneBuilder
     private let aiAgentSceneBuilder: (any AIAgentSceneBuilder)?
 
     init(
@@ -27,12 +30,16 @@ final class DayEventListSceneBuilerImple {
         viewAppearance: ViewAppearance,
         eventDetailSceneBuilder: any EventDetailSceneBuilder,
         eventListSceneBuilder: any EventListSceneBuiler,
+        accountUsecase: any AccountUsecase,
+        memberSceneBuilder: any MemberSceneBuilder,
         aiAgentSceneBuilder: (any AIAgentSceneBuilder)? = nil
     ) {
         self.usecaseFactory = usecaseFactory
         self.viewAppearance = viewAppearance
         self.eventDetailSceneBuilder = eventDetailSceneBuilder
         self.eventListSceneBuilder = eventListSceneBuilder
+        self.accountUsecase = accountUsecase
+        self.memberSceneBuilder = memberSceneBuilder
         self.aiAgentSceneBuilder = aiAgentSceneBuilder
     }
 }
@@ -62,11 +69,13 @@ extension DayEventListSceneBuilerImple: DayEventListSceneBuiler {
             todoEventUsecase: todoEventUsecase,
             foremostEventUsecase: foremostEventUsecase,
             uiSettingUsecase: uiSettingUsecase,
+            accountUsecase: self.accountUsecase,
             aiAgentSceneBuilder: self.aiAgentSceneBuilder
         )
         let router = DayEventListRouter(
             eventDetailSceneBuilder: self.eventDetailSceneBuilder,
-            eventListSceneBuilder: self.eventListSceneBuilder
+            eventListSceneBuilder: self.eventListSceneBuilder,
+            memberSceneBuilder: self.memberSceneBuilder
         )
         viewModel.router = router
         return .init(viewModel: viewModel, router: router)

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListRouter.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListRouter.swift
@@ -16,26 +16,30 @@ import CommonPresentation
 // MARK: - Routing
 
 protocol DayEventListRouting: Routing, Sendable {
-    
+
     func routeToMakeNewEvent(_ withParams: MakeEventParams)
     // TODO: tempplate 관련해서 초기 파라미터 필요할 수 있음
     func routeToSelectTemplateForMakeEvent()
     func showDoneTodoList()
+    func routeToSignIn()
 }
 
 // MARK: - Router
 
 final class DayEventListRouter: BaseRouterImple, DayEventListRouting, @unchecked Sendable {
-    
+
     private let eventDetailSceneBuilder: any EventDetailSceneBuilder
     private let eventListSceneBuilder: any EventListSceneBuiler
-    
+    private let memberSceneBuilder: any MemberSceneBuilder
+
     init(
         eventDetailSceneBuilder: any EventDetailSceneBuilder,
-        eventListSceneBuilder: any EventListSceneBuiler
+        eventListSceneBuilder: any EventListSceneBuiler,
+        memberSceneBuilder: any MemberSceneBuilder
     ) {
         self.eventDetailSceneBuilder = eventDetailSceneBuilder
         self.eventListSceneBuilder = eventListSceneBuilder
+        self.memberSceneBuilder = memberSceneBuilder
     }
 }
 
@@ -60,6 +64,13 @@ extension DayEventListRouter {
         Task { @MainActor in
             let next = self.eventListSceneBuilder.makeDoneTodoEventListScene()
             self.scene?.present(next, animated: true)
+        }
+    }
+
+    func routeToSignIn() {
+        Task { @MainActor in
+            let next = self.memberSceneBuilder.makeSignInScene()
+            self.showBottomSlide(next)
         }
     }
 }

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListViewModel.swift
@@ -79,6 +79,7 @@ final class DayEventListViewModelImple: DayEventListViewModel, @unchecked Sendab
     private let todoEventUsecase: any TodoEventUsecase
     private let foremostEventUsecase: any ForemostEventUsecase
     private let uiSettingUsecase: any UISettingUsecase
+    private let accountUsecase: any AccountUsecase
     private let aiAgentSceneBuilder: (any AIAgentSceneBuilder)?
     var router: (any DayEventListRouting)?
 
@@ -93,6 +94,7 @@ final class DayEventListViewModelImple: DayEventListViewModel, @unchecked Sendab
         todoEventUsecase: any TodoEventUsecase,
         foremostEventUsecase: any ForemostEventUsecase,
         uiSettingUsecase: any UISettingUsecase,
+        accountUsecase: any AccountUsecase,
         aiAgentSceneBuilder: (any AIAgentSceneBuilder)? = nil
     ) {
         self.calendarUsecase = calendarUsecase
@@ -101,6 +103,7 @@ final class DayEventListViewModelImple: DayEventListViewModel, @unchecked Sendab
         self.todoEventUsecase = todoEventUsecase
         self.foremostEventUsecase = foremostEventUsecase
         self.uiSettingUsecase = uiSettingUsecase
+        self.accountUsecase = accountUsecase
         self.aiAgentSceneBuilder = aiAgentSceneBuilder
 
         self.internalBind()
@@ -116,6 +119,7 @@ final class DayEventListViewModelImple: DayEventListViewModel, @unchecked Sendab
         let currentDayAndEventLists = CurrentValueSubject<CurrentDayAndEventLists?, Never>(nil)
         let tagMaps = CurrentValueSubject<[String: any EventTag], Never>([:])
         let pendingTodoEvents = CurrentValueSubject<[PendingTodoEventCellViewModel], Never>([])
+        let isSignedIn = CurrentValueSubject<Bool, Never>(false)
     }
     
     private var cancellables: Set<AnyCancellable> = []
@@ -123,7 +127,12 @@ final class DayEventListViewModelImple: DayEventListViewModel, @unchecked Sendab
     private let cvmCombineScheduler = DispatchQueue(label: "serial-combine")
     
     private func internalBind() {
-        
+        self.accountUsecase.currentAccountInfo
+            .map { $0 != nil }
+            .sink { [weak self] signedIn in
+                self?.subject.isSignedIn.send(signedIn)
+            }
+            .store(in: &self.cancellables)
     }
 }
 
@@ -214,7 +223,19 @@ extension DayEventListViewModelImple {
     }
 
     func enterVoiceInput() {
+        guard self.subject.isSignedIn.value else {
+            self.confirmSignInForAIAgent()
+            return
+        }
         self.aiAgentInteractor?.enterVoiceInput()
+    }
+
+    private func confirmSignInForAIAgent() {
+        let info = ConfirmDialogInfo()
+            |> \.title .~ "aiAgent::needSignIn::title".localized()
+            |> \.message .~ "aiAgent::needSignIn::message".localized()
+            |> \.confirmed .~ { [weak self] in self?.router?.routeToSignIn() }
+        self.router?.showConfirm(dialog: info)
     }
 }
 

--- a/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
@@ -48,12 +48,15 @@ class DayEventListViewModelImpleTests: BaseTestCase, PublisherWaitable {
         self.spyRouter = nil
     }
     
+    private var stubAIAgentSceneBuilder: StubAIAgentSceneBuilder!
+
     // 9-10일: current-todo-1, current-todo-2, todo-with-time, not-repeating-schedule, repeating-schedule(turn 4)
     // 9-11일: current-todo-1, current-todo-2
     private func makeViewModel(
         foremostEventId: ForemostEventId? = nil,
         shouldFailDoneTodo: Bool = false,
-        shouldFailMakeTodo: Bool = false
+        shouldFailMakeTodo: Bool = false,
+        isSignedIn: Bool = true
     ) -> DayEventListViewModelImple {
         let currentTodos: [TodoEvent] = [
             .init(uuid: "current-todo-1", name: "current-todo-1") |> \.creatTimeStamp .~ 100,
@@ -89,6 +92,8 @@ class DayEventListViewModelImpleTests: BaseTestCase, PublisherWaitable {
             uiSettingUsecase: self.stubUISettingUsecase
         )
         
+        let account: AccountInfo? = isSignedIn ? AccountInfo("uid") : nil
+        self.stubAIAgentSceneBuilder = StubAIAgentSceneBuilder()
         let viewModel = DayEventListViewModelImple(
             calendarUsecase: StubCalendarUsecase(),
             calendarSettingUsecase: calendarSettingUsecase,
@@ -96,7 +101,8 @@ class DayEventListViewModelImpleTests: BaseTestCase, PublisherWaitable {
             todoEventUsecase: self.stubTodoUsecase,
             foremostEventUsecase: self.stubForemostEventUsecase,
             uiSettingUsecase: self.stubUISettingUsecase,
-            aiAgentSceneBuilder: StubAIAgentSceneBuilder()
+            accountUsecase: StubAccountUsecase(account),
+            aiAgentSceneBuilder: self.stubAIAgentSceneBuilder
         )
         viewModel.router = self.spyRouter
         return viewModel
@@ -1000,25 +1006,30 @@ extension DayEventListViewModelImpleTests {
 }
 
 extension DayEventListViewModelImpleTests {
-    
+
     private class SpyRouter: BaseSpyRouter, DayEventListRouting, @unchecked Sendable {
-        
+
         var didRouteToMakeNewEventWithParams: MakeEventParams?
         func routeToMakeNewEvent(_ withParams: MakeEventParams) {
             self.didRouteToMakeNewEventWithParams = withParams
         }
-        
+
         func routeToMakeNewEvent() {
-            
+
         }
-        
+
         func routeToSelectTemplateForMakeEvent() {
-            
+
         }
-        
+
         var didShowDoneTodoList: Bool?
         func showDoneTodoList() {
             self.didShowDoneTodoList = true
+        }
+
+        var didRouteToSignIn: Bool?
+        func routeToSignIn() {
+            self.didRouteToSignIn = true
         }
     }
 }
@@ -1040,22 +1051,69 @@ extension DayEventListViewModelImpleTests {
         // then
         XCTAssertEqual(mode, .idle)
     }
+
+    // 미로그인: 진입 시 confirm 팝업, AI interactor로 위임 안 함
+    func testViewModel_whenNotSignedIn_enterVoiceInput_showsSignInConfirm() {
+        // given
+        let viewModel = self.makeViewModel(isSignedIn: false)
+        self.spyRouter.shouldConfirmNotCancel = false
+
+        // when
+        viewModel.enterVoiceInput()
+
+        // then
+        XCTAssertNotNil(self.spyRouter.didShowConfirmWith)
+        XCTAssertNil(self.stubAIAgentSceneBuilder.spyInteractor.didEnterVoiceInput)
+    }
+
+    // 미로그인: confirm 확인 콜백 → SignIn 라우팅
+    func testViewModel_whenNotSignedIn_confirmSignIn_routesToSignIn() {
+        // given
+        let viewModel = self.makeViewModel(isSignedIn: false)
+
+        // when
+        // shouldConfirmNotCancel is true by default — showConfirm auto-calls confirmed?()
+        viewModel.enterVoiceInput()
+
+        // then (confirmed?() was already called by SpyRouter.showConfirm)
+        XCTAssertEqual(self.spyRouter.didRouteToSignIn, true)
+    }
+
+    // 로그인: confirm 없이 AI interactor로 위임
+    func testViewModel_whenSignedIn_enterVoiceInput_forwardsToInteractor() {
+        // given
+        let viewModel = self.makeViewModel(isSignedIn: true)
+        viewModel.selectedDayChanaged(self.september10th(), and: [])
+        // Wait for the MainActor Task (attachAIAgentIfNeeded) to run
+        let attachExpect = expectation(description: "wait for attach")
+        DispatchQueue.main.async { attachExpect.fulfill() }
+        self.wait(for: [attachExpect], timeout: 0.1)
+
+        // when
+        viewModel.enterVoiceInput()
+
+        // then
+        XCTAssertNil(self.spyRouter.didShowConfirmWith)
+        XCTAssertEqual(self.stubAIAgentSceneBuilder.spyInteractor.didEnterVoiceInput, true)
+    }
 }
 
 // MARK: - Test doubles
 
 private final class SpyAIAgentSceneInteractor: AIAgentSceneInteractor {
     func prepare() { }
-    func enterVoiceInput() { }
+    var didEnterVoiceInput: Bool?
+    func enterVoiceInput() { self.didEnterVoiceInput = true }
     func enterKeyboardInput() { }
     func stopInput() { }
     func submit(_ text: String) { }
 }
 
 private final class StubAIAgentSceneBuilder: AIAgentSceneBuilder {
+    let spyInteractor = SpyAIAgentSceneInteractor()
     @MainActor
     func makeInlineComponent(listener: any AIAgentSceneListener) -> AIAgentInlineComponent {
-        return AIAgentInlineComponent(interactor: SpyAIAgentSceneInteractor())
+        return AIAgentInlineComponent(interactor: self.spyInteractor)
     }
 }
 

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -528,3 +528,5 @@
 "aiAgent::done::default" = "Done";
 "aiAgent::failed::default" = "Couldn't complete that";
 "aiAgent::retry" = "Retry";
+"aiAgent::needSignIn::title" = "Sign in required";
+"aiAgent::needSignIn::message" = "Sign in to use AI quick input.";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -528,3 +528,5 @@
 "aiAgent::done::default" = "완료했어요";
 "aiAgent::failed::default" = "처리하지 못했어요";
 "aiAgent::retry" = "다시";
+"aiAgent::needSignIn::title" = "로그인이 필요해요";
+"aiAgent::needSignIn::message" = "AI 빠른 입력은 로그인 후 이용할 수 있어요.";

--- a/TodoCalendarApp/Project.swift
+++ b/TodoCalendarApp/Project.swift
@@ -55,6 +55,10 @@ let project = Project.app(
         .project(
             target: "EventListScenes",
             path: .relativeToCurrentFile("../Presentations/EventListScenes")
+        ),
+        .project(
+            target: "AIAgentScene",
+            path: .relativeToCurrentFile("../Presentations/AIAgentScene")
         )
       ],
     extensionTargets:

--- a/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
@@ -397,6 +397,8 @@ extension ApplicationRootRouter {
             viewAppearance: self.viewAppearanceStore.appearance,
             eventDetailSceneBuilder: self.eventDetailSceneBuilder(),
             eventListSceneBuilder: self.eventListSceneBuilder(),
+            accountUsecase: self.accountUsecase,
+            memberSceneBuilder: self.memberSceneBuilder(),
             aiAgentSceneBuilder: aiAgentSceneBuilder
         )
         self.deepLinkHandler.attach(calendarHandler: builder.calendarDeepLinkHandler)


### PR DESCRIPTION
## 문제

#629 AI 인라인 진입 버튼이 PR #652(Phase 0~1)에서 게이팅 없이 머지돼, 미로그인 유저에게도 그대로 노출·동작했다. 이 기능은 로그인 유저 전용이라, 미로그인 유저가 진입점을 누르면 로그인으로 유도해야 한다.

## 접근

게이팅 분기를 **버튼을 누른 쪽(`DayEventListViewModelImple`)** 에 뒀다. 버튼 자체는 로그인 무관 항상 노출하고, 탭 시점에 로그인 여부로 분기한다.

- `DayEventListViewModelImple.enterVoiceInput` — `AccountUsecase.currentAccountInfo`(nil=미로그인)로 판정한 `isSignedIn`으로 분기. 로그인 → 기존대로 `aiAgentInteractor.enterVoiceInput()`, 미로그인 → `confirmSignInForAIAgent()`로 안내 팝업 후 확인 시 `router.routeToSignIn()`.
- `DayEventListRouter.routeToSignIn` — `MemberSceneBuilder.makeSignInScene()` + `showBottomSlide`. `SettingItemListRouter.routeToSignIn` 선례와 동일한 bottomSlide→SignIn 동선.
- 의존성 주입은 `UsecaseFactory` 프로토콜을 건드리지 않고, `ApplicationRootRouter`가 이미 보유한 `accountUsecase`/`memberSceneBuilder()`를 빌더 체인(`CalendarSceneBuilderImple` → `DayEventListSceneBuilerImple` → VM/Router)으로 직접 내려보냈다.
- `CalendarScenes`는 `MemberScenes`를 직접 import하지 않고 `Scenes` 프레임워크의 `any MemberSceneBuilder` 프로토콜만 의존.

로그인 성공 이후 처리는 기존 로그인 플로우(루트 scene rebuild)가 담당하므로 범위 밖.

## 테스트

`DayEventListViewModelImpleTests`에 게이팅 3 케이스 추가 — 미로그인 탭→confirm 노출/AI 위임 안 함, confirm 확인→`routeToSignIn`, 로그인 탭→confirm 없이 interactor 위임. 3/3 통과, `TodoCalendarApp` 빌드 성공.

## 남은 과제 (후속)

미로그인 유저도 `attachAIAgentIfNeeded`로 `coordinator.prepare()`(`restoreIfNeeded`/`loadUsage`)가 도는 pre-warm은 #652 Phase 1 동작이라 이 PR 범위 밖. 버튼 `.idle` 노출에 필요하지만, 미로그인에 불필요한 사용량/복원 로드는 별도 티켓에서 검토.