### PR TITLE
[#701] AI job 종료 시 data mutation 기반 앱 리프레시

### DIFF
--- a/Domain/Sources/Models/AI/AICommand+Job.swift
+++ b/Domain/Sources/Models/AI/AICommand+Job.swift
@@ -134,9 +134,36 @@ public struct AIJobDataMutation: Sendable {
     
     public let dataType: DataType
     public let operation: Operation
-    
+
     public init(dataType: DataType, operation: Operation) {
         self.dataType = dataType
         self.operation = operation
+    }
+}
+
+
+// MARK: - mutation event-sync 판정
+
+extension AIJobResult {
+
+    public var mutations: [AIJobDataMutation] {
+        switch self {
+        case .done(let result): return result.mutations
+        case .confirm(let result): return result.mutations
+        case .failed(let result): return result.mutations
+        case .canceled(let result): return result.mutations
+        }
+    }
+}
+
+extension AIJobDataMutation.DataType {
+
+    // 델타 event sync(eventTag/todo/schedule)로 커버되는 dataType.
+    // done은 동반 todo mutation으로 반영, event_detail은 상세화면 on-demand 로드라 제외.
+    public var requiresEventSync: Bool {
+        switch self {
+        case .todo, .schedule, .tag: return true
+        case .doneTodo, .eventDetail: return false
+        }
     }
 }

--- a/Domain/Sources/Models/AI/AICommand+Job.swift
+++ b/Domain/Sources/Models/AI/AICommand+Job.swift
@@ -71,6 +71,7 @@ public enum AIJobResult: Sendable {
     case done(DoneResult)
     case confirm(ConfirmResult)
     case failed(FailResult)
+    case canceled(CanceledResult)
 }
 
 extension AIJobResult {
@@ -95,7 +96,13 @@ extension AIJobResult {
         public var reason: String?
         public var mutations: [AIJobDataMutation] = []
         public var errorCode: ServerErrorModel.ErrorCode?
-        
+
+        public init() { }
+    }
+
+    public struct CanceledResult: Sendable {
+        public var mutations: [AIJobDataMutation] = []
+
         public init() { }
     }
 }

--- a/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
@@ -46,15 +46,18 @@ public final class AIAgentOrchestrationUsecaseImple: AIAgentOrchestrationUsecase
     private let commandUsecase: any AICommandUsecase
     private let usageUsecase: any AIAgentUsageUsecase
     private let speechRecognizeUsecase: any SpeechRecognizeUsecase
+    private let eventSyncUsecase: any EventSyncUsecase
 
     public init(
         commandUsecase: any AICommandUsecase,
         usageUsecase: any AIAgentUsageUsecase,
-        speechRecognizeUsecase: any SpeechRecognizeUsecase
+        speechRecognizeUsecase: any SpeechRecognizeUsecase,
+        eventSyncUsecase: any EventSyncUsecase
     ) {
         self.commandUsecase = commandUsecase
         self.usageUsecase = usageUsecase
         self.speechRecognizeUsecase = speechRecognizeUsecase
+        self.eventSyncUsecase = eventSyncUsecase
     }
 
     private struct Subject {
@@ -85,6 +88,7 @@ public final class AIAgentOrchestrationUsecaseImple: AIAgentOrchestrationUsecase
 
     private func handleJobResult(_ job: AIJob) {
         guard job.isFinish else { return }
+        self.triggerEventSyncIfNeeded(job.result)
         if job.status == .rejected || job.status == .canceled {
             self.subject.state.send(.idle)
             return
@@ -106,6 +110,15 @@ public final class AIAgentOrchestrationUsecaseImple: AIAgentOrchestrationUsecase
         case .canceled:
             self.subject.state.send(.idle)
         }
+    }
+
+    // job이 데이터를 바꿨으면(sync 대상 mutation) 델타 sync 1회.
+    // 실제 재조회는 sync→syncEnd→CalendarViewModel.refreshEvents 체인이 처리.
+    private func triggerEventSyncIfNeeded(_ result: AIJobResult?) {
+        guard let result,
+              result.mutations.contains(where: { $0.dataType.requiresEventSync })
+        else { return }
+        self.eventSyncUsecase.sync()
     }
 }
 

--- a/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
@@ -103,6 +103,8 @@ public final class AIAgentOrchestrationUsecaseImple: AIAgentOrchestrationUsecase
             )
         case .failed(let fail):
             self.subject.state.send(.failed(command: job.command ?? "", reason: fail.reason))
