### PR TITLE
[#691] 복잡도 분석기 페이즈 4 — 협업 레벨(타입 의존 그래프 raw)

### DIFF
--- a/tools/complexity-analyzer/Sources/ComplexityAnalyzer/Entry.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityAnalyzer/Entry.swift
@@ -7,7 +7,7 @@ struct ComplexityAnalyzerCLI: AsyncParsableCommand {
 
     static let configuration = CommandConfiguration(
         commandName: "complexity-analyzer",
-        abstract: "TodoCalendar 구조 복잡도 분석기 (메소드: 내부복잡도·CQS·Combine 역할혼합·fan-in / 타입: 응집·표면적·롤업·fan-in)"
+        abstract: "TodoCalendar 구조 복잡도 분석기 (메소드: 내부복잡도·CQS·Combine 역할혼합·fan-in / 타입: 응집·표면적·롤업·fan-in·협업그래프[fan-out·cycle·체인깊이·blast])"
     )
 
     @Option(name: .customLong("source-root"), help: "분석할 소스 루트 경로")

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Analyzer.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Analyzer.swift
@@ -44,7 +44,9 @@ public struct Analyzer {
             }
         }
 
-        let patched = ObjectMetricsAggregator.patched(units: units, factsByQualified: factsByQualified)
-        return patched.filter { scope.includes($0) }
+        let objectPatched = ObjectMetricsAggregator.patched(units: units, factsByQualified: factsByQualified)
+        // 협업 그래프는 whole-scope에서 빌드(엣지가 scope 경계를 넘나듦) → 부착 후 필터.
+        let graphPatched = TypeGraphAggregator.patched(units: objectPatched, index: index, maxBlastHop: 2)
+        return graphPatched.filter { scope.includes($0) }
     }
 }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexProviding.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexProviding.swift
@@ -13,4 +13,7 @@ public protocol IndexProviding {
     func definitionUSR(named name: String, file: String, line: Int) -> String?
     /// 이 USR을 참조하는 지점들. 각 지점은 자신을 감싸는 caller USR을 함께 담는다.
     func references(toUSR usr: String) -> [ReferenceSite]
+    /// 이 심볼(메소드/프로퍼티/생성자 등)을 감싸는 최근접 명목 타입(struct/class/enum/protocol)의 USR.
+    /// extension 멤버는 확장 대상 타입으로 해소. enclosing 타입이 없으면 nil.
+    func enclosingTypeUSR(of usr: String) -> String?
 }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexStoreDBProvider.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexStoreDBProvider.swift
@@ -85,6 +85,36 @@ public struct IndexStoreDBProvider: IndexProviding {
         }
     }
 
