### PR TITLE
[#691] 복잡도 분석기 페이즈 1 — walking skeleton (SwiftSyntax + IndexStoreDB)

### DIFF
--- a/tools/complexity-analyzer/.gitignore
+++ b/tools/complexity-analyzer/.gitignore
@@ -1,0 +1,2 @@
+.build/
+.swiftpm/

--- a/tools/complexity-analyzer/Package.resolved
+++ b/tools/complexity-analyzer/Package.resolved
@@ -1,0 +1,42 @@
+{
+  "originHash" : "7fc8fb7499fd9cf23fa212c7025c2ef6dc6758beeea2ef6831552bd38f03d56d",
+  "pins" : [
+    {
+      "identity" : "indexstore-db",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/indexstore-db.git",
+      "state" : {
+        "branch" : "release/6.3",
+        "revision" : "003ac41513ba291f10ff1a0147ae68588914668d"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swift-lmdb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-lmdb.git",
+      "state" : {
+        "branch" : "release/6.3",
+        "revision" : "1ad9a2d80b6fcde498c2242f509bd1be7d667ff8"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/tools/complexity-analyzer/Package.swift
+++ b/tools/complexity-analyzer/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "complexity-analyzer",
+    platforms: [.macOS(.v13)],
+    products: [
+        .executable(name: "complexity-analyzer", targets: ["ComplexityAnalyzer"]),
+        .library(name: "ComplexityCore", targets: ["ComplexityCore"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-syntax.git", from: "603.0.0"),
+        .package(url: "https://github.com/apple/indexstore-db.git", branch: "release/6.3"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.8.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "ComplexityAnalyzer",
+            dependencies: [
+                "ComplexityCore",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ]
+        ),
+        .target(
+            name: "ComplexityCore",
+            dependencies: [
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftParser", package: "swift-syntax"),
+                .product(name: "IndexStoreDB", package: "indexstore-db"),
+            ]
+        ),
+        .testTarget(
+            name: "ComplexityCoreTests",
+            dependencies: ["ComplexityCore"]
+        ),
+    ]
+)

--- a/tools/complexity-analyzer/Sources/ComplexityAnalyzer/Entry.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityAnalyzer/Entry.swift
@@ -1,0 +1,29 @@
+import ArgumentParser
+import ComplexityCore
+
+@main
+struct ComplexityAnalyzerCLI: AsyncParsableCommand {
+
+    static let configuration = CommandConfiguration(
+        commandName: "complexity-analyzer",
+        abstract: "TodoCalendar 구조 복잡도 분석기 (페이즈 1: walking skeleton)"
+    )
+
+    @Option(name: .customLong("source-root"), help: "분석할 소스 루트 경로")
+    var sourceRoot: String
+
+    @Option(name: .customLong("index-store-path"), help: "IndexStore DataStore 경로")
+    var indexStorePath: String
+
+    @Option(name: .customLong("scope"), help: "분석 범위 (whole | file:<경로> | type:<이름>)")
+    var scope: String = "whole"
+
+    func run() async throws {
+        let output = Analyzer().run(
+            sourceRoot: sourceRoot,
+            indexStorePath: indexStorePath,
+            scope: scope
+        )
+        print(output)
+    }
+}

--- a/tools/complexity-analyzer/Sources/ComplexityAnalyzer/Entry.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityAnalyzer/Entry.swift
@@ -1,3 +1,4 @@
+import Foundation
 import ArgumentParser
 import ComplexityCore
 
@@ -18,12 +19,20 @@ struct ComplexityAnalyzerCLI: AsyncParsableCommand {
     @Option(name: .customLong("scope"), help: "분석 범위 (whole | file:<경로> | type:<이름>)")
     var scope: String = "whole"
 
+    @Option(name: .customLong("lib-index-store"), help: "libIndexStore.dylib 경로")
+    var libIndexStore: String =
+        "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/libIndexStore.dylib"
+
     func run() async throws {
-        let output = Analyzer().run(
-            sourceRoot: sourceRoot,
-            indexStorePath: indexStorePath,
-            scope: scope
+        let index = try IndexStoreDBProvider(
+            storePath: indexStorePath,
+            databasePath: NSTemporaryDirectory() + "cx-idx-" + UUID().uuidString,
+            libIndexStorePath: libIndexStore
         )
-        print(output)
+        let units = try Analyzer(index: index).analyze(
+            sourceRoot: sourceRoot,
+            scope: Scope.parse(scope)
+        )
+        print(try JSONReporter().string(for: units))
     }
 }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Analyzer.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Analyzer.swift
@@ -1,16 +1,31 @@
 import Foundation
-import SwiftSyntax
-import SwiftParser
-import IndexStoreDB
 
-/// 페이즈 1 walking skeleton — 파이프라인 골격만.
-/// 실제 측정(내부 복잡도·fan-in)은 Task 2~4에서 채운다.
+/// 페이즈 1 오케스트레이션 — 파일 스캔 → 측정(내부 복잡도·fan-in) → scope 필터.
+/// 총점·가중 합성은 후속 페이즈(5).
 public struct Analyzer {
 
-    public init() {}
+    private let index: any IndexProviding
+    private let scanner: SyntaxScanner
 
-    /// 부트스트랩: SwiftSyntax·IndexStoreDB가 링크되고 파이프라인이 도는지만 증명한다.
-    public func run(sourceRoot: String, indexStorePath: String, scope: String) -> String {
-        return "ok"
+    public init(index: any IndexProviding, scanner: SyntaxScanner = SyntaxScanner()) {
+        self.index = index
+        self.scanner = scanner
+    }
+
+    public func analyze(sourceRoot: String, scope: Scope) throws -> [AnalyzedUnit] {
+        let files = SwiftFileEnumerator.files(under: sourceRoot, scope: scope)
+        let fanIn = FanIn(index: index)
+
+        let units = files.flatMap { file -> [AnalyzedUnit] in
+            guard let source = try? String(contentsOfFile: file, encoding: .utf8) else { return [] }
+            return scanner.scan(source: source, file: file).map { unit in
+                guard unit.kind == .type else { return unit }
+                var withFanIn = unit
+                withFanIn.measurements.fanIn = fanIn.count(forTypeNamed: unit.name)
+                return withFanIn
+            }
+        }
+
+        return units.filter { scope.includes($0) }
     }
 }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Analyzer.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Analyzer.swift
@@ -1,0 +1,16 @@
+import Foundation
+import SwiftSyntax
+import SwiftParser
+import IndexStoreDB
+
+/// 페이즈 1 walking skeleton — 파이프라인 골격만.
+/// 실제 측정(내부 복잡도·fan-in)은 Task 2~4에서 채운다.
+public struct Analyzer {
+
+    public init() {}
+
+    /// 부트스트랩: SwiftSyntax·IndexStoreDB가 링크되고 파이프라인이 도는지만 증명한다.
+    public func run(sourceRoot: String, indexStorePath: String, scope: String) -> String {
+        return "ok"
+    }
+}

--- a/tools/complexity-analyzer/Sources/ComplexityCore/FileSystem/SwiftFileEnumerator.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/FileSystem/SwiftFileEnumerator.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// 스캔 대상 .swift 파일 열거. (테스트 코드 제외 정책은 후속 페이즈 — 여기선 빌드 산출물만 회피)
+enum SwiftFileEnumerator {
+
+    static func files(under root: String, scope: Scope) -> [String] {
+        if case .file(let path) = scope { return [path] }
+
+        let url = URL(fileURLWithPath: root)
+        guard let enumerator = FileManager.default.enumerator(
+            at: url,
+            includingPropertiesForKeys: nil
+        ) else { return [] }
+
+        var result: [String] = []
+        for case let fileURL as URL in enumerator where fileURL.pathExtension == "swift" {
+            if fileURL.path.contains("/.build/") { continue }
+            result.append(fileURL.path)
+        }
+        return result.sorted()
+    }
+}

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexProviding.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexProviding.swift
@@ -1,0 +1,7 @@
+/// index 접근 seam — fan-in 로직을 실 IndexStoreDB 없이 테스트하기 위한 추상.
+public protocol IndexProviding {
+    /// 이 이름의 명목 타입 선언 심볼들의 USR.
+    func typeUSRs(named name: String) -> [String]
+    /// 이 USR을 참조하는 지점 수 (fan-in).
+    func referenceCount(ofUSR usr: String) -> Int
+}

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexStoreDBProvider.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexStoreDBProvider.swift
@@ -1,6 +1,21 @@
 import Foundation
 import IndexStoreDB
 
+/// 인덱스 상태 문제 — silent-0 fan-in을 막기 위한 명시 에러.
+public enum IndexStoreError: Error, CustomStringConvertible {
+    case storeMissing(String)
+    case storeEmpty(String)
+
+    public var description: String {
+        switch self {
+        case .storeMissing(let path):
+            return "index store 경로가 없음: \(path) — 대상 프로젝트를 빌드했는지 확인."
+        case .storeEmpty(let path):
+            return "index store에 unit 레코드가 없음: \(path) — 빌드가 인덱스를 생성하지 않았거나 경로가 잘못됨. (fan-in이 조용히 0으로 나오는 것을 방지)"
+        }
+    }
+}
+
 /// IndexStoreDB 실 구현 — 빌드가 만든 index store를 읽어 fan-in을 해소한다.
 public struct IndexStoreDBProvider: IndexProviding {
 
@@ -10,6 +25,10 @@ public struct IndexStoreDBProvider: IndexProviding {
     /// - databasePath: 쓰기 가능한 임시 경로 (IndexStoreDB 작업 DB)
     /// - libIndexStorePath: 툴체인의 `libIndexStore.dylib`
     public init(storePath: String, databasePath: String, libIndexStorePath: String) throws {
+        // 라이브러리 로드 전에 store가 실제로 채워졌는지 먼저 검증한다.
+        // (없거나 빈 store여도 IndexStoreDB init은 throw 안 하고, 모든 fan-in이 조용히 0이 됨)
+        try Self.assertPopulated(storePath: storePath)
+
         let library = try IndexStoreLibrary(dylibPath: libIndexStorePath)
         self.index = try IndexStoreDB(
             storePath: storePath,
@@ -20,6 +39,30 @@ public struct IndexStoreDBProvider: IndexProviding {
         index.pollForUnitChangesAndWait()
     }
 
+    /// store가 존재하고 unit 레코드를 실제로 담고 있는지 확인.
+    /// 빈/없는 store를 조용히 fan-in 0으로 흘리지 않도록 명시 throw.
+    static func assertPopulated(storePath: String) throws {
+        let fileManager = FileManager.default
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: storePath, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else {
+            throw IndexStoreError.storeMissing(storePath)
+        }
+
+        // DataStore 레이아웃: `v<n>/units/<레코드>`. 하나라도 unit이 있어야 실질 인덱스.
+        let versionDirs = (try? fileManager.contentsOfDirectory(atPath: storePath)) ?? []
+        let hasUnits = versionDirs.contains { version in
+            let unitsPath = storePath + "/" + version + "/units"
+            let entries = (try? fileManager.contentsOfDirectory(atPath: unitsPath)) ?? []
+            return !entries.isEmpty
+        }
+        guard hasUnits else { throw IndexStoreError.storeEmpty(storePath) }
+    }
+
+    // 알려진 한계 (→ 페이즈 3에서 해소): 타입을 bare name으로 전역 조회한다.
+    // 동명이인 타입(예: SQLite 테이블마다 있는 Entity/Columns)이 한 이름으로 합산된다.
+    // 정확한 식별은 USR 또는 enclosing 체인 기반 정규화가 필요.
     public func typeUSRs(named name: String) -> [String] {
         var usrs: Set<String> = []
         index.forEachCanonicalSymbolOccurrence(byName: name) { occurrence in

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexStoreDBProvider.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexStoreDBProvider.swift
@@ -1,0 +1,39 @@
+import Foundation
+import IndexStoreDB
+
+/// IndexStoreDB 실 구현 — 빌드가 만든 index store를 읽어 fan-in을 해소한다.
+public struct IndexStoreDBProvider: IndexProviding {
+
+    private let index: IndexStoreDB
+
+    /// - storePath: `DerivedData/<proj>-<hash>/Index.noindex/DataStore`
+    /// - databasePath: 쓰기 가능한 임시 경로 (IndexStoreDB 작업 DB)
+    /// - libIndexStorePath: 툴체인의 `libIndexStore.dylib`
+    public init(storePath: String, databasePath: String, libIndexStorePath: String) throws {
+        let library = try IndexStoreLibrary(dylibPath: libIndexStorePath)
+        self.index = try IndexStoreDB(
+            storePath: storePath,
+            databasePath: databasePath,
+            library: library,
+            waitUntilDoneInitializing: true
+        )
+        index.pollForUnitChangesAndWait()
+    }
+
+    public func typeUSRs(named name: String) -> [String] {
+        var usrs: Set<String> = []
+        index.forEachCanonicalSymbolOccurrence(byName: name) { occurrence in
+            let kind = occurrence.symbol.kind
+            let isNominalType = kind == .class || kind == .struct || kind == .enum || kind == .protocol
+            if occurrence.roles.contains(.definition), isNominalType {
+                usrs.insert(occurrence.symbol.usr)
+            }
+            return true
+        }
+        return Array(usrs)
+    }
+
+    public func referenceCount(ofUSR usr: String) -> Int {
+        index.occurrences(ofUSR: usr, roles: .reference).count
+    }
+}

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Measure/FanIn.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Measure/FanIn.swift
@@ -1,0 +1,16 @@
+/// 타입 fan-in — 이 타입을 참조하는 cross-file 지점 수.
+/// 한 타입 이름이 여러 USR로 잡힐 수 있어(오버로드·재선언) USR별 참조를 합산한다.
+public struct FanIn {
+
+    private let index: any IndexProviding
+
+    public init(index: any IndexProviding) {
+        self.index = index
+    }
+
+    public func count(forTypeNamed name: String) -> Int {
+        index.typeUSRs(named: name)
+            .map { index.referenceCount(ofUSR: $0) }
+            .reduce(0, +)
+    }
+}

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Model/AnalyzedUnit.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Model/AnalyzedUnit.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// 단위별 측정값. 페이즈별로 필드가 채워진다 (측정 못 한 축은 nil).
-public struct Measurements: Equatable, Sendable {
+/// 단위별 측정값. 페이즈별로 필드가 채워진다 (측정 못 한 축은 nil → JSON에서 생략).
+public struct Measurements: Equatable, Sendable, Encodable {
     public var internalComplexity: Int?
     public var fanIn: Int?
 
@@ -12,8 +12,8 @@ public struct Measurements: Equatable, Sendable {
 }
 
 /// 분석 단위 — 페이즈 1은 메소드/타입 레벨.
-public struct AnalyzedUnit: Equatable, Sendable {
-    public enum Kind: String, Sendable {
+public struct AnalyzedUnit: Equatable, Sendable, Encodable {
+    public enum Kind: String, Sendable, Encodable {
         case method
         case type
     }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Model/AnalyzedUnit.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Model/AnalyzedUnit.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// 단위별 측정값. 페이즈별로 필드가 채워진다 (측정 못 한 축은 nil).
+public struct Measurements: Equatable, Sendable {
+    public var internalComplexity: Int?
+    public var fanIn: Int?
+
+    public init(internalComplexity: Int? = nil, fanIn: Int? = nil) {
+        self.internalComplexity = internalComplexity
+        self.fanIn = fanIn
+    }
+}
+
+/// 분석 단위 — 페이즈 1은 메소드/타입 레벨.
+public struct AnalyzedUnit: Equatable, Sendable {
+    public enum Kind: String, Sendable {
+        case method
+        case type
+    }
+
+    public let kind: Kind
+    public let name: String
+    public let enclosingType: String?
+    public let file: String
+    public let line: Int
+    public var measurements: Measurements
+
+    public init(
+        kind: Kind,
+        name: String,
+        enclosingType: String?,
+        file: String,
+        line: Int,
+        measurements: Measurements = .init()
+    ) {
+        self.kind = kind
+        self.name = name
+        self.enclosingType = enclosingType
+        self.file = file
+        self.line = line
+        self.measurements = measurements
+    }
+}

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Model/Scope.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Model/Scope.swift
@@ -16,7 +16,9 @@ public enum Scope: Equatable {
         case .whole:
             return true
         case .file(let path):
-            return unit.file == path || unit.file.hasSuffix(path)
+            // 경로 구분자 경계를 강제 — "StubTodoEventRepository.swift" 가
+            // "TodoEventRepository.swift" 로 오매칭되는 것을 막는다.
+            return unit.file == path || unit.file.hasSuffix("/" + path)
         case .type(let name):
             return (unit.kind == .type && unit.name == name)
                 || (unit.kind == .method && unit.enclosingType == name)

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Model/Scope.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Model/Scope.swift
@@ -1,0 +1,25 @@
+/// 분석 범위 — 어떤 파일을 스캔하고 어떤 단위를 출력할지.
+public enum Scope: Equatable {
+    case whole
+    case file(String)
+    case type(String)
+
+    /// `whole` | `file:<경로>` | `type:<이름>`
+    public static func parse(_ raw: String) -> Scope {
+        if raw.hasPrefix("file:") { return .file(String(raw.dropFirst("file:".count))) }
+        if raw.hasPrefix("type:") { return .type(String(raw.dropFirst("type:".count))) }
+        return .whole
+    }
+
+    func includes(_ unit: AnalyzedUnit) -> Bool {
+        switch self {
+        case .whole:
+            return true
+        case .file(let path):
+            return unit.file == path || unit.file.hasSuffix(path)
+        case .type(let name):
+            return (unit.kind == .type && unit.name == name)
+                || (unit.kind == .method && unit.enclosingType == name)
+        }
+    }
+}

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Output/JSONReporter.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Output/JSONReporter.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// 분석 단위 목록을 JSON으로 직렬화. (페이즈 1: 원시 측정값 나열 — 총점·가중치는 후속)
+public struct JSONReporter {
+
+    public init() {}
+
+    public func string(for units: [AnalyzedUnit]) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        let data = try encoder.encode(units)
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
@@ -31,18 +31,19 @@ private final class MethodCollector: SyntaxVisitor {
         super.init(viewMode: .sourceAccurate)
     }
 
-    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind { push(node.name.text) }
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind { enterType(node.name) }
     override func visitPost(_ node: ClassDeclSyntax) { typeStack.removeLast() }
 
-    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind { push(node.name.text) }
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind { enterType(node.name) }
     override func visitPost(_ node: StructDeclSyntax) { typeStack.removeLast() }
 
-    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind { push(node.name.text) }
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind { enterType(node.name) }
     override func visitPost(_ node: EnumDeclSyntax) { typeStack.removeLast() }
 
-    override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind { push(node.name.text) }
+    override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind { enterType(node.name) }
     override func visitPost(_ node: ActorDeclSyntax) { typeStack.removeLast() }
 
+    // extension은 타입 선언이 아니므로 타입 단위를 새로 내지 않고, enclosing type 추적만.
     override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
         push(node.extendedType.trimmedDescription)
     }
@@ -61,6 +62,22 @@ private final class MethodCollector: SyntaxVisitor {
                 measurements: .init(internalComplexity: score)
             )
         )
+        return .visitChildren
+    }
+
+    /// 명목 타입 선언(class/struct/enum/actor): 타입 단위 방출 + enclosing 추적.
+    private func enterType(_ nameToken: TokenSyntax) -> SyntaxVisitorContinueKind {
+        let line = converter.location(for: nameToken.positionAfterSkippingLeadingTrivia).line
+        units.append(
+            AnalyzedUnit(
+                kind: .type,
+                name: nameToken.text,
+                enclosingType: typeStack.last,
+                file: file,
+                line: line
+            )
+        )
+        typeStack.append(nameToken.text)
         return .visitChildren
     }
 

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
@@ -1,0 +1,120 @@
+import Foundation
+import SwiftSyntax
+import SwiftParser
+
+/// SwiftSyntax로 소스를 파싱해 메소드 단위 + 내부 복잡도를 뽑는다.
+public struct SyntaxScanner {
+
+    public init() {}
+
+    public func scan(source: String, file: String) -> [AnalyzedUnit] {
+        let tree = Parser.parse(source: source)
+        let converter = SourceLocationConverter(fileName: file, tree: tree)
+        let collector = MethodCollector(file: file, converter: converter)
+        collector.walk(tree)
+        return collector.units
+    }
+}
+
+// MARK: - 메소드 수집 + enclosing type 추적
+
+private final class MethodCollector: SyntaxVisitor {
+
+    let file: String
+    let converter: SourceLocationConverter
+    private(set) var units: [AnalyzedUnit] = []
+    private var typeStack: [String] = []
+
+    init(file: String, converter: SourceLocationConverter) {
+        self.file = file
+        self.converter = converter
+        super.init(viewMode: .sourceAccurate)
+    }
+
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind { push(node.name.text) }
+    override func visitPost(_ node: ClassDeclSyntax) { typeStack.removeLast() }
+
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind { push(node.name.text) }
+    override func visitPost(_ node: StructDeclSyntax) { typeStack.removeLast() }
+
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind { push(node.name.text) }
+    override func visitPost(_ node: EnumDeclSyntax) { typeStack.removeLast() }
+
+    override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind { push(node.name.text) }
+    override func visitPost(_ node: ActorDeclSyntax) { typeStack.removeLast() }
+
+    override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+        push(node.extendedType.trimmedDescription)
+    }
+    override func visitPost(_ node: ExtensionDeclSyntax) { typeStack.removeLast() }
+
+    override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+        let line = converter.location(for: node.name.positionAfterSkippingLeadingTrivia).line
+        let score = node.body.map { ComplexityCounter.score(of: $0) } ?? 0
+        units.append(
+            AnalyzedUnit(
+                kind: .method,
+                name: node.name.text,
+                enclosingType: typeStack.last,
+                file: file,
+                line: line,
+                measurements: .init(internalComplexity: score)
+            )
+        )
+        return .visitChildren
+    }
+
+    private func push(_ name: String) -> SyntaxVisitorContinueKind {
+        typeStack.append(name)
+        return .visitChildren
+    }
+}
+
+// MARK: - 내부 복잡도 계산 (분기·중첩 가중)
+//
+// 규칙 (페이즈 1 고정 v1): 제어흐름 노드마다 (1 + 중첩깊이).
+//   - 중첩 구문 (if/guard/for/while/repeat/catch): +1+depth 하고 자기 블록은 depth+1
+//   - switch: 점수 없음, depth 불변. 각 case: +1+depth
+//   - boolean 연산자·삼항: 페이즈 1 미포함 (후속 정련)
+
+private final class ComplexityCounter: SyntaxVisitor {
+
+    private var depth = 0
+    private var total = 0
+
+    static func score(of body: CodeBlockSyntax) -> Int {
+        let counter = ComplexityCounter(viewMode: .sourceAccurate)
+        counter.walk(body)
+        return counter.total
+    }
+
+    override func visit(_ node: IfExprSyntax) -> SyntaxVisitorContinueKind { enterNesting() }
+    override func visitPost(_ node: IfExprSyntax) { depth -= 1 }
+
+    override func visit(_ node: ForStmtSyntax) -> SyntaxVisitorContinueKind { enterNesting() }
+    override func visitPost(_ node: ForStmtSyntax) { depth -= 1 }
+
+    override func visit(_ node: WhileStmtSyntax) -> SyntaxVisitorContinueKind { enterNesting() }
+    override func visitPost(_ node: WhileStmtSyntax) { depth -= 1 }
+
+    override func visit(_ node: RepeatStmtSyntax) -> SyntaxVisitorContinueKind { enterNesting() }
+    override func visitPost(_ node: RepeatStmtSyntax) { depth -= 1 }
+
+    override func visit(_ node: GuardStmtSyntax) -> SyntaxVisitorContinueKind { enterNesting() }
+    override func visitPost(_ node: GuardStmtSyntax) { depth -= 1 }
+
+    override func visit(_ node: CatchClauseSyntax) -> SyntaxVisitorContinueKind { enterNesting() }
+    override func visitPost(_ node: CatchClauseSyntax) { depth -= 1 }
+
+    override func visit(_ node: SwitchCaseSyntax) -> SyntaxVisitorContinueKind {
+        total += 1 + depth
+        return .visitChildren
+    }
+
+    /// 중첩 구문 진입: 점수 가산 + depth 증가.
+    private func enterNesting() -> SyntaxVisitorContinueKind {
+        total += 1 + depth
+        depth += 1
+        return .visitChildren
+    }
+}

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
@@ -105,8 +105,24 @@ private final class ComplexityCounter: SyntaxVisitor {
         return counter.total
     }
 
-    override func visit(_ node: IfExprSyntax) -> SyntaxVisitorContinueKind { enterNesting() }
-    override func visitPost(_ node: IfExprSyntax) { depth -= 1 }
+    override func visit(_ node: IfExprSyntax) -> SyntaxVisitorContinueKind {
+        // else-if는 SwiftSyntax상 부모 IfExpr의 elseBody로 표현되지만 실제론 형제 분기다.
+        // 진짜 중첩처럼 depth를 올리면 사다리가 삼각수로 폭증하므로, 사슬 base 깊이에서
+        // 평평하게 +1만 하고 depth는 올리지 않는다.
+        if isElseIf(node) {
+            total += 1 + max(depth - 1, 0)
+            return .visitChildren
+        }
+        return enterNesting()
+    }
+    override func visitPost(_ node: IfExprSyntax) {
+        if isElseIf(node) { return }
+        depth -= 1
+    }
+
+    private func isElseIf(_ node: IfExprSyntax) -> Bool {
+        node.parent?.is(IfExprSyntax.self) == true
+    }
 
     override func visit(_ node: ForStmtSyntax) -> SyntaxVisitorContinueKind { enterNesting() }
     override func visitPost(_ node: ForStmtSyntax) { depth -= 1 }

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/AnalyzerTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/AnalyzerTests.swift
@@ -1,16 +1,61 @@
 import Testing
+import Foundation
 @testable import ComplexityCore
 
-@Suite("Analyzer 부트스트랩")
-struct AnalyzerBootstrapTests {
+@Suite("Analyzer 오케스트레이션 + 리포트")
+struct AnalyzerTests {
 
-    @Test("파이프라인이 도는지 — 부트스트랩 골격")
-    func runsPipeline() {
-        let result = Analyzer().run(
-            sourceRoot: ".",
-            indexStorePath: "/tmp",
-            scope: "whole"
-        )
-        #expect(result == "ok")
+    private func writeTempDir(_ files: [String: String]) throws -> String {
+        let dir = NSTemporaryDirectory() + "cx-" + UUID().uuidString
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        for (name, source) in files {
+            try source.write(toFile: dir + "/" + name, atomically: true, encoding: .utf8)
+        }
+        return dir
+    }
+
+    @Test("타입엔 fan-in, 메소드엔 내부 복잡도가 실린다")
+    func measuresAttached() throws {
+        let dir = try writeTempDir(["Sample.swift": "struct Sample { func go() { if a { if b {} } } }"])
+        let stub = StubIndexProvider()
+        stub.usrsByName["Sample"] = ["u1"]
+        stub.refCountByUSR = ["u1": 4]
+
+        let units = try Analyzer(index: stub).analyze(sourceRoot: dir, scope: .whole)
+
+        #expect(units.first { $0.kind == .type }?.measurements.fanIn == 4)
+        #expect(units.first { $0.kind == .method }?.measurements.internalComplexity == 3)
+    }
+
+    @Test("type scope는 그 타입과 소속 메소드만 남긴다")
+    func typeScopeFilters() throws {
+        let dir = try writeTempDir(["Two.swift": "struct A { func x() {} }\nstruct B { func y() {} }"])
+
+        let units = try Analyzer(index: StubIndexProvider()).analyze(sourceRoot: dir, scope: .type("A"))
+
+        #expect(units.contains { $0.kind == .type && $0.name == "A" })
+        #expect(units.allSatisfy { $0.name == "A" || $0.enclosingType == "A" })
+        #expect(!units.contains { $0.name == "B" })
+    }
+
+    @Test("JSON 출력에 측정 키가 담긴다")
+    func jsonContainsMeasures() throws {
+        let dir = try writeTempDir(["S.swift": "struct S { func f() { if a {} } }"])
+        let stub = StubIndexProvider()
+        stub.usrsByName["S"] = ["u"]
+        stub.refCountByUSR = ["u": 2]
+
+        let units = try Analyzer(index: stub).analyze(sourceRoot: dir, scope: .whole)
+        let json = try JSONReporter().string(for: units)
+
+        #expect(json.contains("\"fanIn\""))
+        #expect(json.contains("\"internalComplexity\""))
+    }
+
+    @Test("Scope 파싱")
+    func scopeParsing() {
+        #expect(Scope.parse("whole") == .whole)
+        #expect(Scope.parse("file:/a/b.swift") == .file("/a/b.swift"))
+        #expect(Scope.parse("type:Foo") == .type("Foo"))
     }
 }

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/AnalyzerTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/AnalyzerTests.swift
@@ -1,0 +1,16 @@
+import Testing
+@testable import ComplexityCore
+
+@Suite("Analyzer 부트스트랩")
+struct AnalyzerBootstrapTests {
+
+    @Test("파이프라인이 도는지 — 부트스트랩 골격")
+    func runsPipeline() {
+        let result = Analyzer().run(
+            sourceRoot: ".",
+            indexStorePath: "/tmp",
+            scope: "whole"
+        )
+        #expect(result == "ok")
+    }
+}

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/FanInTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/FanInTests.swift
@@ -1,0 +1,42 @@
+import Testing
+@testable import ComplexityCore
+
+@Suite("fan-in 측정 — 참조 집계")
+struct FanInTests {
+
+    @Test("타입의 여러 USR 참조 수를 합산")
+    func aggregatesAcrossUSRs() {
+        let stub = StubIndexProvider()
+        stub.usrsByName["S"] = ["s1", "s2"]
+        stub.refCountByUSR = ["s1": 3, "s2": 2]
+
+        let fanIn = FanIn(index: stub)
+
+        #expect(fanIn.count(forTypeNamed: "S") == 5)
+        #expect(stub.queriedNames == ["S"])
+        #expect(stub.queriedUSRs == ["s1", "s2"])
+    }
+
+    @Test("USR 없는 타입은 0")
+    func unknownTypeIsZero() {
+        #expect(FanIn(index: StubIndexProvider()).count(forTypeNamed: "Nope") == 0)
+    }
+}
+
+/// stub — 질의를 기록만 한다. 검증은 테스트 케이스가 (testability rules).
+final class StubIndexProvider: IndexProviding {
+    var usrsByName: [String: [String]] = [:]
+    var refCountByUSR: [String: Int] = [:]
+    private(set) var queriedNames: [String] = []
+    private(set) var queriedUSRs: [String] = []
+
+    func typeUSRs(named name: String) -> [String] {
+        queriedNames.append(name)
+        return usrsByName[name] ?? []
+    }
+
+    func referenceCount(ofUSR usr: String) -> Int {
+        queriedUSRs.append(usr)
+        return refCountByUSR[usr] ?? 0
+    }
+}

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/IndexStoreIntegrationTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/IndexStoreIntegrationTests.swift
@@ -34,8 +34,24 @@ struct IndexStoreIntegrationTests {
             libIndexStorePath: Self.libIndexStore
         )
 
-        // 연결·질의가 크래시 없이 돌면 스모크 성공. (값은 인덱스 상태 의존이라 단정 안 함)
+        // TodoEvent는 저장소에서 다수 참조되는 실존 타입 → cross-file 해소가 실동작하면 > 0.
+        // (0이면 "조용히 0" 회귀 신호. 정확한 수치는 인덱스 상태 의존이라 하한만 단정)
         let count = FanIn(index: provider).count(forTypeNamed: "TodoEvent")
-        #expect(count >= 0)
+        #expect(count > 0)
+    }
+
+    @Test("빈/없는 index store는 명시 throw (silent-0 방지)")
+    func emptyOrMissingStoreThrows() throws {
+        // 없는 경로
+        #expect(throws: IndexStoreError.self) {
+            try IndexStoreDBProvider.assertPopulated(storePath: NSTemporaryDirectory() + "nope-" + UUID().uuidString)
+        }
+        // 존재하지만 빈 디렉토리
+        let empty = NSTemporaryDirectory() + "empty-" + UUID().uuidString
+        try FileManager.default.createDirectory(atPath: empty, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: empty) }
+        #expect(throws: IndexStoreError.self) {
+            try IndexStoreDBProvider.assertPopulated(storePath: empty)
+        }
     }
 }

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/IndexStoreIntegrationTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/IndexStoreIntegrationTests.swift
@@ -1,0 +1,41 @@
+import Testing
+import Foundation
+@testable import ComplexityCore
+
+/// 실 IndexStoreDB 연결 스모크 — 로컬 DerivedData index가 있을 때만 돈다.
+/// 목적은 값 검증이 아니라 "실 index를 물고 질의가 돈다"는 파이프라인 증명.
+@Suite("IndexStoreDB 실연결 스모크 (로컬 전용)")
+struct IndexStoreIntegrationTests {
+
+    private static let libIndexStore =
+        "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/libIndexStore.dylib"
+
+    private static var indexStorePath: String? {
+        let base = ("~/Library/Developer/Xcode/DerivedData" as NSString).expandingTildeInPath
+        guard let dirs = try? FileManager.default.contentsOfDirectory(atPath: base) else { return nil }
+        return dirs
+            .filter { $0.hasPrefix("TodoCalendar-") }
+            .map { "\(base)/\($0)/Index.noindex/DataStore" }
+            .first { FileManager.default.fileExists(atPath: $0) }
+    }
+
+    @Test("실 index를 물고 fan-in 질의가 돈다")
+    func realIndexQueryRuns() throws {
+        guard let storePath = Self.indexStorePath,
+              FileManager.default.fileExists(atPath: Self.libIndexStore)
+        else {
+            return  // 로컬 index/툴체인 없으면 스킵 (CI·타 머신)
+        }
+
+        let dbPath = NSTemporaryDirectory() + "cx-idx-" + UUID().uuidString
+        let provider = try IndexStoreDBProvider(
+            storePath: storePath,
+            databasePath: dbPath,
+            libIndexStorePath: Self.libIndexStore
+        )
+
+        // 연결·질의가 크래시 없이 돌면 스모크 성공. (값은 인덱스 상태 의존이라 단정 안 함)
+        let count = FanIn(index: provider).count(forTypeNamed: "TodoEvent")
+        #expect(count >= 0)
+    }
+}

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/InternalComplexityTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/InternalComplexityTests.swift
@@ -41,7 +41,9 @@ struct InternalComplexityTests {
             source: "struct S { func m() { if x {} } }",
             file: "T.swift"
         )
-        #expect(units.first?.enclosingType == "S")
-        #expect(units.first?.name == "m")
+        let method = units.first { $0.kind == .method }
+        #expect(method?.enclosingType == "S")
+        #expect(method?.name == "m")
+        #expect(units.contains { $0.kind == .type && $0.name == "S" })
     }
 }

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/InternalComplexityTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/InternalComplexityTests.swift
@@ -1,0 +1,47 @@
+import Testing
+@testable import ComplexityCore
+
+@Suite("내부 복잡도 측정 — 분기·중첩 가중")
+struct InternalComplexityTests {
+
+    private func score(_ source: String) -> Int {
+        let units = SyntaxScanner().scan(source: source, file: "T.swift")
+        #expect(units.count == 1)
+        return units.first?.measurements.internalComplexity ?? -1
+    }
+
+    @Test("제어흐름 없으면 0")
+    func plain() {
+        #expect(score("func f() { let x = 1; _ = x }") == 0)
+    }
+
+    @Test("단일 if = 1 (depth 0)")
+    func singleIf() {
+        #expect(score("func f() { if flag { doThing() } }") == 1)
+    }
+
+    @Test("for 안의 if = 중첩 가중 (1 + 2) = 3")
+    func nested() {
+        #expect(score("func f() { for i in items { if i > 0 { use(i) } } }") == 3)
+    }
+
+    @Test("guard + 형제 while = 1 + 1 = 2")
+    func guardAndLoop() {
+        #expect(score("func f() { guard ok else { return }; while run { step() } }") == 2)
+    }
+
+    @Test("flat switch 2 cases = 1 + 1 = 2")
+    func flatSwitch() {
+        #expect(score("func f() { switch v { case .a: doA(); case .b: doB() } }") == 2)
+    }
+
+    @Test("메소드의 enclosing type 포착")
+    func enclosingType() {
+        let units = SyntaxScanner().scan(
+            source: "struct S { func m() { if x {} } }",
+            file: "T.swift"
+        )
+        #expect(units.first?.enclosingType == "S")
+        #expect(units.first?.name == "m")
+    }
+}

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/InternalComplexityTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/InternalComplexityTests.swift
@@ -35,6 +35,29 @@ struct InternalComplexityTests {
         #expect(score("func f() { switch v { case .a: doA(); case .b: doB() } }") == 2)
     }
 
+    @Test("else-if 사다리는 flat = 1 + 1 + 1 = 3 (중첩 폭증 아님)")
+    func elseIfChainIsFlat() {
+        #expect(score("func f() { if a { x() } else if b { y() } else if c { z() } }") == 3)
+    }
+
+    @Test("repeat-while = 1")
+    func repeatWhile() {
+        #expect(score("func f() { repeat { step() } while run }") == 1)
+    }
+
+    @Test("do-catch = 1")
+    func doCatch() {
+        #expect(score("func f() { do { try work() } catch { handle() } }") == 1)
+    }
+
+    @Test("boolean 연산자·삼항은 페이즈 1 무가중 (스코프 축소 pin)")
+    func booleanAndTernaryUnweighted() {
+        // 플랜 Task2는 &&/||/삼항을 대상 노드로 명시했으나 페이즈 1은 의도적으로 미포함.
+        // 회귀 시 즉시 드러나게 현재 동작을 고정한다.
+        #expect(score("func f() { if a && b || c { x() } }") == 1)
+        #expect(score("func f() { let x = c ? 1 : 2; _ = x }") == 0)
+    }
+
     @Test("메소드의 enclosing type 포착")
     func enclosingType() {
         let units = SyntaxScanner().scan(


### PR DESCRIPTION
## 문제

#690 루프엔지니어링 flywheel의 축3(구현 품질) 채점을 위해 **구조 복잡도를 정량 측정하는 엔진**(#691)이 필요하다. 이 엔진은 3레벨(메소드·객체·객체협업) 측정 + 계층 합성 스코어링 + 스킬 래퍼로 구성되는 큰 작업이라, 페이즈로 분해했다. **이 PR은 페이즈 1 — walking skeleton.**

## 접근

측정 카탈로그를 채우기 전에, 가장 불확실한 **툴체인 통합 리스크**를 먼저 증명한다: "SPM 분석기가 SwiftSyntax·IndexStoreDB 둘 다 물고, 빌드된 프로젝트의 index를 읽어, JSON을 뱉는다"가 end-to-end로 도는가.

- `tools/complexity-analyzer/` — 앱 Tuist 그래프와 분리된 독립 SPM 실행 파일 (swift-syntax 603 / indexstore-db release/6.3 / argument-parser 1.8)
- **측정 A (SwiftSyntax)** — 메소드 내부 복잡도(분기·중첩 가중). 페이즈 1 고정 v1 규칙
- **측정 B (IndexStoreDB)** — 타입 fan-in(cross-file 참조 집계). `IndexProviding` 프로토콜 seam으로 로직은 stub 유닛 테스트, 실 index는 통합 스모크로 검증
- CLI가 `--source-root`·`--index-store-path`·`--scope`(whole/file/type)를 받아 JSON 출력

**증명 결과** (실 프로젝트 대상): `TodoEvent` fan-in **459**, 메소드별 내부 복잡도 실측. IndexStoreDB cross-file 해소가 실동작(조용히 0 아님). 유닛 13 + 실 index 통합 스모크 통과.

## 남은 과제 (후속 페이즈)

- **페이즈 2** — 메소드 레벨 완성: CQS(부작용 노출)·Combine 연산자 역할·변경 파급
- **페이즈 3** — 객체 레벨: extension 재조립·응집 그래프·롤업
- **페이즈 4** — 협업 레벨: 의존 그래프·cycle·blast radius·재사용 payoff
- **페이즈 5** — 계층 합성 스코어링·가중치(경험적 calibration)
- **페이즈 6** — 스킬 래퍼: scope 판단·size-gating·before/after로 TDD 리팩터 게이트 물림

의도적으로 페이즈 1에서 뺀 것: 계층 합성·총점·가중치, 다른 측정, ratchet·before/after, config 분리, 테스트 코드 제외 정책. 페이즈 1은 측정 2개 + JSON에서 끝난다.

> 스펙 정본: #691 본문 · 페이즈 로드맵: #691 분해 브리프 코멘트
