### PR TITLE
[#629] AI 명령 처리 E2E 결함 3건 수정 — 인증 토큰·필드명 계약·키보드 입력 씹힘

### DIFF
--- a/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
@@ -194,7 +194,7 @@ extension AIAgentOrchestrationUsecaseImple {
         guard !trimmed.isEmpty else {
             throw RuntimeError(key: "AIAgent.emptyCommand", "command text is empty")
         }
-        guard self.isIdle else {
+        guard self.canSubmit else {
             throw RuntimeError(key: "AIAgent.busy", "already processing a command")
         }
         self.subject.state.send(.processing(command: trimmed))
@@ -204,6 +204,15 @@ extension AIAgentOrchestrationUsecaseImple {
     private var isIdle: Bool {
         switch self.subject.state.value {
         case .none, .idle: return true
+        default: return false
+        }
+    }
+
+    // submit은 입력 대기(idle) + 음성/키보드 입력 중(listening)에서 허용.
+    // 키보드 입력은 .listening(.keyboard) 상태로 send하므로 idle-only면 씹힌다.
+    private var canSubmit: Bool {
+        switch self.subject.state.value {
+        case .none, .idle, .listening: return true
         default: return false
         }
     }

--- a/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
@@ -188,13 +188,32 @@ extension AIAgentOrchestrationUsecaseImpleTests {
         #expect(states.map(self.stateName) == ["processing", "done"])
     }
 
-    @Test func usecase_submit_whenNotIdle_throws() throws {
-        // given — 이미 confirm 처리 중
+    @Test func usecase_submit_whileConfirming_throws() throws {
+        // given — 이미 confirm 처리 중 (진짜 busy 상태)
         let usecase = self.makeUsecaseInConfirm()
-        // when - then — idle이 아니면 throw(거부)
+        // when - then — 처리 중이면 throw(거부)
         #expect(throws: (any Error).self) {
             try usecase.submit("새 명령")
         }
+    }
+
+    // 회귀: 키보드 입력(listening) 상태에서 submit이 busy로 씹히던 버그
+    @Test func usecase_submit_whileKeyboardListening_entersProcessing() async throws {
+        // given — 키보드 입력 진입해 .listening(.keyboard)
+        let expect = expectConfirm("listening 상태 submit → processing → done")
+        expect.count = 2
+        var done = AIJobResult.DoneResult()
+        done.text = "완료"
+        let usecase = self.makeUsecaseWithCommandJob(self.dummyJob(.done(done)))
+        usecase.reset()
+        usecase.enterKeyboardInput()
+        // when
+        let states = try await self.outputs(expect, for: usecase.state.dropFirst()) {
+            try? usecase.submit("회의 잡아줘")
+        }
+        // then — busy 거부 없이 processing부터 시작
+        #expect(states.map(self.stateName) == ["processing", "done"])
+        #expect(self.stubCommand.didProcessCommand == "회의 잡아줘")
     }
 
     @Test func usecase_whenResultConfirm_entersConfirmWithCommand() async throws {

--- a/Repository/Sources/Remote/Authenticators/CalendarAPIAutenticator.swift
+++ b/Repository/Sources/Remote/Authenticators/CalendarAPIAutenticator.swift
@@ -49,6 +49,7 @@ extension CalendarAPIAutenticator {
         case is AppSettingEndpoints: return true
         case is MigrationEndpoints: return true
         case is EventSyncEndPoints: return true
+        case is AIAPIEndpoints: return true
         default: return false
         }
     }

--- a/Repository/Sources/Repository+Imple/AI/AICommand+Mapping.swift
+++ b/Repository/Sources/Repository+Imple/AI/AICommand+Mapping.swift
@@ -19,6 +19,7 @@ extension AIConfirmCommandAction {
 
     func asJson(timeZone: String) -> [String: Any] {
         var json: [String: Any] = [:]
+        json["parent_job_id"] = self.parentJobId
         json["tool"] = self.tool
         json["confirm_token"] = self.confirmToken
         json["timezone"] = timeZone
@@ -52,19 +53,19 @@ struct AIJobMapper {
     let job: AIJob
 
     init(json: [String: Any]) throws {
-        guard let jobId = json["jobId"] as? String
+        guard let jobId = json["job_id"] as? String
         else { throw RuntimeError("invalid AIJob response") }
 
         let resultJson = json["result"] as? [String: Any]
         let result = resultJson.flatMap { try? AIJobResultMapper(json: $0).result }
 
         self.job = AIJob(jobId: jobId)
-            |> \.command .~ (json["commandText"] as? String)
+            |> \.command .~ (json["command_text"] as? String)
             |> \.status .~ (json["status"] as? String).flatMap { AIJob.Status(rawValue: $0) }
             |> \.mode .~ (json["mode"] as? String).flatMap { AIJob.Mode(rawValue: $0) }
             |> \.result .~ result
-            |> \.createAt .~ AICommandDateParser.parse(json["createdAt"])
-            |> \.updatedAt .~ AICommandDateParser.parse(json["updatedAt"])
+            |> \.createAt .~ AICommandDateParser.parse(json["created_at"])
+            |> \.updatedAt .~ AICommandDateParser.parse(json["updated_at"])
     }
 }
 

--- a/Repository/Tests/AI/AICommandRepositoryImpleTests.swift
+++ b/Repository/Tests/AI/AICommandRepositoryImpleTests.swift
@@ -90,6 +90,7 @@ extension AICommandRepositoryImpleTests {
         let action = AIConfirmCommandAction()
             |> \.tool .~ "delete_schedule"
             |> \.confirmToken .~ "tok"
+            |> \.parentJobId .~ "parent-xyz"
             |> \.args .~ args
 
         // when
@@ -102,6 +103,7 @@ extension AICommandRepositoryImpleTests {
         let params = self.stubRemote.didRequestedParams
         XCTAssertEqual(params?["tool"] as? String, "delete_schedule")
         XCTAssertEqual(params?["confirm_token"] as? String, "tok")
+        XCTAssertEqual(params?["parent_job_id"] as? String, "parent-xyz")
         XCTAssertEqual(params?["timezone"] as? String, "Asia/Seoul")
         let argsParam = params?["args"] as? [String: Any]
         XCTAssertEqual(argsParam?["schedule_id"] as? String, "abc")
@@ -376,12 +378,12 @@ private struct DummyResponse {
     private var doneJobJson: String {
         return """
         {
-            "jobId": "done_job",
-            "commandText": "내일 오후 3시",
+            "job_id": "done_job",
+            "command_text": "내일 오후 3시",
             "status": "DONE",
             "mode": "command",
-            "createdAt": "2026-06-01T10:00:00.000Z",
-            "updatedAt": "2026-06-01T10:00:05.000Z",
+            "created_at": "2026-06-01T10:00:00.000Z",
+            "updated_at": "2026-06-01T10:00:05.000Z",
             "result": {
                 "type": "DONE",
                 "text": "일정 등록했어요",
@@ -396,7 +398,7 @@ private struct DummyResponse {
     private var confirmJobJson: String {
         return """
         {
-            "jobId": "confirm_job",
+            "job_id": "confirm_job",
             "status": "CONFIRM",
             "mode": "command",
             "result": {
@@ -416,7 +418,7 @@ private struct DummyResponse {
     private var failedJobJson: String {
         return """
         {
-            "jobId": "failed_job",
+            "job_id": "failed_job",
             "status": "FAILED",
             "mode": "command",
             "result": {
@@ -432,7 +434,7 @@ private struct DummyResponse {
     private var runningJobJson: String {
         return """
         {
-            "jobId": "running_job",
+            "job_id": "running_job",
             "status": "RUNNING",
             "mode": "command"
         }

--- a/Repository/Tests/Auth/CalendarAPIAutenticatorTests.swift
+++ b/Repository/Tests/Auth/CalendarAPIAutenticatorTests.swift
@@ -95,6 +95,25 @@ extension CalendarAPIAutenticatorTests {
         parameterizeTest(
             EventSyncEndPoints.check, method: .get, expecthasToken: true
         )
+        // 회귀: AI Front API도 인증 토큰이 붙어야 한다 (whitelist 누락 수정)
+        parameterizeTest(
+            AIAPIEndpoints.command, method: .post, expecthasToken: true
+        )
+        parameterizeTest(
+            AIAPIEndpoints.confirmCommand, method: .post, expecthasToken: true
+        )
+        parameterizeTest(
+            AIAPIEndpoints.rejectCommand, method: .post, expecthasToken: true
+        )
+        parameterizeTest(
+            AIAPIEndpoints.cancelCommand, method: .post, expecthasToken: true
+        )
+        parameterizeTest(
+            AIAPIEndpoints.job(id: "job-1"), method: .get, expecthasToken: true
+        )
+        parameterizeTest(
+            AIAPIEndpoints.usage, method: .get, expecthasToken: true
+        )
     }
 }
 


### PR DESCRIPTION
## 문제

PR #670 머지 후 AI 기능을 실기로 E2E 돌려보니 명령이 아예 처리되지 않았다. 원인이 세 겹이었다.

1. **AI Front API 호출에 인증 토큰이 안 붙었다** — `/v1/ai/*`는 Firebase Auth 필수인데 서버가 401로 튕겼다.
2. **응답/요청 필드명이 서버 계약과 달랐다** — 서버는 snake_case로 주고받는데 클라는 camelCase로 읽고 썼다. 토큰을 붙여 200을 받아도 job을 파싱하지 못했다.
3. **키보드로 입력한 명령이 씹혔다** — 음성이 아닌 키보드 입력 시 submit이 무시됐다.

## 접근

**인증** — `CalendarAPIAutenticator.isRequireAuth`에 `AIAPIEndpoints` case 추가. 다른 인증 필요 엔드포인트와 같은 자리에서 처리한다.

**필드명 계약** — `AIJobMapper.init` 파싱 키를 서버 계약(snake_case)에 맞춰 정렬: `jobId`→`job_id`, `commandText`→`command_text`, `createdAt`/`updatedAt`→`created_at`/`updated_at`. 요청 쪽 `AIConfirmCommandAction.asJson`에는 누락돼 있던 `parent_job_id`를 추가했다 — 2차 confirm 호출이 대상 job을 특정하지 못하던 문제.

**키보드 입력** — `AIAgentOrchestrationUsecaseImple.sendCommand`의 게이트를 `isIdle`에서 `canSubmit`으로 교체. 키보드 입력은 `.listening(.keyboard)` 상태에서 submit되는데 게이트가 idle만 허용해 전부 거부되고 있었다. `canSubmit`은 `.none`/`.idle`/`.listening`을 허용한다 — 이미 처리 중(`.processing`)인 명령만 막는다는 원래 의도는 유지.

## 남은 과제

- 처리 완료 푸시를 받아도 다음 폴링 차수까지 기다리는 문제 — #694로 분리했다. 이 PR을 베이스로 이어서 작업한다.