### PR TITLE
[#629] AI 인라인 입력 Phase 3 — command 결과 바텀시트 + 진입 버튼 뱃지

### DIFF
--- a/Presentations/AIAgentScene/Sources/AIAgentBuilderImple.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentBuilderImple.swift
@@ -38,7 +38,7 @@ extension AIAgentBuilderImple: AIAgentSceneBuilder {
             speechRecognizeUsecase: self.speechRecognizeUsecase
         )
         coordinator.listener = listener
-        let router = AIAgentRouter()
+        let router = AIAgentRouter(viewAppearance: self.viewAppearance)
         coordinator.router = router
         return AIAgentInlineComponent(interactor: coordinator)
     }

--- a/Presentations/AIAgentScene/Sources/AIAgentCoordinatorViewModel.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentCoordinatorViewModel.swift
@@ -45,11 +45,18 @@ public final class AIAgentCoordinatorViewModelImple: AIAgentCoordinatorViewModel
     private var inputMode: InputMode = .idle
     private var latestState: AIAgentState?
     private var cancellables = Set<AnyCancellable>()
+    private var isCommandSheetShown = false
 
     private lazy var inputViewModel: AIAgentInputViewModelImple = {
         let vm = AIAgentInputViewModelImple(speechRecognizeUsecase: self.speechRecognizeUsecase)
         vm.listener = self
         self.bindInputViewModel(vm)
+        return vm
+    }()
+
+    private lazy var commandViewModel: AIAgentCommandViewModelImple = {
+        let vm = AIAgentCommandViewModelImple(orchestrationUsecase: self.orchestrationUsecase)
+        vm.listener = self
         return vm
     }()
 
@@ -88,10 +95,24 @@ extension AIAgentCoordinatorViewModelImple {
             .sink(receiveValue: { [weak self] state in
                 self?.latestState = state
                 self?.resolveAndNotifyMode()
+                self?.handleCommandSheet(for: state)
             })
             .store(in: &self.cancellables)
         self.orchestrationUsecase.restoreIfNeeded()
         self.orchestrationUsecase.loadUsage()
+    }
+
+    private func handleCommandSheet(for state: AIAgentState) {
+        switch state {
+        case .processing, .confirm, .done, .failed:
+            guard !isCommandSheetShown else { return }
+            router?.showCommandSheet(commandViewModel)
+            isCommandSheetShown = true
+        case .idle:
+            guard isCommandSheetShown else { return }
+            router?.dismissCommandSheet()
+            isCommandSheetShown = false
+        }
     }
 
     private func handlePermissionDenied() {
@@ -150,6 +171,16 @@ extension AIAgentCoordinatorViewModelImple {
 
     public func submit(_ text: String) {
         self.orchestrationUsecase.sendCommand(text)
+    }
+}
+
+
+// MARK: - AIAgentCommandViewModelListener
+
+extension AIAgentCoordinatorViewModelImple: AIAgentCommandViewModelListener {
+
+    func aiAgentCommandRequestClose() {
+        self.orchestrationUsecase.reset()
     }
 }
 

--- a/Presentations/AIAgentScene/Sources/AIAgentRouter.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentRouter.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SwiftUI
 import Scenes
 import CommonPresentation
 
@@ -15,12 +16,22 @@ import CommonPresentation
 
 protocol AIAgentRouting: Routing, Sendable {
     func openSystemSetting()
+    func showCommandSheet(_ viewModel: any AIAgentCommandViewModel)
+    func dismissCommandSheet()
 }
 
 
 // MARK: - AIAgentRouter
 
-final class AIAgentRouter: BaseRouterImple, AIAgentRouting, @unchecked Sendable { }
+final class AIAgentRouter: BaseRouterImple, AIAgentRouting, @unchecked Sendable {
+
+    private let viewAppearance: ViewAppearance
+
+    init(viewAppearance: ViewAppearance) {
+        self.viewAppearance = viewAppearance
+        super.init()
+    }
+}
 
 extension AIAgentRouter {
 
@@ -31,5 +42,24 @@ extension AIAgentRouter {
             else { return }
             UIApplication.shared.open(url)
         }
+    }
+
+    func showCommandSheet(_ viewModel: any AIAgentCommandViewModel) {
+        Task { @MainActor in
+            let eventHandlers = AIAgentCommandViewEventHandler()
+            eventHandlers.bind(viewModel)
+            var containerView = AIAgentCommandStageContainerView(
+                viewAppearance: self.viewAppearance,
+                eventHandlers: eventHandlers
+            )
+            containerView.stateBinding = { $0.bind(viewModel) }
+            let vc = UIHostingController(rootView: containerView)
+            vc.view.backgroundColor = .clear
+            self.showBottomSlide(vc)
+        }
+    }
+
+    func dismissCommandSheet() {
+        self.dismissPresented(animated: true, nil)
     }
 }

