### PR TITLE
[#691] 복잡도 분석기 페이즈 2 — 메소드 레벨 CQS·Combine 역할혼합 측정

### DIFF
--- a/tools/complexity-analyzer/Sources/ComplexityAnalyzer/Entry.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityAnalyzer/Entry.swift
@@ -7,7 +7,7 @@ struct ComplexityAnalyzerCLI: AsyncParsableCommand {
 
     static let configuration = CommandConfiguration(
         commandName: "complexity-analyzer",
-        abstract: "TodoCalendar 구조 복잡도 분석기 (페이즈 1: walking skeleton)"
+        abstract: "TodoCalendar 구조 복잡도 분석기 (메소드: 내부복잡도·CQS·Combine 역할혼합 / 타입: fan-in)"
     )
 
     @Option(name: .customLong("source-root"), help: "분석할 소스 루트 경로")

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Measure/SideEffectAnalyzer.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Measure/SideEffectAnalyzer.swift
@@ -69,6 +69,14 @@ private final class SideEffectCollector: SyntaxVisitor {
 
     private(set) var sites: [Syntax] = []
 
+    // 중첩 함수·local 타입은 각자 독립 unit으로 따로 측정되므로, 바깥 메소드 스코프에
+    // 새어들지 않게 하위로 내려가지 않는다 (클로저는 연산자 컨텍스트용이라 계속 순회).
+    override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind { .skipChildren }
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind { .skipChildren }
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind { .skipChildren }
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind { .skipChildren }
+    override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind { .skipChildren }
+
     /// stored-property/Subject 대입: `self.x = ...`, `subject.value = ...`
     ///
     /// `Parser.parse`는 operator folding을 하지 않아 대입이 `InfixOperatorExpr`가 아니라

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Measure/SideEffectAnalyzer.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Measure/SideEffectAnalyzer.swift
@@ -1,0 +1,95 @@
+import SwiftSyntax
+
+/// query 함수 메인 흐름 / 순수 Combine 연산자 클로저에 노출된 side-effect를 센다.
+/// side-effect v1 (좁게): stored-property/Subject 대입(`self.x =`, `subject.value =`) + `.send(...)`.
+enum SideEffectAnalyzer {
+
+    struct Result: Equatable {
+        var cqsViolations: Int
+        var combineRoleMix: Int
+        static let zero = Result(cqsViolations: 0, combineRoleMix: 0)
+    }
+
+    /// 순수 변형 계약 연산자 — 클로저 안 side-effect는 역할 혼합 위반.
+    private static let pureOperators: Set<String> =
+        ["map", "flatMap", "compactMap", "filter", "reduce", "scan"]
+    /// side-effect 허용 연산자 — 여기 클로저는 위반 아님 (side-effect의 올바른 자리).
+    private static let allowedOperators: Set<String> =
+        ["sink", "handleEvents", "do"]
+
+    static func analyze(body: CodeBlockSyntax, isQuery: Bool) -> Result {
+        let collector = SideEffectCollector(viewMode: .sourceAccurate)
+        collector.walk(body)
+
+        var result = Result.zero
+        let bodyNode = Syntax(body)
+        for site in collector.sites {
+            switch nearestOperator(from: site, stopAt: bodyNode) {
+            case .pure:
+                result.combineRoleMix += 1
+            case .allowed:
+                break
+            case .none:
+                if isQuery { result.cqsViolations += 1 }
+            }
+        }
+        return result
+    }
+
+    private enum OperatorKind { case pure, allowed, none }
+
+    /// site에서 body까지 부모를 거슬러 올라가며 만나는 첫 인식 연산자 클로저의 종류.
+    private static func nearestOperator(from site: Syntax, stopAt body: Syntax) -> OperatorKind {
+        var current = site.parent
+        while let node = current, node != body {
+            if let closure = node.as(ClosureExprSyntax.self),
+               let name = operatorName(wrapping: closure) {
+                if pureOperators.contains(name) { return .pure }
+                if allowedOperators.contains(name) { return .allowed }
+                // 인식 못 한 연산자 클로저(예: forEach) → 계속 상향 탐색
+            }
+            current = node.parent
+        }
+        return .none
+    }
+
+    /// 클로저가 `x.op { }`(trailing) / `x.op(label: { })`(labeled arg) 형태로 붙은 연산자 이름.
+    private static func operatorName(wrapping closure: ClosureExprSyntax) -> String? {
+        let call = closure.parent?.as(FunctionCallExprSyntax.self)
+            ?? closure.parent?.as(LabeledExprSyntax.self)?
+                .parent?.as(LabeledExprListSyntax.self)?
+                .parent?.as(FunctionCallExprSyntax.self)
+        return call?.calledExpression.as(MemberAccessExprSyntax.self)?.declName.baseName.text
+    }
+}
+
+// MARK: - side-effect 부위 수집
+
+private final class SideEffectCollector: SyntaxVisitor {
+
+    private(set) var sites: [Syntax] = []
+
+    /// stored-property/Subject 대입: `self.x = ...`, `subject.value = ...`
+    ///
+    /// `Parser.parse`는 operator folding을 하지 않아 대입이 `InfixOperatorExpr`가 아니라
+    /// unfolded `SequenceExpr`(좌변 · `=`(AssignmentExpr) · 우변)로 나온다. 대입 토큰 직전
+    /// 요소가 MemberAccess(`self.x`, `subject.value`)면 외부 상태 변이로 본다.
+    override func visit(_ node: SequenceExprSyntax) -> SyntaxVisitorContinueKind {
+        let elements = Array(node.elements)
+        for (i, element) in elements.enumerated()
+        where element.is(AssignmentExprSyntax.self) {
+            if i > 0, elements[i - 1].is(MemberAccessExprSyntax.self) {
+                sites.append(Syntax(node))
+            }
+        }
+        return .visitChildren
+    }
+
+    /// Subject 방출: `xxx.send(...)`
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        if node.calledExpression.as(MemberAccessExprSyntax.self)?.declName.baseName.text == "send" {
+            sites.append(Syntax(node))
+        }
+        return .visitChildren
+    }
+}

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Model/AnalyzedUnit.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Model/AnalyzedUnit.swift
@@ -4,10 +4,19 @@ import Foundation
 public struct Measurements: Equatable, Sendable, Encodable {
     public var internalComplexity: Int?
     public var fanIn: Int?
+    public var cqsViolations: Int?
+    public var combineRoleMix: Int?
 
-    public init(internalComplexity: Int? = nil, fanIn: Int? = nil) {
+    public init(
+        internalComplexity: Int? = nil,
+        fanIn: Int? = nil,
+        cqsViolations: Int? = nil,
+        combineRoleMix: Int? = nil
+    ) {
         self.internalComplexity = internalComplexity
         self.fanIn = fanIn
+        self.cqsViolations = cqsViolations
+        self.combineRoleMix = combineRoleMix
     }
 }
 

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
@@ -74,8 +74,11 @@ private final class MethodCollector: SyntaxVisitor {
 
     /// 반환 타입이 non-Void면 query (값·Publisher). Void/무반환 = command.
     private func returnsNonVoid(_ clause: ReturnClauseSyntax?) -> Bool {
-        guard let desc = clause?.type.trimmedDescription else { return false }
-        return desc != "Void" && desc != "()"
+        guard let type = clause?.type else { return false }
+        // 빈 튜플 `()` / `( )` = Void
+        if let tuple = type.as(TupleTypeSyntax.self), tuple.elements.isEmpty { return false }
+        let name = type.trimmedDescription.replacingOccurrences(of: " ", with: "")
+        return name != "Void" && name != "Swift.Void" && name != "()"
     }
 
     /// 명목 타입 선언(class/struct/enum/actor): 타입 단위 방출 + enclosing 추적.

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
@@ -51,7 +51,10 @@ private final class MethodCollector: SyntaxVisitor {
 
     override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
         let line = converter.location(for: node.name.positionAfterSkippingLeadingTrivia).line
-        let score = node.body.map { ComplexityCounter.score(of: $0) } ?? 0
+        let internalC = node.body.map { ComplexityCounter.score(of: $0) } ?? 0
+        let query = returnsNonVoid(node.signature.returnClause)
+        let effects = node.body.map { SideEffectAnalyzer.analyze(body: $0, isQuery: query) }
+            ?? .zero
         units.append(
             AnalyzedUnit(
                 kind: .method,
@@ -59,10 +62,20 @@ private final class MethodCollector: SyntaxVisitor {
                 enclosingType: typeStack.last,
                 file: file,
                 line: line,
-                measurements: .init(internalComplexity: score)
+                measurements: .init(
+                    internalComplexity: internalC,
+                    cqsViolations: query ? effects.cqsViolations : nil,
+                    combineRoleMix: effects.combineRoleMix
+                )
             )
         )
         return .visitChildren
+    }
+
+    /// 반환 타입이 non-Void면 query (값·Publisher). Void/무반환 = command.
+    private func returnsNonVoid(_ clause: ReturnClauseSyntax?) -> Bool {
+        guard let desc = clause?.type.trimmedDescription else { return false }
+        return desc != "Void" && desc != "()"
     }
 
     /// 명목 타입 선언(class/struct/enum/actor): 타입 단위 방출 + enclosing 추적.

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/AnalyzerTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/AnalyzerTests.swift
@@ -52,6 +52,20 @@ struct AnalyzerTests {
         #expect(json.contains("\"internalComplexity\""))
     }
 
+    @Test("메소드 단위에 CQS·Combine 측정이 실려 JSON에 나온다")
+    func methodMeasuresInJSON() throws {
+        let dir = try writeTempDir(["S.swift": "struct S { func f() -> Int { self.x = 1; return x } }"])
+
+        let units = try Analyzer(index: StubIndexProvider()).analyze(sourceRoot: dir, scope: .whole)
+        let method = units.first { $0.kind == .method }
+        #expect(method?.measurements.cqsViolations == 1)
+        #expect(method?.measurements.combineRoleMix == 0)
+
+        let json = try JSONReporter().string(for: units)
+        #expect(json.contains("\"cqsViolations\""))
+        #expect(json.contains("\"combineRoleMix\""))
+    }
+
     @Test("Scope 파싱")
     func scopeParsing() {
         #expect(Scope.parse("whole") == .whole)

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/CQSTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/CQSTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import ComplexityCore
+
+@Suite("CQS — query 함수 메인 흐름의 side-effect 노출")
+struct CQSTests {
+
+    private func method(_ source: String) -> Measurements {
+        SyntaxScanner().scan(source: source, file: "T.swift")
+            .first { $0.kind == .method }?.measurements ?? .init()
+    }
+
+    @Test("query 메인 흐름의 self 대입 = 위반 1")
+    func queryMainFlowAssignment() {
+        #expect(method("struct S { func f() -> Int { self.x = 1; return x } }").cqsViolations == 1)
+    }
+
+    @Test("query의 .send 방출 = 위반 1")
+    func querySend() {
+        #expect(method("struct S { func f() -> Int { subject.send(1); return 0 } }").cqsViolations == 1)
+    }
+
+    @Test("command(Void) 함수는 CQS 대상 아님 = nil")
+    func commandNotMeasured() {
+        #expect(method("struct S { func f() { self.x = 1 } }").cqsViolations == nil)
+    }
+
+    @Test("query라도 handleEvents 클로저 안 side-effect는 제외 = 0")
+    func allowedClosureExcluded() {
+        #expect(method("struct S { func f() -> P { pub.handleEvents(receiveOutput: { self.x = $0 }) } }").cqsViolations == 0)
+    }
+
+    @Test("로컬 var 대입은 side-effect 아님 (self/member 대입만)")
+    func localVarNotSideEffect() {
+        #expect(method("struct S { func f() -> Int { var n = 0; n = 1; return n } }").cqsViolations == 0)
+    }
+}

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/CQSTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/CQSTests.swift
@@ -33,4 +33,19 @@ struct CQSTests {
     func localVarNotSideEffect() {
         #expect(method("struct S { func f() -> Int { var n = 0; n = 1; return n } }").cqsViolations == 0)
     }
+
+    @Test("중첩 함수 안 side-effect는 바깥 메소드로 새지 않는다")
+    func nestedFunctionScopeIsolated() {
+        // outer는 `return 0`뿐인 순수 query — inner의 self.x=1이 새어들면 안 됨.
+        let outer = SyntaxScanner()
+            .scan(source: "struct S { func outer() -> Int { func inner() { self.x = 1 }; return 0 } }", file: "T.swift")
+            .first { $0.name == "outer" }
+        #expect(outer?.measurements.cqsViolations == 0)
+    }
+
+    @Test("Swift.Void·공백 빈 튜플 반환은 command = nil")
+    func voidVariantsAreCommand() {
+        #expect(method("struct S { func f() -> Swift.Void { self.x = 1 } }").cqsViolations == nil)
+        #expect(method("struct S { func f() -> ( ) { self.x = 1 } }").cqsViolations == nil)
+    }
 }

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/CombineRoleTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/CombineRoleTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import ComplexityCore
+
+@Suite("Combine 역할 혼합 — 순수 변형 연산자 클로저의 side-effect")
+struct CombineRoleTests {
+
+    private func method(_ source: String) -> Measurements {
+        SyntaxScanner().scan(source: source, file: "T.swift")
+            .first { $0.kind == .method }?.measurements ?? .init()
+    }
+
+    @Test("map 클로저 안 self 대입 = 역할 혼합 1")
+    func mapSideEffect() {
+        #expect(method("struct S { func f() { _ = pub.map { self.x = $0; return $0 } } }").combineRoleMix == 1)
+    }
+
+    @Test("handleEvents 클로저 side-effect는 역할 혼합 아님 = 0")
+    func handleEventsAllowed() {
+        #expect(method("struct S { func f() { _ = pub.handleEvents(receiveOutput: { self.x = $0 }) } }").combineRoleMix == 0)
+    }
+
+    @Test("역할 혼합은 query/command 무관 — command에서도 잡힌다")
+    func independentOfQuery() {
+        let m = method("struct S { func f() { _ = pub.filter { self.x = $0; return true } } }")
+        #expect(m.combineRoleMix == 1)
+        #expect(m.cqsViolations == nil)   // command라 CQS는 N/A
+    }
+}


### PR DESCRIPTION
## 문제

복잡도 분석기(#691)는 페이즈 1에서 메소드 **내부 복잡도**(분기·중첩)와 타입 **fan-in**만 측정했다. 메소드 레벨엔 구조 품질을 가르는 두 축이 빠져 있었다 — CQS 위반(query 함수가 side-effect를 흘리는가)과 Combine 연산자 역할 혼합(순수 변형 연산자에 side-effect가 섞이는가). CLAUDE.md 설계원칙이 명시하는 규칙인데 측정 수단이 없었다.

## 접근

두 축이 같은 뿌리를 본다 — **"side-effect가 있어선 안 될 자리에 있다."** 차이는 컨텍스트뿐이라 단일 탐지기로 뽑고 컨텍스트로만 가른다. 순수 SwiftSyntax (IndexStore 불필요).

- **`SideEffectAnalyzer`** — side-effect 부위(멤버/Subject 대입 `self.x =`·`.value =`, Subject 방출 `.send`)를 찾고, 각 부위에서 부모 체인을 거슬러 올라 **첫 인식 연산자 클로저**로 분류한다.
  - 순수 변형(`map`/`flatMap`/`compactMap`/`filter`/`reduce`/`scan`) 클로저 → **역할 혼합**
  - 허용(`sink`/`handleEvents`/`do`) 클로저 → 무죄 (side-effect의 올바른 자리)
  - 인식 연산자 없음(메인 흐름) → **query일 때만** CQS 위반
- **`Measurements`** 에 `cqsViolations`(query 메소드만, command는 N/A→nil→JSON 생략)·`combineRoleMix`(query/command 무관) 추가. `MethodCollector`가 반환 타입으로 query를 판별해 부착.
- 대입은 `Parser.parse`가 operator folding을 안 해 `SequenceExpr`(unfolded)로 나오는 걸 그 구조에서 직접 탐지.

측정값은 method 단위 JSON에 실린다. 테스트로 두 축 동작(위반/무죄/컨텍스트 분류)을 pin.

## 남은 과제

- **메소드 fan-in(변경 파급)은 페이즈 3으로 이관** — 오버로드/동명이인이 타입보다 흔해 bare-name 매칭이 오측. 페이즈 3의 USR/enclosing 정규화와 함께 정밀 부착.
- side-effect 탐지 v1은 좁게 고정: 복합 대입(`+=`)·`send` 외 IO 미탐지, 로컬 값타입 인스턴스 변이 오탐 가능성 감수. 정련은 후속.
- 총점·가중 합산은 페이즈 5.