+        case .canceled:
+            self.subject.state.send(.idle)
         }
     }
 }

--- a/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
@@ -12,6 +12,7 @@ import Combine
 import Prelude
 import Optics
 import UnitTestHelpKit
+import TestDoubles
 import Extensions
 
 @testable import Domain
@@ -23,16 +24,19 @@ class AIAgentOrchestrationUsecaseImpleTests: PublisherWaitable {
     private var stubCommand: StubAICommandUsecase!
     private var stubUsage: StubAIAgentUsageUsecase!
     private var stubSpeech: StubSpeechRecognizeUsecase!
+    private var stubSync: StubEventSyncUsecase!
 
     private func makeUsecase(shouldFail: Bool = false) -> AIAgentOrchestrationUsecaseImple {
         self.stubCommand = .init()
         self.stubCommand.shouldFail = shouldFail
         self.stubUsage = .init()
         self.stubSpeech = .init()
+        self.stubSync = .init()
         return AIAgentOrchestrationUsecaseImple(
             commandUsecase: self.stubCommand,
             usageUsecase: self.stubUsage,
-            speechRecognizeUsecase: self.stubSpeech
+            speechRecognizeUsecase: self.stubSpeech,
+            eventSyncUsecase: self.stubSync
         )
     }
 
@@ -90,6 +94,21 @@ class AIAgentOrchestrationUsecaseImpleTests: PublisherWaitable {
         case .failed: return .failed
         case .canceled: return .canceled
         }
+    }
+
+    private func mutation(
+        _ type: AIJobDataMutation.DataType,
+        _ op: AIJobDataMutation.Operation = .created
+    ) -> AIJobDataMutation {
+        return AIJobDataMutation(dataType: type, operation: op)
+    }
+
+    private func doneResult(with mutations: [AIJobDataMutation]) -> AIJobResult {
+        return .done(
+            AIJobResult.DoneResult()
+            |> \.text .~ "완료"
+            |> \.mutations .~ mutations
+        )
     }
 
     private func stateName(_ state: AIAgentState) -> String {
@@ -419,6 +438,141 @@ extension AIAgentOrchestrationUsecaseImpleTests {
         #expect(states.last.map(self.stateName) == "idle")
         #expect(self.stubCommand.didRejectParentJobId == "parent-job")
         #expect(self.stubCommand.didCancelJobId == nil)  // decline은 cancelOngoing 호출 안 함
+    }
+}
+
+
+// MARK: - job 종료 시 mutation 기반 event sync 트리거
+
+// submit은 동기 흐름(Just 방출 → handleJobResult 즉시 실행)이라 submit 반환 시점에
+// sync 트리거 판정이 끝나 있다. 별도 대기 없이 stubSync 호출을 관찰한다.
+extension AIAgentOrchestrationUsecaseImpleTests {
+
+    @Test("done 결과에 todo mutation이 있으면 sync를 1회 트리거한다")
+    func usecase_whenDoneWithTodoMutation_triggersSyncOnce() async throws {
+        // given
+        let usecase = self.makeUsecaseWithCommandJob(
+            self.dummyJob(self.doneResult(with: [self.mutation(.todo)]))
+        )
+        // when
+        try? usecase.submit("할 일 추가해줘")
+        // then
+        #expect(self.stubSync.didSyncRequested == true)
+        #expect(self.stubSync.didSyncRequestedCount == 1)
+    }
+
+    @Test(
+        "schedule/tag mutation도 sync를 트리거한다",
+        arguments: [AIJobDataMutation.DataType.schedule, .tag]
+    )
+    func usecase_whenDoneWithSyncTargetMutation_triggersSync(
+        _ type: AIJobDataMutation.DataType
+    ) async throws {
+        // given
+        let usecase = self.makeUsecaseWithCommandJob(
+            self.dummyJob(self.doneResult(with: [self.mutation(type)]))
+        )
+        // when
+        try? usecase.submit("명령")
+        // then
+        #expect(self.stubSync.didSyncRequested == true)
+    }
+
+    @Test("sync 대상·비대상 mutation이 섞여 있으면 sync를 트리거한다")
+    func usecase_whenMixedMutation_triggersSync() async throws {
+        // given — 한 액션이 done+todo 여러 mutation을 낼 수 있음 (예: complete → [{todo,updated},{done,created}])
+        let usecase = self.makeUsecaseWithCommandJob(
+            self.dummyJob(self.doneResult(with: [
+                self.mutation(.doneTodo), self.mutation(.todo, .updated)
+            ]))
+        )
+        // when
+        try? usecase.submit("완료 처리해줘")
+        // then
+        #expect(self.stubSync.didSyncRequested == true)
+    }
+
+    @Test("done/event_detail mutation만 있으면 sync를 트리거하지 않는다")
+    func usecase_whenDoneWithNonSyncMutationOnly_doesNotTriggerSync() async throws {
+        // given
+        let usecase = self.makeUsecaseWithCommandJob(
+            self.dummyJob(self.doneResult(with: [
+                self.mutation(.doneTodo), self.mutation(.eventDetail, .updated)
+            ]))
+        )
+        // when
+        try? usecase.submit("완료 처리해줘")
+        // then
+        #expect(self.stubSync.didSyncRequested == false)
+    }
+
+    @Test("mutation이 비어있으면 sync를 트리거하지 않는다 (조회 전용 커맨드)")
+    func usecase_whenNoMutation_doesNotTriggerSync() async throws {
+        // given
+        let usecase = self.makeUsecaseWithCommandJob(self.dummyJob(self.doneResult(with: [])))
+        // when
+        try? usecase.submit("오늘 일정 뭐 있어?")
+        // then
+        #expect(self.stubSync.didSyncRequested == false)
+    }
+
+    @Test("confirm 결과에 sync 대상 mutation이 있으면 sync를 트리거한다")
+    func usecase_whenConfirmWithSyncTargetMutation_triggersSync() async throws {
+        // given
+        var confirm = AIJobResult.ConfirmResult()
+        confirm.text = "정말 삭제할까요?"
+        confirm.action = AIConfirmCommandAction() |> \.confirmToken .~ "tk-1"
+        confirm.mutations = [self.mutation(.schedule, .deleted)]
+        let usecase = self.makeUsecaseWithCommandJob(
+            self.dummyJob(.confirm(confirm), command: "일정 삭제해줘")
+        )
+        // when
+        try? usecase.submit("일정 삭제해줘")
+        // then
+        #expect(self.stubSync.didSyncRequested == true)
+    }
+
+    @Test("failed 결과에 sync 대상 mutation이 있으면 sync를 트리거한다")
+    func usecase_whenFailedWithSyncTargetMutation_triggersSync() async throws {
+        // given
+        var fail = AIJobResult.FailResult()
+        fail.reason = "일부만 처리됨"
+        fail.mutations = [self.mutation(.todo)]
+        let usecase = self.makeUsecaseWithCommandJob(self.dummyJob(.failed(fail)))
+        // when
+        try? usecase.submit("여러 개 추가해줘")
+        // then
+        #expect(self.stubSync.didSyncRequested == true)
+    }
+
+    @Test("canceled 결과의 커밋된 mutation도 sync를 트리거한다")
+    func usecase_whenCanceledWithMutation_triggersSync() async throws {
+        // given
+        let canceled = AIJobResult.canceled(
+            AIJobResult.CanceledResult() |> \.mutations .~ [self.mutation(.todo)]
+        )
+        let usecase = self.makeUsecaseWithCommandJob(
+            self.dummyJob(canceled, status: .canceled)
+        )
+        // when
+        try? usecase.submit("추가하다 중지")
+        // then
+        #expect(self.stubSync.didSyncRequested == true)
+    }
+
+    @Test("rejected 결과(직전 confirm의 커밋된 mutation)도 sync를 트리거한다")
+    func usecase_whenRejectedWithPriorMutation_triggersSync() async throws {
+        // given — REJECTED는 result에 직전 CONFIRM 객체가 남고, 그 mutations는 confirm 이전 커밋분
+        var confirm = AIJobResult.ConfirmResult()
+        confirm.action = AIConfirmCommandAction() |> \.confirmToken .~ "tk-1"
+        confirm.mutations = [self.mutation(.schedule, .updated)]
+        let usecase = self.makeUsecaseWithCommandJob(
+            self.dummyJob(.confirm(confirm), status: .rejected)
+        )
+        // when
+        try? usecase.submit("여러 작업 후 거부")
+        // then
+        #expect(self.stubSync.didSyncRequested == true)
     }
 }
 

