### PR TITLE
[#690] 하네스 지속 개선 flywheel — 준수 자가 기록·교정 누적·임계 판정·improve-skill

### DIFF
--- a/.claude/hooks/log-record.py
+++ b/.claude/hooks/log-record.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""에이전트 발동형 레코드 기록기 — skill_end(준수 자가 기록)·correction(유저 교정)·improvement(정비 마킹).
+
+훅이 아니라 에이전트가 CLI로 직접 호출한다 (CLAUDE.md §1 공통 조항, #690).
+사용법 오류는 exit 2 (호출자가 재시도), 그 외 오류는 fail-open exit 0.
+"""
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+LOG_DIR = os.environ.get("USAGE_LOG_DIR") or os.path.expanduser("~/.claude/usage-log")
+
+
+def now_iso():
+    return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+
+
+def append_record(record):
+    os.makedirs(LOG_DIR, exist_ok=True)
+    path = os.path.join(LOG_DIR, datetime.now().strftime("%Y-%m-%d") + ".jsonl")
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def usage_error(message):
+    print(f"log-record: {message}", file=sys.stderr)
+    sys.exit(2)
+
+
+def parse_deviations(raw_list):
+    deviations = []
+    for raw in raw_list:
+        clause, _, reason = raw.partition("::")
+        deviations.append({"clause": clause.strip(), "reason": reason.strip()})
+    return deviations
+
+
+def build_record(args):
+    record = {
+        "ts": now_iso(),
+        "event": args.event,
+        "session_id": args.session or os.environ.get("CLAUDE_CODE_SESSION_ID", ""),
+        "cwd": os.getcwd(),
+    }
+    if args.event == "skill_end":
+        if not args.name or not args.compliance:
+            usage_error("skill_end엔 --name·--compliance 필수")
+        deviations = parse_deviations(args.deviation)
+        if args.compliance == "partial" and not deviations:
+            usage_error("partial엔 --deviation '조항::사유' 필수")
+        record.update({"name": args.name, "compliance": args.compliance, "deviations": deviations})
+    elif args.event == "correction":
+        if not args.summary:
+            usage_error("correction엔 --summary 필수")
+        skills = [s.strip() for s in args.skills.split(",") if s.strip()]
+        record.update({"skills": skills, "summary": args.summary, "gist": args.gist or ""})
+    else:  # improvement
+        if not args.name:
+            usage_error("improvement엔 --name 필수")
+        record["name"] = args.name
+    return record
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("event", choices=["skill_end", "correction", "improvement"])
+    parser.add_argument("--name", help="대상 스킬명 (skill_end·improvement)")
+    parser.add_argument("--compliance", choices=["full", "partial"])
+    parser.add_argument("--deviation", action="append", default=[], help="'조항::사유' 형식, 반복 가능")
+    parser.add_argument("--skills", default="", help="쉼표 구분 귀속 스킬 (correction)")
+    parser.add_argument("--summary", help="교정 요지 (correction)")
+    parser.add_argument("--gist", help="유저 발화 요지 (correction)")
+    parser.add_argument("--session", help="session_id override — 생략 시 CLAUDE_CODE_SESSION_ID env")
+    args = parser.parse_args()
+    append_record(build_record(args))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception:
+        sys.exit(0)

--- a/.claude/hooks/log-record.test.sh
+++ b/.claude/hooks/log-record.test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# log-record.py 회귀 테스트 — 임시 USAGE_LOG_DIR에 CLI 호출을 흘려 기록 검증
+cd "$(dirname "$0")" || exit 1
+PASS=0; FAIL=0
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+export USAGE_LOG_DIR="$TMP_DIR"
+export CLAUDE_CODE_SESSION_ID="env-session"
+TODAY=$(date +%Y-%m-%d)
+LOG="$TMP_DIR/$TODAY.jsonl"
+
+last_line() { tail -1 "$LOG"; }
+field() { # json_line key — 스칼라 값
+  printf '%s' "$1" | python3 -c "import json,sys; print(json.load(sys.stdin).get('$2',''))"
+}
+field_json() { # json_line key — 배열·객체 값을 JSON 문자열로
+  printf '%s' "$1" | python3 -c "import json,sys; print(json.dumps(json.load(sys.stdin).get('$2'), ensure_ascii=False))"
+}
+assert_eq() { # desc expected actual
+  if [ "$2" = "$3" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); echo "FAIL: $1"; echo "  expected: [$2]"; echo "  actual:   [$3]"; fi
+}
+
+# --- skill_end full ---
+python3 log-record.py skill_end --name implement --compliance full
+assert_eq "skill_end 이벤트" "skill_end" "$(field "$(last_line)" event)"
+assert_eq "skill_end 이름" "implement" "$(field "$(last_line)" name)"
+assert_eq "compliance full" "full" "$(field "$(last_line)" compliance)"
+assert_eq "full의 deviations 빈 배열" "[]" "$(field_json "$(last_line)" deviations)"
+assert_eq "session env 폴백" "env-session" "$(field "$(last_line)" session_id)"
+
+# --- skill_end partial + deviation 파싱 ---
+python3 log-record.py skill_end --name implement --compliance partial \
+  --deviation "리팩터 게이트 생략::1파일 단순 수정" --deviation "스킴 계산 생략::테스트 無 경로"
+DEVS=$(field_json "$(last_line)" deviations)
+assert_eq "deviation 2건" "2" "$(printf '%s' "$DEVS" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")"
+assert_eq "clause 파싱" "리팩터 게이트 생략" "$(printf '%s' "$DEVS" | python3 -c "import json,sys; print(json.load(sys.stdin)[0]['clause'])")"
+assert_eq "reason 파싱" "1파일 단순 수정" "$(printf '%s' "$DEVS" | python3 -c "import json,sys; print(json.load(sys.stdin)[0]['reason'])")"
+
+# --- partial인데 deviation 없음 → exit 2 + 미기록 ---
+BEFORE=$(wc -l < "$LOG" | tr -d ' ')
+python3 log-record.py skill_end --name implement --compliance partial 2>/dev/null
+assert_eq "partial deviation 누락 exit 2" "2" "$?"
+assert_eq "partial deviation 누락 미기록" "$BEFORE" "$(wc -l < "$LOG" | tr -d ' ')"
+
+# --- correction 귀속 스킬 리스트 ---
+python3 log-record.py correction --skills "implement, pr" --summary "stub에 검증 넣지 말라" --gist "stub에서 assert 하지마"
+assert_eq "correction 이벤트" "correction" "$(field "$(last_line)" event)"
+assert_eq "skills 파싱" '["implement", "pr"]' "$(field_json "$(last_line)" skills)"
+assert_eq "summary 기록" "stub에 검증 넣지 말라" "$(field "$(last_line)" summary)"
+
+# --- correction 미귀속 (skills 생략) → 빈 배열 ---
+python3 log-record.py correction --summary "귀속 스킬 없는 교정"
+assert_eq "미귀속 skills 빈 배열" "[]" "$(field_json "$(last_line)" skills)"
+
+# --- correction summary 누락 → exit 2 ---
+python3 log-record.py correction --skills implement 2>/dev/null
+assert_eq "correction summary 누락 exit 2" "2" "$?"
+
+# --- improvement 마킹 ---
+python3 log-record.py improvement --name kickoff
+assert_eq "improvement 이벤트" "improvement" "$(field "$(last_line)" event)"
+assert_eq "improvement 이름" "kickoff" "$(field "$(last_line)" name)"
+
+# --- --session 인자가 env보다 우선 ---
+python3 log-record.py skill_end --name plan --compliance full --session "arg-session"
+assert_eq "--session 우선" "arg-session" "$(field "$(last_line)" session_id)"
+
+echo "---"
+echo "PASS: $PASS / FAIL: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.claude/hooks/log-usage.py
+++ b/.claude/hooks/log-usage.py
@@ -9,11 +9,13 @@ import json
 import os
 import re
 import sys
+import time
 from datetime import datetime, timezone
 
 LOG_DIR = os.environ.get("USAGE_LOG_DIR") or os.path.expanduser("~/.claude/usage-log")
 PROMPT_LIMIT = 500
 DETAIL_LIMIT = 200
+SESSION_STATE_TTL_DAYS = 7
 
 
 def now_iso():
@@ -38,6 +40,25 @@ def append_record(record):
     os.makedirs(LOG_DIR, exist_ok=True)
     with open(log_path(), "a", encoding="utf-8") as f:
         f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def enforce_dir_permission():
+    try:
+        os.chmod(LOG_DIR, 0o700)
+    except OSError:
+        pass
+
+
+def prune_stale_sessions():
+    sessions_dir = os.path.join(LOG_DIR, ".sessions")
+    cutoff = time.time() - SESSION_STATE_TTL_DAYS * 86400
+    try:
+        for entry in os.listdir(sessions_dir):
+            path = os.path.join(sessions_dir, entry)
+            if os.path.getmtime(path) < cutoff:
+                os.remove(path)
+    except OSError:
+        pass
 
 
 def save_instruction(session_id, prompt):
@@ -82,6 +103,9 @@ def handle_prompt(data):
         skill_record["via"] = "slash"
         skill_record["instruction"] = snippet
         append_record(skill_record)
+
+    enforce_dir_permission()
+    prune_stale_sessions()
 
 
 def handle_tool(data):

--- a/.claude/hooks/log-usage.test.sh
+++ b/.claude/hooks/log-usage.test.sh
@@ -74,6 +74,19 @@ BEFORE=$(wc -l < "$LOG" | tr -d ' ')
 run_hook '{"hook_event_name":"PostToolUse","session_id":"s1","cwd":"/proj","tool_name":"Read","tool_input":{"file_path":"/foo"}}'
 assert_eq "무관 툴 미기록" "$BEFORE" "$(wc -l < "$LOG" | tr -d ' ')"
 
+# --- 운영: prompt 처리 시 로그 디렉토리 700 강제 ---
+chmod 755 "$TMP_DIR"
+run_hook '{"hook_event_name":"UserPromptSubmit","session_id":"s1","cwd":"/proj","prompt":"권한 확인"}'
+assert_eq "로그 디렉토리 700" "700" "$(stat -f "%Lp" "$TMP_DIR")"
+
+# --- 운영: 7일 지난 세션 state prune, 최신은 보존 ---
+STALE="$TMP_DIR/.sessions/stale-session.json"
+printf '{"instruction":"old"}' > "$STALE"
+touch -t "$(date -v-8d +%Y%m%d%H%M)" "$STALE"
+run_hook '{"hook_event_name":"UserPromptSubmit","session_id":"s1","cwd":"/proj","prompt":"prune 트리거"}'
+assert_eq "8일 지난 state 제거" "0" "$(ls "$TMP_DIR/.sessions" | grep -c stale-session)"
+assert_eq "최신 state 보존" "1" "$(ls "$TMP_DIR/.sessions" | grep -c '^s1.json$')"
+
 # --- fail-open: 깨진 입력에도 exit 0 ---
 printf 'not-json' | python3 log-usage.py
 assert_eq "fail-open exit 0 (깨진 JSON)" "0" "$?"

--- a/.claude/scripts/aggregate-usage.py
+++ b/.claude/scripts/aggregate-usage.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""스킬별 usage-log 집계·임계 판정 — 초과 항목만 정비 권고로 출력한다 (#690).
+
+- improvement 마킹 이벤트의 최대 ts 이후 레코드만 집계 (정비 반영분은 신호에서 소비 처리).
+  ts는 ISO8601 문자열 사전순 비교 — 타임존 혼재 시 근사치.
+- 발동/종료는 count 기반 (세션 조인 없음 — 단순성 우선).
+- (미귀속) 버킷은 --all 진단 표에만 노출 — 스킬이 아니라 정비(improvement 마킹) 소비 경로가 없어 임계 판정에서 제외.
+- exit 0 고정: 게이트가 아니라 제안이다. 임계는 usage-thresholds.json.
+"""
+import argparse
+import glob
+import json
+import os
+
+LOG_DIR = os.environ.get("USAGE_LOG_DIR") or os.path.expanduser("~/.claude/usage-log")
+CONFIG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "usage-thresholds.json")
+UNATTRIBUTED = "(미귀속)"
+
+
+def load_records():
+    records = []
+    for path in sorted(glob.glob(os.path.join(LOG_DIR, "*.jsonl"))):
+        try:
+            with open(path, encoding="utf-8") as f:
+                for line in f:
+                    try:
+                        records.append(json.loads(line))
+                    except ValueError:
+                        continue
+        except OSError:
+            continue
+    return records
+
+
+def improvement_marks(records):
+    marks = {}
+    for record in records:
+        if record.get("event") != "improvement" or not record.get("name"):
+            continue
+        name = record["name"]
+        marks[name] = max(marks.get(name, ""), record.get("ts", ""))
+    return marks
+
+
+def aggregate(records):
+    marks = improvement_marks(records)
+    stats = {}
+
+    def stat(name):
+        return stats.setdefault(name, {"invocations": 0, "ends": 0, "full": 0, "partial": 0, "corrections": 0})
+
+    def is_fresh(name, record):
+        return record.get("ts", "") > marks.get(name, "")
+
+    for record in records:
+        event = record.get("event")
+        if event == "skill":
+            name = record.get("name", "")
+            if name and is_fresh(name, record):
+                stat(name)["invocations"] += 1
+        elif event == "skill_end":
+            name = record.get("name", "")
+            if name and is_fresh(name, record):
+                entry = stat(name)
+                entry["ends"] += 1
+                entry["partial" if record.get("compliance") == "partial" else "full"] += 1
+        elif event == "correction":
+            for name in record.get("skills") or [UNATTRIBUTED]:
+                if is_fresh(name, record):
+                    stat(name)["corrections"] += 1
+    return stats
+
+
+def missing_rate(entry):
+    if entry["invocations"] == 0:
+        return 0.0
+    return max(0.0, 1.0 - entry["ends"] / entry["invocations"])
+
+
+def violations(stats, thresholds):
+    lines = []
+    for name, entry in sorted(stats.items()):
+        if name == UNATTRIBUTED:
+            continue
+        if entry["corrections"] >= thresholds["correction_count"]:
+            lines.append(f"⚠️ {name} — correction {entry['corrections']}건 (임계 {thresholds['correction_count']})")
+        if entry["partial"] >= thresholds["partial_count"]:
+            lines.append(f"⚠️ {name} — 준수 partial {entry['partial']}건 (임계 {thresholds['partial_count']})")
+        if entry["invocations"] >= thresholds["min_invocations_for_missing"]:
+            rate = missing_rate(entry)
+            if rate >= thresholds["missing_rate"]:
+                lines.append(
+                    f"⚠️ {name} — 종료 레코드 누락률 {rate:.0%} "
+                    f"(발동 {entry['invocations']}·종료 {entry['ends']}, 임계 {thresholds['missing_rate']:.0%})"
+                )
+    return lines
+
+
+def full_table(stats):
+    header = f"{'스킬':<24} {'발동':>4} {'종료':>4} {'full':>5} {'partial':>7} {'correction':>10}"
+    lines = [header]
+    for name, entry in sorted(stats.items()):
+        lines.append(
+            f"{name:<24} {entry['invocations']:>4} {entry['ends']:>4} "
+            f"{entry['full']:>5} {entry['partial']:>7} {entry['corrections']:>10}"
+        )
+    return lines
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--all", action="store_true", help="임계와 무관하게 스킬별 전체 집계 표 출력")
+    args = parser.parse_args()
+
+    with open(CONFIG_PATH, encoding="utf-8") as f:
+        thresholds = json.load(f)
+
+    stats = aggregate(load_records())
+    lines = full_table(stats) if args.all else violations(stats, thresholds)
+    if lines:
+        print("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/aggregate-usage.test.sh
+++ b/.claude/scripts/aggregate-usage.test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# aggregate-usage.py 회귀 테스트 — fixture JSONL로 집계·임계 판정 검증
+cd "$(dirname "$0")" || exit 1
+PASS=0; FAIL=0
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+export USAGE_LOG_DIR="$TMP_DIR"
+
+assert_eq() { # desc expected actual
+  if [ "$2" = "$3" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); echo "FAIL: $1"; echo "  expected: [$2]"; echo "  actual:   [$3]"; fi
+}
+assert_contains() { # desc substring text
+  case "$3" in *"$2"*) PASS=$((PASS+1));; *) FAIL=$((FAIL+1)); echo "FAIL: $1"; echo "  missing: [$2]"; echo "  in: [$3]";; esac
+}
+
+FIXTURE="$TMP_DIR/2026-01-01.jsonl"
+cat > "$FIXTURE" << 'JSONL'
+{"ts":"2026-01-01T09:00:00+09:00","event":"skill","session_id":"s1","name":"implement"}
+{"ts":"2026-01-01T09:10:00+09:00","event":"skill","session_id":"s1","name":"implement"}
+{"ts":"2026-01-01T09:20:00+09:00","event":"skill","session_id":"s2","name":"implement"}
+{"ts":"2026-01-01T09:30:00+09:00","event":"skill","session_id":"s2","name":"implement"}
+{"ts":"2026-01-01T09:40:00+09:00","event":"skill","session_id":"s3","name":"implement"}
+{"ts":"2026-01-01T09:45:00+09:00","event":"skill_end","session_id":"s1","name":"implement","compliance":"full","deviations":[]}
+{"ts":"2026-01-01T09:50:00+09:00","event":"skill_end","session_id":"s2","name":"implement","compliance":"full","deviations":[]}
+{"ts":"2026-01-01T10:00:00+09:00","event":"skill","session_id":"s1","name":"pr"}
+{"ts":"2026-01-01T10:01:00+09:00","event":"correction","session_id":"s1","skills":["pr"],"summary":"c1","gist":""}
+{"ts":"2026-01-01T10:02:00+09:00","event":"correction","session_id":"s1","skills":["pr"],"summary":"c2","gist":""}
+{"ts":"2026-01-01T10:03:00+09:00","event":"correction","session_id":"s2","skills":["pr"],"summary":"c3","gist":""}
+{"ts":"2026-01-01T11:00:00+09:00","event":"skill","session_id":"s1","name":"commit"}
+{"ts":"2026-01-01T11:01:00+09:00","event":"skill_end","session_id":"s1","name":"commit","compliance":"partial","deviations":[{"clause":"a","reason":"b"}]}
+{"ts":"2026-01-01T11:02:00+09:00","event":"skill_end","session_id":"s2","name":"commit","compliance":"partial","deviations":[{"clause":"a","reason":"b"}]}
+{"ts":"2026-01-01T11:03:00+09:00","event":"skill_end","session_id":"s3","name":"commit","compliance":"partial","deviations":[{"clause":"a","reason":"b"}]}
+{"ts":"2026-01-01T12:00:00+09:00","event":"correction","session_id":"s9","skills":[],"summary":"미귀속 교정","gist":""}
+{"ts":"2026-01-01T12:01:00+09:00","event":"correction","session_id":"s9","skills":[],"summary":"미귀속 교정2","gist":""}
+{"ts":"2026-01-01T12:02:00+09:00","event":"correction","session_id":"s9","skills":[],"summary":"미귀속 교정3","gist":""}
+{"ts":"2026-01-01T13:00:00+09:00","event":"skill","session_id":"s4","name":"kickoff"}
+{"ts":"2026-01-01T13:01:00+09:00","event":"correction","session_id":"s4","skills":["kickoff"],"summary":"c1","gist":""}
+{"ts":"2026-01-01T13:02:00+09:00","event":"correction","session_id":"s4","skills":["kickoff"],"summary":"c2","gist":""}
+{"ts":"2026-01-01T13:03:00+09:00","event":"correction","session_id":"s4","skills":["kickoff"],"summary":"c3","gist":""}
+{"ts":"2026-01-01T14:00:00+09:00","event":"improvement","session_id":"s4","name":"kickoff"}
+JSONL
+
+OUT=$(python3 aggregate-usage.py)
+
+# implement: 발동 5·종료 2 → 누락률 60% ≥ 50% (min 5 충족) → 초과
+assert_contains "누락률 초과 검출" "implement" "$OUT"
+assert_contains "누락률 수치" "60%" "$OUT"
+# pr: correction 3건 ≥ 3 → 초과
+assert_contains "correction 임계 검출" "pr — correction 3건" "$OUT"
+# commit: partial 3건 ≥ 3 → 초과 (발동 1이라 누락률 판정은 제외돼야 함)
+assert_contains "partial 임계 검출" "commit — 준수 partial 3건" "$OUT"
+# kickoff: correction 3건이지만 improvement 마킹(14:00) 이후 레코드 없음 → 미검출
+BEFORE_KICKOFF=$(printf '%s' "$OUT" | grep -c "kickoff")
+assert_eq "improvement 마킹 이후만 집계" "0" "$BEFORE_KICKOFF"
+# 미귀속 correction 3건 ≥ 3이어도 violations 제외(소비 경로 없음) — --all 표에만 노출
+assert_eq "미귀속 violations 제외" "0" "$(printf '%s' "$OUT" | grep -c "미귀속")"
+ALL=$(python3 aggregate-usage.py --all)
+assert_contains "--all에 미귀속 버킷" "(미귀속)" "$ALL"
+assert_contains "--all에 스킬별 카운트" "implement" "$ALL"
+
+# 초과 없음 → 무출력
+ONLY_OK="$TMP_DIR/only-ok"
+mkdir "$ONLY_OK"
+printf '%s\n' '{"ts":"2026-01-01T09:00:00+09:00","event":"skill","session_id":"s1","name":"plan"}' '{"ts":"2026-01-01T09:01:00+09:00","event":"skill_end","session_id":"s1","name":"plan","compliance":"full","deviations":[]}' > "$ONLY_OK/2026-01-01.jsonl"
+QUIET=$(USAGE_LOG_DIR="$ONLY_OK" python3 aggregate-usage.py)
+RC=$?
+assert_eq "초과 없음 무출력" "" "$QUIET"
+assert_eq "exit 0 고정" "0" "$RC"
+
+echo "---"
+echo "PASS: $PASS / FAIL: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.claude/scripts/usage-thresholds.json
+++ b/.claude/scripts/usage-thresholds.json
@@ -1,0 +1,6 @@
+{
+  "correction_count": 3,
+  "partial_count": 3,
+  "missing_rate": 0.5,
+  "min_invocations_for_missing": 5
+}

