### PR TITLE
[#659] 스킬·서브에이전트 사용 기록 훅 — 유저 지시와 사용 내역을 전역 JSONL로 상관 기록

### DIFF
--- a/.claude/hooks/log-usage.py
+++ b/.claude/hooks/log-usage.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""스킬·서브에이전트 사용 기록 훅.
+
+UserPromptSubmit: 유저 지시를 기록하고 세션별 state에 최신 지시를 저장.
+PostToolUse(Skill·Task·Agent): 사용 레코드에 유발 지시 스니펫을 임베드해 기록.
+fail-open — 어떤 오류에도 exit 0. 기록 실패가 작업을 막지 않는다.
+"""
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+
+LOG_DIR = os.environ.get("USAGE_LOG_DIR") or os.path.expanduser("~/.claude/usage-log")
+PROMPT_LIMIT = 500
+DETAIL_LIMIT = 200
+
+
+def now_iso():
+    return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+
+
+def truncate(text, limit):
+    text = str(text or "").strip()
+    return text if len(text) <= limit else text[:limit] + "…"
+
+
+def log_path():
+    return os.path.join(LOG_DIR, datetime.now().strftime("%Y-%m-%d") + ".jsonl")
+
+
+def state_path(session_id):
+    safe_id = re.sub(r"[^\w.-]", "_", session_id or "unknown")
+    return os.path.join(LOG_DIR, ".sessions", safe_id + ".json")
+
+
+def append_record(record):
+    os.makedirs(LOG_DIR, exist_ok=True)
+    with open(log_path(), "a", encoding="utf-8") as f:
+        f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def save_instruction(session_id, prompt):
+    path = state_path(session_id)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({"instruction": truncate(prompt, PROMPT_LIMIT)}, f, ensure_ascii=False)
+
+
+def load_instruction(session_id):
+    try:
+        with open(state_path(session_id), encoding="utf-8") as f:
+            return json.load(f).get("instruction", "")
+    except (OSError, ValueError):
+        return ""
+
+
+def base_record(event, data):
+    return {
+        "ts": now_iso(),
+        "event": event,
+        "session_id": data.get("session_id", ""),
+        "cwd": data.get("cwd", ""),
+    }
+
+
+def handle_prompt(data):
+    prompt = data.get("prompt", "")
+    snippet = truncate(prompt, PROMPT_LIMIT)
+    save_instruction(data.get("session_id"), prompt)
+
+    record = base_record("prompt", data)
+    record["prompt"] = snippet
+    slash = re.match(r"^/([\w:-]+)", prompt.strip())
+    if slash:
+        record["slash_command"] = slash.group(1)
+    append_record(record)
+
+    if slash:
+        skill_record = base_record("skill", data)
+        skill_record["name"] = slash.group(1)
+        skill_record["via"] = "slash"
+        skill_record["instruction"] = snippet
+        append_record(skill_record)
+
+
+def handle_tool(data):
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input") or {}
+    if tool_name == "Skill":
+        record = base_record("skill", data)
+        record["name"] = tool_input.get("skill", "")
+        record["via"] = "tool"
+        args = truncate(tool_input.get("args", ""), DETAIL_LIMIT)
+        if args:
+            record["args"] = args
+    elif tool_name in ("Task", "Agent"):
+        record = base_record("agent", data)
+        record["name"] = tool_input.get("subagent_type") or "general-purpose"
+        record["detail"] = truncate(tool_input.get("description", ""), DETAIL_LIMIT)
+    else:
+        return
+    record["instruction"] = load_instruction(data.get("session_id"))
+    append_record(record)
+
+
+def main():
+    data = json.load(sys.stdin)
+    event = data.get("hook_event_name", "")
+    if event == "UserPromptSubmit":
+        handle_prompt(data)
+    elif event == "PostToolUse":
+        handle_tool(data)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass
+    sys.exit(0)

--- a/.claude/hooks/log-usage.test.sh
+++ b/.claude/hooks/log-usage.test.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# log-usage.py 회귀 테스트 — 임시 USAGE_LOG_DIR에 fixture 이벤트를 흘려 기록 검증
+cd "$(dirname "$0")" || exit 1
+PASS=0; FAIL=0
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+export USAGE_LOG_DIR="$TMP_DIR"
+TODAY=$(date +%Y-%m-%d)
+LOG="$TMP_DIR/$TODAY.jsonl"
+
+run_hook() { printf '%s' "$1" | python3 log-usage.py; }
+last_line() { tail -1 "$LOG"; }
+field() { # json_line key
+  printf '%s' "$1" | python3 -c "import json,sys; print(json.load(sys.stdin).get('$2',''))"
+}
+
+assert_eq() { # desc expected actual
+  if [ "$2" = "$3" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); echo "FAIL: $1"; echo "  expected: [$2]"; echo "  actual:   [$3]"; fi
+}
+
+# --- prompt 기록 ---
+run_hook '{"hook_event_name":"UserPromptSubmit","session_id":"s1","cwd":"/proj","prompt":"11번 빠르게 시작하자"}'
+assert_eq "prompt 이벤트 기록" "prompt" "$(field "$(last_line)" event)"
+assert_eq "prompt 본문" "11번 빠르게 시작하자" "$(field "$(last_line)" prompt)"
+assert_eq "session_id 기록" "s1" "$(field "$(last_line)" session_id)"
+
+# --- Skill 툴 사용 → 직전 지시 임베드 ---
+run_hook '{"hook_event_name":"PostToolUse","session_id":"s1","cwd":"/proj","tool_name":"Skill","tool_input":{"skill":"kickoff","args":"659"}}'
+assert_eq "skill 이벤트" "skill" "$(field "$(last_line)" event)"
+assert_eq "skill 이름" "kickoff" "$(field "$(last_line)" name)"
+assert_eq "via tool" "tool" "$(field "$(last_line)" via)"
+assert_eq "지시 임베드" "11번 빠르게 시작하자" "$(field "$(last_line)" instruction)"
+
+# --- Task 툴(서브에이전트) 사용 ---
+run_hook '{"hook_event_name":"PostToolUse","session_id":"s1","cwd":"/proj","tool_name":"Task","tool_input":{"subagent_type":"code-reviewer","description":"관점 리뷰","prompt":"..."}}'
+assert_eq "agent 이벤트" "agent" "$(field "$(last_line)" event)"
+assert_eq "agent 타입" "code-reviewer" "$(field "$(last_line)" name)"
+assert_eq "agent 지시 임베드" "11번 빠르게 시작하자" "$(field "$(last_line)" instruction)"
+
+# --- Agent 툴명도 동일 처리 ---
+run_hook '{"hook_event_name":"PostToolUse","session_id":"s1","cwd":"/proj","tool_name":"Agent","tool_input":{"subagent_type":"Explore","description":"탐색"}}'
+assert_eq "Agent 툴명 지원" "agent" "$(field "$(last_line)" event)"
+
+# --- subagent_type 없으면 general-purpose ---
+run_hook '{"hook_event_name":"PostToolUse","session_id":"s1","cwd":"/proj","tool_name":"Task","tool_input":{"description":"기본 에이전트"}}'
+assert_eq "기본 agent 타입" "general-purpose" "$(field "$(last_line)" name)"
+
+# --- 슬래시 커맨드 → prompt 레코드 + skill 레코드 두 줄 ---
+run_hook '{"hook_event_name":"UserPromptSubmit","session_id":"s2","cwd":"/proj","prompt":"/kickoff 659 11번"}'
+assert_eq "슬래시 → skill 기록" "skill" "$(field "$(last_line)" event)"
+assert_eq "슬래시 스킬명" "kickoff" "$(field "$(last_line)" name)"
+assert_eq "via slash" "slash" "$(field "$(last_line)" via)"
+
+# --- 세션 격리: s2 지시가 s1 사용 레코드에 안 섞임 ---
+run_hook '{"hook_event_name":"PostToolUse","session_id":"s1","cwd":"/proj","tool_name":"Skill","tool_input":{"skill":"commit"}}'
+assert_eq "세션별 지시 격리" "11번 빠르게 시작하자" "$(field "$(last_line)" instruction)"
+
+# --- 500자 절단 ---
+LONG=$(python3 -c "print('가'*600)")
+run_hook "{\"hook_event_name\":\"UserPromptSubmit\",\"session_id\":\"s3\",\"cwd\":\"/proj\",\"prompt\":\"$LONG\"}"
+assert_eq "프롬프트 500자 절단" "501" "$(field "$(last_line)" prompt | tr -d '\n' | wc -m | tr -d ' ')"
+
+# --- state 없는 세션의 사용 → instruction 빈 문자열 폴백 ---
+run_hook '{"hook_event_name":"PostToolUse","session_id":"s-nostate","cwd":"/proj","tool_name":"Skill","tool_input":{"skill":"plan"}}'
+assert_eq "state 부재 시 instruction 폴백" "" "$(field "$(last_line)" instruction)"
+
+# --- 비문자열 tool_input 필드 → str 코어션으로 레코드 유실 없음 ---
+run_hook '{"hook_event_name":"PostToolUse","session_id":"s1","cwd":"/proj","tool_name":"Skill","tool_input":{"skill":"kickoff","args":{"n":1}}}'
+assert_eq "비문자열 args 코어션" "skill" "$(field "$(last_line)" event)"
+
+# --- 무관 툴 무시 ---
+BEFORE=$(wc -l < "$LOG" | tr -d ' ')
+run_hook '{"hook_event_name":"PostToolUse","session_id":"s1","cwd":"/proj","tool_name":"Read","tool_input":{"file_path":"/foo"}}'
+assert_eq "무관 툴 미기록" "$BEFORE" "$(wc -l < "$LOG" | tr -d ' ')"
+
+# --- fail-open: 깨진 입력에도 exit 0 ---
+printf 'not-json' | python3 log-usage.py
+assert_eq "fail-open exit 0 (깨진 JSON)" "0" "$?"
+printf '{}' | python3 log-usage.py
+assert_eq "fail-open exit 0 (빈 이벤트)" "0" "$?"
+
+echo "---"
+echo "PASS: $PASS / FAIL: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/log-usage.py\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "^(Skill|Task|Agent)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/log-usage.py\""
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## 문제

하네스에 스킬·subagent가 늘었지만(#659 리스트업 1~14), 실제 작업에서 **어떤 지시에 어떤 스킬·에이전트가 사용되는지** 관측 수단이 없다. 프로세스가 의도대로 도는지(스킬이 제때 invoke되는지, 리뷰 subagent가 어떤 지시로 dispatch되는지) 확인하려면 세션 기억에 의존해야 했다.

## 접근

프로젝트 훅 2개로 관측 파이프라인을 만든다 (`.claude/settings.json` 신설, 스크립트는 `.claude/hooks/log-usage.py` 단일 파일):

- **UserPromptSubmit** — 유저 지시를 기록하고 세션별 state 파일에 최신 지시를 저장. `/kickoff`처럼 직접 친 슬래시 커맨드는 Skill 툴을 안 타므로 여기서 감지해 skill 레코드도 남긴다.
- **PostToolUse** (matcher `^(Skill|Task|Agent)$`) — 스킬·subagent 사용 레코드에 state의 지시 스니펫을 임베드. 로그 한 줄만 봐도 "어떤 지시 → 뭐가 사용됐는지" 읽힌다.

기록은 전역 경로 `~/.claude/usage-log/YYYY-MM-DD.jsonl` (일별 JSONL, 프롬프트 500자 절단). **fail-open** — 스크립트는 어떤 오류에도 exit 0이라 기록 실패가 작업을 막지 않는다. matcher 앵커는 `TaskCreate` 같은 유사 이름 툴 오매칭 방지, 스크립트의 tool_name 정확 비교로 이중 방어. session_id는 파일명 sanitize, 비문자열 tool_input 필드는 str 코어션으로 레코드 유실 없음.

검증: 회귀 테스트 22건(`log-usage.test.sh`, fixture stdin 파이프 — impact-check.test.sh 패턴) + 라이브 확인(headless 세션 prompt 레코드, 현행 세션의 Agent dispatch 실기록 — settings.json 생성 즉시 활성).

## 남은 과제

- `.sessions/` state 파일 누적 정리(opportunistic prune) — 세션당 수백 바이트라 후속으로 defer
- 로그 디렉토리 퍼미션 축소(chmod 700) — `~/.claude` 노출 수준과 동일해 defer
- 쌓인 로그의 소비(프로세스 준수 분석·리포트)는 이 PR 스코프 밖 — 관측 데이터가 모인 뒤 별도 킥오프

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3rfY2j6yrf4TxPfJb2kpf