### PR TITLE
[#674] View.padding(_:spacing:) 토큰 오버로드 — padding 대표값 강제

### DIFF
--- a/.claude/rules/presentations-rules.md
+++ b/.claude/rules/presentations-rules.md
@@ -209,6 +209,7 @@ corner radius·spacing에 숫자 하드코딩 ❌ → `Metric` 상수 ✅ (Commo
 
 - `Metric.Radius.{chip|regular|large|sheet}` = 4 / 8 / 12 / 16 — 칩·뱃지 / 카드·버튼 / 큰 카드·팝업 / 바텀시트·모달
 - `Metric.Spacing.{xxsmall|xsmall|small|regular|large|xlarge|indent}` = 2 / 4 / 8 / 12 / 16 / 20 / 32 — `indent`는 계층 들여쓰기(leading) 전용
+- **padding은 토큰 오버로드로**: `.padding(.top, spacing: .regular)` / `.padding(spacing: .xlarge)` (`View.padding(_:spacing:)`, `Metric.SpacingToken`) — 시스템 `.padding`에 숫자·CGFloat 직접 전달 금지. `Metric.Spacing` 상수는 stack `spacing:` 파라미터처럼 CGFloat가 필요한 자리에만.
 - **신규·수정 코드부터 강제. 기존 뷰 일괄 마이그레이션 금지** — 손대는 기회에 가장 가까운 대표값으로 스냅해 전환 (미세 시각 변화 허용).
 - 대표값에 없는 값이 필요하면 임의 숫자를 박지 말고 유저와 협의해 토큰을 추가한다.
 

--- a/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandStageView.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandStageView.swift
@@ -150,7 +150,7 @@ private extension AIAgentCommandStageView {
                 backgroundColor: appearance.colorSet.secondaryBtnBackground.asColor
             )
             .eventHandler(\.onTap, eventHandlers.cancel)
-            .padding(.top, Metric.Spacing.xsmall)
+            .padding(.top, spacing: .xsmall)
         }
     }
 
@@ -174,8 +174,8 @@ private extension AIAgentCommandStageView {
             }
             .frame(maxHeight: 200)
             .fixedSize(horizontal: false, vertical: true)
-            .padding(.horizontal, Metric.Spacing.large)
-            .padding(.vertical, Metric.Spacing.regular)
+            .padding(.horizontal, spacing: .large)
+            .padding(.vertical, spacing: .regular)
             .background(
                 // 내 메시지 — 다크 배경 + 밝은 글씨. 전용 토큰으로 테마별 대비 자동 유지
                 RoundedRectangle(cornerRadius: Metric.Radius.sheet)
@@ -188,8 +188,8 @@ private extension AIAgentCommandStageView {
     func assistantBubble<Content: View>(@ViewBuilder _ content: () -> Content) -> some View {
         HStack(spacing: 0) {
             content()
-                .padding(.horizontal, Metric.Spacing.large)
-                .padding(.vertical, Metric.Spacing.large)
+                .padding(.horizontal, spacing: .large)
+                .padding(.vertical, spacing: .large)
                 .background(
                     RoundedRectangle(cornerRadius: Metric.Radius.sheet)
                         .fill(appearance.colorSet.bg1.asColor)
@@ -245,7 +245,7 @@ private extension AIAgentCommandStageView {
                 )
                 .eventHandler(\.onTap, eventHandlers.confirm)
             }
-            .padding(.top, Metric.Spacing.xsmall)
+            .padding(.top, spacing: .xsmall)
         }
     }
 }
@@ -281,7 +281,7 @@ private extension AIAgentCommandStageView {
                 backgroundColor: appearance.colorSet.accentAI.asColor
             )
             .eventHandler(\.onTap, eventHandlers.acknowledge)
-            .padding(.top, Metric.Spacing.xsmall)
+            .padding(.top, spacing: .xsmall)
         }
     }
 }
@@ -317,7 +317,7 @@ private extension AIAgentCommandStageView {
                 backgroundColor: appearance.colorSet.accentAI.asColor
             )
             .eventHandler(\.onTap, eventHandlers.acknowledge)
