### PR TITLE
[#691] 복잡도 분석기 — 스코어링 + 신뢰성(오탐/과탐 제거) + index 자동탐색

### DIFF
--- a/tools/complexity-analyzer/Sources/ComplexityAnalyzer/Entry.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityAnalyzer/Entry.swift
@@ -13,8 +13,8 @@ struct ComplexityAnalyzerCLI: AsyncParsableCommand {
     @Option(name: .customLong("source-root"), help: "분석할 소스 루트 경로")
     var sourceRoot: String
 
-    @Option(name: .customLong("index-store-path"), help: "IndexStore DataStore 경로")
-    var indexStorePath: String
+    @Option(name: .customLong("index-store-path"), help: "IndexStore DataStore 경로 (생략 시 현재 워크트리 빌드의 index를 자동 탐색)")
+    var indexStorePath: String?
 
     @Option(name: .customLong("scope"), help: "분석 범위 (whole | file:<경로> | type:<이름>)")
     var scope: String = "whole"
@@ -27,11 +27,18 @@ struct ComplexityAnalyzerCLI: AsyncParsableCommand {
     var configPath: String?
 
     func run() async throws {
-        let index = try IndexStoreDBProvider(
-            storePath: indexStorePath,
-            databasePath: NSTemporaryDirectory() + "cx-idx-" + UUID().uuidString,
-            libIndexStorePath: libIndexStore
-        )
+        // 경로 지정 시 그 store를 열고, 미지정 시 현재 워크트리 소스를 해소하는 index를
+        // 자동 탐색(clean 빌드 불필요). 탐색은 채택한 provider를 그대로 재사용한다.
+        let index: IndexStoreDBProvider
+        if let indexStorePath {
+            index = try IndexStoreDBProvider(
+                storePath: indexStorePath,
+                databasePath: NSTemporaryDirectory() + "cx-idx-" + UUID().uuidString,
+                libIndexStorePath: libIndexStore
+            )
+        } else {
+            index = try IndexStoreLocator.locate(sourceRoot: sourceRoot, libIndexStorePath: libIndexStore)
+        }
         let config: ScoringConfig
         if let configPath {
             let data = try Data(contentsOf: URL(fileURLWithPath: configPath))

--- a/tools/complexity-analyzer/Sources/ComplexityAnalyzer/Entry.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityAnalyzer/Entry.swift
@@ -23,13 +23,23 @@ struct ComplexityAnalyzerCLI: AsyncParsableCommand {
     var libIndexStore: String =
         "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/libIndexStore.dylib"
 
+    @Option(name: .customLong("config"), help: "스코어링 config JSON 경로 (생략 시 기본 가중치)")
+    var configPath: String?
+
     func run() async throws {
         let index = try IndexStoreDBProvider(
             storePath: indexStorePath,
             databasePath: NSTemporaryDirectory() + "cx-idx-" + UUID().uuidString,
             libIndexStorePath: libIndexStore
         )
-        let units = try Analyzer(index: index).analyze(
+        let config: ScoringConfig
+        if let configPath {
+            let data = try Data(contentsOf: URL(fileURLWithPath: configPath))
+            config = try JSONDecoder().decode(ScoringConfig.self, from: data)
+        } else {
+            config = .default
+        }
+        let units = try Analyzer(index: index, config: config).analyze(
             sourceRoot: sourceRoot,
             scope: Scope.parse(scope)
         )

--- a/tools/complexity-analyzer/Sources/ComplexityAnalyzer/Entry.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityAnalyzer/Entry.swift
@@ -23,7 +23,7 @@ struct ComplexityAnalyzerCLI: AsyncParsableCommand {
     var libIndexStore: String =
         "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/libIndexStore.dylib"
 
-    @Option(name: .customLong("config"), help: "스코어링 config JSON 경로 (생략 시 기본 가중치)")
+    @Option(name: .customLong("config"), help: "스코어링 config JSON 경로 (생략 시 기본 가중치, 일부 필드만 줘도 나머지는 기본값)")
     var configPath: String?
 
     func run() async throws {

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Analyzer.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Analyzer.swift
@@ -50,9 +50,19 @@ public struct Analyzer {
             }
         }
 
+        // 테스트 더블·프리뷰 더미(Dummy/Fake/Stub/Spy/Mock)는 측정 대상 아님 — 그래프 빌드 전 제외.
+        // 파일 경로로 못 거른 production 파일 내 프리뷰 더미까지 타입명으로 잡는다.
+        units.removeAll {
+            SwiftFileEnumerator.isTestDoubleName($0.name)
+                || ($0.enclosingType.map(SwiftFileEnumerator.isTestDoubleName) ?? false)
+        }
+        factsByQualified = factsByQualified.filter { qualified, _ in
+            !qualified.split(separator: ".").contains { SwiftFileEnumerator.isTestDoubleName(String($0)) }
+        }
+
         let objectPatched = ObjectMetricsAggregator.patched(units: units, factsByQualified: factsByQualified)
         // 협업 그래프는 whole-scope에서 빌드(엣지가 scope 경계를 넘나듦) → 부착 후 필터.
-        let graphPatched = TypeGraphAggregator.patched(units: objectPatched, index: index, maxBlastHop: 2)
+        let graphPatched = try TypeGraphAggregator.patched(units: objectPatched, index: index, maxBlastHop: 2)
         // 점수는 per-unit pure라 scope 필터 후 부착(드롭될 유닛은 채점 안 함).
         return Scorer(config: config).scored(graphPatched.filter { scope.includes($0) })
     }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Analyzer.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Analyzer.swift
@@ -1,15 +1,21 @@
 import Foundation
 
-/// 페이즈 1 오케스트레이션 — 파일 스캔 → 측정(내부 복잡도·fan-in) → scope 필터.
-/// 총점·가중 합성은 후속 페이즈(5).
+/// 오케스트레이션 — 파일 스캔 → 측정(내부 복잡도·fan-in·객체·협업그래프) → scope 필터 → 채점.
+/// 총점·가중 합성은 Scorer(페이즈 5).
 public struct Analyzer {
 
     private let index: any IndexProviding
     private let scanner: SyntaxScanner
+    private let config: ScoringConfig
 
-    public init(index: any IndexProviding, scanner: SyntaxScanner = SyntaxScanner()) {
+    public init(
+        index: any IndexProviding,
+        scanner: SyntaxScanner = SyntaxScanner(),
+        config: ScoringConfig = .default
+    ) {
         self.index = index
         self.scanner = scanner
+        self.config = config
     }
 
     public func analyze(sourceRoot: String, scope: Scope) throws -> [AnalyzedUnit] {
@@ -47,6 +53,7 @@ public struct Analyzer {
         let objectPatched = ObjectMetricsAggregator.patched(units: units, factsByQualified: factsByQualified)
         // 협업 그래프는 whole-scope에서 빌드(엣지가 scope 경계를 넘나듦) → 부착 후 필터.
         let graphPatched = TypeGraphAggregator.patched(units: objectPatched, index: index, maxBlastHop: 2)
-        return graphPatched.filter { scope.includes($0) }
+        // 점수는 per-unit pure라 scope 필터 후 부착(드롭될 유닛은 채점 안 함).
+        return Scorer(config: config).scored(graphPatched.filter { scope.includes($0) })
     }
 }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/FileSystem/SwiftFileEnumerator.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/FileSystem/SwiftFileEnumerator.swift
@@ -1,9 +1,22 @@
 import Foundation
 
-/// 스캔 대상 .swift 파일 열거. (테스트 코드 제외 정책은 후속 페이즈 — 여기선 빌드 산출물만 회피)
+/// 스캔 대상 .swift 파일 열거. 빌드 산출물(.build)과 테스트 코드는 측정 대상에서 제외한다.
+/// (테스트 더블·헬퍼는 의도적 반복·저응집이라 복잡도로 오탐됨 — 이슈 #691 측정 전제)
 enum SwiftFileEnumerator {
 
+    /// 경로에 이게 있으면 테스트 코드로 본다 (테스트 타겟·더블·헬퍼·스냅샷 디렉토리).
+    private static let testPathMarkers = ["/Tests/", "/DomainTests/", "/TestDoubles/", "/Snapshots/", "TestHelpKit"]
+    /// 테스트 더블·프리뷰 더미 접두 (StubXxx·FakeXxx·DummyXxx 등). 파일명·타입명 공용.
+    static let testDoublePrefixes = ["Stub", "Spy", "Mock", "Fake", "Dummy"]
+
+    /// 타입명이 테스트 더블·프리뷰 더미 접두인가. production 파일 안 프리뷰 더미(DummyXxxViewModel 등)를
+    /// 파일 경로로는 못 걸러 타입명으로도 제외한다.
+    static func isTestDoubleName(_ name: String) -> Bool {
+        testDoublePrefixes.contains { name.hasPrefix($0) }
+    }
+
     static func files(under root: String, scope: Scope) -> [String] {
+        // 명시 파일 지정은 사용자 의도 — 테스트 필터를 적용하지 않는다.
         if case .file(let path) = scope { return [path] }
 
         let url = URL(fileURLWithPath: root)
@@ -15,8 +28,18 @@ enum SwiftFileEnumerator {
         var result: [String] = []
         for case let fileURL as URL in enumerator where fileURL.pathExtension == "swift" {
             if fileURL.path.contains("/.build/") { continue }
+            if isTestCode(fileURL.path) { continue }
             result.append(fileURL.path)
         }
         return result.sorted()
+    }
+
+    /// 테스트 코드 판별 — 경로/타겟 마커 또는 테스트 더블 파일명 접두 + `*Tests.swift` 접미.
+    static func isTestCode(_ path: String) -> Bool {
+        if testPathMarkers.contains(where: { path.contains($0) }) { return true }
+        let name = (path as NSString).lastPathComponent
+        if name.hasSuffix("Tests.swift") { return true }
+        let base = (name as NSString).deletingPathExtension
+        return testDoublePrefixes.contains { base.hasPrefix($0) }
     }
 }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexStoreDBProvider.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexStoreDBProvider.swift
@@ -5,6 +5,7 @@ import IndexStoreDB
 public enum IndexStoreError: Error, CustomStringConvertible {
     case storeMissing(String)
     case storeEmpty(String)
+    case staleOrMismatched(typeUnitCount: Int)
 
     public var description: String {
         switch self {
@@ -12,6 +13,8 @@ public enum IndexStoreError: Error, CustomStringConvertible {
             return "index store 경로가 없음: \(path) — 대상 프로젝트를 빌드했는지 확인."
         case .storeEmpty(let path):
             return "index store에 unit 레코드가 없음: \(path) — 빌드가 인덱스를 생성하지 않았거나 경로가 잘못됨. (fan-in이 조용히 0으로 나오는 것을 방지)"
+        case .staleOrMismatched(let count):
+            return "index store가 현재 소스와 불일치 — 타입 \(count)개 중 USR 해소 0개. 대상을 (재)빌드한 뒤 다시 실행. (협업 측정이 조용히 전부 nil로 나가는 것을 방지)"
         }
     }
 }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexStoreLocator.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexStoreLocator.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+public enum IndexStoreLocatorError: Error, CustomStringConvertible {
+    case noCandidates(derivedDataRoot: String)
+    case noResolvingStore(sourceRoot: String, tried: Int)
+
+    public var description: String {
+        switch self {
+        case .noCandidates(let root):
+            return "DerivedData(\(root))에 populated index store가 없음 — 대상 워크트리를 한 번 빌드했는지 확인."
+        case .noResolvingStore(let root, let tried):
+            return "\(root)의 소스를 해소하는 index store를 못 찾음 (후보 \(tried)개 시도). 이 워크트리를 빌드한 뒤 다시 실행."
+        }
+    }
+}
+
+/// `--index-store-path`를 생략하면, 현재 source-root(워크트리)의 소스를 실제로 해소하는
+/// index store를 DerivedData에서 자동 선택한다. 워크트리마다 자기 빌드가 만든 index를
+/// 자연스럽게 물게 하는 것이 목적 — clean 빌드 없이, TDD로 쌓인 index를 그대로 쓴다.
+public enum IndexStoreLocator {
+
+    public static let defaultDerivedDataRoot =
+        ("~/Library/Developer/Xcode/DerivedData" as NSString).expandingTildeInPath
+
+    /// source-root의 소스를 해소하는 index provider를 열어 반환한다. 후보를 최신순으로 열어
+    /// 충분히 해소되면 그 provider를 그대로 쓴다(재open 없이 analysis에 재사용) — 정상 케이스 1회 open.
+    public static func locate(
+        sourceRoot: String,
+        libIndexStorePath: String,
+        derivedDataRoot: String = defaultDerivedDataRoot
+    ) throws -> IndexStoreDBProvider {
+        let workspace = workspacePath(above: sourceRoot)
+        var candidates = populatedDataStores(under: derivedDataRoot, matchingWorkspace: workspace)
+        if candidates.isEmpty {
+            candidates = populatedDataStores(under: derivedDataRoot, matchingWorkspace: nil)
+        }
+        guard !candidates.isEmpty else {
+            throw IndexStoreLocatorError.noCandidates(derivedDataRoot: derivedDataRoot)
+        }
+
+        let samples = sampleTypeUnits(sourceRoot: sourceRoot, limit: 12)
+        // 최신순으로 열어보며, 잘 해소되면(임계 이상) 즉시 채택. 최선만 백업으로 유지.
+        let goodEnough = max(1, samples.count * 3 / 5)
+        var best: (provider: IndexStoreDBProvider, resolved: Int)?
+        for store in candidates {
+            guard let provider = try? IndexStoreDBProvider(
+                storePath: store,
+                databasePath: NSTemporaryDirectory() + "cx-locate-" + UUID().uuidString,
+                libIndexStorePath: libIndexStorePath
+            ) else { continue }
+            let resolved = samples.filter {
+                provider.definitionUSR(named: $0.name, file: $0.file, line: $0.line) != nil
+            }.count
+            if resolved >= goodEnough { return provider }              // 충분 → 즉시 채택
+            if resolved > (best?.resolved ?? 0) { best = (provider, resolved) }
+        }
+        guard let best, best.resolved > 0 else {
+            throw IndexStoreLocatorError.noResolvingStore(sourceRoot: sourceRoot, tried: candidates.count)
+        }
+        return best.provider
+    }
+
+    // MARK: - DerivedData 열거
+
+    /// `<root>/*/Index.noindex/DataStore` 중 populated인 것을 **최신 빌드순(DataStore mtime desc)**으로.
+    /// workspace 지정 시 info.plist로 현재 워크트리 것만 남긴다.
+    static func populatedDataStores(under root: String, matchingWorkspace workspace: String?) -> [String] {
+        let dirs = (try? FileManager.default.contentsOfDirectory(atPath: root)) ?? []
+        let stores = dirs.compactMap { dir -> (path: String, mtime: Date)? in
+            let ddPath = root + "/" + dir
+            let store = ddPath + "/Index.noindex/DataStore"
+            guard (try? IndexStoreDBProvider.assertPopulated(storePath: store)) != nil else { return nil }
+            if let workspace, self.workspace(ofDerivedData: ddPath) != workspace { return nil }
+            let mtime = (try? FileManager.default.attributesOfItem(atPath: store)[.modificationDate] as? Date) ?? nil
+            return (store, mtime ?? .distantPast)
+        }
+        return stores.sorted { $0.mtime > $1.mtime }.map { $0.path }
+    }
+
+    /// DerivedData의 info.plist가 기록한 WorkspacePath.
+    static func workspace(ofDerivedData ddPath: String) -> String? {
+        guard let dict = NSDictionary(contentsOfFile: ddPath + "/info.plist"),
+              let path = dict["WorkspacePath"] as? String
+        else { return nil }
+        return path
+    }
+
+    // MARK: - source-root 기반 워크스페이스 추정
+
+    /// source-root에서 상위로 올라가며 `.xcworkspace`를 담은 첫 디렉토리의 워크스페이스 경로.
+    static func workspacePath(above sourceRoot: String) -> String? {
+        var dir = (sourceRoot as NSString).standardizingPath
+        while dir != "/" && !dir.isEmpty {
+            let entries = (try? FileManager.default.contentsOfDirectory(atPath: dir)) ?? []
+            if let ws = entries.first(where: { $0.hasSuffix(".xcworkspace") }) {
+                return dir + "/" + ws
+            }
+            dir = (dir as NSString).deletingLastPathComponent
+        }
+        return nil
+    }
+
+    // MARK: - 샘플 타입 수집
+
+    /// source-root의 앞쪽 파일을 스캔해 타입 유닛 이름/위치 샘플을 모은다(해소율 프로브용).
+    static func sampleTypeUnits(sourceRoot: String, limit: Int) -> [(name: String, file: String, line: Int)] {
+        let files = SwiftFileEnumerator.files(under: sourceRoot, scope: .whole)
+        var samples: [(name: String, file: String, line: Int)] = []
+        for file in files {
+            guard let source = try? String(contentsOfFile: file, encoding: .utf8) else { continue }
+            for unit in SyntaxScanner().scan(source: source, file: file) where unit.kind == .type {
+                samples.append((unit.name, unit.file, unit.line))
+                if samples.count >= limit { return samples }
+            }
+        }
+        return samples
+    }
+}

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexStoreLocator.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Index/IndexStoreLocator.swift
@@ -39,25 +39,40 @@ public enum IndexStoreLocator {
         }
 
         let samples = sampleTypeUnits(sourceRoot: sourceRoot, limit: 12)
-        // 최신순으로 열어보며, 잘 해소되면(임계 이상) 즉시 채택. 최선만 백업으로 유지.
-        let goodEnough = max(1, samples.count * 3 / 5)
-        var best: (provider: IndexStoreDBProvider, resolved: Int)?
-        for store in candidates {
-            guard let provider = try? IndexStoreDBProvider(
+        // 후보를 전부 열어 샘플 해소 수가 최대인 것을 채택 — 부분 stale(예: 7/12) 최신 후보를
+        // 완전 해소(12/12) 후보보다 먼저 채택하던 갭을 없앤다. workspace 필터로 후보가 적어 감당 가능.
+        let providers = candidates.compactMap { store -> IndexStoreDBProvider? in
+            try? IndexStoreDBProvider(
                 storePath: store,
                 databasePath: NSTemporaryDirectory() + "cx-locate-" + UUID().uuidString,
                 libIndexStorePath: libIndexStorePath
-            ) else { continue }
-            let resolved = samples.filter {
+            )
+        }
+        let best = pickBest(providers) { provider in
+            samples.filter {
                 provider.definitionUSR(named: $0.name, file: $0.file, line: $0.line) != nil
             }.count
-            if resolved >= goodEnough { return provider }              // 충분 → 즉시 채택
-            if resolved > (best?.resolved ?? 0) { best = (provider, resolved) }
         }
-        guard let best, best.resolved > 0 else {
+        guard let best else {
             throw IndexStoreLocatorError.noResolvingStore(sourceRoot: sourceRoot, tried: candidates.count)
         }
-        return best.provider
+        return best
+    }
+
+    /// 해소 수가 최대인 후보 선택(0이면 제외). 실 index 없이 선택 로직을 검증하도록 프로브를 클로저로 주입.
+    static func pickBest<T>(_ candidates: [T], resolvedCount: (T) -> Int) -> T? {
+        var best: (item: T, resolved: Int)?
+        for candidate in candidates {
+            let resolved = resolvedCount(candidate)
+            if resolved > (best?.resolved ?? 0) { best = (candidate, resolved) }
+        }
+        guard let best, best.resolved > 0 else { return nil }
+        return best.item
+    }
+
+    /// 심볼릭·/private·`..` 차이를 흡수한 경로 정규화 (workspace 등가 비교용).
+    private static func normalized(_ path: String) -> String {
+        URL(fileURLWithPath: path).resolvingSymlinksInPath().path
     }
 
     // MARK: - DerivedData 열거
@@ -70,7 +85,12 @@ public enum IndexStoreLocator {
             let ddPath = root + "/" + dir
             let store = ddPath + "/Index.noindex/DataStore"
             guard (try? IndexStoreDBProvider.assertPopulated(storePath: store)) != nil else { return nil }
-            if let workspace, self.workspace(ofDerivedData: ddPath) != workspace { return nil }
+            if let workspace {
+                // 심볼릭·/private 차이를 흡수해 비교 — 한쪽만 정규화하면 워크트리 매핑이 조용히 깨진다.
+                guard let ddWorkspace = self.workspace(ofDerivedData: ddPath),
+                      normalized(ddWorkspace) == normalized(workspace)
+                else { return nil }
+            }
             let mtime = (try? FileManager.default.attributesOfItem(atPath: store)[.modificationDate] as? Date) ?? nil
             return (store, mtime ?? .distantPast)
         }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Measure/ObjectMetrics.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Measure/ObjectMetrics.swift
@@ -67,7 +67,11 @@ enum ObjectMetricsAggregator {
             result[index].measurements.rolledUpCqsViolations = facts.rollupCqs
             result[index].measurements.rolledUpCombineRoleMix = facts.rollupCombine
             result[index].measurements.publicSurface = facts.publicSurface
-            result[index].measurements.lcom = cohesion.lcom
+            // LCOM(응집도)은 구현체 메소드가 상태를 공유하는지의 지표 — protocol(구현 없음)·enum(case별
+            // 분기라 구조적으로 낮음)엔 비적용. 이 둘엔 lcom을 남기지 않아(nil) 과탐을 막는다.
+            if result[index].measuresCohesion {
+                result[index].measurements.lcom = cohesion.lcom
+            }
             result[index].measurements.internalCoupling = cohesion.internalCoupling
             result[index].measurements.maxCallChainDepth = cohesion.maxCallChainDepth
         }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Measure/SideEffectAnalyzer.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Measure/SideEffectAnalyzer.swift
@@ -24,10 +24,13 @@ enum SideEffectAnalyzer {
         var result = Result.zero
         let bodyNode = Syntax(body)
         for site in collector.sites {
-            switch nearestOperator(from: site, stopAt: bodyNode) {
+            // 로컬 변수(복사본)의 멤버 대입(`var c = self; c.x = ...`)은 functional update —
+            // 외부 상태 변이가 아니므로 side-effect에서 제외한다. self·멤버(subject) 대입만 남긴다.
+            if let base = site.assignmentBase, collector.localVarNames.contains(base) { continue }
+            switch nearestOperator(from: site.node, stopAt: bodyNode) {
             case .pure:
                 result.combineRoleMix += 1
-            case .allowed:
+            case .allowed, .deferred:
                 break
             case .none:
                 if isQuery { result.cqsViolations += 1 }
@@ -36,21 +39,27 @@ enum SideEffectAnalyzer {
         return result
     }
 
-    private enum OperatorKind { case pure, allowed, none }
+    /// none = 메서드 본문 직접 흐름(동기), pure/allowed = 인식된 Combine 연산자,
+    /// deferred = 인식 못 한 클로저(반환 factory·escaping 콜백 등) 안 — 나중 실행이라 동기 side-effect 아님.
+    private enum OperatorKind { case pure, allowed, none, deferred }
 
-    /// site에서 body까지 부모를 거슬러 올라가며 만나는 첫 인식 연산자 클로저의 종류.
+    /// site에서 body까지 부모를 거슬러 올라가며 판정. 인식된 연산자 클로저를 만나면 그 종류,
+    /// 인식 못 한 클로저를 하나라도 통과하면 deferred, 어떤 클로저도 안 거치면 none(본문 직접).
     private static func nearestOperator(from site: Syntax, stopAt body: Syntax) -> OperatorKind {
         var current = site.parent
+        var passedUnrecognizedClosure = false
         while let node = current, node != body {
-            if let closure = node.as(ClosureExprSyntax.self),
-               let name = operatorName(wrapping: closure) {
-                if pureOperators.contains(name) { return .pure }
-                if allowedOperators.contains(name) { return .allowed }
-                // 인식 못 한 연산자 클로저(예: forEach) → 계속 상향 탐색
+            if let closure = node.as(ClosureExprSyntax.self) {
+                if let name = operatorName(wrapping: closure) {
+                    if pureOperators.contains(name) { return .pure }
+                    if allowedOperators.contains(name) { return .allowed }
+                }
+                // 반환 클로저·escaping 콜백·forEach 등 인식 못 한 클로저 → 지연 실행 후보
+                passedUnrecognizedClosure = true
             }
             current = node.parent
         }
-        return .none
+        return passedUnrecognizedClosure ? .deferred : .none
     }
 
     /// 클로저가 `x.op { }`(trailing) / `x.op(label: { })`(labeled arg) 형태로 붙은 연산자 이름.
@@ -67,7 +76,16 @@ enum SideEffectAnalyzer {
 
 private final class SideEffectCollector: SyntaxVisitor {
 
-    private(set) var sites: [Syntax] = []
+    /// side-effect 후보. `assignmentBase`는 멤버 대입의 최상위 base 식별자(예: `self`·`subject`·`c`).
+    /// nil이면 base 판별이 필요 없는 site(예: `.send`).
+    struct Site {
+        let node: Syntax
+        let assignmentBase: String?
+    }
+
+    private(set) var sites: [Site] = []
+    /// 이 메소드 본문에서 선언된 로컬 변수 이름 — 그 멤버 대입은 functional update로 간주해 제외.
+    private(set) var localVarNames: Set<String> = []
 
     // 중첩 함수·local 타입은 각자 독립 unit으로 따로 측정되므로, 바깥 메소드 스코프에
     // 새어들지 않게 하위로 내려가지 않는다 (클로저는 연산자 컨텍스트용이라 계속 순회).
@@ -77,17 +95,29 @@ private final class SideEffectCollector: SyntaxVisitor {
     override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind { .skipChildren }
     override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind { .skipChildren }
 
+    /// 로컬 변수 선언(`var c = self`, `let x = ...`) 이름을 등록. 본문 스코프 한정
+    /// (중첩 func/타입은 skipChildren이라 안 들어옴).
+    override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+        for binding in node.bindings {
+            if let name = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text {
+                localVarNames.insert(name)
+            }
+        }
+        return .visitChildren
+    }
+
     /// stored-property/Subject 대입: `self.x = ...`, `subject.value = ...`
     ///
     /// `Parser.parse`는 operator folding을 하지 않아 대입이 `InfixOperatorExpr`가 아니라
     /// unfolded `SequenceExpr`(좌변 · `=`(AssignmentExpr) · 우변)로 나온다. 대입 토큰 직전
-    /// 요소가 MemberAccess(`self.x`, `subject.value`)면 외부 상태 변이로 본다.
+    /// 요소가 MemberAccess(`self.x`, `subject.value`)면 외부 상태 변이 후보로 본다.
+    /// 단 최상위 base가 로컬 변수면 functional update라 analyze에서 걸러진다.
     override func visit(_ node: SequenceExprSyntax) -> SyntaxVisitorContinueKind {
         let elements = Array(node.elements)
         for (i, element) in elements.enumerated()
         where element.is(AssignmentExprSyntax.self) {
-            if i > 0, elements[i - 1].is(MemberAccessExprSyntax.self) {
-                sites.append(Syntax(node))
+            if i > 0, let member = elements[i - 1].as(MemberAccessExprSyntax.self) {
+                sites.append(Site(node: Syntax(node), assignmentBase: Self.rootBaseName(of: member)))
             }
         }
         return .visitChildren
@@ -96,8 +126,15 @@ private final class SideEffectCollector: SyntaxVisitor {
     /// Subject 방출: `xxx.send(...)`
     override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
         if node.calledExpression.as(MemberAccessExprSyntax.self)?.declName.baseName.text == "send" {
-            sites.append(Syntax(node))
+            sites.append(Site(node: Syntax(node), assignmentBase: nil))
         }
         return .visitChildren
+    }
+
+    /// 멤버 접근 체인의 최상위 base 식별자. `self.subject.value` → `self`, `c.x` → `c`.
+    private static func rootBaseName(of member: MemberAccessExprSyntax) -> String? {
+        var base = member.base
+        while let inner = base?.as(MemberAccessExprSyntax.self) { base = inner.base }
+        return base?.as(DeclReferenceExprSyntax.self)?.baseName.text
     }
 }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Measure/SideEffectAnalyzer.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Measure/SideEffectAnalyzer.swift
@@ -16,6 +16,9 @@ enum SideEffectAnalyzer {
     /// side-effect 허용 연산자 — 여기 클로저는 위반 아님 (side-effect의 올바른 자리).
     private static let allowedOperators: Set<String> =
         ["sink", "handleEvents", "do"]
+    /// 동기 고차함수 — 클로저가 즉시 실행되므로 지연(deferred)이 아니다. 투명하게 통과시켜
+    /// 바깥 컨텍스트(본문·pure·allowed)가 분류하게 한다. `arr.forEach { self.x = ... }`는 동기 변이.
+    private static let synchronousOperators: Set<String> = ["forEach"]
 
     static func analyze(body: CodeBlockSyntax, isQuery: Bool) -> Result {
         let collector = SideEffectCollector(viewMode: .sourceAccurate)
@@ -44,17 +47,23 @@ enum SideEffectAnalyzer {
     private enum OperatorKind { case pure, allowed, none, deferred }
 
     /// site에서 body까지 부모를 거슬러 올라가며 판정. 인식된 연산자 클로저를 만나면 그 종류,
-    /// 인식 못 한 클로저를 하나라도 통과하면 deferred, 어떤 클로저도 안 거치면 none(본문 직접).
+    /// 동기 고차함수(forEach)는 투명 통과, 인식 못 한 클로저를 통과하면 deferred,
+    /// 어떤 클로저도 안 거치면 none(본문 직접).
     private static func nearestOperator(from site: Syntax, stopAt body: Syntax) -> OperatorKind {
         var current = site.parent
         var passedUnrecognizedClosure = false
         while let node = current, node != body {
             if let closure = node.as(ClosureExprSyntax.self) {
-                if let name = operatorName(wrapping: closure) {
+                let name = operatorName(wrapping: closure)
+                if let name {
                     if pureOperators.contains(name) { return .pure }
                     if allowedOperators.contains(name) { return .allowed }
+                    if synchronousOperators.contains(name) {
+                        current = node.parent   // 동기 → 투명 통과(바깥 컨텍스트가 분류)
+                        continue
+                    }
                 }
-                // 반환 클로저·escaping 콜백·forEach 등 인식 못 한 클로저 → 지연 실행 후보
+                // 반환 클로저·escaping 콜백 등 인식 못 한 클로저 → 지연 실행
                 passedUnrecognizedClosure = true
             }
             current = node.parent

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Measure/TypeDependencyGraph.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Measure/TypeDependencyGraph.swift
@@ -50,6 +50,14 @@ struct TypeDependencyGraph {
         return result
     }
 
+    /// 각 SCC의 멤버 노드 목록. 순환 구성(참조 타입 수 등)을 상류에서 집계하는 데 쓴다.
+    func stronglyConnectedComponents() -> [[String]] {
+        let scc = computeSCC()
+        var groups: [Int: [String]] = [:]
+        for node in nodes { groups[scc.idOf[node]!, default: []].append(node) }
+        return Array(groups.values)
+    }
+
     // MARK: - blast radius (역방향 per-hop 전이 의존자, 홉별 새 노드만)
 
     private func blastByHop(of node: String, maxHop: Int) -> [Int] {

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Measure/TypeGraphAggregator.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Measure/TypeGraphAggregator.swift
@@ -7,17 +7,24 @@ enum TypeGraphAggregator {
         units: [AnalyzedUnit],
         index: any IndexProviding,
         maxBlastHop: Int
-    ) -> [AnalyzedUnit] {
+    ) throws -> [AnalyzedUnit] {
         var result = units
 
         // 타입 유닛 → 정확 USR. usr → result 인덱스.
         var indexByUSR: [String: Int] = [:]
+        var typeUnitCount = 0
         for (i, unit) in result.enumerated() where unit.kind == .type {
+            typeUnitCount += 1
             guard let usr = index.definitionUSR(named: unit.name, file: unit.file, line: unit.line)
             else { continue }
             indexByUSR[usr] = i
         }
         let knownUSRs = Set(indexByUSR.keys)
+        // 타입 유닛이 있는데 USR 해소가 하나도 안 되면 = index가 현재 소스와 불일치(stale).
+        // 협업 측정을 조용히 전부 nil로 흘리지 않도록 명시 throw. (store가 비진 않아 assertPopulated는 못 잡음)
+        if typeUnitCount > 0, knownUSRs.isEmpty {
+            throw IndexStoreError.staleOrMismatched(typeUnitCount: typeUnitCount)
+        }
         guard !knownUSRs.isEmpty else { return result }
 
         // 엣지 수집: 각 타입 B의 참조 → caller → enclosing 타입 A. A∈known, A≠B.
@@ -48,6 +55,22 @@ enum TypeGraphAggregator {
             result[i].measurements.dependencyCycleSize = m.cycleSize
             result[i].measurements.collaborationChainDepth = m.chainDepth
             result[i].measurements.blastRadiusByHop = m.blastByHop
+        }
+
+        // 순환(SCC 크기>1)마다 참조 타입(class/actor) 수를 세서 멤버에 부착 — 경중 등급화용.
+        // 값 타입만인 순환(데이터 클러스터)은 0, 참조 타입 낀 순환은 그 수만큼 병리 가중.
+        func isReferenceType(_ usr: String) -> Bool {
+            guard let i = indexByUSR[usr] else { return false }
+            switch result[i].typeDeclKind {
+            case .class, .actor: return true
+            default: return false
+            }
+        }
+        for component in graph.stronglyConnectedComponents() where component.count > 1 {
+            let referenceCount = component.filter(isReferenceType).count
+            for usr in component {
+                if let i = indexByUSR[usr] { result[i].measurements.cycleReferenceTypeCount = referenceCount }
+            }
         }
         return result
     }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Model/AnalyzedUnit.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Model/AnalyzedUnit.swift
@@ -18,6 +18,9 @@ public struct Measurements: Equatable, Sendable, Encodable {
     public var dependencyCycleSize: Int?
     public var collaborationChainDepth: Int?
     public var blastRadiusByHop: [Int]?
+    /// 이 타입이 속한 순환(SCC) 안의 참조 타입(class/actor) 수. 순환이 아니면 nil.
+    /// 값 타입만인 순환(=데이터 클러스터, 경미)과 참조 타입 낀 순환(=병리)을 가른다.
+    public var cycleReferenceTypeCount: Int?
 
     public init(
         internalComplexity: Int? = nil,
@@ -35,7 +38,8 @@ public struct Measurements: Equatable, Sendable, Encodable {
         fanOut: Int? = nil,
         dependencyCycleSize: Int? = nil,
         collaborationChainDepth: Int? = nil,
-        blastRadiusByHop: [Int]? = nil
+        blastRadiusByHop: [Int]? = nil,
+        cycleReferenceTypeCount: Int? = nil
     ) {
         self.internalComplexity = internalComplexity
         self.fanIn = fanIn
@@ -53,6 +57,7 @@ public struct Measurements: Equatable, Sendable, Encodable {
         self.dependencyCycleSize = dependencyCycleSize
         self.collaborationChainDepth = collaborationChainDepth
         self.blastRadiusByHop = blastRadiusByHop
+        self.cycleReferenceTypeCount = cycleReferenceTypeCount
     }
 }
 
@@ -63,11 +68,18 @@ public struct AnalyzedUnit: Equatable, Sendable, Encodable {
         case type
     }
 
+    /// 타입 유닛의 선언 종류. 채점 적용성 분기에 쓴다(예: protocol·enum은 LCOM 비적용).
+    public enum TypeDeclKind: String, Sendable, Encodable {
+        case `struct`, `class`, `enum`, `protocol`, `actor`
+    }
+
     public let kind: Kind
     public let name: String
     public let enclosingType: String?
     public let file: String
     public let line: Int
+    /// `.type` 유닛에만 존재. `.method`는 nil.
+    public let typeDeclKind: TypeDeclKind?
     public var measurements: Measurements
     public var score: Score?
 
@@ -77,6 +89,7 @@ public struct AnalyzedUnit: Equatable, Sendable, Encodable {
         enclosingType: String?,
         file: String,
         line: Int,
+        typeDeclKind: TypeDeclKind? = nil,
         measurements: Measurements = .init(),
         score: Score? = nil
     ) {
@@ -85,7 +98,17 @@ public struct AnalyzedUnit: Equatable, Sendable, Encodable {
         self.enclosingType = enclosingType
         self.file = file
         self.line = line
+        self.typeDeclKind = typeDeclKind
         self.measurements = measurements
         self.score = score
+    }
+
+    /// LCOM(구현체 응집도) 측정이 적용되는 타입인가. protocol(구현 없음)·enum(case별 분기라
+    /// 구조적으로 낮음)은 비적용 — 과탐 방지. struct/class/actor는 적용.
+    var measuresCohesion: Bool {
+        switch typeDeclKind {
+        case .protocol, .enum: return false
+        default: return true
+        }
     }
 }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Model/AnalyzedUnit.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Model/AnalyzedUnit.swift
@@ -69,6 +69,7 @@ public struct AnalyzedUnit: Equatable, Sendable, Encodable {
     public let file: String
     public let line: Int
     public var measurements: Measurements
+    public var score: Score?
 
     public init(
         kind: Kind,
@@ -76,7 +77,8 @@ public struct AnalyzedUnit: Equatable, Sendable, Encodable {
         enclosingType: String?,
         file: String,
         line: Int,
-        measurements: Measurements = .init()
+        measurements: Measurements = .init(),
+        score: Score? = nil
     ) {
         self.kind = kind
         self.name = name
@@ -84,5 +86,6 @@ public struct AnalyzedUnit: Equatable, Sendable, Encodable {
         self.file = file
         self.line = line
         self.measurements = measurements
+        self.score = score
     }
 }

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Model/Score.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Model/Score.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// 단위별 복잡도 점수 — 종합 총점 + 축별 세분 기여도.
+/// 축적형(정규화)·병리형(flag)·롤업 기여가 하나의 breakdown으로 합쳐진다.
+public struct Score: Equatable, Sendable, Encodable {
+    /// 축 이름 → 가중 기여도. 0 기여 축도 포함(다운스트림 diff 일관성).
+    public let breakdown: [String: Double]
+    /// breakdown 값의 합.
+    public let total: Double
+
+    public init(breakdown: [String: Double]) {
+        self.breakdown = breakdown
+        self.total = breakdown.values.reduce(0, +)
+    }
+}

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Parse/SyntaxScanner.swift
@@ -45,19 +45,19 @@ private final class MethodCollector: SyntaxVisitor {
         super.init(viewMode: .sourceAccurate)
     }
 
-    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind { enterType(node.name) }
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind { enterType(node.name, .class) }
     override func visitPost(_ node: ClassDeclSyntax) { typeStack.removeLast() }
 
-    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind { enterType(node.name) }
+    override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind { enterType(node.name, .struct) }
     override func visitPost(_ node: StructDeclSyntax) { typeStack.removeLast() }
 
-    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind { enterType(node.name) }
+    override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind { enterType(node.name, .enum) }
     override func visitPost(_ node: EnumDeclSyntax) { typeStack.removeLast() }
 
-    override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind { enterType(node.name) }
+    override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind { enterType(node.name, .actor) }
     override func visitPost(_ node: ActorDeclSyntax) { typeStack.removeLast() }
 
-    override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind { enterType(node.name) }
+    override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind { enterType(node.name, .protocol) }
     override func visitPost(_ node: ProtocolDeclSyntax) { typeStack.removeLast() }
 
     // extension은 타입 선언이 아니므로 타입 단위를 새로 내지 않고, enclosing type 추적만.
@@ -160,8 +160,8 @@ private final class MethodCollector: SyntaxVisitor {
         return name != "Void" && name != "Swift.Void" && name != "()"
     }
 
-    /// 명목 타입 선언(class/struct/enum/actor): 타입 단위 방출 + enclosing 추적.
-    private func enterType(_ nameToken: TokenSyntax) -> SyntaxVisitorContinueKind {
+    /// 명목 타입 선언(class/struct/enum/actor/protocol): 타입 단위 방출 + enclosing 추적.
+    private func enterType(_ nameToken: TokenSyntax, _ declKind: AnalyzedUnit.TypeDeclKind) -> SyntaxVisitorContinueKind {
         let line = converter.location(for: nameToken.positionAfterSkippingLeadingTrivia).line
         withFacts(qualified(nameToken.text)) { $0.primary = .init(file: file, line: line, name: nameToken.text) }
         units.append(
@@ -170,7 +170,8 @@ private final class MethodCollector: SyntaxVisitor {
                 name: nameToken.text,
                 enclosingType: typeStack.last,
                 file: file,
-                line: line
+                line: line,
+                typeDeclKind: declKind
             )
         )
         typeStack.append(nameToken.text)

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Score/Scorer.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Score/Scorer.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// raw Measurements를 config 가중치로 점수화하는 per-unit pure 함수.
+/// 축적형=soft-cap 정규화, 병리형=고정 flag, 롤업=rolledUp 축에 α.
+public struct Scorer {
+
+    private let config: ScoringConfig
+
+    public init(config: ScoringConfig = .default) {
+        self.config = config
+    }
+
+    // MARK: - 메소드
+
+    public func scoreMethod(_ m: Measurements) -> Score {
+        Score(breakdown: [
+            "internalComplexity": accum(Double(m.internalComplexity ?? 0), config.internalComplexity),
+            "fanIn": accum(hopWeighted(m.fanInByHop), config.methodFanIn),
+            "cqsViolations": flag(m.cqsViolations, config.cqsViolations),
+            "combineRoleMix": flag(m.combineRoleMix, config.combineRoleMix),
+        ])
+    }
+
+    // MARK: - 타입
+
+    public func scoreType(_ m: Measurements) -> Score {
+        let a = config.rollupAlpha
+        return Score(breakdown: [
+            // 롤업 (× α) — 이슈 공식 α·Σ Score(메소드)의 실현
+            "rollup.internalComplexity": a * accum(Double(m.rolledUpInternalComplexity ?? 0), config.rolledUpInternalComplexity),
+            "rollup.cqsViolations": a * flag(m.rolledUpCqsViolations, config.rolledUpCqsViolations),
+            "rollup.combineRoleMix": a * flag(m.rolledUpCombineRoleMix, config.rolledUpCombineRoleMix),
+            // 객체 고유 (연결구조·표면적)
+            "publicSurface": accum(Double(m.publicSurface ?? 0), config.publicSurface),
+            "internalCoupling": accum(Double(m.internalCoupling ?? 0), config.internalCoupling),
+            "maxCallChainDepth": accum(Double(m.maxCallChainDepth ?? 0), config.maxCallChainDepth),
+            "lcom": flag(m.lcom, config.lcom),
+            // 협업
+            "fanOut": accum(Double(m.fanOut ?? 0), config.fanOut),
+            "collaborationChainDepth": accum(Double(m.collaborationChainDepth ?? 0), config.collaborationChainDepth),
+            "blastRadius": accum(hopWeighted(m.blastRadiusByHop), config.blastRadius),
+            "dependencyCycleSize": flag(m.dependencyCycleSize, config.dependencyCycleSize),
+        ])
+    }
+
+    // MARK: - dispatch
+
+    /// 유닛별 kind에 맞춰 score를 부착한다. per-unit pure — 유닛 간 참조 없음.
+    public func scored(_ units: [AnalyzedUnit]) -> [AnalyzedUnit] {
+        units.map { unit in
+            var scored = unit
+            switch unit.kind {
+            case .method: scored.score = scoreMethod(unit.measurements)
+            case .type: scored.score = scoreType(unit.measurements)
+            }
+            return scored
+        }
+    }
+
+    // MARK: - 채점 헬퍼
+
+    /// 축적형: cap으로 [0,1] 정규화 후 가중. cap ≤ 0이면 0.
+    private func accum(_ value: Double, _ p: ScoringConfig.AccumulativeParam) -> Double {
+        guard p.cap > 0 else { return 0 }
+        return min(value / p.cap, 1.0) * p.weight
+    }
+
+    /// 병리형: threshold 초과면 고정 penalty. ratchet 안 함(크기 무관).
+    private func flag(_ value: Int?, _ p: ScoringConfig.PathologyParam) -> Double {
+        Double(value ?? 0) > p.threshold ? p.penalty : 0
+    }
+
+    /// 간접 파급: hop별 비선형 가중 합. 짧은 배열까지만 zip.
+    private func hopWeighted(_ hops: [Int]?) -> Double {
+        guard let hops else { return 0 }
+        return zip(hops, config.hopWeights).reduce(0) { $0 + Double($1.0) * $1.1 }
+    }
+}

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Score/Scorer.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Score/Scorer.swift
@@ -34,13 +34,29 @@ public struct Scorer {
             "publicSurface": accum(Double(m.publicSurface ?? 0), config.publicSurface),
             "internalCoupling": accum(Double(m.internalCoupling ?? 0), config.internalCoupling),
             "maxCallChainDepth": accum(Double(m.maxCallChainDepth ?? 0), config.maxCallChainDepth),
-            "lcom": flag(m.lcom, config.lcom),
+            "lcom": lcomScore(m),
             // 협업
             "fanOut": accum(Double(m.fanOut ?? 0), config.fanOut),
             "collaborationChainDepth": accum(Double(m.collaborationChainDepth ?? 0), config.collaborationChainDepth),
             "blastRadius": accum(hopWeighted(m.blastRadiusByHop), config.blastRadius),
-            "dependencyCycleSize": flag(m.dependencyCycleSize, config.dependencyCycleSize),
+            "cycle": cyclePenalty(m),
         ])
+    }
+
+    /// LCOM 등급화 — 응집(lcom=1)은 0, (lcom-1)을 soft-cap해 쪼개질수록 커진다.
+    /// flat flag는 lcom=2(경미)와 lcom=8(심각)을 같게 벌해 facade를 과탐 → 크기로 등급화.
+    private func lcomScore(_ m: Measurements) -> Double {
+        guard let lcom = m.lcom, lcom > 1 else { return 0 }
+        return accum(Double(lcom - 1), config.lcom)
+    }
+
+    /// 순환 penalty 등급화 — 크기 soft-cap(값 클러스터 포함) + 순환 내 참조 타입당 병리 가중.
+    /// 값 타입만인 순환은 참조 수 0이라 경미하게, class/actor 낀 순환은 크게 벌한다.
+    private func cyclePenalty(_ m: Measurements) -> Double {
+        guard (m.dependencyCycleSize ?? 1) > 1 else { return 0 }
+        let sizeCost = accum(Double(m.dependencyCycleSize ?? 0), config.cycleSize)
+        let referenceCost = config.cycleReferenceTypePenalty * Double(m.cycleReferenceTypeCount ?? 0)
+        return sizeCost + referenceCost
     }
 
     // MARK: - dispatch

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Score/ScoringConfig.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Score/ScoringConfig.swift
@@ -27,12 +27,15 @@ public struct ScoringConfig: Equatable, Sendable, Codable {
     public var publicSurface: AccumulativeParam
     public var internalCoupling: AccumulativeParam
     public var maxCallChainDepth: AccumulativeParam
-    public var lcom: PathologyParam
+    public var lcom: AccumulativeParam  // 등급화: (lcom-1) soft-cap. 응집(1)=0
     // 협업
     public var fanOut: AccumulativeParam
     public var collaborationChainDepth: AccumulativeParam
     public var blastRadius: AccumulativeParam
-    public var dependencyCycleSize: PathologyParam
+    /// 순환 크기 자체(값 클러스터 포함)의 경미 가중 — soft-cap.
+    public var cycleSize: AccumulativeParam
+    /// 순환 안 참조 타입(class/actor) 1개당 병리 가중. 값 타입만인 순환은 0이라 경미하게 남는다.
+    public var cycleReferenceTypePenalty: Double
     // 롤업 (× rollupAlpha)
     public var rolledUpInternalComplexity: AccumulativeParam
     public var rolledUpCqsViolations: PathologyParam
@@ -51,11 +54,12 @@ public struct ScoringConfig: Equatable, Sendable, Codable {
         publicSurface: AccumulativeParam,
         internalCoupling: AccumulativeParam,
         maxCallChainDepth: AccumulativeParam,
-        lcom: PathologyParam,
+        lcom: AccumulativeParam,
         fanOut: AccumulativeParam,
         collaborationChainDepth: AccumulativeParam,
         blastRadius: AccumulativeParam,
-        dependencyCycleSize: PathologyParam,
+        cycleSize: AccumulativeParam,
+        cycleReferenceTypePenalty: Double,
         rolledUpInternalComplexity: AccumulativeParam,
         rolledUpCqsViolations: PathologyParam,
         rolledUpCombineRoleMix: PathologyParam,
@@ -73,7 +77,8 @@ public struct ScoringConfig: Equatable, Sendable, Codable {
         self.fanOut = fanOut
         self.collaborationChainDepth = collaborationChainDepth
         self.blastRadius = blastRadius
-        self.dependencyCycleSize = dependencyCycleSize
+        self.cycleSize = cycleSize
+        self.cycleReferenceTypePenalty = cycleReferenceTypePenalty
         self.rolledUpInternalComplexity = rolledUpInternalComplexity
         self.rolledUpCqsViolations = rolledUpCqsViolations
         self.rolledUpCombineRoleMix = rolledUpCombineRoleMix
@@ -101,11 +106,12 @@ public struct ScoringConfig: Equatable, Sendable, Codable {
         self.publicSurface = try acc(.publicSurface, d.publicSurface)
         self.internalCoupling = try acc(.internalCoupling, d.internalCoupling)
         self.maxCallChainDepth = try acc(.maxCallChainDepth, d.maxCallChainDepth)
-        self.lcom = try pat(.lcom, d.lcom)
+        self.lcom = try acc(.lcom, d.lcom)
         self.fanOut = try acc(.fanOut, d.fanOut)
         self.collaborationChainDepth = try acc(.collaborationChainDepth, d.collaborationChainDepth)
         self.blastRadius = try acc(.blastRadius, d.blastRadius)
-        self.dependencyCycleSize = try pat(.dependencyCycleSize, d.dependencyCycleSize)
+        self.cycleSize = try acc(.cycleSize, d.cycleSize)
+        self.cycleReferenceTypePenalty = try c.decodeIfPresent(Double.self, forKey: .cycleReferenceTypePenalty) ?? d.cycleReferenceTypePenalty
         self.rolledUpInternalComplexity = try acc(.rolledUpInternalComplexity, d.rolledUpInternalComplexity)
         self.rolledUpCqsViolations = try pat(.rolledUpCqsViolations, d.rolledUpCqsViolations)
         self.rolledUpCombineRoleMix = try pat(.rolledUpCombineRoleMix, d.rolledUpCombineRoleMix)
@@ -123,11 +129,12 @@ public struct ScoringConfig: Equatable, Sendable, Codable {
         publicSurface: .init(cap: 20, weight: 0.5),
         internalCoupling: .init(cap: 30, weight: 0.6),
         maxCallChainDepth: .init(cap: 6, weight: 0.5),
-        lcom: .init(threshold: 1, penalty: 4.0),
+        lcom: .init(cap: 6, weight: 1.5),
         fanOut: .init(cap: 20, weight: 0.7),
         collaborationChainDepth: .init(cap: 8, weight: 0.6),
         blastRadius: .init(cap: 60, weight: 0.8),
-        dependencyCycleSize: .init(threshold: 1, penalty: 5.0),
+        cycleSize: .init(cap: 12, weight: 1.0),
+        cycleReferenceTypePenalty: 2.0,
         rolledUpInternalComplexity: .init(cap: 80, weight: 1.0),
         rolledUpCqsViolations: .init(threshold: 0, penalty: 3.0),
         rolledUpCombineRoleMix: .init(threshold: 0, penalty: 2.0),

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Score/ScoringConfig.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Score/ScoringConfig.swift
@@ -81,6 +81,38 @@ public struct ScoringConfig: Equatable, Sendable, Codable {
         self.rollupAlpha = rollupAlpha
     }
 
+    // MARK: - 부분 override 디코딩
+
+    /// `--config` JSON은 일부 필드만 줘도 된다 — 없는 축은 `.default`로 fallback.
+    /// all-or-nothing을 피해 "가중치 하나만 튜닝"을 허용하고, 축 추가 시 기존 JSON이 깨지지 않게 한다.
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let d = ScoringConfig.default
+        func acc(_ k: CodingKeys, _ fallback: AccumulativeParam) throws -> AccumulativeParam {
+            try c.decodeIfPresent(AccumulativeParam.self, forKey: k) ?? fallback
+        }
+        func pat(_ k: CodingKeys, _ fallback: PathologyParam) throws -> PathologyParam {
+            try c.decodeIfPresent(PathologyParam.self, forKey: k) ?? fallback
+        }
+        self.internalComplexity = try acc(.internalComplexity, d.internalComplexity)
+        self.methodFanIn = try acc(.methodFanIn, d.methodFanIn)
+        self.cqsViolations = try pat(.cqsViolations, d.cqsViolations)
+        self.combineRoleMix = try pat(.combineRoleMix, d.combineRoleMix)
+        self.publicSurface = try acc(.publicSurface, d.publicSurface)
+        self.internalCoupling = try acc(.internalCoupling, d.internalCoupling)
+        self.maxCallChainDepth = try acc(.maxCallChainDepth, d.maxCallChainDepth)
+        self.lcom = try pat(.lcom, d.lcom)
+        self.fanOut = try acc(.fanOut, d.fanOut)
+        self.collaborationChainDepth = try acc(.collaborationChainDepth, d.collaborationChainDepth)
+        self.blastRadius = try acc(.blastRadius, d.blastRadius)
+        self.dependencyCycleSize = try pat(.dependencyCycleSize, d.dependencyCycleSize)
+        self.rolledUpInternalComplexity = try acc(.rolledUpInternalComplexity, d.rolledUpInternalComplexity)
+        self.rolledUpCqsViolations = try pat(.rolledUpCqsViolations, d.rolledUpCqsViolations)
+        self.rolledUpCombineRoleMix = try pat(.rolledUpCombineRoleMix, d.rolledUpCombineRoleMix)
+        self.hopWeights = try c.decodeIfPresent([Double].self, forKey: .hopWeights) ?? d.hopWeights
+        self.rollupAlpha = try c.decodeIfPresent(Double.self, forKey: .rollupAlpha) ?? d.rollupAlpha
+    }
+
     /// reasoned default — 전형적 Swift 코드 기준 "이 값에서 완전히 나쁨"을 cap으로,
     /// 병리형은 축적형 최대 기여를 압도하는 penalty로. 실측 튜닝 전 출발점.
     public static let `default` = ScoringConfig(

--- a/tools/complexity-analyzer/Sources/ComplexityCore/Score/ScoringConfig.swift
+++ b/tools/complexity-analyzer/Sources/ComplexityCore/Score/ScoringConfig.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// 스코어링 가중치·threshold·곡선 — 재빌드 없이 `--config <path>` JSON으로 override.
+/// 기본값(`default`)은 reasoned default — 실측 캘리브레이션은 후속(값만 갱신).
+public struct ScoringConfig: Equatable, Sendable, Codable {
+
+    /// 축적형(크기·개수): min(v/cap,1)*weight.
+    public struct AccumulativeParam: Equatable, Sendable, Codable {
+        public var cap: Double
+        public var weight: Double
+        public init(cap: Double, weight: Double) { self.cap = cap; self.weight = weight }
+    }
+
+    /// 병리형(오형태): v>threshold ? penalty : 0. ratchet 안 함.
+    public struct PathologyParam: Equatable, Sendable, Codable {
+        public var threshold: Double
+        public var penalty: Double
+        public init(threshold: Double, penalty: Double) { self.threshold = threshold; self.penalty = penalty }
+    }
+
+    // 메소드
+    public var internalComplexity: AccumulativeParam
+    public var methodFanIn: AccumulativeParam
+    public var cqsViolations: PathologyParam
+    public var combineRoleMix: PathologyParam
+    // 타입 고유 (연결구조·표면적)
+    public var publicSurface: AccumulativeParam
+    public var internalCoupling: AccumulativeParam
+    public var maxCallChainDepth: AccumulativeParam
+    public var lcom: PathologyParam
+    // 협업
+    public var fanOut: AccumulativeParam
+    public var collaborationChainDepth: AccumulativeParam
+    public var blastRadius: AccumulativeParam
+    public var dependencyCycleSize: PathologyParam
+    // 롤업 (× rollupAlpha)
+    public var rolledUpInternalComplexity: AccumulativeParam
+    public var rolledUpCqsViolations: PathologyParam
+    public var rolledUpCombineRoleMix: PathologyParam
+
+    /// 간접 파급 hop 곡선 — 직접(hop0) 싸고 간접 비선형 증폭. fanInByHop·blastRadiusByHop에 적용.
+    public var hopWeights: [Double]
+    /// 롤업 전가 계수 — 하위 복잡도의 상위 전가율.
+    public var rollupAlpha: Double
+
+    public init(
+        internalComplexity: AccumulativeParam,
+        methodFanIn: AccumulativeParam,
+        cqsViolations: PathologyParam,
+        combineRoleMix: PathologyParam,
+        publicSurface: AccumulativeParam,
+        internalCoupling: AccumulativeParam,
+        maxCallChainDepth: AccumulativeParam,
+        lcom: PathologyParam,
+        fanOut: AccumulativeParam,
+        collaborationChainDepth: AccumulativeParam,
+        blastRadius: AccumulativeParam,
+        dependencyCycleSize: PathologyParam,
+        rolledUpInternalComplexity: AccumulativeParam,
+        rolledUpCqsViolations: PathologyParam,
+        rolledUpCombineRoleMix: PathologyParam,
+        hopWeights: [Double],
+        rollupAlpha: Double
+    ) {
+        self.internalComplexity = internalComplexity
+        self.methodFanIn = methodFanIn
+        self.cqsViolations = cqsViolations
+        self.combineRoleMix = combineRoleMix
+        self.publicSurface = publicSurface
+        self.internalCoupling = internalCoupling
+        self.maxCallChainDepth = maxCallChainDepth
+        self.lcom = lcom
+        self.fanOut = fanOut
+        self.collaborationChainDepth = collaborationChainDepth
+        self.blastRadius = blastRadius
+        self.dependencyCycleSize = dependencyCycleSize
+        self.rolledUpInternalComplexity = rolledUpInternalComplexity
+        self.rolledUpCqsViolations = rolledUpCqsViolations
+        self.rolledUpCombineRoleMix = rolledUpCombineRoleMix
+        self.hopWeights = hopWeights
+        self.rollupAlpha = rollupAlpha
+    }
+
+    /// reasoned default — 전형적 Swift 코드 기준 "이 값에서 완전히 나쁨"을 cap으로,
+    /// 병리형은 축적형 최대 기여를 압도하는 penalty로. 실측 튜닝 전 출발점.
+    public static let `default` = ScoringConfig(
+        internalComplexity: .init(cap: 15, weight: 1.0),
+        methodFanIn: .init(cap: 60, weight: 0.8),
+        cqsViolations: .init(threshold: 0, penalty: 3.0),
+        combineRoleMix: .init(threshold: 0, penalty: 2.0),
+        publicSurface: .init(cap: 20, weight: 0.5),
+        internalCoupling: .init(cap: 30, weight: 0.6),
+        maxCallChainDepth: .init(cap: 6, weight: 0.5),
+        lcom: .init(threshold: 1, penalty: 4.0),
+        fanOut: .init(cap: 20, weight: 0.7),
+        collaborationChainDepth: .init(cap: 8, weight: 0.6),
+        blastRadius: .init(cap: 60, weight: 0.8),
+        dependencyCycleSize: .init(threshold: 1, penalty: 5.0),
+        rolledUpInternalComplexity: .init(cap: 80, weight: 1.0),
+        rolledUpCqsViolations: .init(threshold: 0, penalty: 3.0),
+        rolledUpCombineRoleMix: .init(threshold: 0, penalty: 2.0),
+        hopWeights: [1.0, 2.0, 4.0],
+        rollupAlpha: 0.5
+    )
+}

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/AnalyzerTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/AnalyzerTests.swift
@@ -40,8 +40,9 @@ struct AnalyzerTests {
     @Test("type scope는 그 타입과 소속 메소드만 남긴다")
     func typeScopeFilters() throws {
         let dir = try writeTempDir(["Two.swift": "struct A { func x() {} }\nstruct B { func y() {} }"])
+        let stub = StubIndexProvider(); stub.resolveAllTypes = true
 
-        let units = try Analyzer(index: StubIndexProvider()).analyze(sourceRoot: dir, scope: .type("A"))
+        let units = try Analyzer(index: stub).analyze(sourceRoot: dir, scope: .type("A"))
 
         #expect(units.contains { $0.kind == .type && $0.name == "A" })
         #expect(units.allSatisfy { $0.name == "A" || $0.enclosingType == "A" })
@@ -68,8 +69,9 @@ struct AnalyzerTests {
     @Test("메소드 단위에 CQS·Combine 측정이 실려 JSON에 나온다")
     func methodMeasuresInJSON() throws {
         let dir = try writeTempDir(["S.swift": "struct S { func f() -> Int { self.x = 1; return x } }"])
+        let stub = StubIndexProvider(); stub.resolveAllTypes = true
 
-        let units = try Analyzer(index: StubIndexProvider()).analyze(sourceRoot: dir, scope: .whole)
+        let units = try Analyzer(index: stub).analyze(sourceRoot: dir, scope: .whole)
         let method = units.first { $0.kind == .method }
         #expect(method?.measurements.cqsViolations == 1)
         #expect(method?.measurements.combineRoleMix == 0)
@@ -84,7 +86,8 @@ struct AnalyzerTests {
         let dir = try writeTempDir([
             "S.swift": "struct S { var x = 0; public func a() { self.x = 1 }; func b() { print(x) } }"
         ])
-        let units = try Analyzer(index: StubIndexProvider()).analyze(sourceRoot: dir, scope: .whole)
+        let stub = StubIndexProvider(); stub.resolveAllTypes = true
+        let units = try Analyzer(index: stub).analyze(sourceRoot: dir, scope: .whole)
         let type = units.first { $0.kind == .type }
         #expect(type?.measurements.lcom == 1)
         #expect(type?.measurements.publicSurface == 1)
@@ -104,7 +107,8 @@ struct AnalyzerTests {
             "A.swift": "struct S { var x = 0; public func a() { self.x = 1 } }",
             "B.swift": "extension S { public func b() { if q { if r {} } } }",
         ])
-        let units = try Analyzer(index: StubIndexProvider()).analyze(sourceRoot: dir, scope: .whole)
+        let stub = StubIndexProvider(); stub.resolveAllTypes = true
+        let units = try Analyzer(index: stub).analyze(sourceRoot: dir, scope: .whole)
         let s = units.first { $0.kind == .type && $0.name == "S" }?.measurements
         // a: internal 0, b: if{ if{} } = 3 → 다른 파일 extension까지 롤업 3
         #expect(s?.rolledUpInternalComplexity == 3)
@@ -147,6 +151,21 @@ struct AnalyzerTests {
         #expect(json.contains("\"dependencyCycleSize\""))
         #expect(json.contains("\"collaborationChainDepth\""))
         #expect(json.contains("\"blastRadiusByHop\""))
+    }
+
+    @Test("테스트 더블·프리뷰 더미 타입은 분석에서 제외")
+    func excludesTestDoubleTypes() throws {
+        let dir = try writeTempDir([
+            "M.swift": "struct Real { func a() {} }\nstruct DummyReal { func a() {} }\nfinal class FakeVM { func b() {} }"
+        ])
+        let stub = StubIndexProvider(); stub.resolveAllTypes = true
+        let units = try Analyzer(index: stub).analyze(sourceRoot: dir, scope: .whole)
+        let typeNames = Set(units.filter { $0.kind == .type }.map { $0.name })
+        #expect(typeNames.contains("Real"))
+        #expect(!typeNames.contains("DummyReal"))
+        #expect(!typeNames.contains("FakeVM"))
+        // 더미의 메서드도 빠짐
+        #expect(!units.contains { $0.enclosingType == "DummyReal" })
     }
 
     @Test("Scope 파싱")

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/CQSTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/CQSTests.swift
@@ -61,6 +61,14 @@ struct CQSTests {
         #expect(method("struct S { func load() -> Int { service.fetch { self.x = $0 }; return 0 } }").cqsViolations == 0)
     }
 
+    @Test("동기 forEach 안 self 대입은 CQS 위반 (지연 클로저와 구분)")
+    func synchronousForEachCounted() {
+        // forEach는 즉시 실행 → 동기 side-effect. escaping/반환 클로저와 달리 집계.
+        #expect(method("struct S { func f() -> Int { arr.forEach { self.x = 1 }; return 0 } }").cqsViolations == 1)
+        // 단 forEach가 sink(allowed) 안이면 바깥 컨텍스트가 이겨 위반 아님.
+        #expect(method("struct S { func f() -> P { pub.sink { self.arr.forEach { self.x = 1 } } } }").cqsViolations == 0)
+    }
+
     @Test("중첩 함수 안 side-effect는 바깥 메소드로 새지 않는다")
     func nestedFunctionScopeIsolated() {
         // outer는 `return 0`뿐인 순수 query — inner의 self.x=1이 새어들면 안 됨.

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/CQSTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/CQSTests.swift
@@ -34,6 +34,33 @@ struct CQSTests {
         #expect(method("struct S { func f() -> Int { var n = 0; n = 1; return n } }").cqsViolations == 0)
     }
 
+    @Test("로컬 복사본의 멤버 대입은 side-effect 아님 (functional update 패턴)")
+    func localCopyMemberAssignmentNotSideEffect() {
+        // var c = self; c.x = ...; return c — 도메인 immutable update 표준 패턴. self 대입이 아니다.
+        #expect(method("struct S { func f() -> S { var c = self; c.x = 1; return c } }").cqsViolations == 0)
+        // 로컬 복사본은 여러 필드를 갱신해도 위반 0
+        #expect(method("struct S { func f() -> S { var c = self; c.a = 1; c.b = 2; return c } }").cqsViolations == 0)
+    }
+
+    @Test("self·멤버 대입은 여전히 side-effect (오탐 수정이 정탐을 죽이지 않음)")
+    func selfAndMemberAssignmentStillFlagged() {
+        #expect(method("struct S { func f() -> Int { self.x = 1; return x } }").cqsViolations == 1)
+        #expect(method("struct S { func f() -> Int { subject.value = 1; return 0 } }").cqsViolations == 1)
+    }
+
+    @Test("클로저를 반환하는 factory의 클로저 내부 side-effect는 위반 아님 (지연 실행)")
+    func returnedClosureSideEffectNotCounted() {
+        // 반환 타입이 클로저 → 핸들러 factory. 반환 클로저 안 self.x=1·send는 나중에 실행 → 동기 CQS 위반 아님.
+        #expect(method("struct S { func make() -> (Int) -> Void { return { _ in self.x = 1 } } }").cqsViolations == 0)
+        #expect(method("struct S { func make() -> () -> Void { return { self.subject.value = 1 } } }").cqsViolations == 0)
+    }
+
+    @Test("escaping 콜백 클로저 안 side-effect도 위반 아님 (지연 실행)")
+    func escapingCallbackSideEffectNotCounted() {
+        // service.fetch { self.x = $0 } — 콜백은 나중에 실행. query가 값 반환해도 이 side-effect는 동기 아님.
+        #expect(method("struct S { func load() -> Int { service.fetch { self.x = $0 }; return 0 } }").cqsViolations == 0)
+    }
+
     @Test("중첩 함수 안 side-effect는 바깥 메소드로 새지 않는다")
     func nestedFunctionScopeIsolated() {
         // outer는 `return 0`뿐인 순수 query — inner의 self.x=1이 새어들면 안 됨.

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/FanInTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/FanInTests.swift
@@ -9,10 +9,13 @@ final class StubIndexProvider: IndexProviding {
     var referencesByUSR: [String: [ReferenceSite]] = [:]
     /// usr → 그 심볼을 감싸는 타입 usr
     var enclosingByUSR: [String: String] = [:]
+    /// true면 usrByLocation에 없는 정의도 합성 USR로 해소 — 그래프를 안 보는 테스트가
+    /// stale 가드(타입 해소 0개 → throw)에 안 걸리게 opt-in.
+    var resolveAllTypes = false
     private(set) var queriedUSRs: [String] = []
 
     func definitionUSR(named name: String, file: String, line: Int) -> String? {
-        usrByLocation["\(name)@\(file):\(line)"]
+        usrByLocation["\(name)@\(file):\(line)"] ?? (resolveAllTypes ? "usr:\(name):\(line)" : nil)
     }
 
     func references(toUSR usr: String) -> [ReferenceSite] {

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/FileEnumeratorTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/FileEnumeratorTests.swift
@@ -1,0 +1,55 @@
+import Testing
+import Foundation
+@testable import ComplexityCore
+
+@Suite("파일 열거 — 테스트 코드 제외")
+struct FileEnumeratorTests {
+
+    @Test("테스트 경로/타겟·더블 접두·Tests 접미는 테스트 코드")
+    func identifiesTestCode() {
+        #expect(SwiftFileEnumerator.isTestCode("/p/Domain/Tests/Usecases/FooUsecaseImpleTests.swift"))
+        #expect(SwiftFileEnumerator.isTestCode("/p/Supports/TestDoubles/StubTodoRepo.swift"))
+        #expect(SwiftFileEnumerator.isTestCode("/p/Supports/UnitTestHelpKit/BaseTestCase.swift"))
+        #expect(SwiftFileEnumerator.isTestCode("/p/Domain/Sources/StubEventLoader.swift"))   // 접두 Stub
+        #expect(SwiftFileEnumerator.isTestCode("/p/x/SpyRouter.swift"))
+        #expect(SwiftFileEnumerator.isTestCode("/p/x/FooTests.swift"))                        // 접미 Tests
+    }
+
+    @Test("production 소스는 테스트 코드 아님")
+    func productionIsNotTestCode() {
+        #expect(!SwiftFileEnumerator.isTestCode("/p/Domain/Sources/Models/Events/TodoEvent.swift"))
+        #expect(!SwiftFileEnumerator.isTestCode("/p/Domain/Sources/Usecases/EventTagUsecase.swift"))
+    }
+
+    @Test("스냅샷 디렉토리는 테스트 코드")
+    func snapshotsIsTestCode() {
+        #expect(SwiftFileEnumerator.isTestCode("/p/Presentations/CalendarScenes/Snapshots/CalendarScenesSnapshots.swift"))
+    }
+
+    @Test("Dummy/Fake/Stub/Spy/Mock 타입명은 테스트 더블")
+    func identifiesTestDoubleTypeName() {
+        #expect(SwiftFileEnumerator.isTestDoubleName("DummyMonthViewModel"))
+        #expect(SwiftFileEnumerator.isTestDoubleName("FakeDayEventListViewModel"))
+        #expect(SwiftFileEnumerator.isTestDoubleName("StubTodoRepository"))
+        #expect(!SwiftFileEnumerator.isTestDoubleName("TodoEvent"))
+        #expect(!SwiftFileEnumerator.isTestDoubleName("EventDetailRouter"))
+    }
+
+    @Test("열거는 production만 남기고 테스트 파일을 제외한다")
+    func enumerationExcludesTestFiles() throws {
+        let dir = NSTemporaryDirectory() + "cx-enum-" + UUID().uuidString
+        let sub = dir + "/Tests"
+        try FileManager.default.createDirectory(atPath: sub, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        try "struct A {}".write(toFile: dir + "/A.swift", atomically: true, encoding: .utf8)
+        try "struct StubB {}".write(toFile: dir + "/StubB.swift", atomically: true, encoding: .utf8)
+        try "struct C {}".write(toFile: dir + "/CTests.swift", atomically: true, encoding: .utf8)
+        try "struct D {}".write(toFile: sub + "/D.swift", atomically: true, encoding: .utf8)
+
+        let files = SwiftFileEnumerator.files(under: dir, scope: .whole)
+        #expect(files.contains { $0.hasSuffix("/A.swift") })
+        #expect(!files.contains { $0.hasSuffix("/StubB.swift") })   // 더블 접두
+        #expect(!files.contains { $0.hasSuffix("/CTests.swift") })  // Tests 접미
+        #expect(!files.contains { $0.contains("/Tests/") })          // 테스트 경로
+    }
+}

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/IndexStoreLocatorTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/IndexStoreLocatorTests.swift
@@ -72,6 +72,30 @@ struct IndexStoreLocatorTests {
         #expect(Set(stores) == [older, newer])
     }
 
+    @Test("pickBest — 해소 수 최대 후보 채택, 전부 0이면 nil")
+    func pickBestMaxResolved() {
+        let counts = ["a": 3, "b": 7, "c": 5]
+        #expect(IndexStoreLocator.pickBest(["a", "b", "c"]) { counts[$0]! } == "b")
+        #expect(IndexStoreLocator.pickBest(["a", "c"]) { counts[$0]! } == "c")
+        #expect(IndexStoreLocator.pickBest(["x", "y"]) { _ in 0 } == nil)   // 전부 0 → nil
+        #expect(IndexStoreLocator.pickBest([String]()) { _ in 1 } == nil)   // 빈 후보 → nil
+    }
+
+    @Test("workspace 비교는 심볼릭/경로 표기 차이를 정규화해 매칭")
+    func workspaceMatchNormalizesSymlink() throws {
+        let ddRoot = try makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: ddRoot) }
+        let realWs = ddRoot + "/repo/App.xcworkspace"
+        try FileManager.default.createDirectory(atPath: realWs, withIntermediateDirectories: true)
+        let mine = try makeDerivedData(ddRoot, name: "Proj-a", workspace: realWs)
+        // repo를 가리키는 심볼릭 링크 → 심볼릭 경유 경로로 조회해도 매칭돼야
+        try FileManager.default.createSymbolicLink(atPath: ddRoot + "/link", withDestinationPath: ddRoot + "/repo")
+        let viaLink = ddRoot + "/link/App.xcworkspace"
+
+        let stores = IndexStoreLocator.populatedDataStores(under: ddRoot, matchingWorkspace: viaLink)
+        #expect(stores == [mine])
+    }
+
     @Test("populated 아닌(units 빈) DerivedData는 제외")
     func excludesEmptyStore() throws {
         let ddRoot = try makeTempDir()

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/IndexStoreLocatorTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/IndexStoreLocatorTests.swift
@@ -1,0 +1,85 @@
+import Testing
+import Foundation
+@testable import ComplexityCore
+
+@Suite("IndexStoreLocator — 순수 탐색 로직")
+struct IndexStoreLocatorTests {
+
+    private func makeTempDir() throws -> String {
+        let dir = NSTemporaryDirectory() + "cx-loc-" + UUID().uuidString
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    // MARK: - 워크스페이스 추정
+
+    @Test("source-root에서 상위로 올라가며 .xcworkspace를 찾는다")
+    func findsWorkspaceAbove() throws {
+        let root = try makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let repo = root + "/MyRepo"
+        let src = repo + "/Domain/Sources"
+        try FileManager.default.createDirectory(atPath: src, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: repo + "/App.xcworkspace", withIntermediateDirectories: true)
+
+        #expect(IndexStoreLocator.workspacePath(above: src) == repo + "/App.xcworkspace")
+    }
+
+    @Test("워크스페이스가 없으면 nil")
+    func noWorkspaceIsNil() throws {
+        let root = try makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: root) }
+        let src = root + "/loose/Sources"
+        try FileManager.default.createDirectory(atPath: src, withIntermediateDirectories: true)
+        #expect(IndexStoreLocator.workspacePath(above: src) == nil)
+    }
+
+    // MARK: - 후보 열거·정렬·필터
+
+    /// populated DataStore(units 레코드 1개) + info.plist(WorkspacePath)를 가진 가짜 DerivedData 생성.
+    private func makeDerivedData(_ ddRoot: String, name: String, workspace: String) throws -> String {
+        let dd = ddRoot + "/" + name
+        let units = dd + "/Index.noindex/DataStore/v5/units"
+        try FileManager.default.createDirectory(atPath: units, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: units + "/u1", contents: Data("x".utf8))
+        let plist: [String: Any] = ["WorkspacePath": workspace]
+        (plist as NSDictionary).write(toFile: dd + "/info.plist", atomically: true)
+        return dd + "/Index.noindex/DataStore"
+    }
+
+    @Test("workspace로 필터 — 매칭되는 DerivedData만 남긴다")
+    func filtersByWorkspace() throws {
+        let ddRoot = try makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: ddRoot) }
+        let mine = try makeDerivedData(ddRoot, name: "Proj-aaa", workspace: "/repo/mine.xcworkspace")
+        _ = try makeDerivedData(ddRoot, name: "Proj-bbb", workspace: "/repo/other.xcworkspace")
+
+        let stores = IndexStoreLocator.populatedDataStores(under: ddRoot, matchingWorkspace: "/repo/mine.xcworkspace")
+        #expect(stores == [mine])
+    }
+
+    @Test("workspace nil이면 populated 전부, 최신 mtime 순")
+    func allPopulatedNewestFirst() throws {
+        let ddRoot = try makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: ddRoot) }
+        let older = try makeDerivedData(ddRoot, name: "Proj-old", workspace: "/repo/w.xcworkspace")
+        let newer = try makeDerivedData(ddRoot, name: "Proj-new", workspace: "/repo/w.xcworkspace")
+        // newer의 DataStore mtime을 미래로 밀어 최신으로 만든다.
+        try FileManager.default.setAttributes([.modificationDate: Date(timeIntervalSinceNow: 100)], ofItemAtPath: newer)
+
+        let stores = IndexStoreLocator.populatedDataStores(under: ddRoot, matchingWorkspace: nil)
+        #expect(stores.first == newer)
+        #expect(Set(stores) == [older, newer])
+    }
+
+    @Test("populated 아닌(units 빈) DerivedData는 제외")
+    func excludesEmptyStore() throws {
+        let ddRoot = try makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: ddRoot) }
+        // units 디렉토리는 있으나 레코드 없음 → assertPopulated 실패 → 제외
+        let empty = ddRoot + "/Proj-empty/Index.noindex/DataStore/v5/units"
+        try FileManager.default.createDirectory(atPath: empty, withIntermediateDirectories: true)
+
+        #expect(IndexStoreLocator.populatedDataStores(under: ddRoot, matchingWorkspace: nil).isEmpty)
+    }
+}

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/ProtocolUnitTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/ProtocolUnitTests.swift
@@ -28,4 +28,31 @@ struct ProtocolUnitTests {
         #expect(s?.enclosingType == nil)
         #expect(s?.measurements.rolledUpInternalComplexity == 1)
     }
+
+    @Test("타입 유닛에 선언 종류가 실린다")
+    func typeDeclKindCaptured() {
+        let us = units("protocol P { func f() }\nstruct S {}\nenum E { case a }\nclass C {}")
+        func kind(_ n: String) -> AnalyzedUnit.TypeDeclKind? {
+            us.first { $0.kind == .type && $0.name == n }?.typeDeclKind
+        }
+        #expect(kind("P") == .protocol)
+        #expect(kind("S") == .struct)
+        #expect(kind("E") == .enum)
+        #expect(kind("C") == .class)
+    }
+
+    @Test("protocol·enum은 LCOM 비적용(nil), struct/class는 적용")
+    func lcomExcludedForProtocolAndEnum() {
+        // 각 타입에 서로 안 엮이는 메소드 2개 → struct/class면 LCOM>1로 잡히지만
+        // protocol·enum은 nil이어야(과탐 제외).
+        let body = "func a() { print(x) }\n  func b() { print(y) }"
+        func lcom(_ decl: String) -> Int? {
+            SyntaxScanner().scan(source: "\(decl) T { \(body) }", file: "T.swift")
+                .first { $0.kind == .type && $0.name == "T" }?.measurements.lcom
+        }
+        #expect(lcom("struct") != nil)
+        #expect(lcom("class") != nil)
+        #expect(lcom("enum") == nil)
+        #expect(lcom("protocol") == nil)
+    }
 }

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScoreModelTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScoreModelTests.swift
@@ -1,0 +1,37 @@
+import Testing
+import Foundation
+@testable import ComplexityCore
+
+@Suite("Score 출력 모델")
+struct ScoreModelTests {
+
+    @Test("total은 breakdown 값의 합")
+    func totalSumsBreakdown() {
+        let s = Score(breakdown: ["a": 1.5, "b": 2.0, "c": 0.0])
+        #expect(s.total == 3.5)
+    }
+
+    @Test("빈 breakdown이면 total 0")
+    func emptyBreakdownZero() {
+        #expect(Score(breakdown: [:]).total == 0)
+    }
+
+    @Test("score 없는 유닛은 JSON에서 생략")
+    func nilScoreOmitted() throws {
+        let unit = AnalyzedUnit(kind: .method, name: "m", enclosingType: "A", file: "F.swift", line: 1)
+        let data = try JSONEncoder().encode(unit)
+        let json = String(decoding: data, as: UTF8.self)
+        #expect(!json.contains("score"))
+    }
+
+    @Test("score 부착 시 total·breakdown이 JSON에 포함")
+    func scoreSerialized() throws {
+        var unit = AnalyzedUnit(kind: .type, name: "A", enclosingType: nil, file: "F.swift", line: 1)
+        unit.score = Score(breakdown: ["fanOut": 0.7])
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let json = String(decoding: try encoder.encode(unit), as: UTF8.self)
+        #expect(json.contains("\"total\":0.7"))
+        #expect(json.contains("\"fanOut\":0.7"))
+    }
+}

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScorerMethodTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScorerMethodTests.swift
@@ -1,0 +1,53 @@
+import Testing
+@testable import ComplexityCore
+
+@Suite("Scorer — 메소드 채점")
+struct ScorerMethodTests {
+
+    /// cap 20/weight 1.0 등 검증이 쉬운 값으로 고정한 config.
+    private func config() -> ScoringConfig {
+        var c = ScoringConfig.default
+        c.internalComplexity = .init(cap: 20, weight: 1.0)
+        c.methodFanIn = .init(cap: 100, weight: 1.0)
+        c.cqsViolations = .init(threshold: 0, penalty: 3.0)
+        c.combineRoleMix = .init(threshold: 0, penalty: 2.0)
+        c.hopWeights = [1.0, 2.0, 4.0]
+        return c
+    }
+
+    @Test("축적형 soft-cap — cap 미만은 비례, cap 이상은 1.0로 포화")
+    func accumulativeSoftCap() {
+        let s = Scorer(config: config())
+        // internalComplexity 10 / cap 20 = 0.5 * weight 1.0
+        let half = s.scoreMethod(.init(internalComplexity: 10))
+        #expect(half.breakdown["internalComplexity"] == 0.5)
+        // 25 > cap 20 → 1.0 포화
+        let sat = s.scoreMethod(.init(internalComplexity: 25))
+        #expect(sat.breakdown["internalComplexity"] == 1.0)
+    }
+
+    @Test("병리형 flag — threshold 초과면 고정 penalty, 이하면 0")
+    func pathologyFlag() {
+        let s = Scorer(config: config())
+        #expect(s.scoreMethod(.init(cqsViolations: 0)).breakdown["cqsViolations"] == 0)
+        #expect(s.scoreMethod(.init(cqsViolations: 1)).breakdown["cqsViolations"] == 3.0)
+        // 크기 무관 — 5건도 1건과 같은 고정 penalty
+        #expect(s.scoreMethod(.init(cqsViolations: 5)).breakdown["cqsViolations"] == 3.0)
+    }
+
+    @Test("간접 파급 hop 가중 — 비선형 합산 후 soft-cap")
+    func fanInHopWeighted() {
+        let s = Scorer(config: config())
+        // fanInByHop [10,20,5], hopWeights [1,2,4] → 10+40+20 = 70 / cap 100 = 0.7
+        let sc = s.scoreMethod(.init(fanInByHop: [10, 20, 5]))
+        #expect(sc.breakdown["fanIn"] == 0.7)
+    }
+
+    @Test("nil 측정은 0 기여, total은 축 합")
+    func nilIsZeroAndTotalSums() {
+        let s = Scorer(config: config())
+        let sc = s.scoreMethod(.init(internalComplexity: 10, cqsViolations: 1))
+        // 0.5 + 3.0 + 0(roleMix) + 0(fanIn) = 3.5
+        #expect(sc.total == 3.5)
+    }
+}

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScorerMethodTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScorerMethodTests.swift
@@ -50,4 +50,22 @@ struct ScorerMethodTests {
         // 0.5 + 3.0 + 0(roleMix) + 0(fanIn) = 3.5
         #expect(sc.total == 3.5)
     }
+
+    @Test("cap ≤ 0이면 축적형 기여 0 (--config 방어)")
+    func nonPositiveCapIsZero() {
+        var c = config()
+        c.internalComplexity = .init(cap: 0, weight: 1.0)
+        #expect(Scorer(config: c).scoreMethod(.init(internalComplexity: 50)).breakdown["internalComplexity"] == 0)
+        c.internalComplexity = .init(cap: -5, weight: 1.0)
+        #expect(Scorer(config: c).scoreMethod(.init(internalComplexity: 50)).breakdown["internalComplexity"] == 0)
+    }
+
+    @Test("hopWeights가 hop 배열보다 짧으면 꼬리 hop은 truncate (--config로 짧게 준 경우)")
+    func hopWeightsShorterTruncates() {
+        var c = config()
+        c.methodFanIn = .init(cap: 100, weight: 1.0)
+        c.hopWeights = [1.0]  // hop1·2 가중 없음
+        // fanInByHop [10,20,5] → 10*1 = 10 (hop1·2 탈락) / cap 100 = 0.1
+        #expect(Scorer(config: c).scoreMethod(.init(fanInByHop: [10, 20, 5])).breakdown["fanIn"] == 0.1)
+    }
 }

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScorerTypeTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScorerTypeTests.swift
@@ -1,0 +1,81 @@
+import Testing
+@testable import ComplexityCore
+
+@Suite("Scorer — 타입 채점·롤업")
+struct ScorerTypeTests {
+
+    private func config() -> ScoringConfig {
+        var c = ScoringConfig.default
+        c.publicSurface = .init(cap: 20, weight: 1.0)
+        c.fanOut = .init(cap: 10, weight: 1.0)
+        c.blastRadius = .init(cap: 100, weight: 1.0)
+        c.collaborationChainDepth = .init(cap: 8, weight: 1.0)
+        c.internalCoupling = .init(cap: 30, weight: 1.0)
+        c.maxCallChainDepth = .init(cap: 6, weight: 1.0)
+        c.lcom = .init(threshold: 1, penalty: 4.0)
+        c.dependencyCycleSize = .init(threshold: 1, penalty: 5.0)
+        c.rolledUpInternalComplexity = .init(cap: 100, weight: 1.0)
+        c.rolledUpCqsViolations = .init(threshold: 0, penalty: 3.0)
+        c.rolledUpCombineRoleMix = .init(threshold: 0, penalty: 2.0)
+        c.hopWeights = [1.0, 2.0, 4.0]
+        c.rollupAlpha = 0.5
+        return c
+    }
+
+    @Test("객체 고유 축적형 — 표면적 soft-cap")
+    func publicSurfaceScored() {
+        let sc = Scorer(config: config()).scoreType(.init(publicSurface: 10))
+        #expect(sc.breakdown["publicSurface"] == 0.5)  // 10/20
+    }
+
+    @Test("병리형 flag — LCOM4>1·cycle>1 고정 penalty")
+    func typePathologyFlags() {
+        let s = Scorer(config: config())
+        // lcom 1 = 응집(정상) → 0, 2 = 끊김 → 4.0
+        #expect(s.scoreType(.init(lcom: 1)).breakdown["lcom"] == 0)
+        #expect(s.scoreType(.init(lcom: 2)).breakdown["lcom"] == 4.0)
+        // cycleSize 1 = 무순환 → 0, 3 = 순환 → 5.0
+        #expect(s.scoreType(.init(dependencyCycleSize: 1)).breakdown["dependencyCycleSize"] == 0)
+        #expect(s.scoreType(.init(dependencyCycleSize: 3)).breakdown["dependencyCycleSize"] == 5.0)
+    }
+
+    @Test("협업 blast — hop 비선형 가중")
+    func blastHopWeighted() {
+        // blastRadiusByHop [10,20,5], hopWeights [1,2,4] → 70 / cap 100 = 0.7
+        let sc = Scorer(config: config()).scoreType(.init(blastRadiusByHop: [10, 20, 5]))
+        #expect(sc.breakdown["blastRadius"] == 0.7)
+    }
+
+    @Test("롤업 — rolledUp 축에 α 전가")
+    func rollupScaledByAlpha() {
+        let s = Scorer(config: config())
+        // rolledUpInternalComplexity 100 / cap 100 = 1.0 * weight 1.0 * α 0.5 = 0.5
+        let sc = s.scoreType(.init(rolledUpInternalComplexity: 100))
+        #expect(sc.breakdown["rollup.internalComplexity"] == 0.5)
+        // rolledUpCqsViolations 2 > 0 → penalty 3.0 * α 0.5 = 1.5
+        let sc2 = s.scoreType(.init(rolledUpCqsViolations: 2))
+        #expect(sc2.breakdown["rollup.cqsViolations"] == 1.5)
+    }
+
+    @Test("total은 롤업·고유·협업 축 전부 합")
+    func totalSumsAllBlocks() {
+        // publicSurface 10(→0.5) + cycle 3(→5.0), 나머지 0 → 5.5
+        let sc = Scorer(config: config()).scoreType(.init(publicSurface: 10, dependencyCycleSize: 3))
+        #expect(sc.total == 5.5)
+    }
+
+    @Test("scored — kind별 dispatch로 score 부착")
+    func scoredDispatchesByKind() {
+        let units = [
+            AnalyzedUnit(kind: .method, name: "m", enclosingType: "A", file: "F.swift", line: 2,
+                         measurements: .init(internalComplexity: 30)),
+            AnalyzedUnit(kind: .type, name: "A", enclosingType: nil, file: "F.swift", line: 1,
+                         measurements: .init(dependencyCycleSize: 3)),
+        ]
+        let scored = Scorer(config: config()).scored(units)
+        #expect(scored.first { $0.kind == .method }?.score?.breakdown["internalComplexity"] != nil)
+        #expect(scored.first { $0.kind == .type }?.score?.breakdown["dependencyCycleSize"] == 5.0)
+        // 메소드엔 타입 축(dependencyCycleSize)이 없어야
+        #expect(scored.first { $0.kind == .method }?.score?.breakdown["dependencyCycleSize"] == nil)
+    }
+}

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScorerTypeTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScorerTypeTests.swift
@@ -12,8 +12,9 @@ struct ScorerTypeTests {
         c.collaborationChainDepth = .init(cap: 8, weight: 1.0)
         c.internalCoupling = .init(cap: 30, weight: 1.0)
         c.maxCallChainDepth = .init(cap: 6, weight: 1.0)
-        c.lcom = .init(threshold: 1, penalty: 4.0)
-        c.dependencyCycleSize = .init(threshold: 1, penalty: 5.0)
+        c.lcom = .init(cap: 4, weight: 4.0)  // (lcom-1)/4 * 4
+        c.cycleSize = .init(cap: 10, weight: 1.0)
+        c.cycleReferenceTypePenalty = 2.0
         c.rolledUpInternalComplexity = .init(cap: 100, weight: 1.0)
         c.rolledUpCqsViolations = .init(threshold: 0, penalty: 3.0)
         c.rolledUpCombineRoleMix = .init(threshold: 0, penalty: 2.0)
@@ -28,15 +29,29 @@ struct ScorerTypeTests {
         #expect(sc.breakdown["publicSurface"] == 0.5)  // 10/20
     }
 
-    @Test("병리형 flag — LCOM4>1·cycle>1 고정 penalty")
-    func typePathologyFlags() {
-        let s = Scorer(config: config())
-        // lcom 1 = 응집(정상) → 0, 2 = 끊김 → 4.0
-        #expect(s.scoreType(.init(lcom: 1)).breakdown["lcom"] == 0)
-        #expect(s.scoreType(.init(lcom: 2)).breakdown["lcom"] == 4.0)
-        // cycleSize 1 = 무순환 → 0, 3 = 순환 → 5.0
-        #expect(s.scoreType(.init(dependencyCycleSize: 1)).breakdown["dependencyCycleSize"] == 0)
-        #expect(s.scoreType(.init(dependencyCycleSize: 3)).breakdown["dependencyCycleSize"] == 5.0)
+    @Test("LCOM 등급 — 응집(1)은 0, 쪼개질수록 soft-cap으로 커짐")
+    func lcomGraded() {
+        let s = Scorer(config: config())  // (lcom-1)/cap4 * w4.0
+        #expect(s.scoreType(.init(lcom: 1)).breakdown["lcom"] == 0)     // 응집 정상
+        #expect(s.scoreType(.init(lcom: 2)).breakdown["lcom"] == 1.0)   // 경미(1/4*4)
+        #expect(s.scoreType(.init(lcom: 3)).breakdown["lcom"] == 2.0)   // 2/4*4
+        #expect(s.scoreType(.init(lcom: 9)).breakdown["lcom"] == 4.0)   // cap 포화
+        #expect(s.scoreType(.init(lcom: nil)).breakdown["lcom"] == 0)   // 미측정(protocol·enum)
+    }
+
+    @Test("순환 penalty 등급 — 값 클러스터는 크기만, 참조 타입 낀 순환은 크게")
+    func cyclePenaltyGraded() {
+        let s = Scorer(config: config())  // cycleSize cap10 w1.0, refPenalty 2.0
+        // 순환 아님(size 1) → 0
+        #expect(s.scoreType(.init(dependencyCycleSize: 1)).breakdown["cycle"] == 0)
+        // 값 타입만 순환(참조 0), size 3 → accum(3/10) = 0.3
+        #expect(s.scoreType(.init(dependencyCycleSize: 3, cycleReferenceTypeCount: 0)).breakdown["cycle"] == 0.3)
+        // 참조 2개 낀 size 3 → 0.3 + 2*2.0 = 4.3
+        #expect(s.scoreType(.init(dependencyCycleSize: 3, cycleReferenceTypeCount: 2)).breakdown["cycle"] == 4.3)
+        // 큰 값 클러스터(size 10, 참조 0)도 참조 낀 작은 순환보다 낮다
+        let bigValue = s.scoreType(.init(dependencyCycleSize: 10, cycleReferenceTypeCount: 0)).breakdown["cycle"]!
+        let smallRef = s.scoreType(.init(dependencyCycleSize: 2, cycleReferenceTypeCount: 1)).breakdown["cycle"]!
+        #expect(bigValue < smallRef)
     }
 
     @Test("협업 blast — hop 비선형 가중")
@@ -59,9 +74,9 @@ struct ScorerTypeTests {
 
     @Test("total은 롤업·고유·협업 축 전부 합")
     func totalSumsAllBlocks() {
-        // publicSurface 10(→0.5) + cycle 3(→5.0), 나머지 0 → 5.5
-        let sc = Scorer(config: config()).scoreType(.init(publicSurface: 10, dependencyCycleSize: 3))
-        #expect(sc.total == 5.5)
+        // publicSurface 10(→0.5) + cycle size3 값클러스터(→0.3), 나머지 0 → 0.8
+        let sc = Scorer(config: config()).scoreType(.init(publicSurface: 10, dependencyCycleSize: 3, cycleReferenceTypeCount: 0))
+        #expect(sc.total == 0.8)
     }
 
     @Test("scored — kind별 dispatch로 score 부착")
@@ -70,12 +85,13 @@ struct ScorerTypeTests {
             AnalyzedUnit(kind: .method, name: "m", enclosingType: "A", file: "F.swift", line: 2,
                          measurements: .init(internalComplexity: 30)),
             AnalyzedUnit(kind: .type, name: "A", enclosingType: nil, file: "F.swift", line: 1,
-                         measurements: .init(dependencyCycleSize: 3)),
+                         measurements: .init(dependencyCycleSize: 3, cycleReferenceTypeCount: 0)),
         ]
         let scored = Scorer(config: config()).scored(units)
         #expect(scored.first { $0.kind == .method }?.score?.breakdown["internalComplexity"] != nil)
-        #expect(scored.first { $0.kind == .type }?.score?.breakdown["dependencyCycleSize"] == 5.0)
-        // 메소드엔 타입 축(dependencyCycleSize)이 없어야
-        #expect(scored.first { $0.kind == .method }?.score?.breakdown["dependencyCycleSize"] == nil)
+        // 값 클러스터 순환 size3 → cycle 0.3
+        #expect(scored.first { $0.kind == .type }?.score?.breakdown["cycle"] == 0.3)
+        // 메소드엔 타입 축(cycle)이 없어야
+        #expect(scored.first { $0.kind == .method }?.score?.breakdown["cycle"] == nil)
     }
 }

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScorerWiringTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScorerWiringTests.swift
@@ -14,7 +14,7 @@ struct ScorerWiringTests {
         let file = dir + "/Sample.swift"
         try "struct Sample { func run() { if true { print(1) } } }".write(toFile: file, atomically: true, encoding: .utf8)
 
-        let units = try Analyzer(index: EmptyIndex()).analyze(sourceRoot: dir, scope: .whole)
+        let units = try Analyzer(index: ResolvingIndex()).analyze(sourceRoot: dir, scope: .whole)
         #expect(!units.isEmpty)
         // 모든 유닛에 score 부착
         #expect(units.allSatisfy { $0.score != nil })
@@ -44,9 +44,9 @@ struct ScorerWiringTests {
     }
 }
 
-/// 실 index 없이 배선만 검증 — 참조 질의는 전부 빈 결과.
-private struct EmptyIndex: IndexProviding {
-    func definitionUSR(named name: String, file: String, line: Int) -> String? { nil }
+/// 실 index 없이 배선만 검증 — 타입은 해소되게(stale 가드 회피) 하되 참조는 빈 결과.
+private struct ResolvingIndex: IndexProviding {
+    func definitionUSR(named name: String, file: String, line: Int) -> String? { "usr:\(name)" }
     func references(toUSR usr: String) -> [ReferenceSite] { [] }
     func enclosingTypeUSR(of usr: String) -> String? { nil }
 }

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScorerWiringTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScorerWiringTests.swift
@@ -1,0 +1,42 @@
+import Testing
+import Foundation
+@testable import ComplexityCore
+
+@Suite("스코어링 배선 — Analyzer 적용")
+struct ScorerWiringTests {
+
+    @Test("analyze 결과 유닛에 score가 부착되고 raw 측정도 보존")
+    func analyzeAttachesScore() throws {
+        // 최소 소스 하나를 스캔 — 실 index 없이도 SyntaxScanner 측정은 돈다.
+        let dir = NSTemporaryDirectory() + "cx-score-" + UUID().uuidString
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        let file = dir + "/Sample.swift"
+        try "struct Sample { func run() { if true { print(1) } } }".write(toFile: file, atomically: true, encoding: .utf8)
+
+        let units = try Analyzer(index: EmptyIndex()).analyze(sourceRoot: dir, scope: .whole)
+        #expect(!units.isEmpty)
+        // 모든 유닛에 score 부착
+        #expect(units.allSatisfy { $0.score != nil })
+        // raw 측정도 살아있음 (타입은 표면적 등)
+        let type = units.first { $0.kind == .type }
+        #expect(type?.measurements.publicSurface != nil)
+    }
+
+    @Test("JSON 출력에 score.total이 포함")
+    func jsonIncludesScore() throws {
+        let unit = AnalyzedUnit(kind: .type, name: "A", enclosingType: nil, file: "F.swift", line: 1,
+                                measurements: .init(publicSurface: 4),
+                                score: Scorer().scoreType(.init(publicSurface: 4)))
+        let json = try JSONReporter().string(for: [unit])
+        #expect(json.contains("\"total\""))
+        #expect(json.contains("\"publicSurface\""))
+    }
+}
+
+/// 실 index 없이 배선만 검증 — 참조 질의는 전부 빈 결과.
+private struct EmptyIndex: IndexProviding {
+    func definitionUSR(named name: String, file: String, line: Int) -> String? { nil }
+    func references(toUSR usr: String) -> [ReferenceSite] { [] }
+    func enclosingTypeUSR(of usr: String) -> String? { nil }
+}

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScorerWiringTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScorerWiringTests.swift
@@ -23,6 +23,16 @@ struct ScorerWiringTests {
         #expect(type?.measurements.publicSurface != nil)
     }
 
+    @Test("non-default config가 점수를 실제로 바꾼다 (--config 계약)")
+    func customConfigChangesScore() {
+        let m = Measurements(publicSurface: 10)
+        let base = Scorer(config: .default).scoreType(m).breakdown["publicSurface"]!
+        var c = ScoringConfig.default
+        c.publicSurface = .init(cap: c.publicSurface.cap, weight: c.publicSurface.weight * 2)
+        let doubled = Scorer(config: c).scoreType(m).breakdown["publicSurface"]!
+        #expect(doubled == base * 2)
+    }
+
     @Test("JSON 출력에 score.total이 포함")
     func jsonIncludesScore() throws {
         let unit = AnalyzedUnit(kind: .type, name: "A", enclosingType: nil, file: "F.swift", line: 1,

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScoringConfigTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScoringConfigTests.swift
@@ -34,4 +34,21 @@ struct ScoringConfigTests {
         let decoded = try JSONDecoder().decode(ScoringConfig.self, from: data)
         #expect(decoded == original)
     }
+
+    @Test("부분 JSON은 준 필드만 override, 나머지는 기본값")
+    func partialOverride() throws {
+        let json = "{\"rollupAlpha\": 0.9, \"internalComplexity\": {\"cap\": 99, \"weight\": 2.0}}"
+        let c = try JSONDecoder().decode(ScoringConfig.self, from: Data(json.utf8))
+        #expect(c.rollupAlpha == 0.9)
+        #expect(c.internalComplexity == .init(cap: 99, weight: 2.0))
+        // 안 준 필드는 기본값 유지
+        #expect(c.dependencyCycleSize == ScoringConfig.default.dependencyCycleSize)
+        #expect(c.hopWeights == ScoringConfig.default.hopWeights)
+    }
+
+    @Test("빈 JSON 객체는 전부 기본값")
+    func emptyJsonIsAllDefault() throws {
+        let c = try JSONDecoder().decode(ScoringConfig.self, from: Data("{}".utf8))
+        #expect(c == ScoringConfig.default)
+    }
 }

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScoringConfigTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScoringConfigTests.swift
@@ -1,0 +1,37 @@
+import Testing
+import Foundation
+@testable import ComplexityCore
+
+@Suite("ScoringConfig 외부화·기본값")
+struct ScoringConfigTests {
+
+    @Test("기본값은 채점에 필요한 축을 모두 정의")
+    func defaultDefinesAxes() {
+        let c = ScoringConfig.default
+        #expect(c.internalComplexity.cap > 0)
+        #expect(c.dependencyCycleSize.penalty > 0)
+        #expect(c.hopWeights.count == 3)
+        #expect(c.rollupAlpha > 0)
+    }
+
+    @Test("hop 가중은 비선형 증가 — 간접 홉이 더 비쌈")
+    func hopWeightsNonLinearIncreasing() {
+        let w = ScoringConfig.default.hopWeights
+        #expect(w[0] < w[1])
+        #expect(w[1] < w[2])
+    }
+
+    @Test("병리형은 축적형보다 큰 가중 — cycle penalty > publicSurface weight")
+    func pathologyOutweighsAccumulative() {
+        let c = ScoringConfig.default
+        #expect(c.dependencyCycleSize.penalty > c.publicSurface.weight)
+    }
+
+    @Test("JSON encode→decode 라운드트립이 기본값과 동일 (--config 계약)")
+    func jsonRoundTrips() throws {
+        let original = ScoringConfig.default
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ScoringConfig.self, from: data)
+        #expect(decoded == original)
+    }
+}

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScoringConfigTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/ScoringConfigTests.swift
@@ -9,7 +9,8 @@ struct ScoringConfigTests {
     func defaultDefinesAxes() {
         let c = ScoringConfig.default
         #expect(c.internalComplexity.cap > 0)
-        #expect(c.dependencyCycleSize.penalty > 0)
+        #expect(c.cycleReferenceTypePenalty > 0)
+        #expect(c.cycleSize.cap > 0)
         #expect(c.hopWeights.count == 3)
         #expect(c.rollupAlpha > 0)
     }
@@ -21,10 +22,10 @@ struct ScoringConfigTests {
         #expect(w[1] < w[2])
     }
 
-    @Test("병리형은 축적형보다 큰 가중 — cycle penalty > publicSurface weight")
+    @Test("병리형은 축적형보다 큰 가중 — 참조 순환 penalty > publicSurface weight")
     func pathologyOutweighsAccumulative() {
         let c = ScoringConfig.default
-        #expect(c.dependencyCycleSize.penalty > c.publicSurface.weight)
+        #expect(c.cycleReferenceTypePenalty > c.publicSurface.weight)
     }
 
     @Test("JSON encode→decode 라운드트립이 기본값과 동일 (--config 계약)")
@@ -42,7 +43,8 @@ struct ScoringConfigTests {
         #expect(c.rollupAlpha == 0.9)
         #expect(c.internalComplexity == .init(cap: 99, weight: 2.0))
         // 안 준 필드는 기본값 유지
-        #expect(c.dependencyCycleSize == ScoringConfig.default.dependencyCycleSize)
+        #expect(c.cycleSize == ScoringConfig.default.cycleSize)
+        #expect(c.cycleReferenceTypePenalty == ScoringConfig.default.cycleReferenceTypePenalty)
         #expect(c.hopWeights == ScoringConfig.default.hopWeights)
     }
 

--- a/tools/complexity-analyzer/Tests/ComplexityCoreTests/TypeGraphAggregatorTests.swift
+++ b/tools/complexity-analyzer/Tests/ComplexityCoreTests/TypeGraphAggregatorTests.swift
@@ -9,7 +9,7 @@ struct TypeGraphAggregatorTests {
     }
 
     @Test("caller의 enclosing 타입으로 엣지를 만들어 측정을 부착한다")
-    func attachesGraphMeasures() {
+    func attachesGraphMeasures() throws {
         // 타입 A(line 1)·B(line 2). A의 메소드 mA가 B를 참조 → 엣지 A→B.
         let stub = StubIndexProvider()
         stub.usrByLocation["A@F.swift:1"] = "uA"
@@ -17,7 +17,7 @@ struct TypeGraphAggregatorTests {
         stub.referencesByUSR["uB"] = [.init(callerUSRs: ["mA"])]
         stub.enclosingByUSR["mA"] = "uA"
 
-        let patched = TypeGraphAggregator.patched(
+        let patched = try TypeGraphAggregator.patched(
             units: [typeUnit("A", 1), typeUnit("B", 2)],
             index: stub,
             maxBlastHop: 2
@@ -32,35 +32,79 @@ struct TypeGraphAggregatorTests {
     }
 
     @Test("self-참조와 미해소 caller는 엣지에서 제외")
-    func skipsSelfAndUnresolved() {
+    func skipsSelfAndUnresolved() throws {
         let stub = StubIndexProvider()
         stub.usrByLocation["A@F.swift:1"] = "uA"
         stub.referencesByUSR["uA"] = [.init(callerUSRs: ["mA", "orphan"])]
         stub.enclosingByUSR["mA"] = "uA"   // self
         // "orphan"은 enclosingByUSR에 없음 → nil
 
-        let patched = TypeGraphAggregator.patched(units: [typeUnit("A", 1)], index: stub, maxBlastHop: 2)
+        let patched = try TypeGraphAggregator.patched(units: [typeUnit("A", 1)], index: stub, maxBlastHop: 2)
         let a = patched.first { $0.name == "A" }?.measurements
         #expect(a?.fanOut == 0)
         #expect(a?.blastRadiusByHop == [0, 0, 0])
     }
 
     @Test("known 집합 밖 타입으로의 enclosing은 엣지 제외")
-    func skipsEdgeToUnknownType() {
+    func skipsEdgeToUnknownType() throws {
         let stub = StubIndexProvider()
         stub.usrByLocation["A@F.swift:1"] = "uA"
         stub.referencesByUSR["uA"] = [.init(callerUSRs: ["mExternal"])]
         stub.enclosingByUSR["mExternal"] = "uExternal"  // 유닛에 없는 타입
 
-        let patched = TypeGraphAggregator.patched(units: [typeUnit("A", 1)], index: stub, maxBlastHop: 2)
+        let patched = try TypeGraphAggregator.patched(units: [typeUnit("A", 1)], index: stub, maxBlastHop: 2)
         #expect(patched.first { $0.name == "A" }?.measurements.blastRadiusByHop == [0, 0, 0])
     }
 
     @Test("메소드 유닛은 그래프 측정 미부착(패스스루)")
-    func methodUnitsUntouched() {
+    func methodUnitsUntouched() throws {
         let stub = StubIndexProvider()
         let method = AnalyzedUnit(kind: .method, name: "m", enclosingType: "A", file: "F.swift", line: 3)
-        let patched = TypeGraphAggregator.patched(units: [method], index: stub, maxBlastHop: 2)
+        let patched = try TypeGraphAggregator.patched(units: [method], index: stub, maxBlastHop: 2)
         #expect(patched.first?.measurements.fanOut == nil)
+    }
+
+    @Test("순환 멤버에 SCC 내 참조 타입(class/actor) 수가 부착된다")
+    func attachesCycleReferenceCount() throws {
+        // A(class) ↔ B(struct) 상호 참조 → 2-cycle. 참조 타입 1개(A) → 둘 다 count 1.
+        let stub = StubIndexProvider()
+        stub.usrByLocation["A@F.swift:1"] = "uA"
+        stub.usrByLocation["B@F.swift:2"] = "uB"
+        stub.referencesByUSR["uB"] = [.init(callerUSRs: ["mA"])]  // A→B
+        stub.referencesByUSR["uA"] = [.init(callerUSRs: ["mB"])]  // B→A
+        stub.enclosingByUSR["mA"] = "uA"
+        stub.enclosingByUSR["mB"] = "uB"
+
+        let units = [
+            AnalyzedUnit(kind: .type, name: "A", enclosingType: nil, file: "F.swift", line: 1, typeDeclKind: .class),
+            AnalyzedUnit(kind: .type, name: "B", enclosingType: nil, file: "F.swift", line: 2, typeDeclKind: .struct),
+        ]
+        let patched = try TypeGraphAggregator.patched(units: units, index: stub, maxBlastHop: 2)
+        #expect(patched.first { $0.name == "A" }?.measurements.dependencyCycleSize == 2)
+        #expect(patched.first { $0.name == "A" }?.measurements.cycleReferenceTypeCount == 1)
+        #expect(patched.first { $0.name == "B" }?.measurements.cycleReferenceTypeCount == 1)
+    }
+
+    @Test("순환 아닌 타입은 cycleReferenceTypeCount nil")
+    func nonCycleHasNilReferenceCount() throws {
+        let stub = StubIndexProvider()
+        stub.usrByLocation["A@F.swift:1"] = "uA"
+        stub.usrByLocation["B@F.swift:2"] = "uB"
+        stub.referencesByUSR["uB"] = [.init(callerUSRs: ["mA"])]  // A→B (일방)
+        stub.enclosingByUSR["mA"] = "uA"
+        let units = [
+            AnalyzedUnit(kind: .type, name: "A", enclosingType: nil, file: "F.swift", line: 1, typeDeclKind: .struct),
+            AnalyzedUnit(kind: .type, name: "B", enclosingType: nil, file: "F.swift", line: 2, typeDeclKind: .struct),
+        ]
+        let patched = try TypeGraphAggregator.patched(units: units, index: stub, maxBlastHop: 2)
+        #expect(patched.first { $0.name == "A" }?.measurements.cycleReferenceTypeCount == nil)
+    }
+
+    @Test("타입 유닛이 있는데 USR 해소 0개면 stale로 throw (silent-0 방지)")
+    func throwsWhenNoTypeResolves() {
+        let stub = StubIndexProvider()  // usrByLocation 비어있음 → 해소 0
+        #expect(throws: IndexStoreError.self) {
+            try TypeGraphAggregator.patched(units: [typeUnit("A", 1)], index: stub, maxBlastHop: 2)
+        }
     }
 }


### PR DESCRIPTION
복잡도 분석기의 **스코어링 도입 + 신뢰성 확보(오탐/과탐 제거) + index 자동탐색**을 묶은 PR. 페이즈 5(스코어링)로 시작해, 앱 전체 실측에서 드러난 오탐/과탐을 전수 조사·수정하고, 워크트리별 index를 자연스럽게 물도록 인프라를 갖췄다.

## 문제 → 접근

**스코어링(페이즈 5)**: 페이즈 1~4가 raw 측정 16필드를 채우지만 종합할 점수 레이어가 없었다. per-unit pure `Scorer`로 축적형(soft-cap)·병리형(flag)·계층 롤업(α)을 합성, config 외부화(`--config`, 부분 override).

**신뢰성**: 실측을 돌려보니 점수가 오탐/과탐에 오염돼 있었다 — 조사·수정:
- **측정 오탐**: protocol·enum을 LCOM으로 과탐(구현 없는 인터페이스·case 분기) / CQS가 로컬 복사본 mutation·반환·escaping 클로저(지연 실행)를 동기 위반으로 오인 / 테스트·더미·Snapshots 코드가 측정에 혼입
- **스코어링 과탐**: flat flag가 크기를 무시 — 순환은 값 클러스터(struct/enum)와 참조 타입(class/actor) 낀 순환을 갈라 등급화, LCOM은 크기 등급 + 가중 재보정(coordinator 클래스 과탐 완화)

**인프라**: index가 다른 워크트리에서 빌드돼 경로 불일치 → 협업 측정이 조용히 전부 nil. → stale이면 명시 에러 + `--index-store-path` 생략 시 현재 워크트리 소스를 해소하는 index를 자동 선택(clean 빌드 불필요).

## 검증

앱 전체(1667타입·3460메서드) 3레벨 전수 → 진짜 계산 엔진(`EventRepeatTimeEnumerator`)이 제 위치로, 한 축 독점 없음, 참조 타입 순환 0개. 127 유닛 테스트 GREEN.

## 남은 과제 (의도적 제외)

- 판정·게이트(exit 0/1, before/after baseline, size-gating) → 페이즈 6 스킬 래퍼
- 가중치 실제값은 reasoned default — 실측 분포 기반 정밀 튜닝은 값만 `--config`로 갱신
- 경계 CQS(lazy-init memoization·UIKit-Combine 브릿지)는 기술적으로 정확한 측정이라 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3rfY2j6yrf4TxPfJb2kpf