--- a/.claude/skills/improve-skill/SKILL.md
+++ b/.claude/skills/improve-skill/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: improve-skill
+description: Use when running a maintenance cycle on a project skill or subagent — usage-log 레코드를 4분류로 진단해 스킬 md 개정안(diff)을 만들고 유저 승인 후 반영·소비 마킹한다. Triggers on "스킬 정비하자", "improve-skill 돌리자", pr 스킬 머지 단계의 임계 초과 제안을 유저가 수락했을 때. Does NOT trigger on 스킬 신규 작성(superpowers:writing-skills), 코드 리뷰 피드백 반영(feedback-reinforcement-learning), 유저가 지시한 일회성 스킬 문구 수정(직접 수정).
+---
+
+# Improve Skill — 스킬 정비 사이클
+
+usage-log에 쌓인 신호(발동·skill_end·correction)를 근거로 대상 스킬을 진단하고 개정한다. **반영은 유저 승인 후에만** — 하네스는 모든 후속 작업에 곱해지는 레버리지라 무감독 self-modify 금지.
+
+## 1. 레코드 수집
+
+대상 스킬의 미소비 레코드(마지막 improvement 마킹 이후)를 모은다:
+
+```bash
+python3 - << 'EOF'
+import json, glob, os
+NAME = "<대상 스킬>"
+records = []
+for p in sorted(glob.glob(os.path.expanduser("~/.claude/usage-log/*.jsonl"))):
+    try:
+        with open(p, encoding="utf-8") as f:
+            for l in f:
+                try:
+                    records.append(json.loads(l))
+                except ValueError:
+                    continue
+    except OSError:
+        continue
+mark = max((r.get("ts", "") for r in records
+            if r.get("event") == "improvement" and r.get("name") == NAME), default="")
+for r in records:
+    if r.get("ts", "") <= mark:
+        continue
+    if r.get("name") == NAME or NAME in (r.get("skills") or []) or r.get("skills") == []:
+        print(json.dumps(r, ensure_ascii=False))
+EOF
+```
+
+- `skills`가 빈 correction(미귀속)도 함께 나온다 — 발동 실패 후보로 검토.
+- 서브에이전트(code-analyzer 등)를 정비할 땐 `event: agent` 레코드(name 매칭)와 dispatch한 스킬(analyze·review)의 레코드를 함께 조회.
+- 필요하면 prompt 이벤트를 훑어 "스킬이 발동됐어야 했는데 안 된" 지시를 찾는다.
+
+## 2. 4분류 진단
+
+수집한 레코드를 분류하고, finding마다 근거 레코드(ts)를 붙여 표로 정리한다:
+
+| 분류 | 판정 신호 | 처방 |
+|---|---|---|
+| **발동 실패** | 스킬이 떠야 했던 prompt에 skill 이벤트 없음 / 미귀속 correction | description Triggers/Does NOT 경계 수정 |
+| **준수 실패** | skill_end partial 반복 — 특히 같은 clause | 조항 강조·위치 재배치 (조항이 안 읽히는 문제) |
+| **설계 결함** | compliance full인데 correction 발생 | 조항 내용 자체 개정 |
+| **과잉 조항** | 같은 clause 이탈 반복 + correction 없음 | 조항 삭제·완화 (YAGNI) |
+
+## 3. 개정안
+
+- 대상 스킬 md 원문을 읽고, 진단별 개정안을 **diff 형태**로 제시 — 무엇이 어떻게 바뀌고 왜(근거 레코드)인지.
+- 스킬 작성 원칙은 superpowers:writing-skills를 따른다.
+
+## 4. 승인·반영·마킹
+
+- 유저가 승인한 항목만 반영. 프로젝트 스킬(`.claude/skills/`)은 커밋(개정 이력 = git), 글로벌(`~/.claude/skills/`)은 커밋 없이 수정.
+- 반영 후 소비 마킹 — 같은 신호로 재발동되지 않게:
+
+```bash
+python3 .claude/hooks/log-record.py improvement --name <대상 스킬>
+```

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -25,3 +25,4 @@ description: Use when creating or merging a pull request in this project — PR 
 - 머지는 `gh pr merge --rebase`, squash 금지 — 단계별 커밋이 develop에 보존돼야 회귀 분석 시 변경 의도를 추적할 수 있다.
 - 머지 후 브랜치(로컬·리모트) 정리 여부를 유저에게 확인한다.
 - 브랜치가 워크트리에 체크아웃돼 있으면 삭제가 거부된다 — 그 워크트리에서 임시 브랜치를 만들어 이동(`git switch -c <임시-브랜치>`)한 뒤 대상 브랜치를 삭제한다.