-            .padding(.top, Metric.Spacing.xsmall)
+            .padding(.top, spacing: .xsmall)
         }
     }
 }

--- a/Presentations/AIAgentScene/Sources/AIAgentKeyboardInput/AIAgentKeyboardInputView.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentKeyboardInput/AIAgentKeyboardInputView.swift
@@ -109,7 +109,7 @@ private struct AIAgentKeyboardInputView: View {
                     .textInputAutocapitalization(.never)
                     .foregroundStyle(appearance.colorSet.text0.asColor)
                     .font(appearance.fontSet.size(16, weight: .regular).asFont)
-                    .padding(Metric.Spacing.regular)
+                    .padding(spacing: .regular)
                     .background(
                         RoundedRectangle(cornerRadius: Metric.Radius.chip)
                             .fill(appearance.colorSet.bg1.asColor)

--- a/Presentations/CommonPresentation/Sources/Appearance/Metric.swift
+++ b/Presentations/CommonPresentation/Sources/Appearance/Metric.swift
@@ -24,39 +24,39 @@ public enum Metric {
         public static let sheet: CGFloat = 16
     }
 
-    public enum Spacing {
-        /// 밀착 텍스트·아이콘 간격
-        public static let xxsmall: CGFloat = 2
-        public static let xsmall: CGFloat = 4
-        public static let small: CGFloat = 8
-        public static let regular: CGFloat = 12
-        public static let large: CGFloat = 16
-        public static let xlarge: CGFloat = 20
-        /// 계층 들여쓰기 (leading)
-        public static let indent: CGFloat = 32
-    }
-
-    /// padding 전용 정규화 토큰 — View.padding(_:spacing:)이 대표값만 받도록 강제한다.
-    /// 값은 Spacing 상수를 단일 소스로 참조 (Spacing 상수는 stack spacing: 등 CGFloat 자리에 계속 사용).
+    /// spacing 정규화 토큰 — 값의 단일 소스. View.padding(_:spacing:)이 대표값만 받도록 강제한다.
     public enum SpacingToken {
+        /// 밀착 텍스트·아이콘 간격
         case xxsmall
         case xsmall
         case small
         case regular
         case large
         case xlarge
+        /// 계층 들여쓰기 (leading)
         case indent
 
         public var value: CGFloat {
             switch self {
-            case .xxsmall: return Spacing.xxsmall
-            case .xsmall: return Spacing.xsmall
-            case .small: return Spacing.small
-            case .regular: return Spacing.regular
-            case .large: return Spacing.large
-            case .xlarge: return Spacing.xlarge
-            case .indent: return Spacing.indent
+            case .xxsmall: return 2
+            case .xsmall: return 4
+            case .small: return 8
+            case .regular: return 12
+            case .large: return 16
+            case .xlarge: return 20
+            case .indent: return 32
             }
         }
+    }
+
+    /// SpacingToken 값의 CGFloat 파생 상수 — stack spacing: 파라미터 등 CGFloat 자리 전용
+    public enum Spacing {
+        public static let xxsmall: CGFloat = SpacingToken.xxsmall.value
+        public static let xsmall: CGFloat = SpacingToken.xsmall.value
+        public static let small: CGFloat = SpacingToken.small.value
+        public static let regular: CGFloat = SpacingToken.regular.value
+        public static let large: CGFloat = SpacingToken.large.value
+        public static let xlarge: CGFloat = SpacingToken.xlarge.value
+        public static let indent: CGFloat = SpacingToken.indent.value
     }
 }

--- a/Presentations/CommonPresentation/Sources/Appearance/Metric.swift
+++ b/Presentations/CommonPresentation/Sources/Appearance/Metric.swift
@@ -35,4 +35,28 @@ public enum Metric {
         /// 계층 들여쓰기 (leading)
         public static let indent: CGFloat = 32
     }
+
+    /// padding 전용 정규화 토큰 — View.padding(_:spacing:)이 대표값만 받도록 강제한다.
+    /// 값은 Spacing 상수를 단일 소스로 참조 (Spacing 상수는 stack spacing: 등 CGFloat 자리에 계속 사용).
+    public enum SpacingToken {
+        case xxsmall
+        case xsmall
+        case small
+        case regular
+        case large
+        case xlarge
+        case indent
+
+        public var value: CGFloat {
+            switch self {
+            case .xxsmall: return Spacing.xxsmall
+            case .xsmall: return Spacing.xsmall
+            case .small: return Spacing.small
+            case .regular: return Spacing.regular
+            case .large: return Spacing.large
+            case .xlarge: return Spacing.xlarge
+            case .indent: return Spacing.indent
+            }
+        }
+    }
 }

