### PR TITLE
[#694] AI job 상태 푸시 수신·포그라운드 복귀 시 다음 폴링 차수 없이 즉시 조회

### DIFF
--- a/Domain/Sources/Models/AI/AICommand+Job.swift
+++ b/Domain/Sources/Models/AI/AICommand+Job.swift
@@ -34,6 +34,7 @@ public struct AIJob: Sendable {
         case confirm = "CONFIRM"
         case failed = "FAILED"
         case rejected = "REJECTED"
+        case canceled = "CANCELED"
     }
     
     public enum Mode: String, Sendable {
@@ -55,6 +56,7 @@ public struct AIJob: Sendable {
             || self.status == .confirm
             || self.status == .failed
             || self.status == .rejected
+            || self.status == .canceled
     }
     
     public init(jobId: String) {

--- a/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
@@ -33,6 +33,9 @@ public protocol AIAgentOrchestrationUsecase: AnyObject, Sendable {
     func reset()
     func restoreIfNeeded()
     func loadUsage()
+
+    func handleJobStatusChanged(_ jobId: String)
+    func refreshProcessingJobIfNeeded()
 }
 
 
@@ -284,6 +287,21 @@ extension AIAgentOrchestrationUsecaseImple {
 
     public func loadUsage() {
         self.usageUsecase.refresh()
+    }
+
+    // 푸시가 특정 job을 지목해 도착. 추적 중인 job일 때만 즉시 조회.
+    // 콜드 스타트(구독 없음)는 CalendarViewModel.prepare() → restoreIfNeeded()가 커버한다.
+    public func handleJobStatusChanged(_ jobId: String) {
+        guard self.currentProcessingJobId == jobId else { return }
+        self.commandUsecase.refreshJobStatus(jobId)
+    }
+
+    // 포그라운드 복귀 — 백그라운드에서 폴링 Timer가 멈춘 공백을 메운다.
+    public func refreshProcessingJobIfNeeded() {
+        guard case .processing = self.subject.state.value,
+              let jobId = self.currentProcessingJobId
+        else { return }
+        self.commandUsecase.refreshJobStatus(jobId)
     }
 }
 

--- a/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
@@ -82,7 +82,7 @@ public final class AIAgentOrchestrationUsecaseImple: AIAgentOrchestrationUsecase
 
     private func handleJobResult(_ job: AIJob) {
         guard job.isFinish else { return }
-        if job.status == .rejected {
+        if job.status == .rejected || job.status == .canceled {
             self.subject.state.send(.idle)
             return
         }

--- a/Domain/Sources/Usecases/AI/AICommandUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AICommandUsecase.swift
@@ -145,14 +145,18 @@ extension AICommandUsecaseImple {
         self.subject.jobFinishEvent.send(jobId)
     }
     
-    private func checkJob(_ jobId: String) -> AnyPublisher<AIJob, any Error> {
-        
+    private func checkJob(
+        _ jobId: String,
+        immediateCheck: Bool = false
+    ) -> AnyPublisher<AIJob, any Error> {
+
         let refreshWithPolling = self.polling()
         let refreshAfterPushReceive = self.subject.jobFinishEvent
             .filter { $0 == jobId }
             .map { _ in }
-        
+
         let refreshTrigger = Publishers.Merge(refreshWithPolling, refreshAfterPushReceive)
+            .prepend(immediateCheck ? [()] : [])
         let refreshJob = refreshTrigger.map { [weak self] in
             guard let self = self else { return Empty<AIJob, any Error>().eraseToAnyPublisher() }
             return self.loadJobWithFilterError(jobId).eraseToAnyPublisher()
@@ -206,7 +210,7 @@ extension AICommandUsecaseImple {
                         .eraseToAnyPublisher()
                 }
 
-                return self.checkJob(cmd.jobId)
+                return self.checkJob(cmd.jobId, immediateCheck: true)
                     .handleClearProcessingCommand(self.repository)
                     .map { Optional($0) }
                     .eraseToAnyPublisher()

--- a/Domain/Sources/Usecases/AI/AICommandUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AICommandUsecase.swift
@@ -131,7 +131,9 @@ extension AICommandUsecaseImple {
     }
 
     public func cancelOngoingCommand(_ jobId: String) {
-        // fire-and-forget — 클라는 GET /jobs/:id 재폴링으로 CANCELED를 받는다(서버 #250).
+        // fire-and-forget — 호출 시점에 orchestration이 이미 구독을 끊고 idle로 보냈다.
+        // 서버의 CANCELED 통보를 클라가 소비하는 경로는 없다 (clear 전에 앱이 죽어
+        // 잔여 레코드가 restore되는 경우만 예외 — AIJob.Status.canceled가 이를 방어한다).
         let repository = self.repository
         Task {
             try? await repository.cancelCommand(jobId)

--- a/Domain/Sources/Usecases/AI/AICommandUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AICommandUsecase.swift
@@ -25,7 +25,7 @@ public protocol AICommandUsecase: AnyObject, Sendable {
 
     func restoreCommandifNeed() -> AnyPublisher<AIJob?, any Error>
 
-    func handleJobFinishNotification(_ jobId: String)
+    func refreshJobStatus(_ jobId: String)
 }
 
 
@@ -141,7 +141,7 @@ extension AICommandUsecaseImple {
         }
     }
 
-    public func handleJobFinishNotification(_ jobId: String) {
+    public func refreshJobStatus(_ jobId: String) {
         self.subject.jobFinishEvent.send(jobId)
     }
     

--- a/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
@@ -457,7 +457,10 @@ private final class StubAICommandUsecase: AICommandUsecase, @unchecked Sendable 
             .setFailureType(to: (any Error).self)
             .eraseToAnyPublisher()
     }
-    func handleJobFinishNotification(_ jobId: String) { }
+    var didRefreshJobStatusWith: String?
+    func refreshJobStatus(_ jobId: String) {
+        self.didRefreshJobStatusWith = jobId
+    }
 
     private func jobPublisher(_ job: AIJob?) -> AnyPublisher<AIJob, any Error> {
         if self.shouldFail {
@@ -721,5 +724,77 @@ extension AIAgentOrchestrationUsecaseImpleTests {
 
         // then
         #expect(states.map(self.stateName) == ["idle"])
+    }
+}
+
+
+// MARK: - 외부 트리거로 즉시 조회
+
+extension AIAgentOrchestrationUsecaseImpleTests {
+
+    @Test("추적 중인 job의 상태 변경 푸시를 받으면 즉시 조회를 트리거한다")
+    func usecase_whenPushReceivedForCurrentJob_triggerImmediateCheck() async throws {
+        // given
+        let expect = expectConfirm("processing 진입")
+        let usecase = self.makeUsecaseWithCommandJob(
+            AIJob(jobId: "some_job") |> \.status .~ AIJob.Status.running
+        )
+        let _ = try await self.firstOutput(expect, for: usecase.state) {
+            try? usecase.submit("명령")
+        }
+
+        // when
+        usecase.handleJobStatusChanged("some_job")
+
+        // then
+        #expect(self.stubCommand.didRefreshJobStatusWith == "some_job")
+    }
+
+    @Test("추적 중이 아닌 job의 푸시는 무시한다")
+    func usecase_whenPushReceivedForOtherJob_ignore() async throws {
+        // given
+        let expect = expectConfirm("processing 진입")
+        let usecase = self.makeUsecaseWithCommandJob(
+            AIJob(jobId: "some_job") |> \.status .~ AIJob.Status.running
+        )
+        let _ = try await self.firstOutput(expect, for: usecase.state) {
+            try? usecase.submit("명령")
+        }
+
+        // when
+        usecase.handleJobStatusChanged("other_job")
+
+        // then
+        #expect(self.stubCommand.didRefreshJobStatusWith == nil)
+    }
+
+    @Test("처리 중인 job이 없으면 포그라운드 복귀 새로고침은 아무것도 하지 않는다")
+    func usecase_whenNoProcessingJob_foregroundRefreshDoesNothing() async throws {
+        // given
+        let usecase = self.makeUsecaseInIdle()
+
+        // when
+        usecase.refreshProcessingJobIfNeeded()
+
+        // then
+        #expect(self.stubCommand.didRefreshJobStatusWith == nil)
+    }
+
+    @Test("처리 중인 job이 있으면 포그라운드 복귀 시 즉시 조회를 트리거한다")
+    func usecase_whenProcessingJobExists_foregroundRefreshTriggersCheck() async throws {
+        // given
+        let expect = expectConfirm("processing 진입")
+        let usecase = self.makeUsecaseWithCommandJob(
+            AIJob(jobId: "some_job") |> \.status .~ AIJob.Status.running
+        )
+        let _ = try await self.firstOutput(expect, for: usecase.state) {
+            try? usecase.submit("명령")
+        }
+
+        // when
+        usecase.refreshProcessingJobIfNeeded()
+
+        // then
+        #expect(self.stubCommand.didRefreshJobStatusWith == "some_job")
     }
 }

--- a/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
@@ -66,6 +66,12 @@ class AIAgentOrchestrationUsecaseImpleTests: PublisherWaitable {
         return usecase
     }
 
+    private func makeUsecaseWithRestoredJob(_ job: AIJob) -> AIAgentOrchestrationUsecaseImple {
+        let usecase = self.makeUsecase()
+        self.stubCommand.stubRestoreJob = job
+        return usecase
+    }
+
     private func dummyJob(
         _ result: AIJobResult,
         command: String? = "회의 잡아줘",
@@ -693,5 +699,27 @@ extension AIAgentOrchestrationUsecaseImpleTests {
         usecase.enterVoiceInput()
         // then — startListening은 첫 번째 한 번만 (두 번째 호출은 no-op)
         #expect(self.stubSpeech.startListeningCount == 1)
+    }
+}
+
+
+// MARK: - 중지된 job이 남아있는 채로 재시작한 경우 (방어)
+
+extension AIAgentOrchestrationUsecaseImpleTests {
+
+    @Test("restore가 읽은 job이 CANCELED면 폴링을 더 돌지 않고 idle로 종결한다")
+    func usecase_whenRestoredJobIsCanceled_backToIdle() async throws {
+        // given
+        let expect = expectConfirm("CANCELED 잔여 job 복원 시 idle 방출")
+        let job = AIJob(jobId: "some_job") |> \.status .~ AIJob.Status.canceled
+        let usecase = self.makeUsecaseWithRestoredJob(job)
+
+        // when
+        let states = try await self.outputs(expect, for: usecase.state) {
+            usecase.restoreIfNeeded()
+        }
+
+        // then
+        #expect(states.map(self.stateName) == ["idle"])
     }
 }

--- a/Domain/Tests/Usecases/AICommandUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AICommandUsecaseImpleTests.swift
@@ -523,6 +523,34 @@ extension AICommandUsecaseImpleTests {
         #expect(processingCmd == nil)
     }
     
+    // restore 대상 processing command를 세팅하고, 폴링 tick(3초)으로는 절대 도달 못 하는 usecase.
+    // 이 안에서 완료 job이 방출되면 폴링이 아니라 즉시 조회가 낸 것이다.
+    private func makeUsecaseWithRestoredJob(_ job: AIJob) -> AICommandUsecaseImple {
+        let usecase = self.makeUsecase(
+            customPollingPolicy: .init(checkInterval: 3, totalTimeout: 10)
+        )
+        self.stubRepository.stubProcessingCommand = ProcessingAICommand(
+            jobId: job.jobId, isConfirmJob: false
+        )
+        self.stubRepository.loadJobMocking = .success(job)
+        return usecase
+    }
+
+    // 커맨드 복원: 폴링 차수를 기다리지 않고 즉시 job을 조회한다
+    @Test func usecase_restore_checkJobImmediately() async throws {
+        // given
+        // checkInterval(3초)보다 훨씬 짧은 타임아웃 — 폴링으로는 절대 도달 못 함
+        let expect = expectConfirm("폴링 tick 전에 완료 job 방출")
+        expect.timeout = .milliseconds(500)
+        let usecase = self.makeUsecaseWithRestoredJob(.dummyDoneJob)
+
+        // when
+        let job = try await self.firstOutput(expect, for: usecase.restoreCommandifNeed())
+
+        // then
+        #expect(job??.status == .done)
+    }
+
     private func makeUsecaseWithFinishProcessCmd(
         isFail: Bool = false,
         isConfirm: Bool = false

--- a/Domain/Tests/Usecases/AICommandUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AICommandUsecaseImpleTests.swift
@@ -142,7 +142,7 @@ extension AICommandUsecaseImpleTests {
             try await Task.sleep(for: .milliseconds(10))
             self.stubRepository.loadJobMocking = .success(.dummyConfirmJob)
             
-            usecase.handleJobFinishNotification("some_job")
+            usecase.refreshJobStatus("some_job")
         }
         
         // then
@@ -308,7 +308,7 @@ extension AICommandUsecaseImpleTests {
             try await Task.sleep(for: .milliseconds(10))
             self.stubRepository.loadJobMocking = .success(.dummyDoneJob)
 
-            usecase.handleJobFinishNotification("some_job")
+            usecase.refreshJobStatus("some_job")
         }
 
         // then

--- a/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandBuilderImple.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandBuilderImple.swift
@@ -25,7 +25,7 @@ public final class AIAgentCommandBuilderImple: AIAgentCommandSceneBuilder {
     @MainActor
     public func makeCommandScene() -> any AIAgentCommandScene {
         let viewModel = AIAgentCommandViewModelImple(
-            orchestrationUsecase: self.usecaseFactory.makeAIAgentOrchestrationUsecase()
+            orchestrationUsecase: self.usecaseFactory.aiAgentOrchestrationUsecase
         )
         let viewController = AIAgentCommandViewController(
             viewModel: viewModel,

--- a/Presentations/AIAgentScene/Sources/AIAgentKeyboardInput/AIAgentKeyboardInputBuilderImple.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentKeyboardInput/AIAgentKeyboardInputBuilderImple.swift
@@ -27,7 +27,7 @@ public final class AIAgentKeyboardInputBuilderImple: AIAgentKeyboardInputSceneBu
     @MainActor
     public func makeKeyboardInputScene() -> any AIAgentKeyboardInputScene {
         let viewModel = AIAgentKeyboardInputViewModelImple(
-            aiAgentOrchestrationUsecase: self.usecaseFactory.makeAIAgentOrchestrationUsecase()
+            aiAgentOrchestrationUsecase: self.usecaseFactory.aiAgentOrchestrationUsecase
         )
         let viewController = AIAgentKeyboardInputViewController(
             viewModel: viewModel,

--- a/Presentations/AIAgentScene/Tests/Doubles/StubAIAgentOrchestrationUsecase.swift
+++ b/Presentations/AIAgentScene/Tests/Doubles/StubAIAgentOrchestrationUsecase.swift
@@ -48,6 +48,16 @@ final class StubAIAgentOrchestrationUsecase: AIAgentOrchestrationUsecase, @unche
     func restoreIfNeeded() { self.didRestore = true }
     func loadUsage() { self.didLoadUsage = true }
 
+    private(set) var didHandleJobStatusChangedWith: String?
+    func handleJobStatusChanged(_ jobId: String) {
+        self.didHandleJobStatusChangedWith = jobId
+    }
+
+    private(set) var didRefreshProcessingJob = false
+    func refreshProcessingJobIfNeeded() {
+        self.didRefreshProcessingJob = true
+    }
+
     var state: AnyPublisher<AIAgentState, Never> {
         self.stateSubject.compactMap { $0 }.eraseToAnyPublisher()
     }

--- a/Presentations/CalendarScenes/Sources/CalendarSceneBuilderImple.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarSceneBuilderImple.swift
@@ -68,7 +68,7 @@ extension CalendarSceneBuilderImple: CalendarSceneBuilder {
             appleCalendarUsecase: self.usecaseFactory.makeAppleCalendarUsecase(),
             eventUploadService: self.usecaseFactory.eventUploadService,
             eventSyncUsecase: self.usecaseFactory.eventSyncUsecase,
-            aiAgentOrchestrationUsecase: self.usecaseFactory.makeAIAgentOrchestrationUsecase()
+            aiAgentOrchestrationUsecase: self.usecaseFactory.aiAgentOrchestrationUsecase
         )
         viewModel.listener = listener
         let viewController = CalendarViewController(

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListBuilderImple.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListBuilderImple.swift
@@ -70,7 +70,7 @@ extension DayEventListSceneBuilerImple: DayEventListSceneBuiler {
             foremostEventUsecase: foremostEventUsecase,
             uiSettingUsecase: uiSettingUsecase,
             accountUsecase: self.accountUsecase,
-            aiAgentOrchestrationUsecase: self.usecaseFactory.makeAIAgentOrchestrationUsecase()
+            aiAgentOrchestrationUsecase: self.usecaseFactory.aiAgentOrchestrationUsecase
         )
         let router = DayEventListRouter(
             eventDetailSceneBuilder: self.eventDetailSceneBuilder,

--- a/Presentations/Scenes/Sources/Factories.swift
+++ b/Presentations/Scenes/Sources/Factories.swift
@@ -73,7 +73,7 @@ public protocol ExternalCalendarUsecaseFactory {
 
 public protocol AIAgentUsecaseFactory {
 
-    func makeAIAgentOrchestrationUsecase() -> any AIAgentOrchestrationUsecase
+    var aiAgentOrchestrationUsecase: any AIAgentOrchestrationUsecase { get }
     func makeSpeechRecognizeUsecase() -> any SpeechRecognizeUsecase
 }
 

--- a/Supports/TestDoubles/Sources/Usecases/StubAIAgentOrchestrationUsecase.swift
+++ b/Supports/TestDoubles/Sources/Usecases/StubAIAgentOrchestrationUsecase.swift
@@ -35,6 +35,16 @@ public final class StubAIAgentOrchestrationUsecase: AIAgentOrchestrationUsecase,
     public func restoreIfNeeded() {}
     public func loadUsage() {}
 
+    public var didHandleJobStatusChangedWith: String?
+    public func handleJobStatusChanged(_ jobId: String) {
+        self.didHandleJobStatusChangedWith = jobId
+    }
+
+    public var didRefreshProcessingJob: Bool?
+    public func refreshProcessingJobIfNeeded() {
+        self.didRefreshProcessingJob = true
+    }
+
     public var state: AnyPublisher<AIAgentState, Never> {
         self.stateSubject.compactMap { $0 }.eraseToAnyPublisher()
     }

--- a/TodoCalendarApp/Sources/AppDelegate.swift
+++ b/TodoCalendarApp/Sources/AppDelegate.swift
@@ -89,13 +89,18 @@ extension AppDelegate: @MainActor UNUserNotificationCenterDelegate, @MainActor M
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
+        self.applicationViewModel.handleReceivePushNotification(
+            userInfo: notification.request.content.userInfo
+        )
         return [.banner]
     }
-    
+
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse
     ) async {
-        // TODO: handle notification tap
+        self.applicationViewModel.handleReceivePushNotification(
+            userInfo: response.notification.request.content.userInfo
+        )
     }
 }

--- a/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
+++ b/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
@@ -330,10 +330,6 @@ extension NonLoginUsecaseFactoryImple {
 
 extension NonLoginUsecaseFactoryImple {
 
-    func makeAIAgentOrchestrationUsecase() -> any AIAgentOrchestrationUsecase {
-        return self.aiAgentOrchestrationUsecase
-    }
-
     func makeSpeechRecognizeUsecase() -> any SpeechRecognizeUsecase {
         return SpeechRecognizeUsecaseImple(
             service: SpeechRecognizeServiceImple(),
@@ -790,10 +786,6 @@ extension LoginUsecaseFactoryImple {
 
 
 extension LoginUsecaseFactoryImple {
-
-    func makeAIAgentOrchestrationUsecase() -> any AIAgentOrchestrationUsecase {
-        return self.aiAgentOrchestrationUsecase
-    }
 
     func makeSpeechRecognizeUsecase() -> any SpeechRecognizeUsecase {
         return SpeechRecognizeUsecaseImple(

--- a/TodoCalendarApp/Sources/Root/AIJobRefreshUsecase.swift
+++ b/TodoCalendarApp/Sources/Root/AIJobRefreshUsecase.swift
@@ -1,0 +1,46 @@
+//
+//  AIJobRefreshUsecase.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 7/14/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Domain
+import Scenes
+
+
+protocol AIJobRefreshUsecase: Sendable {
+
+    func change(factory: any UsecaseFactory)
+
+    func handleJobStatusChanged(_ jobId: String)
+    func refreshProcessingJobIfNeeded()
+}
+
+
+final class AIJobRefreshUsecaseImple: AIJobRefreshUsecase, @unchecked Sendable {
+
+    private var usecaseFactory: (any UsecaseFactory)?
+
+    init() { }
+}
+
+
+extension AIJobRefreshUsecaseImple {
+
+    func change(factory: any UsecaseFactory) {
+        self.usecaseFactory = factory
+    }
+
+    func handleJobStatusChanged(_ jobId: String) {
+        self.usecaseFactory?.aiAgentOrchestrationUsecase
+            .handleJobStatusChanged(jobId)
+    }
+
+    func refreshProcessingJobIfNeeded() {
+        self.usecaseFactory?.aiAgentOrchestrationUsecase
+            .refreshProcessingJobIfNeeded()
+    }
+}

--- a/TodoCalendarApp/Sources/Root/ApplicationRootBuilder.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootBuilder.swift
@@ -64,6 +64,7 @@ final class ApplicationRootBuilder {
         )
 
         let backgroundEventSyncUsecase = BackgroundEventSyncUsecaseImple()
+        let aiJobRefreshUsecase = AIJobRefreshUsecaseImple()
         let deepLinkHandler = ApplicationDeepLinkHandlerImple()
         let rootViewModel = ApplicationRootViewModelImple(
             authUsecase: accountUsecase,
@@ -73,6 +74,7 @@ final class ApplicationRootBuilder {
             externalCalendarServiceUsecase: externalCalendarIntegrationUsecase,
             userNotificationUsecase: userNotificationUsecase,
             backgroundEventSyncUsecase: backgroundEventSyncUsecase,
+            aiJobRefreshUsecase: aiJobRefreshUsecase,
             appUpdateCheckUsecase: appUpdateCheckUsecase
         )
         remote.attach(listener: rootViewModel)
@@ -82,6 +84,7 @@ final class ApplicationRootBuilder {
             accountUsecase: accountUsecase,
             externalCalenarIntegrationUsecase: externalCalendarIntegrationUsecase,
             backgroundEventSyncUsecase: backgroundEventSyncUsecase,
+            aiJobRefreshUsecase: aiJobRefreshUsecase,
             applicationBase: applicationBase,
             deepLinkHandler: deepLinkHandler,
             appUpdateCheckUsecase: appUpdateCheckUsecase

--- a/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
@@ -217,6 +217,7 @@ final class ApplicationRootRouter: ApplicationRouting, @unchecked Sendable {
     private let accountUsecase: any AccountUsecase
     private let externalCalenarIntegrationUsecase: any ExternalCalendarIntegrationUsecase
     private let backgroundEventSyncUsecase: any BackgroundEventSyncUsecase
+    private let aiJobRefreshUsecase: any AIJobRefreshUsecase
     private let applicationBase: ApplicationBase
     private let deepLinkHandler: ApplicationDeepLinkHandlerImple
     private let appUpdateCheckUsecase: any AppUpdateCheckUsecase
@@ -227,6 +228,7 @@ final class ApplicationRootRouter: ApplicationRouting, @unchecked Sendable {
         accountUsecase: any AccountUsecase,
         externalCalenarIntegrationUsecase: any ExternalCalendarIntegrationUsecase,
         backgroundEventSyncUsecase: any BackgroundEventSyncUsecase,
+        aiJobRefreshUsecase: any AIJobRefreshUsecase,
         applicationBase: ApplicationBase,
         deepLinkHandler: ApplicationDeepLinkHandlerImple,
         appUpdateCheckUsecase: any AppUpdateCheckUsecase
@@ -235,6 +237,7 @@ final class ApplicationRootRouter: ApplicationRouting, @unchecked Sendable {
         self.accountUsecase = accountUsecase
         self.externalCalenarIntegrationUsecase = externalCalenarIntegrationUsecase
         self.backgroundEventSyncUsecase = backgroundEventSyncUsecase
+        self.aiJobRefreshUsecase = aiJobRefreshUsecase
         self.applicationBase = applicationBase
         self.deepLinkHandler = deepLinkHandler
         self.appUpdateCheckUsecase = appUpdateCheckUsecase
@@ -370,6 +373,7 @@ extension ApplicationRootRouter {
             )
         }
         self.backgroundEventSyncUsecase.change(factory: self.usecaseFactory)
+        self.aiJobRefreshUsecase.change(factory: self.usecaseFactory)
     }
     
     @MainActor

--- a/TodoCalendarApp/Sources/Root/ApplicationRootViewModel.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootViewModel.swift
@@ -25,6 +25,7 @@ final class ApplicationRootViewModelImple: @unchecked Sendable {
     private let externalCalendarServiceUsecase: any ExternalCalendarIntegrationUsecase
     private let userNotificationUsecase: any UserNotificationUsecase
     private let backgroundEventSyncUsecase: any BackgroundEventSyncUsecase
+    private let aiJobRefreshUsecase: any AIJobRefreshUsecase
     private let appUpdateCheckUsecase: any AppUpdateCheckUsecase
     var router: ApplicationRootRouter?
 
@@ -36,6 +37,7 @@ final class ApplicationRootViewModelImple: @unchecked Sendable {
         externalCalendarServiceUsecase: any ExternalCalendarIntegrationUsecase,
         userNotificationUsecase: any UserNotificationUsecase,
         backgroundEventSyncUsecase: any BackgroundEventSyncUsecase,
+        aiJobRefreshUsecase: any AIJobRefreshUsecase,
         appUpdateCheckUsecase: any AppUpdateCheckUsecase
     ) {
         self.authUsecase = authUsecase
@@ -45,6 +47,7 @@ final class ApplicationRootViewModelImple: @unchecked Sendable {
         self.externalCalendarServiceUsecase = externalCalendarServiceUsecase
         self.userNotificationUsecase = userNotificationUsecase
         self.backgroundEventSyncUsecase = backgroundEventSyncUsecase
+        self.aiJobRefreshUsecase = aiJobRefreshUsecase
         self.appUpdateCheckUsecase = appUpdateCheckUsecase
 
         self.bindAccountStatusChanged()
@@ -191,6 +194,7 @@ extension ApplicationRootViewModelImple {
 
     private func handleWillEnterForeground() {
         self.appUpdateCheckUsecase.checkUpdateIsNeed()
+        self.aiJobRefreshUsecase.refreshProcessingJobIfNeeded()
     }
 
     private func bindUpdateRequirement() {
@@ -249,5 +253,22 @@ extension ApplicationRootViewModelImple {
             }
         }
         .store(in: &self.cancellables)
+    }
+}
+
+
+// MARK: - 푸시 수신
+
+extension ApplicationRootViewModelImple {
+
+    func handleReceivePushNotification(userInfo: [AnyHashable: Any]) {
+
+        // AI job 상태 변경 — data.jobId로 식별 (서버 aiFront 스펙)
+        if let jobId = userInfo["jobId"] as? String {
+            self.aiJobRefreshUsecase.handleJobStatusChanged(jobId)
+            return
+        }
+
+        // 그 외 푸시(이벤트 리마인더 등)는 현재 앱에서 별도 처리 없음 — 표시만 된다.
     }
 }

--- a/TodoCalendarApp/TodoCalendarAppTests/ApplicationRootViewModelImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/ApplicationRootViewModelImpleTests.swift
@@ -1,0 +1,141 @@
+//
+//  ApplicationRootViewModelImpleTests.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 7/14/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Combine
+import Domain
+import Scenes
+import TestDoubles
+import UnitTestHelpKit
+
+@testable import TodoCalendarApp
+
+
+final class ApplicationRootViewModelImpleTests {
+
+    private let spyAIJobRefreshUsecase = SpyAIJobRefreshUsecase()
+
+    private func makeViewModel() -> ApplicationRootViewModelImple {
+        return ApplicationRootViewModelImple(
+            authUsecase: StubAuthUsecase(),
+            accountUsecase: StubAccountUsecase(),
+            prepareUsecase: StubApplicationPrepareUsecase(),
+            deepLinkHandler: ApplicationDeepLinkHandlerImple(),
+            externalCalendarServiceUsecase: StubExternalCalendarIntegrationUsecase([]),
+            userNotificationUsecase: StubUserNotificationUsecase(),
+            backgroundEventSyncUsecase: StubBackgroundEventSyncUsecase(),
+            aiJobRefreshUsecase: self.spyAIJobRefreshUsecase,
+            appUpdateCheckUsecase: StubAppUpdateCheckUsecase()
+        )
+    }
+}
+
+
+// MARK: - 푸시 payload 분기
+
+extension ApplicationRootViewModelImpleTests {
+
+    @Test("jobId가 담긴 푸시는 AI job 즉시 조회로 라우팅한다")
+    func viewModel_whenPushHasJobId_routeToAIJobRefresh() {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        viewModel.handleReceivePushNotification(
+            userInfo: ["jobId": "some_job", "status": "DONE"]
+        )
+
+        // then
+        #expect(self.spyAIJobRefreshUsecase.didHandleJobStatusChangedWith == "some_job")
+    }
+
+    @Test("jobId가 없는 푸시는 AI job 조회를 트리거하지 않는다")
+    func viewModel_whenPushHasNoJobId_doNotRouteToAIJobRefresh() {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        viewModel.handleReceivePushNotification(
+            userInfo: ["aps": ["alert": "이벤트 알림"]]
+        )
+
+        // then
+        #expect(self.spyAIJobRefreshUsecase.didHandleJobStatusChangedWith == nil)
+    }
+}
+
+
+// MARK: - doubles
+
+private final class SpyAIJobRefreshUsecase: AIJobRefreshUsecase, @unchecked Sendable {
+
+    var didHandleJobStatusChangedWith: String?
+    func handleJobStatusChanged(_ jobId: String) {
+        self.didHandleJobStatusChangedWith = jobId
+    }
+
+    var didRefreshProcessingJob: Bool?
+    func refreshProcessingJobIfNeeded() {
+        self.didRefreshProcessingJob = true
+    }
+
+    var didChangeFactory: Bool?
+    func change(factory: any UsecaseFactory) {
+        self.didChangeFactory = true
+    }
+}
+
+private final class StubApplicationPrepareUsecase: ApplicationPrepareUsecase {
+
+    func prepareLaunch() async throws -> ApplicationPrepareResult {
+        return ApplicationPrepareResult(
+            latestLoginAcount: nil,
+            appearnceSetings: AppearanceSettings(
+                calendar: .init(colorSetKey: .systemTheme, fontSetKey: .systemDefault),
+                defaultTagColor: .init(holiday: "", default: "")
+            )
+        )
+    }
+
+    func prepareEnterBackground() { }
+
+    func prepareSignedIn(_ auth: Auth) async { }
+
+    func prepareSignedOut() async { }
+
+    func prepareExternalCalendarIntegrated(_ serviceId: String) { }
+
+    func prepareExternalCalendarStopIntegrated(_ serviceId: String) { }
+}
+
+private final class StubUserNotificationUsecase: UserNotificationUsecase, @unchecked Sendable {
+
+    func register(fcmToken: String) async throws { }
+}
+
+private final class StubBackgroundEventSyncUsecase: BackgroundEventSyncUsecase, @unchecked Sendable {
+
+    func change(factory: any UsecaseFactory) { }
+
+    func scheduleTask() { }
+
+    func registerTask() { }
+}
+
+private final class StubAppUpdateCheckUsecase: AppUpdateCheckUsecase, @unchecked Sendable {
+
+    func checkUpdateIsNeed() { }
+
+    var updateRequirement: AnyPublisher<AppUpdateRequirement, Never> {
+        return Empty().eraseToAnyPublisher()
+    }
+
+    var isUpdateAvailable: AnyPublisher<Bool, Never> {
+        return Empty().eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
## 문제

AI job 처리가 끝나 완료 푸시가 도착해도, 클라는 다음 폴링 차수(최대 10초)까지 기다린 뒤에야 상태를 반영한다. 수신 훅(`AICommandUsecaseImple.checkJob`이 폴링 Timer와 `jobFinishEvent` subject를 이미 `Publishers.Merge`로 합쳐 둠)은 있는데 **AppDelegate → usecase 배선이 비어 있어**(`handleJobFinishNotification` 프로덕션 콜사이트 0개, `AppDelegate`의 notification 핸들러가 TODO) 푸시가 즉시 트리거로 이어지지 않았다.

## 접근

폴링은 백업 채널로 유지하고, 그 위에 즉발 트리거를 얹는다.

- **factory 네이밍 교정** — orchestration usecase는 앱 생애 상주하는 단일 인스턴스인데 `make*` 함수로 노출돼 수명을 오도했다. `aiAgentOrchestrationUsecase` 프로퍼티로 바꿔, 앱 레벨에서 꺼내는 인스턴스가 폴링 중인 인스턴스와 동일함을 명확히 했다.
- **CANCELED 방어 로직** — 정상 동선에선 클라가 CANCELED를 소비할 일이 없지만(중지는 명령 쏜 기기에서 유저가 누르고 `reset()`이 그 자리에서 전부 정리), DB clear가 비동기라 그 전에 앱이 죽으면 잔여 레코드가 남아 restore가 CANCELED job을 읽는다. 이때 status 매핑이 nil로 떨어져 스트림이 안 끝나고 10분 타임아웃 뒤 failed로 표시됐다. `AIJob.Status.canceled`를 종결로 인정해 idle로 빠지게 했다.
- **restore 즉시 조회** — 폴링 Timer는 구독 즉시 방출이 없어 첫 조회가 10초 뒤다. 앱이 죽어 있는 동안 서버가 끝낸 job도 재시작 후 10초를 기다려야 읽혔다. `checkJob(_:immediateCheck:)`로 restore 재구독 시에만 구독 즉시 1회 로드를 prepend. (신규 submit은 방금 만든 job이라 무조건 PENDING이므로 즉시 조회 안 붙임.)
- **외부 트리거 진입점** — 파사드인 orchestration에 `handleJobStatusChanged(_:)`(푸시가 지목한 jobId가 추적 중일 때만)와 `refreshProcessingJobIfNeeded()`(포그라운드 복귀, processing 상태일 때만)를 노출.
- **앱 레벨 배선** — `AppDelegate`(willPresent + didReceive 양쪽)가 payload를 해석하지 않고 `ApplicationRootViewModel.handleReceivePushNotification(userInfo:)`으로 위임. 푸시 종류 분기는 VM이 담당(jobId 있으면 AI job 조회, 없으면 무시). 로그인/로그아웃마다 교체되는 UsecaseFactory는 `AIJobRefreshUsecase`가 라우터로부터 밀어받아 항상 현재 세대의 orchestration으로 위임한다(`BackgroundEventSyncUsecase`와 같은 패턴). 포그라운드 복귀는 `handleWillEnterForeground`에 연결.

콜드 스타트(푸시 탭으로 앱 재시작)는 여기서 처리하지 않는다 — `jobFinishEvent`가 PassthroughSubject라 구독 전 send가 유실되므로, `CalendarViewModel.prepare()` → `restoreIfNeeded()` + restore 즉시 조회가 커버한다.

## 남은 과제

- **실기 검증(E2E)**: 유닛 테스트로는 FCM payload 전달·백그라운드 Timer 정지를 못 잡는다. 에뮬레이터로 포그라운드 수신 / 푸시 탭 복귀 / 콜드 스타트 3경로를 확인해야 한다. (아직 미실행)
- **알림 권한 요청 동선(이번 PR 밖)**: `requestAuthorization`이 이벤트 알림 시간 설정 화면 두 곳에서만 일어나, 그 화면을 안 거친 유저는 배너를 못 본다. 알려진 공백이고 별도 처리 대상.

## base 참고

이 PR은 #696(develop 대상, 아직 open) 위에 쌓인 stacked PR이라 base가 `features/629-mic-permission`이다. #696 머지 후 base를 develop으로 전환한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
