### PR TITLE
[#659] CLAUDE.md 상황 매핑 재배치 — 스킬 정본 중복 제거 + 상황→하네스 매핑 표

### DIFF
--- a/.claude/skills/add-framework/SKILL.md
+++ b/.claude/skills/add-framework/SKILL.md
@@ -30,7 +30,7 @@ description: Use when creating a new framework (module) in this project — 신�
 - `scripts/run-all-tests.sh` — `ALL_SCHEMES` 배열
 - `.claude/skills/implement/scripts/impact-check.sh` — `ALL_SCHEMES`/`ALL_PRESENTATION` 상수 + 경로→스킴 매핑 블록 + **이 프레임워크에 의존하는 상위 레이어(Domain 등) 블록에 새 스킴 파급 추가** + `impact-check.test.sh`의 배열·assertion 갱신
 - `.claude/skills/run-tests/SKILL.md` — 스킴 목록과 개수 문구
-- `CLAUDE.md` — §2 모듈 구조·§3 주요 스킴 목록
+- `CLAUDE.md` — §2 모듈 구조 (스킴 목록은 run-tests 스킬이 정본 — 위 항목이 커버)
 
 ## 4. 문서·rules
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -18,6 +18,7 @@ description: Use when writing or modifying code in this project — 구현 착�
 시작할 때:
 
 - 변경 대상 경로에 걸리는 `.claude/rules/*.md` 조항을 확인하고, 구현 결정 시점에 해당 조항을 적극 invoke한다.
+- child CLAUDE.md가 있는 프레임워크(Domain·Repository·각 Presentation 등)를 수정할 땐 해당 child CLAUDE.md를 확인하고, 수정 후 그 규칙과 어긋남이 없는지 재점검한다.
 - 동종 컴포넌트를 grep해 구조 패턴(상태관리·합성·추상화 수준)을 파악하고 그 패턴을 따른다. 요구사항만 보고 즉흥 구현하지 않는다.
 - 서브에이전트에 구현을 dispatch할 땐 프롬프트에 적용 rules 조항·대상 테스트 스킴·따라야 할 구조 패턴을 명시한다.
 

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -22,12 +22,14 @@ DESTINATION='platform=iOS Simulator,name=iPhone 16,OS=18.1' ./scripts/run-all-te
 
 ## Available Schemes
 
-`Domain` / `Repository` / `CalendarScenes` / `EventDetailScene` / `EventListScenes` / `SettingScene` / `MemberScenes` / `TodoCalendarApp` / `TodoCalendarAppWidget`
+`Domain` / `Repository` / `CalendarScenes` / `EventDetailScene` / `EventListScenes` / `SettingScene` / `MemberScenes` / `AIAgentScene` / `TodoCalendarApp` / `TodoCalendarAppWidget`
+
+이 목록이 문서 쪽 스킴 목록의 **정본**이다 (CLAUDE.md §3에서 이관). 신규 스킴 등록 절차는 add-framework 스킬.
 
 ## Instructions
 
 1. 프로젝트 루트(`/Users/sudo.park/Documents/codebase/TodoCalendar`)에서 실행
-2. 인자 없이 실행하면 9개 스킴 전체 순차 실행
+2. 인자 없이 실행하면 10개 스킴 전체 순차 실행
 3. 실패 시 `FAILED` 스킴 목록과 상위 에러 라인 출력
 4. 빌드 실패(`BUILD FAILED`)도 FAILED로 판정됨
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,15 +3,12 @@
 ## 1. 절대 규칙
 
 - **수정 전 파일 먼저 read.** 추측 수정 금지.
-- **파일 추가/삭제 시 `tuist generate` 재실행.**
 - **Query/Command 분리.** 읽기와 사이드이펙트를 한 흐름에 섞지 말 것.
-- **TDD 워크플로우.** 테스트 → 실패 확인 → 구현 → 통과.
-- **child CLAUDE.md가 있는 프레임워크 코드를 수정한 경우** 해당 child CLAUDE.md 재분석.
-- **객체 변경 시** 참조하는 다른 객체 영향도 확인 (빌드 + 테스트).
+- **객체 변경 시** 참조하는 다른 객체 영향도 확인 (빌드 + 테스트) — 절차는 implement 스킬의 impact-check가 기계화.
 - **짝지어진 두 위치는 함께 갱신.** 한쪽만 바꾸면 무효가 되는 쌍은 추가/변경 시 대응처도 반드시 확인:
   - `AppEnvironment.dbVersion` ↔ `Table.migrateStatement(for:)` case
   - CI `pr_test.yml` — `detect-changes`의 scheme 매핑(grep) ↔ `test` job의 `Test <scheme>` 실행 step (둘 중 하나만 추가하면 감지만 되고 실행 안 됨)
-  - 신규 테스트 스킴 ↔ 스킴 목록 하드코딩 전부 (`pr_test.yml` 3곳·`scripts/run-all-tests.sh`·`impact-check.sh`+테스트·`run-tests` 스킬·CLAUDE.md 스킴 목록 — 상세는 add-framework 스킬. 단 `<Name>Snapshots` 스킴은 의도된 예외 — 로컬 전용, snapshot-check 스킬)
+  - 신규 테스트 스킴 ↔ 스킴 목록 하드코딩 전부 (`pr_test.yml` 3곳·`scripts/run-all-tests.sh`·`impact-check.sh`+테스트·`run-tests` 스킬 — 상세는 add-framework 스킬. 단 `<Name>Snapshots` 스킴은 의도된 예외 — 로컬 전용, snapshot-check 스킬)
   - init 시그니처 ↔ 콜사이트
 - **`.claude/rules/*.md`는 path 매칭 시 자동 로드** — 로드된 조항을 구현 결정 시점에 적극 invoke.
 
@@ -45,14 +42,14 @@ Presentation 모듈끼리 직접 import 금지. `Scenes` 프레임워크의 공�
 
 | 파일 | 역할 |
 |---|---|
-| `TodoCalendarApp/AppEnvironment.swift` | DB version, App Group ID, 외부 캘린더 서비스 목록 |
+| `TodoCalendarApp/Sources/AppEnvironment.swift` | DB version, App Group ID, 외부 캘린더 서비스 목록 |
 | `TodoCalendarApp/Sources/Root/ApplicationRootBuilder.swift` | 앱 시작 시 모든 Repository/Usecase/Factory 조립 |
 | `TodoCalendarApp/Sources/Factories/ApplicationBase.swift` | Pool/Factory 인스턴스 생성 (다중 계정 인프라 포함) |
 | `Tuist/ProjectDescriptionHelpers/Project+Templates.swift` | `Project.app()` / `Project.framework()` 팩토리 헬퍼 |
 
 ---
 
-## 3. 빌드 / 테스트
+## 3. 워크플로우 — 상황별 하네스
 
 ```bash
 ./install/install.sh          # 더미 config 복사 (최초 1회)
@@ -60,7 +57,21 @@ tuist install                 # SPM 의존성 resolve
 tuist generate --no-open      # 파일 추가/삭제 후 재실행 필수
 ```
 
-테스트는 `./scripts/run-all-tests.sh [scheme...]`. 주요 스킴: `Domain`, `Repository`, `CalendarScenes`, `EventDetailScene`, `EventListScenes`, `SettingScene`, `MemberScenes`, `AIAgentScene`.
+상황이 오면 대응 하네스를 invoke한다 (스킬 자동 트리거의 보강 인덱스):
+
+| 상황 | 하네스 |
+|---|---|
+| 이슈 기반 작업 착수 | kickoff 스킬 |
+| 페어 프로그래밍 선언 | pair-programming 스킬 |
+| 구현 계획 작성 | plan 스킬 (superpowers writing-plans 컴패니언) |
+| 코드 작성·수정 | implement 스킬 (superpowers 코딩 절차 컴패니언) |
+| 파일·프레임워크 추가 | add-file / add-framework 스킬 |
+| 테스트 실행 | run-tests 스킬 (스킴 목록 정본) |
+| UI 디자인 | design 스킬 |
+| 스냅샷 검증·화면 카탈로그 | snapshot-check / app-catalog 스킬 |
+| 코드 분석 (로직·추적·관계·영향도) | analyze 스킬 → code-analyzer subagent |
+| 커밋 / PR / 이슈 | commit / pr / issue 스킬 |
+| 공개 PR 에이전트 리뷰 | review 스킬 → code-reviewer subagent |
 
 > 테스트 작성 원칙: [`.claude/rules/testability.md`](.claude/rules/testability.md) (path 매칭 자동 로드)
 
@@ -117,6 +128,8 @@ tuist generate --no-open      # 파일 추가/삭제 후 재실행 필수
 
 모든 Usecase가 공유하는 Combine 기반 싱글톤. 키: `todos`, `schedules`, `tags`, `googleCalendarEvents`, `googleCalendarTags`, `foremostEventId`.
 
+> 키 상세·구독 패턴: [`Domain/CLAUDE.md`](Domain/CLAUDE.md)
+
 ### 앱 버전 체크
 
 원격 JSON(`app-config/update-info.json`, GitHub raw)에서 최소 지원 버전을 받아 `forceRequired`(강제, dismiss 차단) / `recommended`(권장 팝업) 판정. `AppUpdateCheckUsecase`가 앱 시작 + 포그라운드 복귀 시 트리거. 세부: [`docs/spec/infrastructure.md §7`](docs/spec/infrastructure.md).
@@ -124,6 +137,8 @@ tuist generate --no-open      # 파일 추가/삭제 후 재실행 필수
 ### DB 마이그레이션
 
 `AppEnvironment.dbVersion` 증가 + 해당 `Table.migrateStatement(for:)`에 case 추가. 둘 다 변경해야 실행됨. 외부 캘린더 DB는 `googleCalendarDBVersion` + `ExternalCalendarDBConnectionPool`이 `onFirstOpen` 시 마이그레이션 실행.
+
+> 마이그레이션 작성 예제: [`Repository/CLAUDE.md`](Repository/CLAUDE.md)
 
 ---
 


### PR DESCRIPTION
#659 리스트업 6번 (스펙 브리프: https://github.com/sudopark/TodoCalendar/issues/659#issuecomment-4957420314)

## 문제

#659에서 스킬 14종·subagent 2종이 생기면서 루트 CLAUDE.md의 지침 다수가 스킬과 중복됐다 — tuist generate는 3개 스킬과 §1·§3 자체 중복, 테스트 커맨드·스킴 목록은 run-tests와 완전 중복이면서 3중 불일치(스크립트 10종 vs 문서 9종), §4 일부는 child CLAUDE.md와 링크 없이 중복돼 드리프트 중. 반대로 "child CLAUDE.md 재분석"은 워크플로우 시점 지침인데 어느 스킬에도 없는 갭이었다. CLAUDE.md는 상시 로드라 중복은 곧 토큰 비용이다.

## 접근

**커밋 순서가 정합성을 지킨다** — 스킬 쪽을 먼저 완결 상태로 만들고 CLAUDE.md에서 걷어냈다 (중간 상태에도 정본 공백 없음).

1. **스킬 쪽 이관 수신** — run-tests 스킴 목록을 스크립트 실측 10종으로 보정(AIAgentScene 누락 해소)하고 문서 스킴 목록의 정본으로 선언. implement 착수 절에 child CLAUDE.md 확인을 이관(갭 해소). add-framework의 "§3 주요 스킴 목록" 참조를 run-tests로 갱신.
2. **CLAUDE.md 재배치** — §1에서 스킬이 정본인 항목 삭제(tuist generate·TDD·child 재분석)·축약(객체 영향도 → impact-check 참조), 짝 목록에서 "CLAUDE.md 스킴 목록" 제거. §3을 "워크플로우 — 상황별 하네스"로 전환: 온보딩 커맨드 + 상황→하네스 매핑 표 11행 (스킬 자동 트리거의 보강 인덱스). §4 SharedDataStore·DB 마이그레이션에 child CLAUDE.md 명시 링크(외부캘린더 절 모범 패턴). §2 주요 파일 표 AppEnvironment 경로 오기 수정.

**유지한 것**: §1 짝지어진 두 위치(6개 하네스 파일이 참조하는 정본), §4 도메인 컨텍스트(어느 스킬에도 없는 고아 지식), §5 커밋 예시(3스킬 참조 정본).

16번 정비 메모 2건(AppEnvironment 경로 오기·run-tests 스킴 누락)이 이 PR에서 함께 소진됐다.

## 남은 과제

- docs/coding-style-and-philosophy.md·docs/scene-spec.md와 CLAUDE.md 간 중복 여부는 미확인 — 필요 시 별도 정리
- 매핑 표는 스킬 추가 시 갱신 짝이 하나 늘어난 것 — add-framework류 절차엔 해당 없음(워크플로우 스킬 신설 시에만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3rfY2j6yrf4TxPfJb2kpf