--- a/Presentations/CommonPresentation/Sources/Appearance/View+MetricPadding.swift
+++ b/Presentations/CommonPresentation/Sources/Appearance/View+MetricPadding.swift
@@ -1,0 +1,19 @@
+//
+//  View+MetricPadding.swift
+//  CommonPresentation
+//
+//  Created by sudo.park on 7/12/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import SwiftUI
+
+
+extension View {
+
+    /// Metric 대표값만 허용하는 padding — 임의 CGFloat 대신 이 오버로드를 사용한다 (rules §8).
+    /// `spacing:` 레이블로 시스템 `padding(_:_:)`과 시그니처가 분리된다.
+    public func padding(_ edges: Edge.Set = .all, spacing: Metric.SpacingToken) -> some View {
+        return self.padding(edges, spacing.value)
+    }
+}

--- a/Presentations/CommonPresentation/Sources/UIComponents/FullScreenLoadingView.swift
+++ b/Presentations/CommonPresentation/Sources/UIComponents/FullScreenLoadingView.swift
@@ -30,7 +30,7 @@ public struct FullScreenLoadingView: View {
                 self.messageLabel
                 self.loadingView
             }
-            .padding(Metric.Spacing.xlarge)
+            .padding(spacing: .xlarge)
             .background(Color.black.opacity(0.8))
             .cornerRadius(Metric.Radius.sheet)
         } else {

--- a/Presentations/CommonPresentation/Sources/UIComponents/SheetHeaderView.swift
+++ b/Presentations/CommonPresentation/Sources/UIComponents/SheetHeaderView.swift
@@ -33,7 +33,7 @@ public struct SheetHeaderView: View {
 
             self.closeButton
         }
-        .padding(.top, Metric.Spacing.regular)
+        .padding(.top, spacing: .regular)
     }
 
     // 리퀴드 글래스는 iOS 26 전용이라 #available로 분기, 하위 버전은 CloseButton.


### PR DESCRIPTION
## 문제

Metric 토큰을 padding에 쓸 때 시스템 `.padding(CGFloat)`가 그대로 열려 있어 임의 숫자 전달을 API 레벨에서 막지 못한다 (#674 진행 중 유저 제안 — 대표값 강제를 타입으로).

## 접근

- **`Metric.SpacingToken`** — padding 전용 정규화 토큰 enum (xxsmall~indent). 값은 `Metric.Spacing` 상수를 단일 소스로 참조하고, 상수는 stack `spacing:` 파라미터처럼 CGFloat가 필요한 자리 전용으로 존치 (마이그레이션 중 어휘 유지).
- **`View.padding(_:spacing:)`** — `.padding(.top, spacing: .regular)` / `.padding(spacing: .xlarge)`. `spacing:` 레이블로 시스템 `padding(_:_:)`과 시그니처 충돌 없음.
- **기존 치환지 전환 11곳** (Phase 1·2 산출) — 값 동일 전환, 스냅샷 5스킴 재실행 png diff 0. rules §8에 사용 규칙 명문화, 플랜 §5 치환 형태도 갱신 (Phase 3~7부터 padding 히트는 이 형태로 치환).

## 남은 과제

- 다음 페이즈: Phase 3 MemberScenes — padding 히트부터 새 오버로드 적용
- stack `spacing:` 파라미터의 토큰 강제(커스텀 이니셜라이저)는 미도입 — 필요해지면 별도 협의

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdJTyzNcHRqkBvDwogYg3k
