### PR TITLE
[#663] 룩앤필 메트릭 토큰 도입 + presentations-rules 룩앤필 조항

### DIFF
--- a/.claude/rules/presentations-rules.md
+++ b/.claude/rules/presentations-rules.md
@@ -30,6 +30,8 @@ ConfirmButton(
 
 기타: `BottomConfirmButton`, `BottomSlideView`, `CloseButton`, `DescriptionView` 등. `import CommonPresentation` 누락 주의.
 
+새 UI 요소 작성 전 `ls Presentations/CommonPresentation/Sources/`로 전체 인벤토리를 확인한다 — 위 나열이 전부가 아니다.
+
 ## 3. Scene 구조 (6파일)
 
 ```
@@ -174,3 +176,19 @@ private struct Subject {
 다른 모듈에서 참조 필요한 신규 Scene 프로토콜은 위 파일에 추가. 모듈 내부 전용은 해당 모듈 `XxxScene+Builder.swift`.
 
 **Why:** 모듈 간 결합을 끊어 빌드 시간·순환 의존을 관리. 공유 인터페이스만 노출해 구현 디테일 숨김.
+
+## 8. 룩앤필 — 메트릭·그림자·모션
+
+### 메트릭 토큰
+
+corner radius·spacing에 숫자 하드코딩 ❌ → `Metric` 상수 ✅ (CommonPresentation 소속, 테마 무관 고정값이라 ViewAppearance 주입 아님):
+
+- `Metric.Radius.{chip|regular|large|sheet}` = 4 / 8 / 12 / 16 — 칩·뱃지 / 카드·버튼 / 큰 카드·팝업 / 바텀시트·모달
+- `Metric.Spacing.{xsmall|small|regular|large|xlarge}` = 4 / 8 / 12 / 16 / 20
+- **신규·수정 코드부터 강제. 기존 뷰 일괄 마이그레이션 금지** — 손대는 기회에 가장 가까운 대표값으로 스냅해 전환 (미세 시각 변화 허용).
+- 대표값에 없는 값이 필요하면 임의 숫자를 박지 말고 유저와 협의해 토큰을 추가한다.
+
+### 그림자·모션
+
+- **그림자 지양** — 앱은 플랫 톤. 예외는 설정 미리보기류의 시각 강조뿐.
+- **모션 절제** — 상태 전환에 필요한 최소한(easeInOut 계열)만. 장식적 애니메이션 금지.

--- a/Presentations/CommonPresentation/Sources/Appearance/Metric.swift
+++ b/Presentations/CommonPresentation/Sources/Appearance/Metric.swift
@@ -1,0 +1,34 @@
+//
+//  Metric.swift
+//  CommonPresentation
+//
+//  Created by sudo.park on 2026/07/09.
+//
+
+import CoreGraphics
+
+
+// MARK: - Metric
+
+// 룩앤필 메트릭 토큰 — 테마·사용자 설정과 무관한 고정값이라 ViewAppearance 주입 대상이 아님
+public enum Metric {
+
+    public enum Radius {
+        /// 태그 칩, 작은 뱃지
+        public static let chip: CGFloat = 4
+        /// 카드, 버튼
+        public static let regular: CGFloat = 8
+        /// 큰 카드, 팝업
+        public static let large: CGFloat = 12
+        /// 바텀시트, 모달
+        public static let sheet: CGFloat = 16
+    }
+
+    public enum Spacing {
+        public static let xsmall: CGFloat = 4
+        public static let small: CGFloat = 8
+        public static let regular: CGFloat = 12
+        public static let large: CGFloat = 16
+        public static let xlarge: CGFloat = 20
+    }
+}


### PR DESCRIPTION
## 문제

UI 룩앤필 중 색·폰트는 ViewAppearance 토큰으로 강제되지만, corner radius·spacing은 규칙 없이 매직넘버로 산재해 있다 (radius만 90곳+, 8이 지배적이고 칩 3~4·시트 12~16이 뒤섞임). 그림자·모션도 "사실상 플랫·절제 톤"이라는 암묵 관례만 있고 명문화돼 있지 않아, 신규 UI 작업마다 룩앤필 정합을 감으로 맞춰야 했다. (#663, #659 하네스 고도화 리스트업 12번)

## 접근

- `Metric` (CommonPresentation/Appearance 신설) — radius·spacing 대표값 static 상수. `Radius.{chip 4|regular 8|large 12|sheet 16}`, `Spacing.{4~20 5단계}`. 실측 분포를 대표값으로 정규화. 테마·유저 설정과 무관한 고정값이라 ColorSet/FontSet과 달리 ViewAppearance 주입 없이 static 접근 (주입 필요가 생기면 그때 승격)
- `presentations-rules.md §8` 신설 — 메트릭 하드코딩 금지·토큰 강제(신규·수정 코드부터), 기존 뷰는 손대는 기회에 대표값으로 스냅해 점진 전환(일괄 마이그레이션 금지), 그림자 지양(플랫 톤), 모션 절제(easeInOut 계열만)
- `presentations-rules.md §2` 보강 — 새 UI 작성 전 CommonPresentation 전체 인벤토리 확인 절차

## 남은 과제

- 기존 뷰 점진 전환 시 private `enum Metric` 쉐도잉 파일 주의 (MonthView·WeekEventsView·ForemostEventWidget 등) — 로컬 Metric 정리 또는 풀네임 참조 필요
- 완료 판정 스킴 테스트(영향 8스킴)는 로컬 실행 대신 본 PR CI로 가늠

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3rfY2j6yrf4TxPfJb2kpf