--- a/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
@@ -88,6 +88,7 @@ class AIAgentOrchestrationUsecaseImpleTests: PublisherWaitable {
         case .done: return .done
         case .confirm: return .confirm
         case .failed: return .failed
+        case .canceled: return .canceled
         }
     }
 

--- a/Repository/Sources/Repository+Imple/AI/AICommand+Mapping.swift
+++ b/Repository/Sources/Repository+Imple/AI/AICommand+Mapping.swift
@@ -107,6 +107,12 @@ struct AIJobResultMapper {
                 |> \.mutations .~ mutations
             )
 
+        case "CANCELED":
+            self.result = .canceled(
+                AIJobResult.CanceledResult()
+                |> \.mutations .~ mutations
+            )
+
         default:
             self.result = nil
         }

--- a/Repository/Tests/AI/AICommandRepositoryImpleTests.swift
+++ b/Repository/Tests/AI/AICommandRepositoryImpleTests.swift
@@ -214,6 +214,22 @@ extension AICommandRepositoryImpleTests {
         XCTAssertFalse(job.isFinish)
         XCTAssertNil(job.result)
     }
+
+    func testRepository_loadJob_canceled_parsesMutations() async throws {
+        // given
+        let repository = self.makeRepository()
+
+        // when
+        let job = try await repository.loadJob("canceled_job")
+
+        // then — CANCELED result의 mutation이 파싱된다
+        XCTAssertEqual(job.status, .canceled)
+        guard case .canceled(let result) = job.result else {
+            XCTFail("expect canceled result"); return
+        }
+        XCTAssertEqual(result.mutations.map { $0.dataType }, [.todo])
+        XCTAssertEqual(result.mutations.map { $0.operation }, [.created])
+    }
 }
 
 
