### PR TITLE
[#691] 복잡도 분석기 페이즈 3 — 객체 레벨 + USR 정규화 + 메소드 fan-in

### DIFF
--- a/tools/complexity-analyzer/Sources/ComplexityAnalyzer/Entry.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityAnalyzer/Entry.swift
@@ -7,7 +7,7 @@ struct ComplexityAnalyzerCLI: AsyncParsableCommand {
 
     static let configuration = CommandConfiguration(
         commandName: "complexity-analyzer",
-        abstract: "TodoCalendar 구조 복잡도 분석기 (메소드: 내부복잡도·CQS·Combine 역할혼합 / 타입: fan-in)"
+        abstract: "TodoCalendar 구조 복잡도 분석기 (메소드: 내부복잡도·CQS·Combine 역할혼합·fan-in / 타입: 응집·표면적·롤업·fan-in)"
     )
 
     @Option(name: .customLong("source-root"), help: "분석할 소스 루트 경로")

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Analyzer.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Analyzer.swift
@@ -19,9 +19,15 @@ public struct Analyzer {
         let units = files.flatMap { file -> [AnalyzedUnit] in
             guard let source = try? String(contentsOfFile: file, encoding: .utf8) else { return [] }
             return scanner.scan(source: source, file: file).map { unit in
-                guard unit.kind == .type else { return unit }
                 var withFanIn = unit
-                withFanIn.measurements.fanIn = fanIn.count(forTypeNamed: unit.name)
+                switch unit.kind {
+                case .type:
+                    withFanIn.measurements.fanIn =
+                        fanIn.directCount(name: unit.name, file: file, line: unit.line)
+                case .method:
+                    withFanIn.measurements.fanInByHop =
+                        fanIn.byHop(name: unit.name, file: file, line: unit.line, maxHop: 2)
+                }
                 return withFanIn
             }
         }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Analyzer.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Analyzer.swift
@@ -16,9 +16,16 @@ public struct Analyzer {
         let files = SwiftFileEnumerator.files(under: sourceRoot, scope: scope)
         let fanIn = FanIn(index: index)
 
-        let units = files.flatMap { file -> [AnalyzedUnit] in
-            guard let source = try? String(contentsOfFile: file, encoding: .utf8) else { return [] }
-            return scanner.scan(source: source, file: file).map { unit in
+        // 파일별 유닛(fan-in 부착) + 정규화 타입별 facts 수집. 객체 측정은 facts를 파일 간
+        // 병합한 뒤 whole-scope에서 계산해야 cross-file extension이 원본 타입에 재조립된다.
+        var units: [AnalyzedUnit] = []
+        var factsByQualified: [String: TypeFacts] = [:]
+
+        for file in files {
+            guard let source = try? String(contentsOfFile: file, encoding: .utf8) else { continue }
+            let (fileUnits, fileFacts) = scanner.unitsAndFacts(source: source, file: file)
+
+            units += fileUnits.map { unit in
                 var withFanIn = unit
                 switch unit.kind {
                 case .type:
@@ -30,8 +37,14 @@ public struct Analyzer {
                 }
                 return withFanIn
             }
+
+            for (qualified, facts) in fileFacts {
+                factsByQualified[qualified] =
+                    factsByQualified[qualified].map { TypeFacts.merged($0, facts) } ?? facts
+            }
         }
 
-        return units.filter { scope.includes($0) }
+        let patched = ObjectMetricsAggregator.patched(units: units, factsByQualified: factsByQualified)
+        return patched.filter { scope.includes($0) }
     }
 }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexProviding.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexProviding.swift
@@ -1,7 +1,16 @@
 /// index 접근 seam — fan-in 로직을 실 IndexStoreDB 없이 테스트하기 위한 추상.
+
+/// 한 참조 지점 — 그 참조를 감싸는(호출/포함하는) caller 심볼들의 USR.
+public struct ReferenceSite: Equatable, Sendable {
+    public let callerUSRs: [String]
+    public init(callerUSRs: [String]) {
+        self.callerUSRs = callerUSRs
+    }
+}
+
 public protocol IndexProviding {
-    /// 이 이름의 명목 타입 선언 심볼들의 USR.
-    func typeUSRs(named name: String) -> [String]
-    /// 이 USR을 참조하는 지점 수 (fan-in).
-    func referenceCount(ofUSR usr: String) -> Int
+    /// `(name, file, line)`에 정의된 심볼의 정확한 USR. 동명이인 방지(bare-name 전역 조회 X).
+    func definitionUSR(named name: String, file: String, line: Int) -> String?
+    /// 이 USR을 참조하는 지점들. 각 지점은 자신을 감싸는 caller USR을 함께 담는다.
+    func references(toUSR usr: String) -> [ReferenceSite]
 }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexStoreDBProvider.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexStoreDBProvider.swift
@@ -60,23 +60,33 @@ public struct IndexStoreDBProvider: IndexProviding {
         guard hasUnits else { throw IndexStoreError.storeEmpty(storePath) }
     }
 
-    // 알려진 한계 (→ 페이즈 3에서 해소): 타입을 bare name으로 전역 조회한다.
-    // 동명이인 타입(예: SQLite 테이블마다 있는 Entity/Columns)이 한 이름으로 합산된다.
-    // 정확한 식별은 USR 또는 enclosing 체인 기반 정규화가 필요.
-    public func typeUSRs(named name: String) -> [String] {
-        var usrs: Set<String> = []
+    /// `(name, file, line)`에 정의된 심볼의 정확한 USR.
+    /// 이름으로 canonical occurrence를 순회하다 정의 role + 위치(파일·라인) 일치를 찾으면 그 USR.
+    public func definitionUSR(named name: String, file: String, line: Int) -> String? {
+        let targetPath = Self.resolvedPath(file)
+        var found: String?
         index.forEachCanonicalSymbolOccurrence(byName: name) { occurrence in
-            let kind = occurrence.symbol.kind
-            let isNominalType = kind == .class || kind == .struct || kind == .enum || kind == .protocol
-            if occurrence.roles.contains(.definition), isNominalType {
-                usrs.insert(occurrence.symbol.usr)
-            }
-            return true
+            guard occurrence.roles.contains(.definition) else { return true }
+            guard occurrence.location.line == line else { return true }
+            guard Self.resolvedPath(occurrence.location.path) == targetPath else { return true }
+            found = occurrence.symbol.usr
+            return false // 찾았으니 순회 중단
         }
-        return Array(usrs)
+        return found
     }
 
-    public func referenceCount(ofUSR usr: String) -> Int {
-        index.occurrences(ofUSR: usr, roles: .reference).count
+    /// 이 USR을 참조하는 지점들 — 각 지점의 caller(calledBy/containedBy) USR 포함.
+    public func references(toUSR usr: String) -> [ReferenceSite] {
+        index.occurrences(ofUSR: usr, roles: .reference).map { occurrence in
+            let callers = occurrence.relations
+                .filter { $0.roles.contains(.calledBy) || $0.roles.contains(.containedBy) }
+                .map { $0.symbol.usr }
+            return ReferenceSite(callerUSRs: callers)
+        }
+    }
+
+    /// 경로 비교 정규화 — /private 심볼릭·상대 표기 차이를 흡수.
+    private static func resolvedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).resolvingSymlinksInPath().path
     }
 }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Measure/CohesionAnalyzer.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Measure/CohesionAnalyzer.swift
@@ -3,26 +3,26 @@
 /// - internalCoupling: 타입 내부 메소드 호출 간선 수(과밀 — 결합).
 /// - maxCallChainDepth: 내부 호출 그래프의 최장 경로 메소드 수(과밀 — 체인 깊이).
 
-public struct MethodNode: Equatable {
-    public let name: String
-    public let referencedProps: Set<String>
-    public let calledMethods: Set<String> // 이미 타입 내부 메소드로 교집합된 이름
-    public init(name: String, referencedProps: Set<String>, calledMethods: Set<String>) {
+struct MethodNode: Equatable {
+    let name: String
+    let referencedProps: Set<String>
+    let calledMethods: Set<String> // 이미 타입 내부 메소드로 교집합된 이름
+    init(name: String, referencedProps: Set<String>, calledMethods: Set<String>) {
         self.name = name
         self.referencedProps = referencedProps
         self.calledMethods = calledMethods
     }
 }
 
-public enum CohesionAnalyzer {
+enum CohesionAnalyzer {
 
-    public struct Metrics: Equatable {
-        public var lcom: Int
-        public var internalCoupling: Int
-        public var maxCallChainDepth: Int
+    struct Metrics: Equatable {
+        var lcom: Int
+        var internalCoupling: Int
+        var maxCallChainDepth: Int
     }
 
-    public static func metrics(methods: [MethodNode]) -> Metrics {
+    static func metrics(methods: [MethodNode]) -> Metrics {
         let names = Set(methods.map { $0.name })
         // 타입 내부로 한정된 인접(호출) 그래프.
         let adjacency = Dictionary(
@@ -66,19 +66,23 @@ public enum CohesionAnalyzer {
         return Set(methods.indices.map { find($0) }).count
     }
 
-    /// 내부 호출 그래프의 가장 긴 경로(메소드 수). 방문 가드로 사이클에서도 유한.
+    /// 내부 호출 그래프의 가장 긴 경로(메소드 수). 노드별 memo로 O(V+E) —
+    /// dense 그래프에서 simple-path 전수 탐색이 지수 폭발하는 것을 막는다.
+    /// 사이클은 `onStack` back-edge에서 0으로 끊어 유한(DAG면 정확, 순환 그래프는 근사).
     private static func maxChainDepth(names: Set<String>, adjacency: [String: Set<String>]) -> Int {
-        var best = 0
-        for start in names {
-            best = max(best, dfsDepth(start, adjacency, visiting: []))
-        }
-        return best
-    }
+        var memo: [String: Int] = [:]
+        var onStack: Set<String> = []
 
-    private static func dfsDepth(_ node: String, _ adjacency: [String: Set<String>], visiting: Set<String>) -> Int {
-        guard !visiting.contains(node) else { return 0 } // 사이클 차단
-        let next = visiting.union([node])
-        let deeper = (adjacency[node] ?? []).map { dfsDepth($0, adjacency, visiting: next) }.max() ?? 0
-        return 1 + deeper
+        func depth(_ node: String) -> Int {
+            if let cached = memo[node] { return cached }
+            guard !onStack.contains(node) else { return 0 } // 사이클 back-edge
+            onStack.insert(node)
+            let deeper = (adjacency[node] ?? []).map { depth($0) }.max() ?? 0
+            onStack.remove(node)
+            let result = 1 + deeper
+            memo[node] = result
+            return result
+        }
+        return names.map { depth($0) }.max() ?? 0
     }
 }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Measure/CohesionAnalyzer.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Measure/CohesionAnalyzer.swift
@@ -1,0 +1,84 @@
+/// 타입 내부 멤버 그래프에서 응집·결합 지표를 낸다(순수 함수).
+/// - lcom: 메소드 그래프의 연결 요소 수(공유 프로퍼티 또는 호출로 연결). ≥2 = 분리 후보(끊김).
+/// - internalCoupling: 타입 내부 메소드 호출 간선 수(과밀 — 결합).
+/// - maxCallChainDepth: 내부 호출 그래프의 최장 경로 메소드 수(과밀 — 체인 깊이).
+
+public struct MethodNode: Equatable {
+    public let name: String
+    public let referencedProps: Set<String>
+    public let calledMethods: Set<String> // 이미 타입 내부 메소드로 교집합된 이름
+    public init(name: String, referencedProps: Set<String>, calledMethods: Set<String>) {
+        self.name = name
+        self.referencedProps = referencedProps
+        self.calledMethods = calledMethods
+    }
+}
+
+public enum CohesionAnalyzer {
+
+    public struct Metrics: Equatable {
+        public var lcom: Int
+        public var internalCoupling: Int
+        public var maxCallChainDepth: Int
+    }
+
+    public static func metrics(methods: [MethodNode]) -> Metrics {
+        let names = Set(methods.map { $0.name })
+        // 타입 내부로 한정된 인접(호출) 그래프.
+        let adjacency = Dictionary(
+            methods.map { ($0.name, $0.calledMethods.intersection(names)) },
+            uniquingKeysWith: { a, b in a.union(b) }
+        )
+        return Metrics(
+            lcom: lcom(methods),
+            internalCoupling: adjacency.values.reduce(0) { $0 + $1.count },
+            maxCallChainDepth: maxChainDepth(names: names, adjacency: adjacency)
+        )
+    }
+
+    /// LCOM4 — 메소드 정점 그래프의 연결 요소 수. 간선: 공유 프로퍼티 || 호출 관계.
+    private static func lcom(_ methods: [MethodNode]) -> Int {
+        guard !methods.isEmpty else { return 0 }
+
+        var parent = Array(0..<methods.count)
+        func find(_ i: Int) -> Int {
+            var r = i
+            while parent[r] != r { parent[r] = parent[parent[r]]; r = parent[r] }
+            return r
+        }
+        func union(_ i: Int, _ j: Int) { parent[find(i)] = find(j) }
+
+        let nameToIndex = Dictionary(
+            methods.enumerated().map { ($1.name, $0) },
+            uniquingKeysWith: { a, _ in a }
+        )
+
+        for i in methods.indices {
+            for j in methods.indices where j > i {
+                if !methods[i].referencedProps.isDisjoint(with: methods[j].referencedProps) {
+                    union(i, j)
+                }
+            }
+            for callee in methods[i].calledMethods {
+                if let j = nameToIndex[callee] { union(i, j) }
+            }
+        }
+        return Set(methods.indices.map { find($0) }).count
+    }
+
+    /// 내부 호출 그래프의 가장 긴 경로(메소드 수). 방문 가드로 사이클에서도 유한.
+    private static func maxChainDepth(names: Set<String>, adjacency: [String: Set<String>]) -> Int {
+        var best = 0
+        for start in names {
+            best = max(best, dfsDepth(start, adjacency, visiting: []))
+        }
+        return best
+    }
+
+    private static func dfsDepth(_ node: String, _ adjacency: [String: Set<String>], visiting: Set<String>) -> Int {
+        guard !visiting.contains(node) else { return 0 } // 사이클 차단
+        let next = visiting.union([node])
+        let deeper = (adjacency[node] ?? []).map { dfsDepth($0, adjacency, visiting: next) }.max() ?? 0
+        return 1 + deeper
+    }
+}

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Measure/FanIn.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Measure/FanIn.swift
@@ -1,5 +1,5 @@
-/// 타입 fan-in — 이 타입을 참조하는 cross-file 지점 수.
-/// 한 타입 이름이 여러 USR로 잡힐 수 있어(오버로드·재선언) USR별 참조를 합산한다.
+/// fan-in — 유닛을 정확한 USR로 해소한 뒤 caller 그래프를 홉 상한까지 BFS해 per-hop 참조 수를 낸다.
+/// 가중(홉별 감쇠)은 페이즈 5. 여기선 raw per-hop 카운트만.
 public struct FanIn {
 
     private let index: any IndexProviding
@@ -8,9 +8,38 @@ public struct FanIn {
         self.index = index
     }
 
-    public func count(forTypeNamed name: String) -> Int {
-        index.typeUSRs(named: name)
-            .map { index.referenceCount(ofUSR: $0) }
-            .reduce(0, +)
+    /// hop0(직접)부터 maxHop까지 각 홉의 참조 지점 수. 배열 길이 = maxHop+1.
+    /// USR 못 찾으면 nil(측정 불가). frontier 소진 시 남은 홉은 0.
+    public func byHop(name: String, file: String, line: Int, maxHop: Int) -> [Int]? {
+        guard let usr = index.definitionUSR(named: name, file: file, line: line) else { return nil }
+
+        var counts: [Int] = []
+        var frontier: Set<String> = [usr]
+        var visited: Set<String> = [usr]
+
+        for hop in 0...maxHop {
+            let refs = frontier.flatMap { index.references(toUSR: $0) }
+            counts.append(refs.count)
+            if hop == maxHop { break }
+
+            var next: Set<String> = []
+            for site in refs {
+                for caller in site.callerUSRs where !visited.contains(caller) {
+                    visited.insert(caller)
+                    next.insert(caller)
+                }
+            }
+            if next.isEmpty {
+                counts.append(contentsOf: Array(repeating: 0, count: maxHop - hop))
+                break
+            }
+            frontier = next
+        }
+        return counts
+    }
+
+    /// 직접 참조 수(hop0). type fan-in용. USR 못 찾으면 0.
+    public func directCount(name: String, file: String, line: Int) -> Int {
+        byHop(name: name, file: file, line: line, maxHop: 0)?.first ?? 0
     }
 }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Measure/ObjectMetrics.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Measure/ObjectMetrics.swift
@@ -1,0 +1,76 @@
+/// 한 정규화 타입의 raw 객체-레벨 사실(파일 간 병합 전).
+/// extension이 여러 파일에 흩어져도 정규화 이름으로 모아 원본 타입에 집계하기 위한 중간 표현.
+struct TypeFacts: Equatable {
+    var rollupInternal = 0
+    var rollupCqs = 0
+    var rollupCombine = 0
+    var publicSurface = 0
+    var storedProps: Set<String> = []
+    var methods: [MethodMembership] = []
+    /// 원본(primary) 타입 선언 위치. extension만 있는 파일에선 nil.
+    var primary: SourceRef?
+
+    struct MethodMembership: Equatable {
+        var name: String
+        var uses: Set<String>
+        var calls: Set<String>
+    }
+
+    struct SourceRef: Equatable {
+        var file: String
+        var line: Int
+        var name: String
+    }
+
+    /// 같은 정규화 이름의 파일별 facts를 합친다(롤업 합산·프로퍼티 union·메소드 concat·primary 보존).
+    static func merged(_ a: TypeFacts, _ b: TypeFacts) -> TypeFacts {
+        var r = a
+        r.rollupInternal += b.rollupInternal
+        r.rollupCqs += b.rollupCqs
+        r.rollupCombine += b.rollupCombine
+        r.publicSurface += b.publicSurface
+        r.storedProps.formUnion(b.storedProps)
+        r.methods.append(contentsOf: b.methods)
+        r.primary = a.primary ?? b.primary
+        return r
+    }
+}
+
+/// 정규화 타입별 raw facts(파일 간 병합 완료)를 받아 객체-레벨 측정을 계산,
+/// 원본 타입 유닛(primary 선언 위치)에 패치한다. cross-file extension 재조립이 여기서 성립.
+enum ObjectMetricsAggregator {
+
+    static func patched(units: [AnalyzedUnit], factsByQualified: [String: TypeFacts]) -> [AnalyzedUnit] {
+        var result = units
+
+        var indexByLocation: [String: Int] = [:]
+        for (i, unit) in result.enumerated() where unit.kind == .type {
+            indexByLocation["\(unit.file):\(unit.line):\(unit.name)"] = i
+        }
+
+        for facts in factsByQualified.values {
+            guard let primary = facts.primary,
+                  let index = indexByLocation["\(primary.file):\(primary.line):\(primary.name)"]
+            else { continue }
+
+            let methodNames = Set(facts.methods.map { $0.name })
+            let nodes = facts.methods.map {
+                MethodNode(
+                    name: $0.name,
+                    referencedProps: $0.uses.intersection(facts.storedProps),
+                    calledMethods: $0.calls.intersection(methodNames)
+                )
+            }
+            let cohesion = CohesionAnalyzer.metrics(methods: nodes)
+
+            result[index].measurements.rolledUpInternalComplexity = facts.rollupInternal
+            result[index].measurements.rolledUpCqsViolations = facts.rollupCqs
+            result[index].measurements.rolledUpCombineRoleMix = facts.rollupCombine
+            result[index].measurements.publicSurface = facts.publicSurface
+            result[index].measurements.lcom = cohesion.lcom
+            result[index].measurements.internalCoupling = cohesion.internalCoupling
+            result[index].measurements.maxCallChainDepth = cohesion.maxCallChainDepth
+        }
+        return result
+    }
+}

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Model/AnalyzedUnit.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Model/AnalyzedUnit.swift
@@ -11,6 +11,9 @@ public struct Measurements: Equatable, Sendable, Encodable {
     public var rolledUpCqsViolations: Int?
     public var rolledUpCombineRoleMix: Int?
     public var publicSurface: Int?
+    public var lcom: Int?
+    public var internalCoupling: Int?
+    public var maxCallChainDepth: Int?
 
     public init(
         internalComplexity: Int? = nil,
@@ -21,7 +24,10 @@ public struct Measurements: Equatable, Sendable, Encodable {
         rolledUpInternalComplexity: Int? = nil,
         rolledUpCqsViolations: Int? = nil,
         rolledUpCombineRoleMix: Int? = nil,
-        publicSurface: Int? = nil
+        publicSurface: Int? = nil,
+        lcom: Int? = nil,
+        internalCoupling: Int? = nil,
+        maxCallChainDepth: Int? = nil
     ) {
         self.internalComplexity = internalComplexity
         self.fanIn = fanIn
@@ -32,6 +38,9 @@ public struct Measurements: Equatable, Sendable, Encodable {
         self.rolledUpCqsViolations = rolledUpCqsViolations
         self.rolledUpCombineRoleMix = rolledUpCombineRoleMix
         self.publicSurface = publicSurface
+        self.lcom = lcom
+        self.internalCoupling = internalCoupling
+        self.maxCallChainDepth = maxCallChainDepth
     }
 }
 

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Model/AnalyzedUnit.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Model/AnalyzedUnit.swift
@@ -6,17 +6,20 @@ public struct Measurements: Equatable, Sendable, Encodable {
     public var fanIn: Int?
     public var cqsViolations: Int?
     public var combineRoleMix: Int?
+    public var fanInByHop: [Int]?
 
     public init(
         internalComplexity: Int? = nil,
         fanIn: Int? = nil,
         cqsViolations: Int? = nil,
-        combineRoleMix: Int? = nil
+        combineRoleMix: Int? = nil,
+        fanInByHop: [Int]? = nil
     ) {
         self.internalComplexity = internalComplexity
         self.fanIn = fanIn
         self.cqsViolations = cqsViolations
         self.combineRoleMix = combineRoleMix
+        self.fanInByHop = fanInByHop
     }
 }
 

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Model/AnalyzedUnit.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Model/AnalyzedUnit.swift
@@ -7,19 +7,31 @@ public struct Measurements: Equatable, Sendable, Encodable {
     public var cqsViolations: Int?
     public var combineRoleMix: Int?
     public var fanInByHop: [Int]?
+    public var rolledUpInternalComplexity: Int?
+    public var rolledUpCqsViolations: Int?
+    public var rolledUpCombineRoleMix: Int?
+    public var publicSurface: Int?
 
     public init(
         internalComplexity: Int? = nil,
         fanIn: Int? = nil,
         cqsViolations: Int? = nil,
         combineRoleMix: Int? = nil,
-        fanInByHop: [Int]? = nil
+        fanInByHop: [Int]? = nil,
+        rolledUpInternalComplexity: Int? = nil,
+        rolledUpCqsViolations: Int? = nil,
+        rolledUpCombineRoleMix: Int? = nil,
+        publicSurface: Int? = nil
     ) {
         self.internalComplexity = internalComplexity
         self.fanIn = fanIn
         self.cqsViolations = cqsViolations
         self.combineRoleMix = combineRoleMix
         self.fanInByHop = fanInByHop
+        self.rolledUpInternalComplexity = rolledUpInternalComplexity
+        self.rolledUpCqsViolations = rolledUpCqsViolations
+        self.rolledUpCombineRoleMix = rolledUpCombineRoleMix
+        self.publicSurface = publicSurface
     }
 }
 

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
@@ -12,6 +12,7 @@ public struct SyntaxScanner {
         let converter = SourceLocationConverter(fileName: file, tree: tree)
         let collector = MethodCollector(file: file, converter: converter)
         collector.walk(tree)
+        collector.finalize()
         return collector.units
     }
 }
@@ -24,6 +25,18 @@ private final class MethodCollector: SyntaxVisitor {
     let converter: SourceLocationConverter
     private(set) var units: [AnalyzedUnit] = []
     private var typeStack: [String] = []
+
+    /// 정규화 타입 이름(enclosing 체인 + 이름) → 소속 메소드 측정 누적.
+    private var rollupByQualified: [String: (internal: Int, cqs: Int, combine: Int)] = [:]
+    /// 정규화 타입 이름 → units 배열 내 그 타입 유닛 인덱스(post-walk 패치용).
+    private var typeUnitIndexByQualified: [String: Int] = [:]
+    /// 정규화 타입 이름 → public/open 멤버 수.
+    private var publicSurfaceByQualified: [String: Int] = [:]
+
+    private var currentQualified: String { typeStack.joined(separator: ".") }
+    private func qualified(_ name: String) -> String {
+        (typeStack + [name]).joined(separator: ".")
+    }
 
     init(file: String, converter: SourceLocationConverter) {
         self.file = file
@@ -69,7 +82,44 @@ private final class MethodCollector: SyntaxVisitor {
                 )
             )
         )
+
+        var acc = rollupByQualified[currentQualified] ?? (0, 0, 0)
+        acc.internal += internalC
+        acc.cqs += effects.cqsViolations
+        acc.combine += effects.combineRoleMix
+        rollupByQualified[currentQualified] = acc
+
+        if isPublicOrOpen(node.modifiers) { addSurface(1) }
+
         return .visitChildren
+    }
+
+    /// 타입 멤버 프로퍼티(로컬 var 제외)의 public/open 표면적 카운트.
+    override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+        if node.parent?.is(MemberBlockItemSyntax.self) == true, isPublicOrOpen(node.modifiers) {
+            addSurface(node.bindings.count)
+        }
+        return .visitChildren
+    }
+
+    private func isPublicOrOpen(_ modifiers: DeclModifierListSyntax) -> Bool {
+        modifiers.contains { $0.name.text == "public" || $0.name.text == "open" }
+    }
+
+    private func addSurface(_ n: Int) {
+        publicSurfaceByQualified[currentQualified, default: 0] += n
+    }
+
+    /// post-walk: 정규화 타입별 누적을 타입 유닛에 패치.
+    func finalize() {
+        for (qualified, index) in typeUnitIndexByQualified {
+            if let roll = rollupByQualified[qualified] {
+                units[index].measurements.rolledUpInternalComplexity = roll.internal
+                units[index].measurements.rolledUpCqsViolations = roll.cqs
+                units[index].measurements.rolledUpCombineRoleMix = roll.combine
+            }
+            units[index].measurements.publicSurface = publicSurfaceByQualified[qualified] ?? 0
+        }
     }
 
     /// 반환 타입이 non-Void면 query (값·Publisher). Void/무반환 = command.
@@ -84,6 +134,7 @@ private final class MethodCollector: SyntaxVisitor {
     /// 명목 타입 선언(class/struct/enum/actor): 타입 단위 방출 + enclosing 추적.
     private func enterType(_ nameToken: TokenSyntax) -> SyntaxVisitorContinueKind {
         let line = converter.location(for: nameToken.positionAfterSkippingLeadingTrivia).line
+        typeUnitIndexByQualified[qualified(nameToken.text)] = units.count
         units.append(
             AnalyzedUnit(
                 kind: .type,

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
@@ -32,6 +32,10 @@ private final class MethodCollector: SyntaxVisitor {
     private var typeUnitIndexByQualified: [String: Int] = [:]
     /// 정규화 타입 이름 → public/open 멤버 수.
     private var publicSurfaceByQualified: [String: Int] = [:]
+    /// 정규화 타입 이름 → stored property 이름들.
+    private var storedPropsByQualified: [String: Set<String>] = [:]
+    /// 정규화 타입 이름 → (메소드 이름, 참조 식별자 후보, 호출 후보) 목록.
+    private var methodGraphByQualified: [String: [(name: String, uses: Set<String>, calls: Set<String>)]] = [:]
 
     private var currentQualified: String { typeStack.joined(separator: ".") }
     private func qualified(_ name: String) -> String {
@@ -91,15 +95,37 @@ private final class MethodCollector: SyntaxVisitor {
 
         if isPublicOrOpen(node.modifiers) { addSurface(1) }
 
+        let uses = node.body.map { MemberUseCollector.collect(from: $0) } ?? (uses: [], calls: [])
+        methodGraphByQualified[currentQualified, default: []].append(
+            (name: node.name.text, uses: uses.uses, calls: uses.calls)
+        )
+
         return .visitChildren
     }
 
-    /// 타입 멤버 프로퍼티(로컬 var 제외)의 public/open 표면적 카운트.
+    /// 타입 멤버 프로퍼티(로컬 var 제외): 표면적 카운트 + stored property 등록.
     override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
-        if node.parent?.is(MemberBlockItemSyntax.self) == true, isPublicOrOpen(node.modifiers) {
-            addSurface(node.bindings.count)
+        guard node.parent?.is(MemberBlockItemSyntax.self) == true else { return .visitChildren }
+        if isPublicOrOpen(node.modifiers) { addSurface(node.bindings.count) }
+        for binding in node.bindings where isStored(binding) {
+            if let name = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text {
+                storedPropsByQualified[currentQualified, default: []].insert(name)
+            }
         }
         return .visitChildren
+    }
+
+    /// stored(저장) 프로퍼티인가 — accessor 없음 또는 willSet/didSet만.
+    private func isStored(_ binding: PatternBindingSyntax) -> Bool {
+        guard let accessor = binding.accessorBlock else { return true }
+        switch accessor.accessors {
+        case .accessors(let list):
+            return list.allSatisfy {
+                $0.accessorSpecifier.text == "willSet" || $0.accessorSpecifier.text == "didSet"
+            }
+        case .getter:
+            return false // `var x: Int { ... }` computed
+        }
     }
 
     private func isPublicOrOpen(_ modifiers: DeclModifierListSyntax) -> Bool {
@@ -119,6 +145,21 @@ private final class MethodCollector: SyntaxVisitor {
                 units[index].measurements.rolledUpCombineRoleMix = roll.combine
             }
             units[index].measurements.publicSurface = publicSurfaceByQualified[qualified] ?? 0
+
+            let stored = storedPropsByQualified[qualified] ?? []
+            let raw = methodGraphByQualified[qualified] ?? []
+            let methodNames = Set(raw.map { $0.name })
+            let nodes = raw.map { m in
+                MethodNode(
+                    name: m.name,
+                    referencedProps: m.uses.intersection(stored),
+                    calledMethods: m.calls.intersection(methodNames)
+                )
+            }
+            let cohesion = CohesionAnalyzer.metrics(methods: nodes)
+            units[index].measurements.lcom = cohesion.lcom
+            units[index].measurements.internalCoupling = cohesion.internalCoupling
+            units[index].measurements.maxCallChainDepth = cohesion.maxCallChainDepth
         }
     }
 
@@ -216,5 +257,50 @@ private final class ComplexityCounter: SyntaxVisitor {
         total += 1 + depth
         depth += 1
         return .visitChildren
+    }
+}
+
+// MARK: - 메소드 본문의 멤버 사용 수집 (프로퍼티 참조 후보 · 메소드 호출 후보)
+
+private final class MemberUseCollector: SyntaxVisitor {
+
+    private(set) var uses: Set<String> = []   // 프로퍼티 참조 후보(식별자)
+    private(set) var calls: Set<String> = []  // 메소드 호출 후보
+
+    static func collect(from body: CodeBlockSyntax) -> (uses: Set<String>, calls: Set<String>) {
+        let c = MemberUseCollector(viewMode: .sourceAccurate)
+        c.walk(body)
+        return (c.uses, c.calls)
+    }
+
+    // 중첩 함수·local 타입은 별도 unit — 이 메소드 사용에 섞지 않는다(클로저는 유지: 캡처가 이 메소드 결합).
+    override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind { .skipChildren }
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind { .skipChildren }
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind { .skipChildren }
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind { .skipChildren }
+    override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind { .skipChildren }
+
+    override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+        if let member = node.calledExpression.as(MemberAccessExprSyntax.self) {
+            if isSelfBase(member.base) { calls.insert(member.declName.baseName.text) }
+        } else if let ref = node.calledExpression.as(DeclReferenceExprSyntax.self) {
+            calls.insert(ref.baseName.text)
+        }
+        return .visitChildren
+    }
+
+    override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
+        if isSelfBase(node.base) { uses.insert(node.declName.baseName.text) }
+        return .visitChildren
+    }
+
+    override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
+        uses.insert(node.baseName.text) // 암묵 self 프로퍼티(`x`)까지 후보로. 교집합에서 stored만 남음.
+        return .visitChildren
+    }
+
+    private func isSelfBase(_ base: ExprSyntax?) -> Bool {
+        guard let base else { return false }
+        return base.as(DeclReferenceExprSyntax.self)?.baseName.text == "self"
     }
 }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
@@ -7,13 +7,19 @@ public struct SyntaxScanner {
 
     public init() {}
 
+    /// 단일 소스 편의 — 유닛 + 객체 측정 패치까지. (같은 소스 안 extension은 정규화 이름으로 병합)
     public func scan(source: String, file: String) -> [AnalyzedUnit] {
+        let (units, facts) = unitsAndFacts(source: source, file: file)
+        return ObjectMetricsAggregator.patched(units: units, factsByQualified: facts)
+    }
+
+    /// 유닛(객체 측정 미패치) + 정규화 타입별 raw facts. cross-file 집계는 Analyzer가 facts를 병합해 수행.
+    func unitsAndFacts(source: String, file: String) -> (units: [AnalyzedUnit], facts: [String: TypeFacts]) {
         let tree = Parser.parse(source: source)
         let converter = SourceLocationConverter(fileName: file, tree: tree)
         let collector = MethodCollector(file: file, converter: converter)
         collector.walk(tree)
-        collector.finalize()
-        return collector.units
+        return (collector.units, collector.factsByQualified)
     }
 }
 
@@ -24,18 +30,9 @@ private final class MethodCollector: SyntaxVisitor {
     let file: String
     let converter: SourceLocationConverter
     private(set) var units: [AnalyzedUnit] = []
+    /// 정규화 타입 이름(enclosing 체인 + 이름) → 이 파일의 raw 객체 facts. 파일 간 병합은 Analyzer.
+    private(set) var factsByQualified: [String: TypeFacts] = [:]
     private var typeStack: [String] = []
-
-    /// 정규화 타입 이름(enclosing 체인 + 이름) → 소속 메소드 측정 누적.
-    private var rollupByQualified: [String: (internal: Int, cqs: Int, combine: Int)] = [:]
-    /// 정규화 타입 이름 → units 배열 내 그 타입 유닛 인덱스(post-walk 패치용).
-    private var typeUnitIndexByQualified: [String: Int] = [:]
-    /// 정규화 타입 이름 → public/open 멤버 수.
-    private var publicSurfaceByQualified: [String: Int] = [:]
-    /// 정규화 타입 이름 → stored property 이름들.
-    private var storedPropsByQualified: [String: Set<String>] = [:]
-    /// 정규화 타입 이름 → (메소드 이름, 참조 식별자 후보, 호출 후보) 목록.
-    private var methodGraphByQualified: [String: [(name: String, uses: Set<String>, calls: Set<String>)]] = [:]
 
     private var currentQualified: String { typeStack.joined(separator: ".") }
     private func qualified(_ name: String) -> String {
@@ -87,18 +84,15 @@ private final class MethodCollector: SyntaxVisitor {
             )
         )
 
-        var acc = rollupByQualified[currentQualified] ?? (0, 0, 0)
-        acc.internal += internalC
-        acc.cqs += effects.cqsViolations
-        acc.combine += effects.combineRoleMix
-        rollupByQualified[currentQualified] = acc
-
-        if isPublicOrOpen(node.modifiers) { addSurface(1) }
-
         let uses = node.body.map { MemberUseCollector.collect(from: $0) } ?? (uses: [], calls: [])
-        methodGraphByQualified[currentQualified, default: []].append(
-            (name: node.name.text, uses: uses.uses, calls: uses.calls)
-        )
+        let isPublic = isPublicOrOpen(node.modifiers)
+        withFacts(currentQualified) {
+            $0.rollupInternal += internalC
+            $0.rollupCqs += effects.cqsViolations
+            $0.rollupCombine += effects.combineRoleMix
+            $0.methods.append(.init(name: node.name.text, uses: uses.uses, calls: uses.calls))
+            if isPublic { $0.publicSurface += 1 }
+        }
 
         return .visitChildren
     }
@@ -106,12 +100,27 @@ private final class MethodCollector: SyntaxVisitor {
     /// 타입 멤버 프로퍼티(로컬 var 제외): 표면적 카운트 + stored property 등록.
     override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
         guard node.parent?.is(MemberBlockItemSyntax.self) == true else { return .visitChildren }
-        if isPublicOrOpen(node.modifiers) { addSurface(node.bindings.count) }
-        for binding in node.bindings where isStored(binding) {
-            if let name = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text {
-                storedPropsByQualified[currentQualified, default: []].insert(name)
-            }
+        let stored = node.bindings.compactMap { binding -> String? in
+            guard isStored(binding) else { return nil }
+            return binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text
         }
+        let isPublic = isPublicOrOpen(node.modifiers)
+        let bindingCount = node.bindings.count
+        withFacts(currentQualified) {
+            if isPublic { $0.publicSurface += bindingCount }
+            $0.storedProps.formUnion(stored)
+        }
+        return .visitChildren
+    }
+
+    /// init·subscript도 public 노출 표면적. (enum case는 v1 제외)
+    override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+        if isPublicOrOpen(node.modifiers) { withFacts(currentQualified) { $0.publicSurface += 1 } }
+        return .visitChildren
+    }
+
+    override func visit(_ node: SubscriptDeclSyntax) -> SyntaxVisitorContinueKind {
+        if isPublicOrOpen(node.modifiers) { withFacts(currentQualified) { $0.publicSurface += 1 } }
         return .visitChildren
     }
 
@@ -132,35 +141,11 @@ private final class MethodCollector: SyntaxVisitor {
         modifiers.contains { $0.name.text == "public" || $0.name.text == "open" }
     }
 
-    private func addSurface(_ n: Int) {
-        publicSurfaceByQualified[currentQualified, default: 0] += n
-    }
-
-    /// post-walk: 정규화 타입별 누적을 타입 유닛에 패치.
-    func finalize() {
-        for (qualified, index) in typeUnitIndexByQualified {
-            if let roll = rollupByQualified[qualified] {
-                units[index].measurements.rolledUpInternalComplexity = roll.internal
-                units[index].measurements.rolledUpCqsViolations = roll.cqs
-                units[index].measurements.rolledUpCombineRoleMix = roll.combine
-            }
-            units[index].measurements.publicSurface = publicSurfaceByQualified[qualified] ?? 0
-
-            let stored = storedPropsByQualified[qualified] ?? []
-            let raw = methodGraphByQualified[qualified] ?? []
-            let methodNames = Set(raw.map { $0.name })
-            let nodes = raw.map { m in
-                MethodNode(
-                    name: m.name,
-                    referencedProps: m.uses.intersection(stored),
-                    calledMethods: m.calls.intersection(methodNames)
-                )
-            }
-            let cohesion = CohesionAnalyzer.metrics(methods: nodes)
-            units[index].measurements.lcom = cohesion.lcom
-            units[index].measurements.internalCoupling = cohesion.internalCoupling
-            units[index].measurements.maxCallChainDepth = cohesion.maxCallChainDepth
-        }
+    /// 정규화 이름의 facts를 in-place 갱신.
+    private func withFacts(_ qualified: String, _ mutate: (inout TypeFacts) -> Void) {
+        var facts = factsByQualified[qualified] ?? TypeFacts()
+        mutate(&facts)
+        factsByQualified[qualified] = facts
     }
 
     /// 반환 타입이 non-Void면 query (값·Publisher). Void/무반환 = command.
@@ -175,7 +160,7 @@ private final class MethodCollector: SyntaxVisitor {
     /// 명목 타입 선언(class/struct/enum/actor): 타입 단위 방출 + enclosing 추적.
     private func enterType(_ nameToken: TokenSyntax) -> SyntaxVisitorContinueKind {
         let line = converter.location(for: nameToken.positionAfterSkippingLeadingTrivia).line
-        typeUnitIndexByQualified[qualified(nameToken.text)] = units.count
+        withFacts(qualified(nameToken.text)) { $0.primary = .init(file: file, line: line, name: nameToken.text) }
         units.append(
             AnalyzedUnit(
                 kind: .type,

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/AnalyzerTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/AnalyzerTests.swift
@@ -11,8 +11,8 @@ struct AnalyzerTests {
         for (name, source) in files {
             try source.write(toFile: dir + "/" + name, atomically: true, encoding: .utf8)
         }
-        // 열거자는 realpath(/var→/private/var)로 경로를 내므로, stub 키·검증 경로도
-        // 같은 realpath로 맞춘다. (URL.resolvingSymlinksInPath는 반대로 /private를 떼어 불일치)
+        // realpath로 해소한 sourceRoot를 넘겨, 열거자가 내는 파일 경로 접두와 stub 키·검증 경로를
+        // 일치시킨다. (URL.resolvingSymlinksInPath는 /private를 떼는 반대 정규화라 불일치)
         return dir.withCString { cPath in
             guard let resolved = realpath(cPath, nil) else { return dir }
             defer { free(resolved) }
@@ -96,6 +96,20 @@ struct AnalyzerTests {
         #expect(json.contains("\"internalCoupling\""))
         #expect(json.contains("\"maxCallChainDepth\""))
         #expect(json.contains("\"rolledUpInternalComplexity\""))
+    }
+
+    @Test("cross-file extension 멤버가 원본 타입 롤업·표면적에 합산된다")
+    func crossFileExtensionAggregated() throws {
+        let dir = try writeTempDir([
+            "A.swift": "struct S { var x = 0; public func a() { self.x = 1 } }",
+            "B.swift": "extension S { public func b() { if q { if r {} } } }",
+        ])
+        let units = try Analyzer(index: StubIndexProvider()).analyze(sourceRoot: dir, scope: .whole)
+        let s = units.first { $0.kind == .type && $0.name == "S" }?.measurements
+        // a: internal 0, b: if{ if{} } = 3 → 다른 파일 extension까지 롤업 3
+        #expect(s?.rolledUpInternalComplexity == 3)
+        // public a(A.swift) + public b(B.swift) = 2
+        #expect(s?.publicSurface == 2)
     }
 
     @Test("Scope 파싱")

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/AnalyzerTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/AnalyzerTests.swift
@@ -11,20 +11,30 @@ struct AnalyzerTests {
         for (name, source) in files {
             try source.write(toFile: dir + "/" + name, atomically: true, encoding: .utf8)
         }
-        return dir
+        // 열거자는 realpath(/var→/private/var)로 경로를 내므로, stub 키·검증 경로도
+        // 같은 realpath로 맞춘다. (URL.resolvingSymlinksInPath는 반대로 /private를 떼어 불일치)
+        return dir.withCString { cPath in
+            guard let resolved = realpath(cPath, nil) else { return dir }
+            defer { free(resolved) }
+            return String(cString: resolved)
+        }
     }
 
-    @Test("타입엔 fan-in, 메소드엔 내부 복잡도가 실린다")
+    @Test("타입엔 direct fan-in, 메소드엔 per-hop fan-in이 실린다")
     func measuresAttached() throws {
         let dir = try writeTempDir(["Sample.swift": "struct Sample { func go() { if a { if b {} } } }"])
         let stub = StubIndexProvider()
-        stub.usrsByName["Sample"] = ["u1"]
-        stub.refCountByUSR = ["u1": 4]
+        // 타입 Sample은 1번째 줄, 메소드 go도 1번째 줄
+        stub.usrByLocation["Sample@\(dir)/Sample.swift:1"] = "uSample"
+        stub.usrByLocation["go@\(dir)/Sample.swift:1"] = "uGo"
+        stub.referencesByUSR["uSample"] = Array(repeating: .init(callerUSRs: []), count: 4)
+        stub.referencesByUSR["uGo"] = [.init(callerUSRs: [])]
 
         let units = try Analyzer(index: stub).analyze(sourceRoot: dir, scope: .whole)
 
         #expect(units.first { $0.kind == .type }?.measurements.fanIn == 4)
         #expect(units.first { $0.kind == .method }?.measurements.internalComplexity == 3)
+        #expect(units.first { $0.kind == .method }?.measurements.fanInByHop == [1, 0, 0])
     }
 
     @Test("type scope는 그 타입과 소속 메소드만 남긴다")
@@ -42,14 +52,17 @@ struct AnalyzerTests {
     func jsonContainsMeasures() throws {
         let dir = try writeTempDir(["S.swift": "struct S { func f() { if a {} } }"])
         let stub = StubIndexProvider()
-        stub.usrsByName["S"] = ["u"]
-        stub.refCountByUSR = ["u": 2]
+        stub.usrByLocation["S@\(dir)/S.swift:1"] = "u"
+        stub.referencesByUSR["u"] = [.init(callerUSRs: []), .init(callerUSRs: [])]
+        stub.usrByLocation["f@\(dir)/S.swift:1"] = "uf"
+        stub.referencesByUSR["uf"] = [.init(callerUSRs: [])]
 
         let units = try Analyzer(index: stub).analyze(sourceRoot: dir, scope: .whole)
         let json = try JSONReporter().string(for: units)
 
         #expect(json.contains("\"fanIn\""))
         #expect(json.contains("\"internalComplexity\""))
+        #expect(json.contains("\"fanInByHop\""))
     }
 
     @Test("메소드 단위에 CQS·Combine 측정이 실려 JSON에 나온다")

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/AnalyzerTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/AnalyzerTests.swift
@@ -79,6 +79,25 @@ struct AnalyzerTests {
         #expect(json.contains("\"combineRoleMix\""))
     }
 
+    @Test("객체 측정(응집·표면적·롤업)이 JSON에 나온다")
+    func objectMeasuresInJSON() throws {
+        let dir = try writeTempDir([
+            "S.swift": "struct S { var x = 0; public func a() { self.x = 1 }; func b() { print(x) } }"
+        ])
+        let units = try Analyzer(index: StubIndexProvider()).analyze(sourceRoot: dir, scope: .whole)
+        let type = units.first { $0.kind == .type }
+        #expect(type?.measurements.lcom == 1)
+        #expect(type?.measurements.publicSurface == 1)
+        #expect(type?.measurements.rolledUpInternalComplexity == 0)
+
+        let json = try JSONReporter().string(for: units)
+        #expect(json.contains("\"lcom\""))
+        #expect(json.contains("\"publicSurface\""))
+        #expect(json.contains("\"internalCoupling\""))
+        #expect(json.contains("\"maxCallChainDepth\""))
+        #expect(json.contains("\"rolledUpInternalComplexity\""))
+    }
+
     @Test("Scope 파싱")
     func scopeParsing() {
         #expect(Scope.parse("whole") == .whole)

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/CohesionScanTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/CohesionScanTests.swift
@@ -61,6 +61,18 @@ struct CohesionScanTests {
         #expect(m?.maxCallChainDepth == 3)     // a→b→c
     }
 
+    @Test("willSet/didSet observer만 있는 property는 stored로 응집에 쓰인다")
+    func observedPropertyIsStored() {
+        let src = """
+        struct S {
+            var x: Int = 0 { didSet {} }
+            func a() { self.x = 1 }
+            func b() { print(x) }
+        }
+        """
+        #expect(measure(src, name: "S")?.lcom == 1)
+    }
+
     @Test("computed property는 stored 아님 — 응집 연결에 안 쓰임")
     func computedNotStored() {
         // a·b가 computed c만 참조하면 stored 공유 없음 → 두 요소.

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/CohesionScanTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/CohesionScanTests.swift
@@ -1,0 +1,76 @@
+import Testing
+@testable import ComplexityCore
+
+@Suite("응집 — scanner 통합(멤버 그래프 → 지표)")
+struct CohesionScanTests {
+
+    private func measure(_ source: String, name: String) -> Measurements? {
+        SyntaxScanner().scan(source: source, file: "T.swift")
+            .first { $0.kind == .type && $0.name == name }?.measurements
+    }
+
+    @Test("공유 stored property를 쓰는 메소드는 한 요소")
+    func sharedStoredProp() {
+        let src = """
+        struct S {
+            var x = 0
+            func a() { self.x = 1 }
+            func b() { print(x) }
+        }
+        """
+        #expect(measure(src, name: "S")?.lcom == 1)
+    }
+
+    @Test("서로 다른 프로퍼티만 쓰는 두 메소드는 두 요소")
+    func disjoint() {
+        let src = """
+        struct S {
+            var x = 0
+            var y = 0
+            func a() { self.x = 1 }
+            func b() { self.y = 1 }
+        }
+        """
+        #expect(measure(src, name: "S")?.lcom == 2)
+    }
+
+    @Test("메소드 호출로 이어지면 한 요소")
+    func connectedByCall() {
+        let src = """
+        struct S {
+            var x = 0
+            var y = 0
+            func a() { self.x = 1; b() }
+            func b() { self.y = 1 }
+        }
+        """
+        #expect(measure(src, name: "S")?.lcom == 1)
+    }
+
+    @Test("내부 호출 결합·체인 깊이가 타입에 실린다")
+    func couplingAndDepthAttached() {
+        let src = """
+        struct S {
+            func a() { b() }
+            func b() { c() }
+            func c() {}
+        }
+        """
+        let m = measure(src, name: "S")
+        #expect(m?.internalCoupling == 2)      // a→b, b→c
+        #expect(m?.maxCallChainDepth == 3)     // a→b→c
+    }
+
+    @Test("computed property는 stored 아님 — 응집 연결에 안 쓰임")
+    func computedNotStored() {
+        // a·b가 computed c만 참조하면 stored 공유 없음 → 두 요소.
+        let src = """
+        struct S {
+            var c: Int { 0 }
+            func a() { _ = self.c }
+            func b() { _ = self.c }
+        }
+        """
+        #expect(measure(src, name: "S")?.lcom == 2)
+    }
+}

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/CohesionTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/CohesionTests.swift
@@ -1,0 +1,78 @@
+import Testing
+@testable import ComplexityCore
+
+@Suite("응집 — LCOM·내부 결합·체인 깊이 (순수 함수)")
+struct CohesionTests {
+
+    @Test("공유 프로퍼티로 이어진 메소드는 한 요소")
+    func sharedPropConnects() {
+        let methods = [
+            MethodNode(name: "a", referencedProps: ["x"], calledMethods: []),
+            MethodNode(name: "b", referencedProps: ["x"], calledMethods: []),
+        ]
+        #expect(CohesionAnalyzer.metrics(methods: methods).lcom == 1)
+    }
+
+    @Test("공유 없는 두 메소드는 두 요소(분리 후보)")
+    func disjointMethodsSplit() {
+        let methods = [
+            MethodNode(name: "a", referencedProps: ["x"], calledMethods: []),
+            MethodNode(name: "b", referencedProps: ["y"], calledMethods: []),
+        ]
+        #expect(CohesionAnalyzer.metrics(methods: methods).lcom == 2)
+    }
+
+    @Test("호출 관계도 연결로 본다")
+    func callConnects() {
+        let methods = [
+            MethodNode(name: "a", referencedProps: ["x"], calledMethods: ["b"]),
+            MethodNode(name: "b", referencedProps: ["y"], calledMethods: []),
+        ]
+        #expect(CohesionAnalyzer.metrics(methods: methods).lcom == 1)
+    }
+
+    @Test("메소드 없으면 0")
+    func emptyIsZero() {
+        #expect(CohesionAnalyzer.metrics(methods: []).lcom == 0)
+    }
+
+    @Test("내부 호출 결합 = 타입 내부 메소드 호출 간선 수")
+    func internalCouplingCountsEdges() {
+        let methods = [
+            MethodNode(name: "a", referencedProps: [], calledMethods: ["b", "c"]),
+            MethodNode(name: "b", referencedProps: [], calledMethods: ["c"]),
+            MethodNode(name: "c", referencedProps: [], calledMethods: []),
+        ]
+        // a→b, a→c, b→c = 3
+        #expect(CohesionAnalyzer.metrics(methods: methods).internalCoupling == 3)
+    }
+
+    @Test("외부 호출(타입 밖 이름)은 결합에서 제외")
+    func externalCallsExcluded() {
+        let methods = [
+            MethodNode(name: "a", referencedProps: [], calledMethods: ["external"]),
+            MethodNode(name: "b", referencedProps: [], calledMethods: []),
+        ]
+        #expect(CohesionAnalyzer.metrics(methods: methods).internalCoupling == 0)
+    }
+
+    @Test("체인 깊이 = 가장 긴 내부 호출 경로의 메소드 수")
+    func chainDepthLongestPath() {
+        let methods = [
+            MethodNode(name: "a", referencedProps: [], calledMethods: ["b"]),
+            MethodNode(name: "b", referencedProps: [], calledMethods: ["c"]),
+            MethodNode(name: "c", referencedProps: [], calledMethods: []),
+        ]
+        // a→b→c = 3
+        #expect(CohesionAnalyzer.metrics(methods: methods).maxCallChainDepth == 3)
+    }
+
+    @Test("사이클 있어도 유한(방문 가드)")
+    func chainDepthCycleSafe() {
+        let methods = [
+            MethodNode(name: "a", referencedProps: [], calledMethods: ["b"]),
+            MethodNode(name: "b", referencedProps: [], calledMethods: ["a"]),
+        ]
+        #expect(CohesionAnalyzer.metrics(methods: methods).maxCallChainDepth == 2)
+    }
+}

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/CohesionTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/CohesionTests.swift
@@ -36,6 +36,27 @@ struct CohesionTests {
         #expect(CohesionAnalyzer.metrics(methods: []).lcom == 0)
     }
 
+    @Test("독립 3그룹은 3요소")
+    func threeComponents() {
+        let methods = [
+            MethodNode(name: "a", referencedProps: ["x"], calledMethods: []),
+            MethodNode(name: "b", referencedProps: ["y"], calledMethods: []),
+            MethodNode(name: "c", referencedProps: ["z"], calledMethods: []),
+        ]
+        #expect(CohesionAnalyzer.metrics(methods: methods).lcom == 3)
+    }
+
+    @Test("분기된 경로 중 최장을 고른다")
+    func chainDepthPicksLongestBranch() {
+        let methods = [
+            MethodNode(name: "a", referencedProps: [], calledMethods: ["b", "c"]),
+            MethodNode(name: "b", referencedProps: [], calledMethods: []),      // a→b = 2
+            MethodNode(name: "c", referencedProps: [], calledMethods: ["d"]),
+            MethodNode(name: "d", referencedProps: [], calledMethods: []),      // a→c→d = 3
+        ]
+        #expect(CohesionAnalyzer.metrics(methods: methods).maxCallChainDepth == 3)
+    }
+
     @Test("내부 호출 결합 = 타입 내부 메소드 호출 간선 수")
     func internalCouplingCountsEdges() {
         let methods = [

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/FanInTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/FanInTests.swift
@@ -40,6 +40,19 @@ struct FanInHopTests {
         #expect(hops == [2, 3, 1])
     }
 
+    @Test("한 홉에 서로 다른 caller들의 참조가 합산된다")
+    func sumsDistinctCallers() {
+        let stub = StubIndexProvider()
+        stub.usrByLocation[loc("m", "F.swift", 1)] = "m"
+        // m 참조 1건이 서로 다른 caller c1·c2를 가리킴
+        stub.referencesByUSR["m"] = [.init(callerUSRs: ["c1", "c2"])]
+        // c1 참조 2건, c2 참조 3건 → hop1 = 5 (두 frontier USR 합산)
+        stub.referencesByUSR["c1"] = [.init(callerUSRs: []), .init(callerUSRs: [])]
+        stub.referencesByUSR["c2"] = [.init(callerUSRs: []), .init(callerUSRs: []), .init(callerUSRs: [])]
+
+        #expect(FanIn(index: stub).byHop(name: "m", file: "F.swift", line: 1, maxHop: 2) == [1, 5, 0])
+    }
+
     @Test("caller 없으면 남은 홉은 0으로 채운다")
     func zeroFillsWhenFrontierExhausted() {
         let stub = StubIndexProvider()

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/FanInTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/FanInTests.swift
@@ -1,42 +1,76 @@
 import Testing
 @testable import ComplexityCore
 
-@Suite("fan-in 측정 — 참조 집계")
-struct FanInTests {
+/// stub — 질의를 기록만 한다. 검증은 테스트 케이스가 (testability rules).
+final class StubIndexProvider: IndexProviding {
+    /// "name@file:line" → usr
+    var usrByLocation: [String: String] = [:]
+    /// usr → 그 usr을 참조하는 지점들
+    var referencesByUSR: [String: [ReferenceSite]] = [:]
+    private(set) var queriedUSRs: [String] = []
 
-    @Test("타입의 여러 USR 참조 수를 합산")
-    func aggregatesAcrossUSRs() {
-        let stub = StubIndexProvider()
-        stub.usrsByName["S"] = ["s1", "s2"]
-        stub.refCountByUSR = ["s1": 3, "s2": 2]
-
-        let fanIn = FanIn(index: stub)
-
-        #expect(fanIn.count(forTypeNamed: "S") == 5)
-        #expect(stub.queriedNames == ["S"])
-        #expect(stub.queriedUSRs == ["s1", "s2"])
+    func definitionUSR(named name: String, file: String, line: Int) -> String? {
+        usrByLocation["\(name)@\(file):\(line)"]
     }
 
-    @Test("USR 없는 타입은 0")
-    func unknownTypeIsZero() {
-        #expect(FanIn(index: StubIndexProvider()).count(forTypeNamed: "Nope") == 0)
+    func references(toUSR usr: String) -> [ReferenceSite] {
+        queriedUSRs.append(usr)
+        return referencesByUSR[usr] ?? []
     }
 }
 
-/// stub — 질의를 기록만 한다. 검증은 테스트 케이스가 (testability rules).
-final class StubIndexProvider: IndexProviding {
-    var usrsByName: [String: [String]] = [:]
-    var refCountByUSR: [String: Int] = [:]
-    private(set) var queriedNames: [String] = []
-    private(set) var queriedUSRs: [String] = []
+@Suite("fan-in per-hop — caller 그래프 BFS")
+struct FanInHopTests {
 
-    func typeUSRs(named name: String) -> [String] {
-        queriedNames.append(name)
-        return usrsByName[name] ?? []
+    private func loc(_ name: String, _ file: String, _ line: Int) -> String { "\(name)@\(file):\(line)" }
+
+    @Test("홉0/1/2 참조 수를 caller 그래프로 센다")
+    func countsPerHop() {
+        let stub = StubIndexProvider()
+        stub.usrByLocation[loc("m", "F.swift", 1)] = "m"
+        // m 참조 2건, 둘 다 caller c
+        stub.referencesByUSR["m"] = [.init(callerUSRs: ["c"]), .init(callerUSRs: ["c"])]
+        // c 참조 3건, 모두 caller d
+        stub.referencesByUSR["c"] = [.init(callerUSRs: ["d"]), .init(callerUSRs: ["d"]), .init(callerUSRs: ["d"])]
+        // d 참조 1건, caller 없음(top-level)
+        stub.referencesByUSR["d"] = [.init(callerUSRs: [])]
+
+        let hops = FanIn(index: stub).byHop(name: "m", file: "F.swift", line: 1, maxHop: 2)
+
+        #expect(hops == [2, 3, 1])
     }
 
-    func referenceCount(ofUSR usr: String) -> Int {
-        queriedUSRs.append(usr)
-        return refCountByUSR[usr] ?? 0
+    @Test("caller 없으면 남은 홉은 0으로 채운다")
+    func zeroFillsWhenFrontierExhausted() {
+        let stub = StubIndexProvider()
+        stub.usrByLocation[loc("m", "F.swift", 1)] = "m"
+        stub.referencesByUSR["m"] = [.init(callerUSRs: [])]
+
+        #expect(FanIn(index: stub).byHop(name: "m", file: "F.swift", line: 1, maxHop: 2) == [1, 0, 0])
+    }
+
+    @Test("caller 사이클은 visited로 차단")
+    func cycleGuarded() {
+        let stub = StubIndexProvider()
+        stub.usrByLocation[loc("m", "F.swift", 1)] = "m"
+        stub.referencesByUSR["m"] = [.init(callerUSRs: ["c"])]
+        stub.referencesByUSR["c"] = [.init(callerUSRs: ["m"])] // m으로 되돌아감
+
+        #expect(FanIn(index: stub).byHop(name: "m", file: "F.swift", line: 1, maxHop: 2) == [1, 1, 0])
+    }
+
+    @Test("USR 못 찾으면 nil")
+    func unresolvedIsNil() {
+        #expect(FanIn(index: StubIndexProvider()).byHop(name: "nope", file: "F.swift", line: 9, maxHop: 2) == nil)
+    }
+
+    @Test("directCount는 hop0만, 미해소는 0")
+    func directCountIsHopZero() {
+        let stub = StubIndexProvider()
+        stub.usrByLocation[loc("T", "F.swift", 3)] = "t"
+        stub.referencesByUSR["t"] = [.init(callerUSRs: []), .init(callerUSRs: []), .init(callerUSRs: [])]
+
+        #expect(FanIn(index: stub).directCount(name: "T", file: "F.swift", line: 3) == 3)
+        #expect(FanIn(index: stub).directCount(name: "Nope", file: "F.swift", line: 3) == 0)
     }
 }

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/IndexStoreIntegrationTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/IndexStoreIntegrationTests.swift
@@ -19,12 +19,29 @@ struct IndexStoreIntegrationTests {
             .first { FileManager.default.fileExists(atPath: $0) }
     }
 
+    /// 리포 루트 — 이 테스트 파일(#filePath)에서 4단계 상위.
+    /// .../TodoCalendar/tools/complexity-analyzer/Tests/ComplexityCoreTests/<이 파일>
+    private static var repoRoot: String {
+        (0..<5).reduce(#filePath) { path, _ in (path as NSString).deletingLastPathComponent }
+    }
+
     @Test("실 index를 물고 fan-in 질의가 돈다")
     func realIndexQueryRuns() throws {
         guard let storePath = Self.indexStorePath,
               FileManager.default.fileExists(atPath: Self.libIndexStore)
         else {
             return  // 로컬 index/툴체인 없으면 스킵 (CI·타 머신)
+        }
+
+        // 실 소스에서 TodoEvent 선언 위치(file:line)를 얻어 정확 USR로 해소한다.
+        let source = Self.repoRoot + "/Domain/Sources/Models/Events/Todo/TodoEvent.swift"
+        guard let content = try? String(contentsOfFile: source, encoding: .utf8) else {
+            return  // 소스 배치가 다르면 스킵
+        }
+        guard let todoEvent = SyntaxScanner().scan(source: content, file: source)
+            .first(where: { $0.kind == .type && $0.name == "TodoEvent" })
+        else {
+            return
         }
 
         let dbPath = NSTemporaryDirectory() + "cx-idx-" + UUID().uuidString
@@ -34,10 +51,16 @@ struct IndexStoreIntegrationTests {
             libIndexStorePath: Self.libIndexStore
         )
 
-        // TodoEvent는 저장소에서 다수 참조되는 실존 타입 → cross-file 해소가 실동작하면 > 0.
-        // (0이면 "조용히 0" 회귀 신호. 정확한 수치는 인덱스 상태 의존이라 하한만 단정)
-        let count = FanIn(index: provider).count(forTypeNamed: "TodoEvent")
-        #expect(count > 0)
+        // 정확 USR 해소는 index가 이 소스 경로에서 빌드됐을 때만 성립.
+        // nil이면 index가 다른 워크트리/체크아웃에서 빌드된 것 → 스모크 불가로 스킵.
+        // (bare-name 시절과 달리 USR은 path-specific이라 워크트리 차이에 민감)
+        guard let usr = provider.definitionUSR(named: "TodoEvent", file: source, line: todoEvent.line) else {
+            return
+        }
+
+        // TodoEvent는 다수 참조되는 실존 타입 → 참조 질의가 실동작하면 > 0.
+        // USR은 해소됐는데 0이면 "조용히 0" 회귀 신호(하한만 단정).
+        #expect(provider.references(toUSR: usr).count > 0)
     }
 
     @Test("빈/없는 index store는 명시 throw (silent-0 방지)")

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/RollupTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/RollupTests.swift
@@ -30,6 +30,18 @@ struct RollupTests {
         #expect(m?.rolledUpCombineRoleMix == 1)
     }
 
+    @Test("command의 self-write은 롤업 cqs에 안 섞인다(query 위반만 합산)")
+    func commandWriteNotInRollupCqs() {
+        // c: command(self.x=1) → cqs 0. q: query 위반 1. 롤업 cqs = 1.
+        let src = """
+        struct S {
+            func c() { self.x = 1 }
+            func q() -> Int { self.y = 1; return y }
+        }
+        """
+        #expect(type(src, name: "S")?.rolledUpCqsViolations == 1)
+    }
+
     @Test("한 파일 내 extension 메소드도 원본 타입으로 롤업")
     func rollsUpExtensionMethods() {
         let src = "struct S { func f() { if a {} } }\nextension S { func g() { if a { if b {} } } }"

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/RollupTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/RollupTests.swift
@@ -1,0 +1,51 @@
+import Testing
+@testable import ComplexityCore
+
+@Suite("타입 롤업 — 소속 메소드 측정 합산")
+struct RollupTests {
+
+    private func type(_ source: String, name: String) -> Measurements? {
+        SyntaxScanner().scan(source: source, file: "T.swift")
+            .first { $0.kind == .type && $0.name == name }?.measurements
+    }
+
+    @Test("소속 메소드의 internalComplexity 합이 타입에 실린다")
+    func rollsUpInternalComplexity() {
+        // f: if a{} = 1, g: if a{ if b{} } = 3 → 합 4
+        let m = type("struct S { func f() { if a {} }; func g() { if a { if b {} } } }", name: "S")
+        #expect(m?.rolledUpInternalComplexity == 4)
+    }
+
+    @Test("cqsViolations·combineRoleMix도 합산(nil은 0으로)")
+    func rollsUpEffectMeasures() {
+        // q: query self.x=1 → cqs 1. c: command → cqs 0. map 역할혼합 1건.
+        let src = """
+        struct S {
+            func q() -> Int { self.x = 1; return x }
+            func c() { _ = pub.map { self.y = $0; return $0 } }
+        }
+        """
+        let m = type(src, name: "S")
+        #expect(m?.rolledUpCqsViolations == 1)
+        #expect(m?.rolledUpCombineRoleMix == 1)
+    }
+
+    @Test("한 파일 내 extension 메소드도 원본 타입으로 롤업")
+    func rollsUpExtensionMethods() {
+        let src = "struct S { func f() { if a {} } }\nextension S { func g() { if a { if b {} } } }"
+        #expect(type(src, name: "S")?.rolledUpInternalComplexity == 4)
+    }
+
+    @Test("동명 nested 타입은 enclosing으로 분리 — 롤업 안 섞임")
+    func nestedSameNameNotMerged() {
+        let src = """
+        struct A { struct Entity { func f() { if x {} } } }
+        struct B { struct Entity { func g() { if x { if y {} } } } }
+        """
+        let units = SyntaxScanner().scan(source: src, file: "T.swift")
+        let aEntity = units.first { $0.kind == .type && $0.name == "Entity" && $0.enclosingType == "A" }
+        let bEntity = units.first { $0.kind == .type && $0.name == "Entity" && $0.enclosingType == "B" }
+        #expect(aEntity?.measurements.rolledUpInternalComplexity == 1)
+        #expect(bEntity?.measurements.rolledUpInternalComplexity == 3)
+    }
+}

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/SurfaceTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/SurfaceTests.swift
@@ -1,0 +1,37 @@
+import Testing
+@testable import ComplexityCore
+
+@Suite("노출 표면적 — public/open 멤버 수")
+struct SurfaceTests {
+
+    private func surface(_ source: String, name: String) -> Int? {
+        SyntaxScanner().scan(source: source, file: "T.swift")
+            .first { $0.kind == .type && $0.name == name }?.measurements.publicSurface
+    }
+
+    @Test("public 메소드·프로퍼티만 센다")
+    func countsPublicMembers() {
+        let src = """
+        struct S {
+            public var a: Int = 0
+            var b: Int = 0
+            public func f() {}
+            func g() {}
+            open func h() {}
+        }
+        """
+        // public a, public f, open h = 3
+        #expect(surface(src, name: "S") == 3)
+    }
+
+    @Test("public 멤버 없으면 0")
+    func zeroWhenNoPublic() {
+        #expect(surface("struct S { var a: Int = 0; func f() {} }", name: "S") == 0)
+    }
+
+    @Test("extension의 public 멤버도 원본 타입 표면적에 합산")
+    func includesExtensionPublicMembers() {
+        let src = "struct S { public func f() {} }\nextension S { public func g() {} }"
+        #expect(surface(src, name: "S") == 2)
+    }
+}


### PR DESCRIPTION
## 문제

복잡도 분석기(#691)의 페이즈 3. 페이즈 2까지 메소드 레벨(내부복잡도·CQS·Combine 역할혼합)이 있었지만 (1) 타입 fan-in이 bare-name 전역 조회라 동명이인 타입(SQLite 테이블마다 있는 `Entity` 8개 등)을 한 이름으로 합산했고(페이즈 1 알려진 한계), (2) 객체 레벨 측정과 메소드 변경 파급이 통째로 비어 있었다.

## 접근

두 서브시스템으로 나눠 raw 측정만 추가한다(가중·스코어링·config·총점은 페이즈 5).

**Index/fan-in (IndexStore)** — `IndexProviding` seam을 `definitionUSR(named:file:line:)` + `references(toUSR:)`로 재설계. 유닛의 (name,file,line)으로 정확 USR을 해소해 동명이인 합산을 제거하고, `references`는 각 참조의 caller(`.calledBy`/`.containedBy`) USR을 동반한다. `FanIn.byHop`이 caller 그래프를 홉2까지 BFS해 per-hop 참조 수를 낸다. 타입은 direct(hop0), 메소드는 per-hop 배열.

**객체 레벨 (SwiftSyntax)** — `SyntaxScanner`를 정규화 타입 이름(enclosing 체인)별 누적 + post-walk `finalize()` 패치 구조로 바꿔, cross-file extension을 원본 타입에 묶고 동명 nested 타입은 분리한다. 세 측정:
- **롤업** — 소속 메소드의 internalComplexity·cqsViolations·combineRoleMix 각 합산
- **표면적** — public/open 메소드·프로퍼티 수
- **응집** — `CohesionAnalyzer`(순수): LCOM4 연결요소 수(끊김) + 내부 호출 결합 간선 수·최장 호출 체인 깊이(과밀)

커밋 3개 = fan-in USR 정규화 → 롤업·표면적 → 응집. 53 테스트 GREEN.

## 남은 과제

- **가중치·스코어링·config·총점** = 페이즈 5. 이번 per-hop(1/0.5/0.25)·롤업 계수 α 등 가중은 전부 미적용, raw만.
- **잔여 한계(문서화, v1 수용)**: (a) top-level 동명 타입이 다른 모듈에 있으면 정규화 이름이 합쳐짐(단일 모듈 스캔 무영향). (b) 참조 후보의 bare 식별자는 stored/method 이름과 교집합해 남기므로 동명 로컬 shadowing이 드물게 오연결. (c) 오버로드 동명 메소드는 이름 그래프에서 병합.
- **협업 레벨**(의존 그래프·cycle·blast radius) = 페이즈 4.
- 통합 스모크는 index가 현재 체크아웃에서 빌드됐을 때만 검증(다른 워크트리 index면 스킵) — precise-USR이 path-specific이라.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3rfY2j6yrf4TxPfJb2kpf