+- 머지 후 `python3 .claude/scripts/aggregate-usage.py` 실행 — 출력(⚠️ 줄)이 있으면 해당 스킬의 정비를 유저에게 제안한다 (수락 시 improve-skill 스킬). 무출력이면 조용히 넘어간다 (#690 flywheel).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,9 @@
   - CI `pr_test.yml` — `detect-changes`의 scheme 매핑(grep) ↔ `test` job의 `Test <scheme>` 실행 step (둘 중 하나만 추가하면 감지만 되고 실행 안 됨)
   - 신규 테스트 스킴 ↔ 스킴 목록 하드코딩 전부 (`pr_test.yml` 3곳·`scripts/run-all-tests.sh`·`impact-check.sh`+테스트·`run-tests` 스킬 — 상세는 add-framework 스킬. 단 `<Name>Snapshots` 스킴은 의도된 예외 — 로컬 전용, snapshot-check 스킬)
   - init 시그니처 ↔ 콜사이트
+- **스킬 종료·유저 교정은 레코드로 남긴다** (#690 flywheel 측정 신호):
+  - 발동한 스킬의 절차가 끝나면: `python3 .claude/hooks/log-record.py skill_end --name <스킬> --compliance full|partial [--deviation "조항::사유"]` — 조항을 의도적으로 이행 안 했으면 partial + 이탈 조항·사유 필수.
+  - 유저가 작업 결과·방식을 교정하면 그 자리에서: `python3 .claude/hooks/log-record.py correction --skills <귀속 스킬(쉼표 구분)> --summary "교정 요지" --gist "발화 요지"` — 발동 중이던 스킬이 없으면 `--skills` 생략.
 - **`.claude/rules/*.md`는 path 매칭 시 자동 로드** — 로드된 조항을 구현 결정 시점에 적극 invoke.
 - **외운 지식 말고 이 문서를 보고 판단할 것.** (도메인 경계·용어는 [`docs/domain-context-map.md`](docs/domain-context-map.md) 정본 기준)
 


### PR DESCRIPTION
Closes #690

## 문제

하네스(스킬·rules) 개선이 단발 피드백에 의존해 왔다 — 스킬이 실제로 준수됐는지, 유저 교정이 어느 스킬 결함에서 왔는지 측정 신호가 없어, 무엇을 언제 정비해야 할지 데이터로 판단할 수 없었다.

## 접근

기존 usage-log 훅 체계를 확장해 **기록 → 집계 → 정비 제안 → 정비 실행 → 소비 마킹**의 개선 루프를 배선했다. 전부 Python 표준 라이브러리 + 셸 회귀 테스트, Swift 무관.

- **기록기 신설** (`log-record.py`): 에이전트가 CLI로 직접 호출하는 이벤트 3종 — `skill_end`(준수 자가 기록, partial이면 이탈 조항·사유 필수), `correction`(유저 교정의 스킬 귀속), `improvement`(정비 반영 마킹). 사용법 오류만 exit 2, 그 외 fail-open.
- **운영 보강** (`log-usage.py`): 로그 디렉토리 700 강제 + 7일 지난 세션 state 자동 prune (#688 이관분).
- **공통 조항** (CLAUDE.md §1): 모든 세션이 스킬 종료·유저 교정을 레코드로 남기도록 의무화. 글로벌 feedback-reinforcement-learning 스킬에도 Log 단계 추가 (레포 밖이라 이 PR엔 없음).
- **집계·임계 판정** (`aggregate-usage.py` + `usage-thresholds.json`): 스킬별 correction·partial·종료 누락률을 improvement 마킹 이후 윈도우로 집계, 임계 초과 항목만 `⚠️` 출력 (무출력=이상 없음, exit 0 고정 — 게이트가 아니라 제안). 임계값은 config 분리.
- **improve-skill 신설**: 레코드 4분류(발동 실패/준수 실패/설계 결함/과잉 조항) 진단 → 개정안 diff → 유저 승인 반영 → 소비 마킹. 무감독 self-modify 금지.
- **pr 스킬 배선**: 머지 후 임계 판정 실행, 초과 시 improve-skill 정비 제안 — flywheel의 소비 시점.

최종 리뷰에서 `(미귀속)` correction 버킷이 임계 초과 시 소비 경로 없이 머지 게이트에 영구 경고로 남는 문제가 발견돼, violations에서 제외하고 `--all` 진단 표에만 노출하도록 확정했다.

## 남은 과제

- 임계 초기값(correction 3·partial 3·누락률 50%)은 실데이터 축적 후 튜닝.
- `full_table` 고정폭(24자)이 긴 스킬명에서 표 정렬 깨짐 — 계약 무영향, 후속.
- `usage-thresholds.json` 로드 무방어 — config 유실 시 exit≠0 가능(동봉 파일이라 저위험), 후속.
- 미귀속 correction의 윈도잉이 대상 스킬 마킹 기준이라 stale 신호가 숨을 수 있음 — violations 제외로 완화, 정밀화는 후속.
- Stop 훅 리마인드·4축 채점 신호 합류는 후속 (#690 재정의 스코프 밖).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3rfY2j6yrf4TxPfJb2kpf