@@ -361,6 +377,11 @@ private struct DummyResponse {
             ),
             .init(
                 method: .get,
+                endpoint: AIAPIEndpoints.job(id: "canceled_job"),
+                resultJsonString: .success(self.canceledJobJson)
+            ),
+            .init(
+                method: .get,
                 endpoint: AIAPIEndpoints.usage,
                 resultJsonString: .success(self.usageJson)
             )
@@ -437,6 +458,23 @@ private struct DummyResponse {
             "job_id": "running_job",
             "status": "RUNNING",
             "mode": "command"
+        }
+        """
+    }
+
+    private var canceledJobJson: String {
+        return """
+        {
+            "job_id": "canceled_job",
+            "status": "CANCELED",
+            "mode": "command",
+            "result": {
+                "type": "CANCELED",
+                "text": "중지했어요",
+                "mutations": [
+                    { "dataType": "todo", "op": "created" }
+                ]
+            }
         }
         """
     }

--- a/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
+++ b/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
@@ -68,10 +68,11 @@ struct NonLoginUsecaseFactoryImple: UsecaseFactory {
         self.aiAgentOrchestrationUsecase = AIAgentOrchestrationUsecaseImple(
             commandUsecase: aiCommandUsecase,
             usageUsecase: aiUsageUsecase,
-            speechRecognizeUsecase: speech
+            speechRecognizeUsecase: speech,
+            eventSyncUsecase: self.eventSyncUsecase
         )
     }
-    
+
     var eventNotifyService: SharedEventNotifyService {
         return self.applicationBase.eventNotifyService
     }
@@ -475,7 +476,8 @@ struct LoginUsecaseFactoryImple: UsecaseFactory {
         self.aiAgentOrchestrationUsecase = AIAgentOrchestrationUsecaseImple(
             commandUsecase: aiCommandUsecase,
             usageUsecase: aiUsageUsecase,
-            speechRecognizeUsecase: speech
+            speechRecognizeUsecase: speech,
+            eventSyncUsecase: self.eventSyncUsecase
         )
     }
 


### PR DESCRIPTION
## 문제

AI job이 종료(done/confirm/failed/canceled/rejected)되면 서버는 이미 데이터를 바꿨지만, 앱은 응답의 `result.mutations`를 아무도 읽지 않는다. `handleJobResult`가 status→state만 방출하고 mutation을 버려서, **앱이 켜진 채 job이 끝나는 케이스**가 사각지대 — 다음 포그라운드 복귀/range 변경/sync까지 변경이 안 보인다. #694(job 상태 즉시 반영)의 후속.

부수 결함: 매퍼가 CANCELED result를 `nil`로 떨궈, 사용자 중지 시점까지 커밋된 mutation이 파싱 단계에서 유실됐다.

## 접근

mutation을 보는 유일한 앱 레벨 단일 지점 `AIAgentOrchestrationUsecaseImple`에 `eventSyncUsecase`를 주입하고, finished job의 mutation에 sync 대상(todo/schedule/tag) dataType이 있으면 `sync()`를 1회 던진다. 실제 재조회는 **기존 `sync()` → `syncEnd` → `CalendarViewModel.refreshEvents(가시범위)` 체인을 재사용** — 신규 range 인프라 0. 트리거를 status early-return **앞**에 둬 canceled/rejected의 커밋된 mutation까지 커버.

- **커밋 1** — `AIJobResult.canceled(CanceledResult)` case 신설 + 매퍼 `CANCELED` 분기로 mutation 파싱. exhaustive switch 리플.
- **커밋 2** — `handleJobResult`에 mutation→sync 배선(CQS로 state 방출과 분리), `AIJobResult.mutations`/`DataType.requiresEventSync` 판정 헬퍼, 콜사이트 2곳 주입.

dataType 분기: schedule/todo/tag → sync(델타 싱크가 커버) / done → sync 밖(동반 todo mutation으로 반영) / event_detail → no-op(상세화면 on-demand).

타이밍: `sync()` 진입 시 `cancelSync()` 선호출이라 포그라운드 복귀 sync와 겹쳐도 중복 없음.

## 검증

- Repository: CANCELED 파싱 테스트. Domain: 종료 결과 5종(done/confirm/failed/canceled/rejected) × dataType 매트릭스(sync 대상·비대상·혼합·빈 배열) behavior 테스트로 트리거 판별력 검증. 앱 타깃 빌드로 콜사이트 무결성 확인.
- 서버 스키마 확정(#228): `result` 내부 camelCase는 의도된 것 — 매핑 형식은 이미 맞아 수정 대상 아님.

## 남은 과제 (의도적 제외)

- done 목록 화면은 자체 페이징, event_detail은 상세 진입 시 on-demand 로드 — sync 범위 밖으로 남긴다.
- `CanceledResult.text`·`result.notification`은 소비처가 없어 미파싱(YAGNI). 소비 필요 시 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UAbJ6T8Wak4oCosu7JFNdJ