--- a/Presentations/AIAgentScene/Tests/AIAgentCoordinatorViewModelImpleTests.swift
+++ b/Presentations/AIAgentScene/Tests/AIAgentCoordinatorViewModelImpleTests.swift
@@ -38,7 +38,7 @@ final class AIAgentCoordinatorViewModelImpleTests: PublisherWaitable {
 
     private func makeCoordinator(
         initialState: AIAgentState? = nil
-    ) -> (AIAgentCoordinatorViewModelImple, StubAIAgentOrchestrationUsecase, StubSpeechRecognizeUsecase) {
+    ) -> (AIAgentCoordinatorViewModelImple, StubAIAgentOrchestrationUsecase, StubSpeechRecognizeUsecase, SpyAIAgentRouter) {
         let stubOrchestration = StubAIAgentOrchestrationUsecase()
         if let initialState {
             stubOrchestration.stateSubject.send(initialState)
@@ -48,7 +48,9 @@ final class AIAgentCoordinatorViewModelImpleTests: PublisherWaitable {
             orchestrationUsecase: stubOrchestration,
             speechRecognizeUsecase: stubSpeech
         )
-        return (coordinator, stubOrchestration, stubSpeech)
+        let spyRouter = SpyAIAgentRouter()
+        coordinator.router = spyRouter
+        return (coordinator, stubOrchestration, stubSpeech, spyRouter)
     }
 }
 
@@ -60,7 +62,7 @@ extension AIAgentCoordinatorViewModelImpleTests {
     @Test func coordinator_whenOrchestratorIdle_notifiesIdleMode() {
         // given
         let spy = SpyAIAgentSceneListener()
-        let (coordinator, _, _) = self.makeCoordinator(initialState: .idle)
+        let (coordinator, _, _, _) = self.makeCoordinator(initialState: .idle)
         coordinator.listener = spy
         // when
         coordinator.prepare()
@@ -71,7 +73,7 @@ extension AIAgentCoordinatorViewModelImpleTests {
     @Test func coordinator_whenProcessing_notifiesProcessingBadge() {
         // given
         let spy = SpyAIAgentSceneListener()
-        let (coordinator, _, _) = self.makeCoordinator(initialState: .processing(command: "내일 회의"))
+        let (coordinator, _, _, _) = self.makeCoordinator(initialState: .processing(command: "내일 회의"))
         coordinator.listener = spy
         // when
         coordinator.prepare()
@@ -82,7 +84,7 @@ extension AIAgentCoordinatorViewModelImpleTests {
     @Test func coordinator_whenConfirm_notifiesNeedConfirmBadge() {
         // given
         let spy = SpyAIAgentSceneListener()
-        let (coordinator, _, _) = self.makeCoordinator(
+        let (coordinator, _, _, _) = self.makeCoordinator(
             initialState: .confirm(command: "삭제", message: "정말?", action: AIConfirmCommandAction())
         )
         coordinator.listener = spy
@@ -95,7 +97,7 @@ extension AIAgentCoordinatorViewModelImpleTests {
     @Test func coordinator_whenDone_notifiesDoneBadge() {
         // given
         let spy = SpyAIAgentSceneListener()
-        let (coordinator, _, _) = self.makeCoordinator(initialState: .done(message: "완료"))
+        let (coordinator, _, _, _) = self.makeCoordinator(initialState: .done(message: "완료"))
         coordinator.listener = spy
         // when
         coordinator.prepare()
@@ -106,7 +108,7 @@ extension AIAgentCoordinatorViewModelImpleTests {
     @Test func coordinator_whenFailed_notifiesFailedBadge() {
         // given
         let spy = SpyAIAgentSceneListener()
-        let (coordinator, _, _) = self.makeCoordinator(initialState: .failed(reason: "오류"))
+        let (coordinator, _, _, _) = self.makeCoordinator(initialState: .failed(reason: "오류"))
         coordinator.listener = spy
         // when
         coordinator.prepare()
@@ -117,7 +119,7 @@ extension AIAgentCoordinatorViewModelImpleTests {
     @Test func coordinator_whenStateChangesAfterPrepare_notifiesUpdatedMode() {
         // given
         let spy = SpyAIAgentSceneListener()
-        let (coordinator, stubOrchestration, _) = self.makeCoordinator(initialState: .idle)
+        let (coordinator, stubOrchestration, _, _) = self.makeCoordinator(initialState: .idle)
         coordinator.listener = spy
         coordinator.prepare()
         // when
@@ -130,7 +132,7 @@ extension AIAgentCoordinatorViewModelImpleTests {
     @Test func coordinator_beforeStateDetermined_doesNotNotify() {
         // given
         let spy = SpyAIAgentSceneListener()
-        let (coordinator, _, _) = self.makeCoordinator(initialState: nil)
+        let (coordinator, _, _, _) = self.makeCoordinator(initialState: nil)
         coordinator.listener = spy
         // when — orchestrator state 미확정 (nil)
         coordinator.prepare()
@@ -146,7 +148,7 @@ extension AIAgentCoordinatorViewModelImpleTests {
 
     @Test func coordinator_prepare_callsRestoreIfNeeded() {
         // given
-        let (coordinator, stubOrchestration, _) = self.makeCoordinator()
+        let (coordinator, stubOrchestration, _, _) = self.makeCoordinator()
         // when
         coordinator.prepare()
         // then
@@ -155,7 +157,7 @@ extension AIAgentCoordinatorViewModelImpleTests {
 
     @Test func coordinator_prepare_callsLoadUsage() {
         // given
-        let (coordinator, stubOrchestration, _) = self.makeCoordinator()
+        let (coordinator, stubOrchestration, _, _) = self.makeCoordinator()
         // when
         coordinator.prepare()
         // then
@@ -170,7 +172,7 @@ extension AIAgentCoordinatorViewModelImpleTests {
 
     @Test func coordinator_submit_delegatesToOrchestrationUsecase() {
         // given
-        let (coordinator, stubOrchestration, _) = self.makeCoordinator()
+        let (coordinator, stubOrchestration, _, _) = self.makeCoordinator()
         // when
         coordinator.submit("내일 회의 잡아줘")
         // then
@@ -186,7 +188,7 @@ extension AIAgentCoordinatorViewModelImpleTests {
     @Test func coordinator_enterVoiceInput_startsSpeechAndNotifiesVoiceMode() {
         // given
         let spy = SpyAIAgentSceneListener()
-        let (coordinator, _, stubSpeech) = self.makeCoordinator(initialState: .idle)
+        let (coordinator, _, stubSpeech, _) = self.makeCoordinator(initialState: .idle)
         coordinator.listener = spy
         coordinator.prepare()
         let modeCountBeforeVoice = spy.didChangedModes.count
@@ -201,7 +203,7 @@ extension AIAgentCoordinatorViewModelImpleTests {
     @Test func coordinator_recognizingText_forwardsToListener() {
         // given
         let spy = SpyAIAgentSceneListener()
-        let (coordinator, _, stubSpeech) = self.makeCoordinator(initialState: .idle)
+        let (coordinator, _, stubSpeech, _) = self.makeCoordinator(initialState: .idle)
         coordinator.listener = spy
         coordinator.prepare()
         coordinator.enterVoiceInput()
@@ -214,7 +216,7 @@ extension AIAgentCoordinatorViewModelImpleTests {
     @Test func coordinator_inputLevel_forwardsToListener() {
         // given
         let spy = SpyAIAgentSceneListener()
-        let (coordinator, _, stubSpeech) = self.makeCoordinator(initialState: .idle)
+        let (coordinator, _, stubSpeech, _) = self.makeCoordinator(initialState: .idle)
         coordinator.listener = spy
         coordinator.prepare()
         coordinator.enterVoiceInput()
@@ -226,7 +228,7 @@ extension AIAgentCoordinatorViewModelImpleTests {
 
     @Test func coordinator_recognizeSuccess_sendsCommandToOrchestration() {
         // given
-        let (coordinator, stubOrchestration, stubSpeech) = self.makeCoordinator(initialState: .idle)
+        let (coordinator, stubOrchestration, stubSpeech, _) = self.makeCoordinator(initialState: .idle)
         coordinator.listener = SpyAIAgentSceneListener()
         coordinator.prepare()
         coordinator.enterVoiceInput()
@@ -239,7 +241,7 @@ extension AIAgentCoordinatorViewModelImpleTests {
     @Test func coordinator_permissionDenied_notifiesKeyboardAvailableAndSwitchesToKeyboard() {
         // given
         let spy = SpyAIAgentSceneListener()
-        let (coordinator, _, stubSpeech) = self.makeCoordinator(initialState: .idle)
+        let (coordinator, _, stubSpeech, _) = self.makeCoordinator(initialState: .idle)
         coordinator.listener = spy
         coordinator.prepare()
         coordinator.enterVoiceInput()
@@ -254,7 +256,7 @@ extension AIAgentCoordinatorViewModelImpleTests {
     @Test func coordinator_enterKeyboardInput_stopsSpeechAndNotifiesKeyboardMode() {
         // given
         let spy = SpyAIAgentSceneListener()
-        let (coordinator, _, stubSpeech) = self.makeCoordinator(initialState: .idle)
+        let (coordinator, _, stubSpeech, _) = self.makeCoordinator(initialState: .idle)
         coordinator.listener = spy
         coordinator.prepare()
         coordinator.enterVoiceInput()
@@ -270,7 +272,7 @@ extension AIAgentCoordinatorViewModelImpleTests {
     @Test func coordinator_stopInput_stopsSpeechAndNotifiesIdleMode() {
         // given
         let spy = SpyAIAgentSceneListener()
-        let (coordinator, _, stubSpeech) = self.makeCoordinator(initialState: .idle)
+        let (coordinator, _, stubSpeech, _) = self.makeCoordinator(initialState: .idle)
         coordinator.listener = spy
         coordinator.prepare()
         coordinator.enterVoiceInput()
@@ -286,7 +288,7 @@ extension AIAgentCoordinatorViewModelImpleTests {
     @Test func coordinator_voiceInputThenOrchestrationProcessing_notifiesProcessingMode() {
         // given — orchestrator idle, enter voice
         let spy = SpyAIAgentSceneListener()
-        let (coordinator, stubOrchestration, _) = self.makeCoordinator(initialState: .idle)
+        let (coordinator, stubOrchestration, _, _) = self.makeCoordinator(initialState: .idle)
         coordinator.listener = spy
         coordinator.prepare()
         coordinator.enterVoiceInput()
@@ -299,7 +301,7 @@ extension AIAgentCoordinatorViewModelImpleTests {
     @Test func coordinator_voiceRecognizeSuccess_sendsCommandAndTransitionsDirectlyToProcessing() {
         // given — voice 입력 중 상태
         let spy = SpyAIAgentSceneListener()
-        let (coordinator, stubOrchestration, stubSpeech) = self.makeCoordinator(initialState: .idle)
+        let (coordinator, stubOrchestration, stubSpeech, _) = self.makeCoordinator(initialState: .idle)
         coordinator.listener = spy
         coordinator.prepare()
         coordinator.enterVoiceInput()
@@ -312,5 +314,57 @@ extension AIAgentCoordinatorViewModelImpleTests {
         let modesAfterSuccess = Array(spy.didChangedModes.dropFirst(modeCountBeforeSuccess))
         #expect(!modesAfterSuccess.contains(.idle))
         #expect(modesAfterSuccess.last == .command(.processing))
+    }
+}
+
+
+// MARK: - command sheet routing
+
+extension AIAgentCoordinatorViewModelImpleTests {
+
+    @Test func coordinator_whenProcessingStateEmitted_showsCommandSheetOnce() {
+        // given
+        let (coordinator, stubOrchestration, _, spyRouter) = self.makeCoordinator(initialState: .idle)
+        coordinator.prepare()
+        // when
+        stubOrchestration.stateSubject.send(.processing(command: "일정 추가"))
+        // then — sheet는 첫 command 계열 진입 시 1회만 present
+        #expect(spyRouter.didShowCommandSheet == true)
+    }
+
+    @Test func coordinator_whenProcessingThenConfirm_doesNotRepresentSheet() {
+        // given
+        let (coordinator, stubOrchestration, _, spyRouter) = self.makeCoordinator(initialState: .idle)
+        coordinator.prepare()
+        stubOrchestration.stateSubject.send(.processing(command: "일정 추가"))
+        let showCountAfterProcessing = spyRouter.didShowCommandSheetCount
+        // when — confirm 상태로 전환 (시트는 유지, 재표출 없음)
+        stubOrchestration.stateSubject.send(
+            .confirm(command: "일정 추가", message: "정말?", action: AIConfirmCommandAction())
+        )
+        // then
+        #expect(spyRouter.didShowCommandSheetCount == showCountAfterProcessing)
+    }
+
+    @Test func coordinator_whenIdleAfterCommandSheet_dismissesSheet() {
+        // given
+        let (coordinator, stubOrchestration, _, spyRouter) = self.makeCoordinator(initialState: .idle)
+        coordinator.prepare()
+        stubOrchestration.stateSubject.send(.processing(command: "일정 추가"))
+        // when — idle 복귀
+        stubOrchestration.stateSubject.send(.idle)
+        // then — 정확히 1회만 dismiss (중복 dismiss 방지)
+        #expect(spyRouter.didDismissCommandSheetCount == 1)
+    }
+
+    @Test func coordinator_commandRequestClose_resetsOrchestration() {
+        // given
+        let (coordinator, stubOrchestration, _, _) = self.makeCoordinator(initialState: .idle)
+        coordinator.prepare()
+        stubOrchestration.stateSubject.send(.processing(command: "일정 추가"))
+        // when — command VM이 close 요청
+        coordinator.aiAgentCommandRequestClose()
+        // then — orchestrationUsecase.reset() 호출
+        #expect(stubOrchestration.didReset == true)
     }
 }

--- a/Presentations/AIAgentScene/Tests/Doubles/SpyAIAgentRouter.swift
+++ b/Presentations/AIAgentScene/Tests/Doubles/SpyAIAgentRouter.swift
@@ -19,4 +19,20 @@ final class SpyAIAgentRouter: BaseSpyRouter, AIAgentRouting, @unchecked Sendable
     func openSystemSetting() {
         self.didOpenSystemSetting = true
     }
+
+    var didShowCommandSheet = false
+    var didShowCommandSheetCount = 0
+    var lastShownCommandViewModel: (any AIAgentCommandViewModel)?
+    func showCommandSheet(_ viewModel: any AIAgentCommandViewModel) {
+        self.didShowCommandSheet = true
+        self.didShowCommandSheetCount += 1
+        self.lastShownCommandViewModel = viewModel
+    }
+
+    var didDismissCommandSheet = false
+    var didDismissCommandSheetCount = 0
+    func dismissCommandSheet() {
+        self.didDismissCommandSheet = true
+        self.didDismissCommandSheetCount += 1
+    }
 }

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListView.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListView.swift
@@ -229,6 +229,10 @@ struct DayEventListView: View {
     
     private func aiAgentEntryButton() -> some View {
         let isIdle = self.state.aiAgentEntryMode == .idle
+        let commandBadge: AIAgentCommandBadge? = {
+            if case .command(let badge) = self.state.aiAgentEntryMode { return badge }
+            return nil
+        }()
         return Button {
             self.isFocusInput = false
             self.eventHandler.enterVoiceInput()
@@ -243,6 +247,35 @@ struct DayEventListView: View {
         }
         .opacity(isIdle ? 1.0 : 0.3)
         .disabled(!isIdle)
+        .overlay(alignment: .topTrailing) {
+            if let badge = commandBadge {
+                aiAgentCommandBadge(badge)
+                    .opacity(1.0)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func aiAgentCommandBadge(_ badge: AIAgentCommandBadge) -> some View {
+        let (bgColor, iconName): (UIColor, String) = {
+            switch badge {
+            case .processing:  return (appearance.colorSet.accentInfo, "ellipsis")
+            case .needConfirm: return (appearance.colorSet.accentWarn, "exclamationmark")
+            case .done:        return (appearance.colorSet.accent, "checkmark")
+            case .failed:      return (appearance.colorSet.negativeBtnBackground, "xmark")
+            }
+        }()
+        Circle()
+            .fill(bgColor.asColor)
+            .frame(width: 16, height: 16)
+            .overlay(
+                Image(systemName: iconName)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 8, height: 8)
+                    .foregroundColor(appearance.colorSet.primaryBtnText.asColor)
+            )
+            .offset(x: 2, y: -2)
     }
 
     private func addNewButton() -> some View {
@@ -488,7 +521,7 @@ struct DayEventListViewPreviewProvider: PreviewProvider {
                 // 완료처리 실패하게 하던지
                 withAnimation {
 //                    state.requestDoneTodoIds = []
-                    
+
                     // 혹은 완료처리 성공 이후 셀 목록 업데이트 시뮬레이션
                     let newCells = state.cellViewModels.filter { $0.todoEventId != id }
                     state.cellViewModels = newCells
@@ -498,16 +531,16 @@ struct DayEventListViewPreviewProvider: PreviewProvider {
         eventHandler.addNewTodoQuickly = { name in
             let pending = PendingTodoEventCellViewModel(name: name, defaultTagId: nil)
             let index = state.cellViewModels.firstIndex(where: { !$0.name.starts(with: "current todo") })!
-            
+
             withAnimation {
                 state.cellViewModels.insert(pending, at: index)
-                
+
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                     if let index = state.cellViewModels.firstIndex(where: { $0.eventIdentifier == pending.eventIdentifier }) {
                         withAnimation {
                             // 삭제하여 실패했을때 가정
 //                                state.cellViewModels.remove(at: index)
-                            
+
                             // 추가하여 성공했을때 가정
                             let newCell = TodoEventCellViewModel("new-current-todo", name: name)
                                 |> \.periodText .~ .singleText(.init(text: "Todo".localized()))
@@ -522,7 +555,36 @@ struct DayEventListViewPreviewProvider: PreviewProvider {
             .environment(eventHandler)
             .environment(PendingCompleteTodoState())
             .environment(viewAppearance)
-        return containerView
+            .previewDisplayName("idle (default)")
+
+        return Group {
+            containerView
+            makeCommandBadgePreview(.processing, modeName: "processing")
+            makeCommandBadgePreview(.needConfirm, modeName: "needConfirm")
+            makeCommandBadgePreview(.done, modeName: "done")
+            makeCommandBadgePreview(.failed, modeName: "failed")
+        }
+    }
+
+    static func makeCommandBadgePreview(_ badge: AIAgentCommandBadge, modeName: String) -> some View {
+        let calendar = CalendarAppearanceSettings(
+            colorSetKey: .defaultDark,
+            fontSetKey: .systemDefault
+        )
+        let tag = DefaultEventTagColorSetting(holiday: "#ff0000", default: "#ff00ff")
+        let setting = AppearanceSettings(calendar: calendar, defaultTagColor: tag)
+        let viewAppearance = ViewAppearance(setting: setting, isSystemDarkTheme: false)
+        let state = DayEventListViewState()
+        state.dayModel = .init(dateText: "2020년 9월 15일(금)", lunarDateText: "6월 4일")
+        state.cellViewModels = []
+        state.aiAgentEntryMode = .command(badge)
+        let eventHandler = DayEventListViewEventHandler()
+        return DayEventListView()
+            .environment(state)
+            .environment(eventHandler)
+            .environment(PendingCompleteTodoState())
+            .environment(viewAppearance)
+            .previewDisplayName("badge: \(modeName)")
     }
     
     private static func dummyUncompleteds() -> [TodoEventCellViewModel] {


### PR DESCRIPTION
> **base: `features/629-aiagent-inline-input` (PR #654).** Phase 2를 base로 한 stacked PR. #654 머지 후 base가 develop으로 자동 전환된다.

## 배경

#629 인라인 진입점 재구성의 **Phase 3**. Phase 2(#654)에서 인라인 voice/keyboard 입력까지 완성됐다. 이번 PR은 명령을 보낸 뒤 **결과(처리중/확인/완료/실패)를 보여주는 command 바텀시트**와 **진입 버튼 상태 뱃지**를 붙인다.

## 접근

command UI(`AIAgentCommandViewModel`/`StageView`/`ContainerView`)는 이미 완성돼 있어 **재사용**. 이번 작업은 coordinator↔router 배선이 핵심. 두 커밋:

- **coordinator가 command 바텀시트 표출** — coordinator가 `AIAgentCommandViewModelImple`을 소유(listener=self). orchestrator state가 command 계열(processing/confirm/done/fail)로 **진입하면 1회 present**, `.idle` 복귀 시 dismiss. 시트가 떠 있는 동안의 processing→confirm→done 내부 전환은 CommandVM이 자체 `commandState` 구독으로 그린다. `CommandVM.close()`→`aiAgentCommandRequestClose`→`orchestrator.reset()`→`.idle`→dismiss로 닫힘 루프 완결. 시트 표출(side effect)과 진입 버튼 mode 통지(`resolveAndNotifyMode`)는 별도 메서드로 분리(CQS). router는 `viewAppearance`를 init 주입받아 `CommandStageContainerView`를 `UIHostingController`로 BottomSlide 표출.

- **진입 버튼 command 뱃지** — `.command(badge)` 상태일 때 진입 버튼 우상단에 상태 뱃지 overlay. processing/needConfirm/done/failed를 색·아이콘으로 구분.

## 동작

명령 전송 → processing 시트 자동 노출 → 결과(confirm/done/fail)까지 시트가 따라감 → 진입 버튼 뱃지로 상태 표시 → close/decline/retry로 idle 복귀·dismiss. 앱 재시작 후 진행 중이던 command도 `restoreIfNeeded`로 시트 복원.

## 디자인 (임시)

뱃지·시트 색은 `colorSet` 임시 매핑(processing=accentInfo, needConfirm=accentWarn, done=accent, failed=negativeBtn). 최종 비주얼은 디자인 확정 후 교체.

## 남은 과제 (Phase 4 — 디자인 전면 의존)

done/fail 시트를 "agent와의 대화 형식"으로 재디자인 + 폐기 파일 정리(`AIAgentView`/`ViewController`/옛 `makeAIAgentScene`). plan상 디자인 확정 후 상세 재작성 예정이라 이 PR 범위 밖.

## 테스트

coordinator의 시트 표출(1회)/dismiss(정확히 1회, 카운터 검증)/close→reset, command state 매핑 신규 테스트 GREEN. 진입 버튼 뱃지는 순수 뷰라 Preview(4 badge 케이스) 검증.