+    /// 심볼을 감싸는 최근접 명목 타입 USR. childOf 관계를 타고 올라가며 판정.
+    /// - 부모가 struct/class/enum/protocol → 그 USR
+    /// - 부모가 extension → 확장 대상 명목 타입으로 해소(extension USR은 타입 USR이 아님)
+    /// - 부모가 중첩 함수 등 → 한 단계 더 위로 (깊이 상한 8)
+    public func enclosingTypeUSR(of usr: String) -> String? {
+        resolveEnclosingType(of: usr, depth: 0)
+    }
+
+    private func resolveEnclosingType(of usr: String, depth: Int) -> String? {
+        guard depth < 8 else { return nil }
+        guard let def = index.occurrences(ofUSR: usr, roles: .definition).first else { return nil }
+        if Self.isNominalType(def.symbol.kind) { return usr }
+        guard let parent = def.relations.first(where: { $0.roles.contains(.childOf) })?.symbol
+        else { return nil }
+        if Self.isNominalType(parent.kind) { return parent.usr }
+        if parent.kind == .extension {
+            return index.occurrences(relatedToUSR: parent.usr, roles: .all)
+                .first { Self.isNominalType($0.symbol.kind) }?.symbol.usr
+        }
+        return resolveEnclosingType(of: parent.usr, depth: depth + 1)
+    }
+
+    /// index가 명목 타입으로 인덱싱하는 kind (actor는 .class로 들어옴).
+    private static func isNominalType(_ kind: IndexSymbolKind) -> Bool {
+        switch kind {
+        case .struct, .class, .enum, .protocol: return true
+        default: return false
+        }
+    }
+
     /// 경로 비교 정규화 — /private 심볼릭·상대 표기 차이를 흡수.
     private static func resolvedPath(_ path: String) -> String {
         URL(fileURLWithPath: path).resolvingSymlinksInPath().path

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexStoreDBProvider.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexStoreDBProvider.swift
@@ -101,10 +101,24 @@ public struct IndexStoreDBProvider: IndexProviding {
         else { return nil }
         if Self.isNominalType(parent.kind) { return parent.usr }
         if parent.kind == .extension {
-            return index.occurrences(relatedToUSR: parent.usr, roles: .all)
-                .first { Self.isNominalType($0.symbol.kind) }?.symbol.usr
+            // extension USR과 관련된 occurrence엔 확장 대상 타입(extendedBy)뿐 아니라
+            // 그 extension 본문의 중첩 명목 타입(childOf)도 섞인다. 둘 다 nominal이라
+            // kind만으로 고르면 중첩 타입을 오인할 수 있으므로 extendedBy role로 가른다.
+            let candidates = index.occurrences(relatedToUSR: parent.usr, roles: .all)
+                .map { (isExtendedBy: $0.roles.contains(.extendedBy),
+                        isNominal: Self.isNominalType($0.symbol.kind),
+                        usr: $0.symbol.usr) }
+            return Self.pickExtendedType(candidates)
         }
         return resolveEnclosingType(of: parent.usr, depth: depth + 1)
+    }
+
+    /// extension 관련 occurrence 후보 중 확장 대상 명목 타입만 고른다(중첩 멤버 타입 제외).
+    /// occurrence 반환 순서 보장이 없으므로 role로 확정 — 순서 무관하게 결정적.
+    static func pickExtendedType(
+        _ candidates: [(isExtendedBy: Bool, isNominal: Bool, usr: String)]
+    ) -> String? {
+        candidates.first { $0.isExtendedBy && $0.isNominal }?.usr
     }
 
     /// index가 명목 타입으로 인덱싱하는 kind (actor는 .class로 들어옴).

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Measure/TypeDependencyGraph.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Measure/TypeDependencyGraph.swift
@@ -1,0 +1,156 @@
+/// 타입 의존 그래프 — 노드 = 타입 USR, 엣지 A→B = "A가 B를 의존".
+/// raw 협업 측정(fan-out·cycle 크기·chain depth·blast radius)만 파생. 판정·가중은 페이즈 5.
+struct TypeDependencyGraph {
+
+    struct Edge: Equatable {
+        let from: String
+        let to: String
+        init(from: String, to: String) {
+            self.from = from
+            self.to = to
+        }
+    }
+
+    struct Measures: Equatable {
+        var fanOut: Int
+        var cycleSize: Int
+        var chainDepth: Int
+        var blastByHop: [Int]
+    }
+
+    let nodes: Set<String>
+    private let outEdges: [String: Set<String>]
+    private let inEdges: [String: Set<String>]
+
+    init(nodes: Set<String>, edges: [Edge]) {
+        self.nodes = nodes
+        var out: [String: Set<String>] = [:]
+        var inc: [String: Set<String>] = [:]
+        for e in edges where e.from != e.to {
+            out[e.from, default: []].insert(e.to)
+            inc[e.to, default: []].insert(e.from)
+        }
+        self.outEdges = out
+        self.inEdges = inc
+    }
+
+    /// 모든 노드의 raw 측정.
+    func measures(maxBlastHop: Int) -> [String: Measures] {
+        let scc = computeSCC()
+        let chains = chainDepths(sccIdOf: scc.idOf)
+        var result: [String: Measures] = [:]
+        for node in nodes {
+            result[node] = Measures(
+                fanOut: outEdges[node]?.count ?? 0,
+                cycleSize: scc.sizeOf[node] ?? 1,
+                chainDepth: chains[node] ?? 1,
+                blastByHop: blastByHop(of: node, maxHop: maxBlastHop)
+            )
+        }
+        return result
+    }
+
+    // MARK: - blast radius (역방향 per-hop 전이 의존자, 홉별 새 노드만)
+
+    private func blastByHop(of node: String, maxHop: Int) -> [Int] {
+        var counts: [Int] = []
+        var visited: Set<String> = [node]
+        var frontier: Set<String> = [node]
+        for hop in 0...maxHop {
+            var next: Set<String> = []
+            for f in frontier {
+                for dep in inEdges[f] ?? [] where !visited.contains(dep) {
+                    visited.insert(dep)
+                    next.insert(dep)
+                }
+            }
+            counts.append(next.count)
+            if next.isEmpty {
+                counts.append(contentsOf: Array(repeating: 0, count: maxHop - hop))
+                break
+            }
+            frontier = next
+        }
+        return counts
+    }
+
+    // MARK: - chain depth (SCC 응축 DAG의 최장 경로 = 구별되는 의존 층 수)
+    //
+    // 사이클은 순수 최장경로로 정의 불가(NP·비결정)라, SCC로 응축한 DAG에서 최장 경로를 잰다.
+    // DAG라 메모가 순회 순서에 무관하게 결정적. 순수 DAG면 노드 수 최장경로와 동일하고,
+    // 사이클은 한 층(SCC)으로 접혀 대칭적. cycleSize가 별도로 사이클 소속을 알려준다.
+
+    private func chainDepths(sccIdOf: [String: Int]) -> [String: Int] {
+        // 응축 DAG 인접(SCC id → SCC id).
+        var condensed: [Int: Set<Int>] = [:]
+        for node in nodes {
+            let a = sccIdOf[node]!
+            for w in outEdges[node] ?? [] {
+                let b = sccIdOf[w]!
+                if a != b { condensed[a, default: []].insert(b) }
+            }
+        }
+        var memo: [Int: Int] = [:]
+        func depth(_ scc: Int) -> Int {
+            if let cached = memo[scc] { return cached }
+            let deeper = (condensed[scc] ?? []).map { depth($0) }.max() ?? 0
+            let result = 1 + deeper
+            memo[scc] = result
+            return result
+        }
+        var result: [String: Int] = [:]
+        for node in nodes { result[node] = depth(sccIdOf[node]!) }
+        return result
+    }
+
+    // MARK: - SCC (Tarjan) → 노드별 SCC id + 크기
+
+    private struct SCCResult {
+        let idOf: [String: Int]
+        let sizeOf: [String: Int]
+    }
+
+    private func computeSCC() -> SCCResult {
+        var indexOf: [String: Int] = [:]
+        var lowlink: [String: Int] = [:]
+        var onStack: Set<String> = []
+        var stack: [String] = []
+        var counter = 0
+        var idOf: [String: Int] = [:]
+        var sizeOf: [String: Int] = [:]
+        var nextId = 0
+
+        func strongconnect(_ v: String) {
+            indexOf[v] = counter
+            lowlink[v] = counter
+            counter += 1
+            stack.append(v)
+            onStack.insert(v)
+            for w in (outEdges[v] ?? []).sorted() {
+                if indexOf[w] == nil {
+                    strongconnect(w)
+                    lowlink[v] = min(lowlink[v]!, lowlink[w]!)
+                } else if onStack.contains(w) {
+                    lowlink[v] = min(lowlink[v]!, indexOf[w]!)
+                }
+            }
+            if lowlink[v] == indexOf[v] {
+                var component: [String] = []
+                while true {
+                    let w = stack.removeLast()
+                    onStack.remove(w)
+                    component.append(w)
+                    if w == v { break }
+                }
+                for m in component {
+                    idOf[m] = nextId
+                    sizeOf[m] = component.count
+                }
+                nextId += 1
+            }
+        }
+
+        for v in nodes.sorted() where indexOf[v] == nil { strongconnect(v) }
+        return SCCResult(idOf: idOf, sizeOf: sizeOf)
+    }
+}

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Measure/TypeDependencyGraph.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Measure/TypeDependencyGraph.swift
@@ -110,6 +110,8 @@ struct TypeDependencyGraph {
         let sizeOf: [String: Int]
     }
 
+    // force unwrap은 Tarjan 불변식상 안전: 외부 루프가 nodes 전체를 방문하고, 도달 가능한
+    // 노드는 재귀 진입 시 반드시 indexOf/lowlink가 먼저 채워진다.
     private func computeSCC() -> SCCResult {
         var indexOf: [String: Int] = [:]
         var lowlink: [String: Int] = [:]

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Measure/TypeGraphAggregator.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Measure/TypeGraphAggregator.swift
@@ -1,0 +1,54 @@
+/// 타입 유닛을 정확 USR로 해소해 전역 의존 그래프를 만들고,
+/// 협업 raw 측정(fan-out·cycle 크기·chain depth·blast radius)을 타입 유닛에 패치한다.
+/// 그래프는 whole-scope로 만들고(엣지가 scope를 넘나듦) 필터는 상류(Analyzer)에서.
+enum TypeGraphAggregator {
+
+    static func patched(
+        units: [AnalyzedUnit],
+        index: any IndexProviding,
+        maxBlastHop: Int
+    ) -> [AnalyzedUnit] {
+        var result = units
+
+        // 타입 유닛 → 정확 USR. usr → result 인덱스.
+        var indexByUSR: [String: Int] = [:]
+        for (i, unit) in result.enumerated() where unit.kind == .type {
+            guard let usr = index.definitionUSR(named: unit.name, file: unit.file, line: unit.line)
+            else { continue }
+            indexByUSR[usr] = i
+        }
+        let knownUSRs = Set(indexByUSR.keys)
+        guard !knownUSRs.isEmpty else { return result }
+
+        // 엣지 수집: 각 타입 B의 참조 → caller → enclosing 타입 A. A∈known, A≠B.
+        var enclosingMemo: [String: String?] = [:]
+        var edges: [TypeDependencyGraph.Edge] = []
+        for usrB in knownUSRs {
+            for site in index.references(toUSR: usrB) {
+                for caller in site.callerUSRs {
+                    let usrA: String?
+                    if let cached = enclosingMemo[caller] {
+                        usrA = cached
+                    } else {
+                        let resolved = index.enclosingTypeUSR(of: caller)
+                        enclosingMemo[caller] = resolved
+                        usrA = resolved
+                    }
+                    guard let a = usrA, a != usrB, knownUSRs.contains(a) else { continue }
+                    edges.append(.init(from: a, to: usrB))
+                }
+            }
+        }
+
+        let graph = TypeDependencyGraph(nodes: knownUSRs, edges: edges)
+        let measures = graph.measures(maxBlastHop: maxBlastHop)
+        for (usr, i) in indexByUSR {
+            guard let m = measures[usr] else { continue }
+            result[i].measurements.fanOut = m.fanOut
+            result[i].measurements.dependencyCycleSize = m.cycleSize
+            result[i].measurements.collaborationChainDepth = m.chainDepth
+            result[i].measurements.blastRadiusByHop = m.blastByHop
+        }
+        return result
+    }
+}

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Model/AnalyzedUnit.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Model/AnalyzedUnit.swift
@@ -14,6 +14,10 @@ public struct Measurements: Equatable, Sendable, Encodable {
     public var lcom: Int?
     public var internalCoupling: Int?
     public var maxCallChainDepth: Int?
+    public var fanOut: Int?
+    public var dependencyCycleSize: Int?
+    public var collaborationChainDepth: Int?
+    public var blastRadiusByHop: [Int]?
 
     public init(
         internalComplexity: Int? = nil,
@@ -27,7 +31,11 @@ public struct Measurements: Equatable, Sendable, Encodable {
         publicSurface: Int? = nil,
         lcom: Int? = nil,
         internalCoupling: Int? = nil,
-        maxCallChainDepth: Int? = nil
+        maxCallChainDepth: Int? = nil,
+        fanOut: Int? = nil,
+        dependencyCycleSize: Int? = nil,
+        collaborationChainDepth: Int? = nil,
+        blastRadiusByHop: [Int]? = nil
     ) {
         self.internalComplexity = internalComplexity
         self.fanIn = fanIn
@@ -41,6 +49,10 @@ public struct Measurements: Equatable, Sendable, Encodable {
         self.lcom = lcom
         self.internalCoupling = internalCoupling
         self.maxCallChainDepth = maxCallChainDepth
+        self.fanOut = fanOut
+        self.dependencyCycleSize = dependencyCycleSize
+        self.collaborationChainDepth = collaborationChainDepth
+        self.blastRadiusByHop = blastRadiusByHop
     }
 }
 

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
@@ -57,6 +57,9 @@ private final class MethodCollector: SyntaxVisitor {
     override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind { enterType(node.name) }
     override func visitPost(_ node: ActorDeclSyntax) { typeStack.removeLast() }
 
+    override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind { enterType(node.name) }
+    override func visitPost(_ node: ProtocolDeclSyntax) { typeStack.removeLast() }
+
     // extension은 타입 선언이 아니므로 타입 단위를 새로 내지 않고, enclosing type 추적만.
     override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
         push(node.extendedType.trimmedDescription)

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/AnalyzerTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/AnalyzerTests.swift
@@ -112,6 +112,43 @@ struct AnalyzerTests {
         #expect(s?.publicSurface == 2)
     }
 
+    @Test("협업 그래프 측정이 타입 유닛에 실린다")
+    func graphMeasuresAttached() throws {
+        // 타입 A(line1)·B(line2). A의 메소드 mA가 B 참조 → 엣지 A→B.
+        let dir = try writeTempDir(["G.swift": "struct A { func mA() {} }\nstruct B {}"])
+        let stub = StubIndexProvider()
+        stub.usrByLocation["A@\(dir)/G.swift:1"] = "uA"
+        stub.usrByLocation["B@\(dir)/G.swift:2"] = "uB"
+        stub.referencesByUSR["uB"] = [.init(callerUSRs: ["umA"])]
+        stub.enclosingByUSR["umA"] = "uA"
+
+        let units = try Analyzer(index: stub).analyze(sourceRoot: dir, scope: .whole)
+        let a = units.first { $0.kind == .type && $0.name == "A" }?.measurements
+        let b = units.first { $0.kind == .type && $0.name == "B" }?.measurements
+        #expect(a?.fanOut == 1)
+        #expect(a?.collaborationChainDepth == 2)
+        #expect(b?.fanOut == 0)
+        #expect(b?.blastRadiusByHop == [1, 0, 0])
+        #expect(b?.dependencyCycleSize == 1)
+    }
+
+    @Test("협업 그래프 측정 키가 JSON에 나온다")
+    func graphMeasuresInJSON() throws {
+        let dir = try writeTempDir(["G.swift": "struct A { func mA() {} }\nstruct B {}"])
+        let stub = StubIndexProvider()
+        stub.usrByLocation["A@\(dir)/G.swift:1"] = "uA"
+        stub.usrByLocation["B@\(dir)/G.swift:2"] = "uB"
+        stub.referencesByUSR["uB"] = [.init(callerUSRs: ["umA"])]
+        stub.enclosingByUSR["umA"] = "uA"
+
+        let units = try Analyzer(index: stub).analyze(sourceRoot: dir, scope: .whole)
+        let json = try JSONReporter().string(for: units)
+        #expect(json.contains("\"fanOut\""))
+        #expect(json.contains("\"dependencyCycleSize\""))
+        #expect(json.contains("\"collaborationChainDepth\""))
+        #expect(json.contains("\"blastRadiusByHop\""))
+    }
+
     @Test("Scope 파싱")
     func scopeParsing() {
         #expect(Scope.parse("whole") == .whole)

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/ExtendedTypePickTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/ExtendedTypePickTests.swift
@@ -1,0 +1,32 @@
+import Testing
+@testable import ComplexityCore
+
+@Suite("extension 확장 대상 타입 선택 — 중첩 타입 오인 방지")
+struct ExtendedTypePickTests {
+
+    // 실측 구조: extension 관련 occurrence = 확장 대상(extendedBy) + 본문 중첩 타입(childOf).
+    // 둘 다 nominal이라 role로만 갈린다.
+    private let extended = (isExtendedBy: true, isNominal: true, usr: "uExtended")
+    private let nested = (isExtendedBy: false, isNominal: true, usr: "uNested")
+
+    @Test("extendedBy인 확장 대상만 고른다 (중첩 타입 제외)")
+    func picksExtendedNotNested() {
+        #expect(IndexStoreDBProvider.pickExtendedType([extended, nested]) == "uExtended")
+    }
+
+    @Test("occurrence 순서가 뒤바뀌어도 결정적으로 확장 대상")
+    func orderIndependent() {
+        #expect(IndexStoreDBProvider.pickExtendedType([nested, extended]) == "uExtended")
+    }
+
+    @Test("extendedBy 후보 없으면 nil")
+    func nilWhenNoExtended() {
+        #expect(IndexStoreDBProvider.pickExtendedType([nested]) == nil)
+    }
+
+    @Test("extendedBy지만 non-nominal(있을 리 없는 방어)은 제외")
+    func excludesNonNominalExtended() {
+        let weird = (isExtendedBy: true, isNominal: false, usr: "uWeird")
+        #expect(IndexStoreDBProvider.pickExtendedType([weird, extended]) == "uExtended")
+    }
+}

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/FanInTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/FanInTests.swift
@@ -7,6 +7,8 @@ final class StubIndexProvider: IndexProviding {
     var usrByLocation: [String: String] = [:]
     /// usr → 그 usr을 참조하는 지점들
     var referencesByUSR: [String: [ReferenceSite]] = [:]
+    /// usr → 그 심볼을 감싸는 타입 usr
+    var enclosingByUSR: [String: String] = [:]
     private(set) var queriedUSRs: [String] = []
 
     func definitionUSR(named name: String, file: String, line: Int) -> String? {
@@ -16,6 +18,10 @@ final class StubIndexProvider: IndexProviding {
     func references(toUSR usr: String) -> [ReferenceSite] {
         queriedUSRs.append(usr)
         return referencesByUSR[usr] ?? []
+    }
+
+    func enclosingTypeUSR(of usr: String) -> String? {
+        enclosingByUSR[usr]
     }
 }
 

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/IndexStoreIntegrationTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/IndexStoreIntegrationTests.swift
@@ -63,6 +63,34 @@ struct IndexStoreIntegrationTests {
         #expect(provider.references(toUSR: usr).count > 0)
     }
 
+    @Test("실 index에서 caller USR을 enclosing 타입으로 해소")
+    func enclosingTypeResolves() throws {
+        guard let storePath = Self.indexStorePath,
+              FileManager.default.fileExists(atPath: Self.libIndexStore)
+        else { return }
+
+        let source = Self.repoRoot + "/Domain/Sources/Models/Events/Todo/TodoEvent.swift"
+        guard let content = try? String(contentsOfFile: source, encoding: .utf8),
+              let todoEvent = SyntaxScanner().scan(source: content, file: source)
+                .first(where: { $0.kind == .type && $0.name == "TodoEvent" })
+        else { return }
+
+        let provider = try IndexStoreDBProvider(
+            storePath: storePath,
+            databasePath: NSTemporaryDirectory() + "cx-idx-" + UUID().uuidString,
+            libIndexStorePath: Self.libIndexStore
+        )
+        // 워크트리 mismatch면 USR nil → 스모크 불가로 skip (bare-name 아닌 path-specific USR).
+        guard let usr = provider.definitionUSR(named: "TodoEvent", file: source, line: todoEvent.line)
+        else { return }
+
+        // TodoEvent를 참조하는 caller가 있고, 그 caller는 어떤 타입에 속한다.
+        let callers = provider.references(toUSR: usr).flatMap { $0.callerUSRs }
+        guard let firstCaller = callers.first else { return }
+        // caller의 enclosing 타입이 실 index에서 해소되면 non-nil (childOf/extension 경로 실동작 증명).
+        #expect(provider.enclosingTypeUSR(of: firstCaller) != nil)
+    }
+
     @Test("빈/없는 index store는 명시 throw (silent-0 방지)")
     func emptyOrMissingStoreThrows() throws {
         // 없는 경로

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/ProtocolUnitTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/ProtocolUnitTests.swift
@@ -1,0 +1,31 @@
+import Testing
+@testable import ComplexityCore
+
+@Suite("protocol 타입 유닛 방출")
+struct ProtocolUnitTests {
+
+    private func units(_ source: String) -> [AnalyzedUnit] {
+        SyntaxScanner().scan(source: source, file: "P.swift")
+    }
+
+    @Test("protocol 선언이 타입 유닛으로 방출된다")
+    func protocolEmitsTypeUnit() {
+        let us = units("protocol Drawable { func draw() -> Int }")
+        #expect(us.contains { $0.kind == .type && $0.name == "Drawable" })
+    }
+
+    @Test("protocol requirement는 enclosingType이 protocol인 메소드 유닛")
+    func requirementIsMethodUnitOfProtocol() {
+        let us = units("protocol Drawable { func draw() -> Int }")
+        let draw = us.first { $0.kind == .method && $0.name == "draw" }
+        #expect(draw?.enclosingType == "Drawable")
+    }
+
+    @Test("protocol 스택 push/pop이 형제 타입을 오염시키지 않는다")
+    func nestedUnderProtocolTracked() {
+        let us = units("protocol P { func f() }\nstruct S { func g() { if a {} } }")
+        let s = us.first { $0.kind == .type && $0.name == "S" }
+        #expect(s?.enclosingType == nil)
+        #expect(s?.measurements.rolledUpInternalComplexity == 1)
+    }
+}

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/TypeGraphAggregatorTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/TypeGraphAggregatorTests.swift
@@ -1,0 +1,66 @@
+import Testing
+@testable import ComplexityCore
+
+@Suite("타입 그래프 배선 — 유닛 부착")
+struct TypeGraphAggregatorTests {
+
+    private func typeUnit(_ name: String, _ line: Int) -> AnalyzedUnit {
+        AnalyzedUnit(kind: .type, name: name, enclosingType: nil, file: "F.swift", line: line)
+    }
+
+    @Test("caller의 enclosing 타입으로 엣지를 만들어 측정을 부착한다")
+    func attachesGraphMeasures() {
+        // 타입 A(line 1)·B(line 2). A의 메소드 mA가 B를 참조 → 엣지 A→B.
+        let stub = StubIndexProvider()
+        stub.usrByLocation["A@F.swift:1"] = "uA"
+        stub.usrByLocation["B@F.swift:2"] = "uB"
+        stub.referencesByUSR["uB"] = [.init(callerUSRs: ["mA"])]
+        stub.enclosingByUSR["mA"] = "uA"
+
+        let patched = TypeGraphAggregator.patched(
+            units: [typeUnit("A", 1), typeUnit("B", 2)],
+            index: stub,
+            maxBlastHop: 2
+        )
+        let a = patched.first { $0.name == "A" }?.measurements
+        let b = patched.first { $0.name == "B" }?.measurements
+        #expect(a?.fanOut == 1)
+        #expect(b?.fanOut == 0)
+        #expect(b?.blastRadiusByHop == [1, 0, 0])
+        #expect(a?.dependencyCycleSize == 1)
+        #expect(a?.collaborationChainDepth == 2)
+    }
+
+    @Test("self-참조와 미해소 caller는 엣지에서 제외")
+    func skipsSelfAndUnresolved() {
+        let stub = StubIndexProvider()
+        stub.usrByLocation["A@F.swift:1"] = "uA"
+        stub.referencesByUSR["uA"] = [.init(callerUSRs: ["mA", "orphan"])]
+        stub.enclosingByUSR["mA"] = "uA"   // self
+        // "orphan"은 enclosingByUSR에 없음 → nil
+
+        let patched = TypeGraphAggregator.patched(units: [typeUnit("A", 1)], index: stub, maxBlastHop: 2)
+        let a = patched.first { $0.name == "A" }?.measurements
+        #expect(a?.fanOut == 0)
+        #expect(a?.blastRadiusByHop == [0, 0, 0])
+    }
+
+    @Test("known 집합 밖 타입으로의 enclosing은 엣지 제외")
+    func skipsEdgeToUnknownType() {
+        let stub = StubIndexProvider()
+        stub.usrByLocation["A@F.swift:1"] = "uA"
+        stub.referencesByUSR["uA"] = [.init(callerUSRs: ["mExternal"])]
+        stub.enclosingByUSR["mExternal"] = "uExternal"  // 유닛에 없는 타입
+
+        let patched = TypeGraphAggregator.patched(units: [typeUnit("A", 1)], index: stub, maxBlastHop: 2)
+        #expect(patched.first { $0.name == "A" }?.measurements.blastRadiusByHop == [0, 0, 0])
+    }
+
+    @Test("메소드 유닛은 그래프 측정 미부착(패스스루)")
+    func methodUnitsUntouched() {
+        let stub = StubIndexProvider()
+        let method = AnalyzedUnit(kind: .method, name: "m", enclosingType: "A", file: "F.swift", line: 3)
+        let patched = TypeGraphAggregator.patched(units: [method], index: stub, maxBlastHop: 2)
+        #expect(patched.first?.measurements.fanOut == nil)
+    }
+}

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/TypeGraphTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/TypeGraphTests.swift
@@ -1,0 +1,87 @@
+import Testing
+@testable import ComplexityCore
+
+@Suite("타입 의존 그래프 raw 측정")
+struct TypeGraphTests {
+
+    private func graph(_ nodes: [String], _ edges: [(String, String)]) -> TypeDependencyGraph {
+        TypeDependencyGraph(
+            nodes: Set(nodes),
+            edges: edges.map { .init(from: $0.0, to: $0.1) }
+        )
+    }
+
+    @Test("fan-out = distinct 외부 의존 수 (self·중복 제외)")
+    func fanOutDistinct() {
+        // A→B, A→C, A→B(중복), A→A(self)
+        let m = graph(["A", "B", "C"], [("A","B"), ("A","C"), ("A","B"), ("A","A")])
+            .measures(maxBlastHop: 2)
+        #expect(m["A"]?.fanOut == 2)
+        #expect(m["B"]?.fanOut == 0)
+    }
+
+    @Test("cycle 크기 = SCC 크기 (사이클 없으면 1)")
+    func cycleSizeIsSCC() {
+        // A→B→C→A 순환, D는 고립
+        let m = graph(["A","B","C","D"], [("A","B"), ("B","C"), ("C","A")])
+            .measures(maxBlastHop: 2)
+        #expect(m["A"]?.cycleSize == 3)
+        #expect(m["B"]?.cycleSize == 3)
+        #expect(m["C"]?.cycleSize == 3)
+        #expect(m["D"]?.cycleSize == 1)
+    }
+
+    @Test("2-노드 상호 의존도 cycle 크기 2")
+    func twoNodeCycle() {
+        let m = graph(["A","B"], [("A","B"), ("B","A")]).measures(maxBlastHop: 2)
+        #expect(m["A"]?.cycleSize == 2)
+    }
+
+    @Test("chain depth = outbound 최장 경로 노드 수")
+    func chainDepthLongestPath() {
+        // A→B→C→D 선형, leaf는 1
+        let m = graph(["A","B","C","D"], [("A","B"), ("B","C"), ("C","D")])
+            .measures(maxBlastHop: 2)
+        #expect(m["A"]?.chainDepth == 4)
+        #expect(m["D"]?.chainDepth == 1)
+    }
+
+    @Test("사이클은 한 SCC 층으로 접혀 chain depth 1 (결정적·대칭)")
+    func chainDepthCycleCollapses() {
+        let m = graph(["A","B"], [("A","B"), ("B","A")]).measures(maxBlastHop: 2)
+        // A·B가 한 SCC → 응축 DAG 단일 노드 → 둘 다 depth 1 (방문 순서 무관).
+        #expect(m["A"]?.chainDepth == 1)
+        #expect(m["B"]?.chainDepth == 1)
+    }
+
+    @Test("사이클 SCC 위에 꼬리가 붙으면 층 수로 chain depth")
+    func chainDepthThroughCycle() {
+        // {A,B} 사이클 + A→C. 응축: {AB}→{C}. depth({AB})=2, depth(C)=1.
+        let m = graph(["A","B","C"], [("A","B"), ("B","A"), ("A","C")])
+            .measures(maxBlastHop: 2)
+        #expect(m["A"]?.chainDepth == 2)
+        #expect(m["B"]?.chainDepth == 2)
+        #expect(m["C"]?.chainDepth == 1)
+    }
+
+    @Test("blast radius = 역방향 per-hop 전이 의존자 수 (dedup·zero-fill)")
+    func blastByHopReverse() {
+        // 엣지 X→Y = X가 Y 의존. blast(Y) = Y를 의존하는 X 전이.
+        // 엣지: A→B, B→C, A→C. blast(C): 직접 의존자 {A,B}=2(hop0), 그 위 없음 → [2,0,0].
+        let m = graph(["A","B","C"], [("A","B"), ("B","C"), ("A","C")])
+            .measures(maxBlastHop: 2)
+        #expect(m["C"]?.blastByHop == [2, 0, 0])
+        // blast(B): 직접 의존자 {A}(hop0). A의 의존자 없음 → [1,0,0].
+        #expect(m["B"]?.blastByHop == [1, 0, 0])
+        // blast(A): 의존자 없음 → [0,0,0].
+        #expect(m["A"]?.blastByHop == [0, 0, 0])
+    }
+
+    @Test("blast per-hop은 홉별로 새로 도달한 노드만 (재방문 제외)")
+    func blastDedupAcrossHops() {
+        // 체인 D→C→B→A : blast(A) hop0={B}, hop1={C}, hop2={D}
+        let m = graph(["A","B","C","D"], [("B","A"), ("C","B"), ("D","C")])
+            .measures(maxBlastHop: 2)
+        #expect(m["A"]?.blastByHop == [1, 1, 1])
+    }
+}


### PR DESCRIPTION
## 문제

페이즈 2·3은 메소드/타입의 **경계 안쪽**만 측정했다(내부복잡도·CQS·응집·표면적·롤업). 타입이 **다른 타입들과 어떻게 얽혀 협업하는지** — 의존 그래프의 구조 병리(cycle·과도 fan-out·긴 협업 체인·넓은 변경 반경) — 는 못 봤다. #691 측정 카탈로그의 "객체 협업" 레벨이 빈 상태였다.

## 접근

전 타입을 정확 USR로 해소한 뒤, 각 타입의 참조(fan-in)를 caller의 enclosing 타입으로 역매핑해 **전역 타입→타입 의존 그래프**를 만들고, 그 위에서 raw 측정 4종을 파생한다. substrate 하나(그래프)가 네 측정을 먹인다.

- **fanOut** — distinct 외부 의존 수 (out-degree)
- **dependencyCycleSize** — 속한 SCC 크기 (1 = 순환 없음, Tarjan)
- **collaborationChainDepth** — SCC 응축 DAG의 최장 경로(구별되는 의존 층 수)
- **blastRadiusByHop** — 역방향 per-hop 전이 의존자 수 (hop 상한 2, `fanInByHop`과 동형)

커밋 서사(4단계):
1. `IndexProviding.enclosingTypeUSR(of:)` seam — caller 심볼을 감싸는 명목 타입 USR로 역매핑. childOf 워크업 + **extension 예외**(synthetic `s:e:` USR → `relatedToUSR` extendedBy로 확장 대상 해소). 로컬 index probe로 관계 의미 실측 확정
2. protocol을 타입 유닛으로 방출 — protocol-first 코드라 concrete→protocol 의존이 그래프 노드가 돼야 fan-out·blast가 실측됨
3. `TypeDependencyGraph` 순수 측정 — index 무의존 값 타입, 단위 테스트. chainDepth는 per-node 메모+onStack이 Set 순회 순서에 비결정이라 SCC 응축 DAG 최장경로로 정의(결정적·대칭)
4. `TypeGraphAggregator` 배선 — USR 해소→엣지 수집(enclosing 역매핑·메모)→그래프→타입 유닛 패치. `Measurements` 4필드·`Analyzer`·CLI·JSON

**e2e 검증**: Domain 313타입 전부 그래프 부착, 14개 사이클 감지. EventTime·TodoEvent·ScheduleEvent 등 코어 값타입 10개가 한 SCC(상호 참조 클러스터), EventTagId blast=[23,37,8] 같은 널리 쓰이는 seam이 큰 blast. 실 index 스모크(enclosingTypeUSR 해소)도 실데이터로 통과.

## 남은 과제 (의도적 제외)

- **판정·점수·가중·config·churn 곱·payoff 판정은 전부 페이즈 5.** 이 PR은 raw 숫자만.
- **known 한계(v1 수용, 문서화)**: protocol의 페이즈3 측정(응집·표면적)은 대부분 trivial 노이즈 / 그래프는 in-scope 해소 타입만(외부 Foundation 등 미포함) / blast hop 상한 2 / 기존 타입 `fanIn`(참조 site 수)과 `blastRadiusByHop`(distinct 의존 타입)은 별개 의미로 공존.
- **chainDepths ↔ CohesionAnalyzer.maxChainDepth 중복**: 스코프 경계상 CohesionAnalyzer 불변이라 공유 graph util 미추출. 페이즈 5 스코어링 재편 때 흡수 후보.

🤖 Generated with [Claude Code](https://claude.com/claude-code)