### PR TITLE
[#659] 리스트업 16번 잔여 정비 — kickoff A-3 plan 컴패니언 + impact-check.sh tuist 오탐

### DIFF
--- a/.claude/skills/implement/scripts/impact-check.sh
+++ b/.claude/skills/implement/scripts/impact-check.sh
@@ -35,7 +35,6 @@ fi
 
 # R100<TAB>old<TAB>new 같은 rename은 old/new 경로 모두 영향 대상
 FILES=$(printf '%s\n' "$CHANGES" | awk -F'\t' 'NF>=2 {for (i=2; i<=NF; i++) print $i}')
-STATUSES=$(printf '%s\n' "$CHANGES" | awk 'NF {print substr($1,1,1)}')
 
 # ---- 테스트 스킴 (pr_test.yml detect-changes 미러) ----
 schemes=()
@@ -92,9 +91,11 @@ if printf '%s\n' "$FILES" | grep -q "^TodoCalendarApp/AppExtensions/Widget/"; th
 fi
 
 # ---- tuist generate (테스트보다 선행 액션 — 첫 섹션으로 출력) ----
+# tuist 재생성은 소스 멤버십(.swift) 추가/삭제/이동에만 필요 — 비소스(.md·png·.claude·scripts 등)는 무관
 echo "## tuist generate"
-if printf '%s\n' "$STATUSES" | grep -q '[ADRC]'; then
-  echo "필요 — 파일 추가/삭제/이동 감지"
+ADRC_SWIFT=$(printf '%s\n' "$CHANGES" | awk -F'\t' 'substr($1,1,1) ~ /[ADRC]/ {for (i=2; i<=NF; i++) print $i}' | grep '\.swift$')
+if [ -n "$ADRC_SWIFT" ]; then
+  echo "필요 — .swift 파일 추가/삭제/이동 감지"
 else
   echo "불필요"
 fi

--- a/.claude/skills/implement/scripts/impact-check.sh
+++ b/.claude/skills/implement/scripts/impact-check.sh
@@ -91,11 +91,13 @@ if printf '%s\n' "$FILES" | grep -q "^TodoCalendarApp/AppExtensions/Widget/"; th
 fi
 
 # ---- tuist generate (테스트보다 선행 액션 — 첫 섹션으로 출력) ----
-# tuist 재생성은 소스 멤버십(.swift) 추가/삭제/이동에만 필요 — 비소스(.md·png·.claude·scripts 등)는 무관
+# tuist 재생성 필요: (1) .swift 소스 멤버십 추가/삭제/이동(ADRC), (2) 매니페스트(Project/Workspace/Package/Tuist) 변경(수정 포함).
+# 비소스(.md·png·.claude·scripts 등) 추가는 무관.
 echo "## tuist generate"
 ADRC_SWIFT=$(printf '%s\n' "$CHANGES" | awk -F'\t' 'substr($1,1,1) ~ /[ADRC]/ {for (i=2; i<=NF; i++) print $i}' | grep '\.swift$')
-if [ -n "$ADRC_SWIFT" ]; then
-  echo "필요 — .swift 파일 추가/삭제/이동 감지"
+MANIFEST=$(printf '%s\n' "$FILES" | grep -E '(^|/)(Project|Workspace)\.swift$|^(Package\.(swift|resolved)|Tuist\.swift)$|^Tuist/')
+if [ -n "$ADRC_SWIFT" ] || [ -n "$MANIFEST" ]; then
+  echo "필요 — .swift 추가/삭제/이동 또는 매니페스트 변경 감지"
 else
   echo "불필요"
 fi

--- a/.claude/skills/implement/scripts/impact-check.test.sh
+++ b/.claude/skills/implement/scripts/impact-check.test.sh
@@ -46,6 +46,9 @@ assert_contains "삭제 → 필요" "필요" "$(tuist_for 'D\tDomain/Sources/Old
 assert_contains "이동(R) → 필요" "필요" "$(tuist_for 'R100\tDomain/Sources/Old.swift\tDomain/Sources/New.swift')"
 assert_eq "비소스 추가(A) → 불필요" "불필요" "$(tuist_for 'A\tdocs/spec/new.md')"
 assert_eq "비소스 추가(.claude) → 불필요" "불필요" "$(tuist_for 'A\t.claude/skills/foo/SKILL.md')"
+assert_contains "Project.swift 수정(M) → 필요" "필요" "$(tuist_for 'M\tPresentations/SettingScene/Project.swift')"
+assert_contains "Tuist helper 수정(M) → 필요" "필요" "$(tuist_for 'M\tTuist/ProjectDescriptionHelpers/Project+Templates.swift')"
+assert_contains "Package.swift 수정(M) → 필요" "필요" "$(tuist_for 'M\tPackage.swift')"
 
 # --- 짝 위치 경고 (stdin 모드는 파일 존재 기반 경고만) ---
 assert_contains "pr_test.yml 변경 → 3곳 동기화 경고" "impact-check.sh" "$(pairs_for 'M\t.github/workflows/pr_test.yml')"

--- a/.claude/skills/implement/scripts/impact-check.test.sh
+++ b/.claude/skills/implement/scripts/impact-check.test.sh
@@ -44,6 +44,8 @@ assert_eq "수정만 → 불필요" "불필요" "$(tuist_for 'M\tDomain/Sources/
 assert_contains "추가 → 필요" "필요" "$(tuist_for 'A\tDomain/Sources/New.swift')"
 assert_contains "삭제 → 필요" "필요" "$(tuist_for 'D\tDomain/Sources/Old.swift')"
 assert_contains "이동(R) → 필요" "필요" "$(tuist_for 'R100\tDomain/Sources/Old.swift\tDomain/Sources/New.swift')"
+assert_eq "비소스 추가(A) → 불필요" "불필요" "$(tuist_for 'A\tdocs/spec/new.md')"
+assert_eq "비소스 추가(.claude) → 불필요" "불필요" "$(tuist_for 'A\t.claude/skills/foo/SKILL.md')"
 
 # --- 짝 위치 경고 (stdin 모드는 파일 존재 기반 경고만) ---
 assert_contains "pr_test.yml 변경 → 3곳 동기화 경고" "impact-check.sh" "$(pairs_for 'M\t.github/workflows/pr_test.yml')"

--- a/.claude/skills/kickoff/SKILL.md
+++ b/.claude/skills/kickoff/SKILL.md
@@ -89,7 +89,7 @@ argument-hint: "[issue-number]"
 
 ### A-3. 계획 작성으로 전환
 
-superpowers의 writing-plans 스킬을 invoke해 구현 계획을 작성한다. 스펙 브리프가 그 입력이다. kickoff 안에서 계획 방법론을 중복 구현하지 않는다.
+프로젝트 `plan` 스킬을 invoke해 구현 계획을 작성한다 (`plan`은 superpowers writing-plans 위에 프로젝트 종속 요구 — 자족성·커밋 시퀀스·모델 티어 — 를 얹는 컴패니언이다). 스펙 브리프가 그 입력이다. kickoff 안에서 계획 방법론을 중복 구현하지 않는다.
 
 ### A-4. 플랜을 이슈에 기록
 


### PR DESCRIPTION
## 문제
#659 리스트업 16번(자잘한 정비) 잔여 2건 + impact-check.sh tuist 판정 정합성. 16번 8개 항목 중 6개는 타 작업으로 해소(2·3 → claude-md-remap `d68270b7`·`0742352f` / 5 → #674 Metric rename / 7 → #673 AIAgentScene child / 8 → code-analyzer Write 계약), 6은 "실사용 관찰 후" 조건이라 17번 이관.

## 접근
- **kickoff A-3** — 계획 전환 단계가 `superpowers writing-plans`만 가리켜 프로젝트 `plan` 컴패니언(자족성·커밋 시퀀스·모델 티어 요구를 얹음)을 건너뛰던 문제. A-3가 `plan`을 진입점으로 명시하도록 수정.
- **impact-check.sh tuist 판정 정비 (2커밋)**:
  - (오탐 제거) `$STATUSES`만 검사해 문서·`.claude/`·png 등 비소스 추가에도 "필요" 오탐 → `$CHANGES`에서 ADRC `.swift`만 판정(dead `$STATUSES` 제거).
  - (미탐 제거) 매니페스트 **수정(M)** — Project.swift `snapshotTests`·dependency 변경, Tuist helper 수정 등 — 은 `.swift`지만 M이라 안 잡히던 false negative → `$FILES`에서 매니페스트(Project/Workspace/Package/Tuist) 변경을 상태 무관으로 감지.
  - 짝 테스트 `impact-check.test.sh` 회귀 케이스 5건(비소스 추가 2 + 매니페스트 수정 3), 26 PASS/0 FAIL.

## 남은 과제
- 16번 6번 항목(design·implement 트리거 경계 조정)은 usage-log 분석(17번)에 종속돼 이관.
