### PR TITLE
[#629] AI 진입 버튼·뱃지·음성 waveform 디자인 정리

### DIFF
--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListView.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListView.swift
@@ -20,7 +20,7 @@ import CommonPresentation
 
 // MARK: - AICommandBadge
 
-private enum AICommandBadge {
+private enum AICommandBadge: Equatable {
     case processing
     case needConfirm
     case done
@@ -241,12 +241,10 @@ struct DayEventListView: View {
                 if self.state.isListening {
                     AIAgentInlineInputView()
                 } else {
-                    HStack(spacing: 8) {
-                        QuickAddNewTodoView(isFocusInput: $isFocusInput)
-                            .eventHandler(\.addNewTodoQuickly, eventHandler.addNewTodoQuickly)
-                            .eventHandler(\.makeNewTodoWithGivenNameAndDetails, eventHandler.makeNewTodoWithGivenNameAndDetails)
-                        aiAgentEntryButton()
-                    }
+                    QuickAddNewTodoView(isFocusInput: $isFocusInput)
+                        .eventHandler(\.addNewTodoQuickly, eventHandler.addNewTodoQuickly)
+                        .eventHandler(\.makeNewTodoWithGivenNameAndDetails, eventHandler.makeNewTodoWithGivenNameAndDetails)
+                        .eventHandler(\.handleAIEntryButtonTap, eventHandler.handleAIEntryButtonTap)
                 }
 
                 addNewButton()
@@ -257,51 +255,6 @@ struct DayEventListView: View {
         }
         .padding()
         .background(self.appearance.colorSet.bg0.asColor)
-    }
-
-    private func aiAgentEntryButton() -> some View {
-        return Button {
-            self.isFocusInput = false
-            self.eventHandler.handleAIEntryButtonTap()
-        } label: {
-            Circle()
-                .fill(self.appearance.colorSet.primaryBtnBackground.asColor)
-                .frame(width: 44, height: 44)
-                .overlay(
-                    Image(systemName: "sparkles")
-                        .foregroundColor(self.appearance.colorSet.primaryBtnText.asColor)
-                )
-                .overlay(alignment: .topTrailing) {
-                    if let badge = self.state.aiCommandBadge {
-                        self.badgeView(badge)
-                    }
-                }
-        }
-    }
-
-    @ViewBuilder
-    private func badgeView(_ badge: AICommandBadge) -> some View {
-        switch badge {
-        case .processing:
-            Circle()
-                .fill(self.appearance.colorSet.accent.asColor)
-                .frame(width: 12, height: 12)
-                .offset(x: 4, y: -4)
-        case .needConfirm:
-            badgeCircle("questionmark", self.appearance.colorSet.primaryBtnBackground.asColor)
-        case .done:
-            badgeCircle("checkmark", self.appearance.colorSet.accent.asColor)
-        case .failed:
-            badgeCircle("exclamationmark", self.appearance.colorSet.accentWarn.asColor)
-        }
-    }
-
-    private func badgeCircle(_ name: String, _ color: Color) -> some View {
-        Image(systemName: "\(name).circle.fill")
-            .font(.system(size: 16))
-            .foregroundStyle(color)
-            .background(Circle().fill(self.appearance.colorSet.bg0.asColor))
-            .offset(x: 4, y: -4)
     }
 
     private func addNewButton() -> some View {
@@ -463,8 +416,21 @@ private struct QuickAddNewTodoView: View {
 
     fileprivate var addNewTodoQuickly: (String) -> Void = { _ in }
     fileprivate var makeNewTodoWithGivenNameAndDetails: (String) -> Void = { _ in }
+    fileprivate var handleAIEntryButtonTap: () -> Void = { }
 
     var body: some View {
+        HStack(spacing: 8) {
+            quickAddField()
+                .opacity(self.isEntering ? 1.0 : 0.5)
+
+            aiAgentEntryButton()
+        }
+        .padding(.vertical, 4).padding(.horizontal, 8)
+        .frame(height: 50)
+        .backgroundAsRoundedRectForEventList(self.appearance)
+    }
+
+    private func quickAddField() -> some View {
         HStack(spacing: 8) {
 
             Text(R.String.calendarEventTimeTodo)
@@ -511,12 +477,132 @@ private struct QuickAddNewTodoView: View {
                 }
             }
         }
-        .opacity(self.isEntering ? 1.0 : 0.5)
-        .padding(.vertical, 4).padding(.horizontal, 8)
-        .frame(height: 50)
-        .backgroundAsRoundedRectForEventList(self.appearance)
+    }
+
+    private func aiAgentEntryButton() -> some View {
+        return Button {
+            self.isFocusInput = false
+            self.handleAIEntryButtonTap()
+        } label: {
+            Circle()
+                .fill(self.appearance.colorSet.primaryBtnBackground.asColor)
+                .frame(width: 40, height: 40)
+                .overlay { self.entryButtonIcon() }
+                .overlay(alignment: .topTrailing) {
+                    if let badge = self.state.aiCommandBadge, badge != .processing {
+                        self.badgeView(badge)
+                    }
+                }
+        }
+    }
+
+    @ViewBuilder
+    private func entryButtonIcon() -> some View {
+        if self.state.aiCommandBadge == .processing {
+            ProgressView()
+                .progressViewStyle(.circular)
+                .controlSize(.small)
+                .tint(self.appearance.colorSet.primaryBtnText.asColor)
+        } else {
+            Image(systemName: "sparkles")
+                .foregroundColor(self.appearance.colorSet.primaryBtnText.asColor)
+        }
+    }
+
+    private func badgeView(_ badge: AICommandBadge) -> some View {
+        let style = self.badgeStyle(badge)
+        return Image(systemName: style.symbol)
+            .font(.system(size: 11, weight: .heavy))
+            .foregroundColor(style.color)
+            .frame(width: 18, height: 18)
+            .background(Circle().fill(self.appearance.colorSet.bg0.asColor))
+            .overlay(Circle().stroke(style.color, lineWidth: 1.5))
+            .offset(x: 5, y: -5)
+    }
+
+    private func badgeStyle(_ badge: AICommandBadge) -> (symbol: String, color: Color) {
+        switch badge {
+        case .processing, .needConfirm:
+            return ("questionmark", self.appearance.colorSet.accentInfo.asColor)
+        case .done:
+            return ("checkmark", self.appearance.colorSet.accent.asColor)
+        case .failed:
+            return ("exclamationmark", self.appearance.colorSet.accentWarn.asColor)
+        }
     }
 }
+
+
+// MARK: - AIAgentInlineInputView (inline component, only shown when listening)
+
+private struct AIAgentInlineInputView: View {
+
+    @Environment(DayEventListViewState.self) private var state: DayEventListViewState
+    @Environment(DayEventListViewEventHandler.self) private var eventHandler: DayEventListViewEventHandler
+    @Environment(ViewAppearance.self) private var appearance: ViewAppearance
+
+    var body: some View {
+        voiceModeView()
+    }
+
+    private func voiceModeView() -> some View {
+        HStack(spacing: 8) {
+
+            Button {
+                self.eventHandler.enterKeyboardInput()
+            } label: {
+                Image(systemName: "keyboard")
+                    .foregroundColor(self.appearance.colorSet.text0.asColor)
+            }
+            .frame(width: 52)
+
+            RoundedRectangle(cornerRadius: 3)
+                .fill(self.appearance.tagColors.defaultColor.asColor)
+                .frame(width: 6)
+
+            VoiceWaveformView(
+                level: self.state.voiceLevel,
+                tintColor: self.appearance.colorSet.text1.asColor
+            )
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+
+            HStack(spacing: 4) {
+                Button {
+                    self.eventHandler.stopAIAgentInput()
+                } label: {
+                    Circle()
+                        .fill(
+                            appearance.colorSet.secondaryBtnBackground.asColor
+                        )
+                        .overlay(
+                            Image(systemName: "square")
+                                .foregroundColor(self.appearance.colorSet.secondaryBtnText.asColor)
+                                .padding(8)
+                        )
+                }
+
+                Button {
+                    self.eventHandler.finishVoiceInput()
+                } label: {
+                    Circle()
+                        .fill(
+                            appearance.colorSet.primaryBtnBackground.asColor
+                        )
+                        .overlay(
+                            Image(systemName: "arrow.up")
+                                .foregroundColor(self.appearance.colorSet.primaryBtnText.asColor)
+                                .padding(8)
+                        )
+                }
+            }
+        }
+        .padding(.vertical, 8).padding(.horizontal, 8)
+        .frame(height: 50)
+        .backgroundAsRoundedRectForEventList(appearance)
+    }
+}
+
 
 // MARK: - preview
 
@@ -693,7 +779,7 @@ struct DayEventListBadgePreviewProvider: PreviewProvider {
 
     static var previews: some View {
         let calendar = CalendarAppearanceSettings(
-            colorSetKey: .defaultDark,
+            colorSetKey: .defaultLight,
             fontSetKey: .systemDefault
         )
         let tag = DefaultEventTagColorSetting(holiday: "#ff0000", default: "#ff00ff")
@@ -739,72 +825,31 @@ struct DayEventListBadgePreviewProvider: PreviewProvider {
 }
 
 
-// MARK: - AIAgentInlineInputView (inline component, only shown when listening)
+// MARK: - AIAgentInlineInputView Preview (listening state)
 
-private struct AIAgentInlineInputView: View {
+struct DayEventListInlineInputPreviewProvider: PreviewProvider {
 
-    @Environment(DayEventListViewState.self) private var state: DayEventListViewState
-    @Environment(DayEventListViewEventHandler.self) private var eventHandler: DayEventListViewEventHandler
-    @Environment(ViewAppearance.self) private var appearance: ViewAppearance
+    static var previews: some View {
+        let calendar = CalendarAppearanceSettings(
+            colorSetKey: .defaultLight,
+            fontSetKey: .systemDefault
+        )
+        let tag = DefaultEventTagColorSetting(holiday: "#ff0000", default: "#ff00ff")
+        let setting = AppearanceSettings(calendar: calendar, defaultTagColor: tag)
+        let viewAppearance = ViewAppearance(setting: setting, isSystemDarkTheme: false)
+        let eventHandler = DayEventListViewEventHandler()
 
-    var body: some View {
-        voiceModeView()
-    }
+        let listeningState = DayEventListViewState()
+        listeningState.dayModel = .init(dateText: "2020년 9월 15일(금)", lunarDateText: "6월 4일")
+        listeningState.aiAgentState = .listening(.voice)
+        listeningState.voiceLevel = 0.4
+        listeningState.recognizingText = "내일 오전 9시 회의 추가"
 
-    private func voiceModeView() -> some View {
-        HStack(spacing: 8) {
-
-            Button {
-                self.eventHandler.enterKeyboardInput()
-            } label: {
-                Image(systemName: "keyboard")
-                    .foregroundColor(self.appearance.colorSet.text0.asColor)
-            }
-            .frame(width: 52)
-
-            RoundedRectangle(cornerRadius: 3)
-                .fill(self.appearance.tagColors.defaultColor.asColor)
-                .frame(width: 6)
-
-            VoiceWaveformView(
-                level: self.state.voiceLevel,
-                tintColor: self.appearance.colorSet.text1.asColor
-            )
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 8)
-
-            HStack(spacing: 4) {
-                Button {
-                    self.eventHandler.stopAIAgentInput()
-                } label: {
-                    Circle()
-                        .fill(
-                            appearance.colorSet.secondaryBtnBackground.asColor
-                        )
-                        .overlay(
-                            Image(systemName: "square")
-                                .foregroundColor(self.appearance.colorSet.secondaryBtnText.asColor)
-                                .padding(8)
-                        )
-                }
-
-                Button {
-                    self.eventHandler.finishVoiceInput()
-                } label: {
-                    Circle()
-                        .fill(
-                            appearance.colorSet.primaryBtnBackground.asColor
-                        )
-                        .overlay(
-                            Image(systemName: "arrow.up")
-                                .foregroundColor(self.appearance.colorSet.primaryBtnText.asColor)
-                                .padding(8)
-                        )
-                }
-            }
-        }
-        .padding(.vertical, 8).padding(.horizontal, 8)
-        .frame(height: 50)
-        .backgroundAsRoundedRectForEventList(appearance)
+        return DayEventListView()
+            .environment(listeningState)
+            .environment(eventHandler)
+            .environment(PendingCompleteTodoState())
+            .environment(viewAppearance)
+            .previewDisplayName("Inline input - listening")
     }
 }

--- a/Presentations/CommonPresentation/Sources/Views/VoiceWaveformView.swift
+++ b/Presentations/CommonPresentation/Sources/Views/VoiceWaveformView.swift
@@ -23,7 +23,8 @@ public struct VoiceWaveformView: View {
 
     public var body: some View {
         WaveformBars(level: CGFloat(self.level), color: self.tintColor)
-            .frame(width: 144, height: 56)
+            .frame(maxWidth: .infinity)
+            .frame(height: 56)
     }
 }
 
@@ -32,28 +33,46 @@ private struct WaveformBars: View {
     let level: CGFloat
     let color: Color
 
-    private let barCount: Int = 7
+    private let barWidth: CGFloat = 5
+    private let minSpacing: CGFloat = 10
+    private let horizontalMargin: CGFloat = 8
     private let minHeight: CGFloat = 4
-    private let maxHeight: CGFloat = 56
+    private let maxHeight: CGFloat = 36
 
     var body: some View {
-        TimelineView(.animation) { context in
-            let time = context.date.timeIntervalSinceReferenceDate
-            HStack(spacing: 5) {
-                ForEach(0..<self.barCount, id: \.self) { index in
-                    Capsule()
-                        .fill(self.color)
-                        .frame(width: 5, height: self.barHeight(index, at: time))
+        GeometryReader { proxy in
+            let count = self.barCount(for: proxy.size.width)
+            TimelineView(.animation) { context in
+                let time = context.date.timeIntervalSinceReferenceDate
+                HStack(spacing: 0) {
+                    ForEach(Array(0..<count), id: \.self) { index in
+                        Capsule()
+                            .fill(self.color)
+                            .frame(width: self.barWidth, height: self.barHeight(index, count, at: time))
+                        if index < count - 1 {
+                            Spacer(minLength: self.minSpacing)
+                        }
+                    }
                 }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
+            .padding(.horizontal, self.horizontalMargin)
         }
+    }
+
+    // 주어진 너비에서 좌우 여백을 뺀 뒤, 막대+최소간격 단위로 최대 몇 개가 들어가는지 계산.
+    private func barCount(for width: CGFloat) -> Int {
+        let available = width - self.horizontalMargin * 2
+        guard available > self.barWidth else { return 1 }
+        let count = Int((available + self.minSpacing) / (self.barWidth + self.minSpacing))
+        return max(1, count)
     }
 
     // 막대 높이는 level이 강도로 깔리고(0.8), 위에 작은 출렁임(0.2)만 얹는다.
     // 가운데 막대일수록 크게 반응(bell). level 0이면 전부 minHeight로 평평.
-    private func barHeight(_ index: Int, at time: TimeInterval) -> CGFloat {
-        let center = Double(self.barCount - 1) / 2
-        let weight = 1.0 - abs(Double(index) - center) / (center + 1)
+    private func barHeight(_ index: Int, _ count: Int, at time: TimeInterval) -> CGFloat {
+        let center = Double(count - 1) / 2
+        let weight = center <= 0 ? 1.0 : 1.0 - abs(Double(index) - center) / (center + 1)
         let wiggle = (sin(time * 9 + Double(index) * 0.9) + 1) / 2
         let intensity = self.level * CGFloat(weight) * (0.8 + 0.2 * CGFloat(wiggle))
         return self.minHeight + (self.maxHeight - self.minHeight) * intensity


### PR DESCRIPTION
## 배경

#629 AI 자연어 입력 인라인 진입점의 UI 디자인 마감. Phase 0~3(진입 버튼·command 시트·게이팅)이 develop에 들어온 뒤, 진입 버튼 배치·상태 뱃지·음성 입력 waveform의 디자인 완성도를 다듬음.

## 변경

### AI 진입 버튼 (`DayEventListView`)
- **QuickAddNewTodoView 배경 내 통합** — 기존엔 quick-add 박스 옆에 형제로 떠 있던 sparkles 버튼을, quick-add와 같은 rounded-rect 배경 안으로 넣음. `opacity`는 입력부에만 걸어 AI 버튼은 항상 선명.
- **processing 상태** — sparkles 대신 `ProgressView` 스피너로 교체해 로딩을 명확히 표현. 별도 점 뱃지 제거.
- **confirm/done/failed 뱃지 재디자인** — 흰(bg0) chip + 컬러 글리프·링으로 통일 (confirm=주황 물음표 / done=파랑 체크 / failed=빨강 느낌표). 기존엔 `primaryBtnBackground`·`accent`가 버튼과 같은 `systemBlue`라 confirm/done 뱃지가 파랑-위-파랑으로 안 튀던 문제를 해소.
- **listening 상태 preview 추가** (`DayEventListInlineInputPreviewProvider`) — `AIAgentInlineInputView`가 노출되는 상태를 프리뷰로 확인 가능.

### 음성 waveform (`VoiceWaveformView`, CommonPresentation)
- **가용 너비 채우기** — 고정 144pt 너비 제거, `maxWidth: .infinity`로 컨테이너 폭을 채움.
- **막대 자동 분배** — `GeometryReader`로 실제 너비를 재서 좌우 여백·최소 간격 기준으로 barCount를 동적 산출하고 `Spacer`로 균등 분배. `barHeight`를 count 인자화해 막대 수가 바뀌어도 bell 곡선(가운데가 크게)을 유지.
- **막대 크기 조정** — 최대 높이 56→36으로 축소해 입력 바 높이에 맞춤.

## 남은 과제 (별도)
- **Phase 4** — done/fail 대화형 재디자인 (디자인 확정 후 착수).
- **미로그인 pre-warm** — 미로그인 유저에도 `coordinator.prepare()`의 사용량/복원 로드가 도는 것. 별도 티켓 검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)