### PR TITLE
[#690] axis_leak 누수 레코드 배선 — 축4 finding을 축1~3 관문 누수로 태깅·집계

### DIFF
--- a/.claude/hooks/log-record.py
+++ b/.claude/hooks/log-record.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""에이전트 발동형 레코드 기록기 — skill_end(준수 자가 기록)·correction(유저 교정)·improvement(정비 마킹).
+"""에이전트 발동형 레코드 기록기 — skill_end(준수 자가 기록)·correction(유저 교정)·improvement(정비 마킹)·axis_leak(채점 축 누수).
 
 훅이 아니라 에이전트가 CLI로 직접 호출한다 (CLAUDE.md §1 공통 조항, #690).
 사용법 오류는 exit 2 (호출자가 재시도), 그 외 오류는 fail-open exit 0.
@@ -56,22 +56,29 @@ def build_record(args):
             usage_error("correction엔 --summary 필수")
         skills = [s.strip() for s in args.skills.split(",") if s.strip()]
         record.update({"skills": skills, "summary": args.summary, "gist": args.gist or ""})
-    else:  # improvement
+    elif args.event == "improvement":
         if not args.name:
             usage_error("improvement엔 --name 필수")
         record["name"] = args.name
+    else:  # axis_leak
+        if args.missed_axis is None or not args.finding:
+            usage_error("axis_leak엔 --missed-axis·--finding 필수")
+        record.update({"missed_axis": args.missed_axis, "finding": args.finding, "pr": args.pr or ""})
     return record
 
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("event", choices=["skill_end", "correction", "improvement"])
+    parser.add_argument("event", choices=["skill_end", "correction", "improvement", "axis_leak"])
     parser.add_argument("--name", help="대상 스킬명 (skill_end·improvement)")
     parser.add_argument("--compliance", choices=["full", "partial"])
     parser.add_argument("--deviation", action="append", default=[], help="'조항::사유' 형식, 반복 가능")
     parser.add_argument("--skills", default="", help="쉼표 구분 귀속 스킬 (correction)")
     parser.add_argument("--summary", help="교정 요지 (correction)")
     parser.add_argument("--gist", help="유저 발화 요지 (correction)")
+    parser.add_argument("--missed-axis", type=int, choices=[1, 2, 3], help="놓쳤어야 할 채점 축 (axis_leak)")
+    parser.add_argument("--finding", help="누수 한 줄 요약 (axis_leak)")
+    parser.add_argument("--pr", help="관련 PR 번호 (axis_leak, 생략 가능)")
     parser.add_argument("--session", help="session_id override — 생략 시 CLAUDE_CODE_SESSION_ID env")
     args = parser.parse_args()
     append_record(build_record(args))

--- a/.claude/hooks/log-record.test.sh
+++ b/.claude/hooks/log-record.test.sh
@@ -66,6 +66,27 @@ assert_eq "improvement 이름" "kickoff" "$(field "$(last_line)" name)"
 python3 log-record.py skill_end --name plan --compliance full --session "arg-session"
 assert_eq "--session 우선" "arg-session" "$(field "$(last_line)" session_id)"
 
+# --- axis_leak 정상 기록 ---
+python3 log-record.py axis_leak --missed-axis 3 --finding "RED 단계에서 반복 종료조건 케이스 누락"
+assert_eq "axis_leak 이벤트" "axis_leak" "$(field "$(last_line)" event)"
+assert_eq "axis_leak missed_axis" "3" "$(field "$(last_line)" missed_axis)"
+assert_eq "axis_leak finding" "RED 단계에서 반복 종료조건 케이스 누락" "$(field "$(last_line)" finding)"
+assert_eq "axis_leak pr 생략 시 빈 문자열" "" "$(field "$(last_line)" pr)"
+
+# --- axis_leak --pr 포함 ---
+python3 log-record.py axis_leak --missed-axis 1 --finding "명세 표현 누락" --pr 705
+assert_eq "axis_leak pr 기록" "705" "$(field "$(last_line)" pr)"
+
+# --- axis_leak --finding 누락 → exit 2 + 미기록 ---
+BEFORE_AXIS=$(wc -l < "$LOG" | tr -d ' ')
+python3 log-record.py axis_leak --missed-axis 2 2>/dev/null
+assert_eq "axis_leak finding 누락 exit 2" "2" "$?"
+assert_eq "axis_leak finding 누락 미기록" "$BEFORE_AXIS" "$(wc -l < "$LOG" | tr -d ' ')"
+
+# --- axis_leak --missed-axis 범위 밖(4) → argparse 거부 exit 2 ---
+python3 log-record.py axis_leak --missed-axis 4 --finding "범위밖" 2>/dev/null
+assert_eq "axis_leak missed-axis 범위밖 exit 2" "2" "$?"
+
 echo "---"
 echo "PASS: $PASS / FAIL: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.claude/scripts/aggregate-usage.py
+++ b/.claude/scripts/aggregate-usage.py
@@ -5,6 +5,7 @@
   ts는 ISO8601 문자열 사전순 비교 — 타임존 혼재 시 근사치.
 - 발동/종료는 count 기반 (세션 조인 없음 — 단순성 우선).
 - (미귀속) 버킷은 --all 진단 표에만 노출 — 스킬이 아니라 정비(improvement 마킹) 소비 경로가 없어 임계 판정에서 제외.
+- axis_leak 이벤트는 missed_axis(1/2/3)별로 별도 집계하며, improvement name이 합성 버킷 "axis:<n>" 형식이면 그 ts 이후만 신선 처리(소비 마킹) — 스킬 stats와 섞지 않는다.
 - exit 0 고정: 게이트가 아니라 제안이다. 임계는 usage-thresholds.json.
 """
 import argparse
@@ -45,6 +46,7 @@ def improvement_marks(records):
 def aggregate(records):
     marks = improvement_marks(records)
     stats = {}
+    axis_stats = {1: 0, 2: 0, 3: 0}
 
     def stat(name):
         return stats.setdefault(name, {"invocations": 0, "ends": 0, "full": 0, "partial": 0, "corrections": 0})
@@ -68,7 +70,11 @@ def aggregate(records):
             for name in record.get("skills") or [UNATTRIBUTED]:
                 if is_fresh(name, record):
                     stat(name)["corrections"] += 1
-    return stats
+        elif event == "axis_leak":
+            axis = record.get("missed_axis")
+            if axis in (1, 2, 3) and is_fresh(f"axis:{axis}", record):
+                axis_stats[axis] += 1
+    return stats, axis_stats
 
 
 def missing_rate(entry):
@@ -77,7 +83,7 @@ def missing_rate(entry):
     return max(0.0, 1.0 - entry["ends"] / entry["invocations"])
 
 
-def violations(stats, thresholds):
+def violations(stats, axis_stats, thresholds):
     lines = []
     for name, entry in sorted(stats.items()):
         if name == UNATTRIBUTED:
@@ -93,10 +99,17 @@ def violations(stats, thresholds):
                     f"⚠️ {name} — 종료 레코드 누락률 {rate:.0%} "
                     f"(발동 {entry['invocations']}·종료 {entry['ends']}, 임계 {thresholds['missing_rate']:.0%})"
                 )
+    for axis in (1, 2, 3):
+        count = axis_stats[axis]
+        if count >= thresholds["axis_leak_count"]:
+            lines.append(
+                f"⚠️ 축{axis} 누수 {count}건 (임계 {thresholds['axis_leak_count']}) — "
+                f"implement 스킬 축{axis} 관문 정비 검토 (소비 마킹 버킷 axis:{axis})"
+            )
     return lines
 
 
-def full_table(stats):
+def full_table(stats, axis_stats):
     header = f"{'스킬':<24} {'발동':>4} {'종료':>4} {'full':>5} {'partial':>7} {'correction':>10}"
     lines = [header]
     for name, entry in sorted(stats.items()):
@@ -104,6 +117,8 @@ def full_table(stats):
             f"{name:<24} {entry['invocations']:>4} {entry['ends']:>4} "
             f"{entry['full']:>5} {entry['partial']:>7} {entry['corrections']:>10}"
         )
+    if any(axis_stats.values()):
+        lines.append(f"축별 누수 — 축1 {axis_stats[1]} · 축2 {axis_stats[2]} · 축3 {axis_stats[3]}")
     return lines
 
 
@@ -115,8 +130,8 @@ def main():
     with open(CONFIG_PATH, encoding="utf-8") as f:
         thresholds = json.load(f)
 
-    stats = aggregate(load_records())
-    lines = full_table(stats) if args.all else violations(stats, thresholds)
+    stats, axis_stats = aggregate(load_records())
+    lines = full_table(stats, axis_stats) if args.all else violations(stats, axis_stats, thresholds)
     if lines:
         print("\n".join(lines))
 

--- a/.claude/scripts/aggregate-usage.test.sh
+++ b/.claude/scripts/aggregate-usage.test.sh
@@ -39,6 +39,11 @@ cat > "$FIXTURE" << 'JSONL'
 {"ts":"2026-01-01T13:02:00+09:00","event":"correction","session_id":"s4","skills":["kickoff"],"summary":"c2","gist":""}
 {"ts":"2026-01-01T13:03:00+09:00","event":"correction","session_id":"s4","skills":["kickoff"],"summary":"c3","gist":""}
 {"ts":"2026-01-01T14:00:00+09:00","event":"improvement","session_id":"s4","name":"kickoff"}
+{"ts":"2026-01-02T09:00:00+09:00","event":"axis_leak","session_id":"s5","missed_axis":1,"finding":"f1","pr":""}
+{"ts":"2026-01-02T09:01:00+09:00","event":"axis_leak","session_id":"s5","missed_axis":1,"finding":"f2","pr":""}
+{"ts":"2026-01-02T09:02:00+09:00","event":"axis_leak","session_id":"s5","missed_axis":1,"finding":"f3","pr":"705"}
+{"ts":"2026-01-02T09:03:00+09:00","event":"axis_leak","session_id":"s5","missed_axis":2,"finding":"g1","pr":""}
+{"ts":"2026-01-02T09:04:00+09:00","event":"axis_leak","session_id":"s5","missed_axis":2,"finding":"g2","pr":""}
 JSONL
 
 OUT=$(python3 aggregate-usage.py)
@@ -59,6 +64,21 @@ ALL=$(python3 aggregate-usage.py --all)
 assert_contains "--all에 미귀속 버킷" "(미귀속)" "$ALL"
 assert_contains "--all에 스킬별 카운트" "implement" "$ALL"
 
+# --- 축별 누수 집계 ---
+# 축1: 3건 ≥ 임계 3 → 초과, 축2: 2건 < 임계 3 → 미검출, 축3: 0건
+assert_contains "축1 누수 임계 초과 검출" "축1 누수 3건 (임계 3)" "$OUT"
+assert_eq "축2 누수 임계 미만 미검출" "0" "$(printf '%s' "$OUT" | grep -c "축2 누수")"
+assert_eq "축3 누수 없음 미검출" "0" "$(printf '%s' "$OUT" | grep -c "축3 누수")"
+
+assert_contains "--all 축별 누수 라인" "축별 누수 — 축1 3 · 축2 2 · 축3 0" "$ALL"
+
+# --- improvement axis:1 마킹(누수 이후 ts) → 축1 소비돼 라인 사라짐 ---
+cat >> "$FIXTURE" << 'JSONL'
+{"ts":"2026-01-02T10:00:00+09:00","event":"improvement","session_id":"s5","name":"axis:1"}
+JSONL
+OUT_AFTER_MARK=$(python3 aggregate-usage.py)
+assert_eq "axis:1 마킹 이후 축1 라인 소비" "0" "$(printf '%s' "$OUT_AFTER_MARK" | grep -c "축1 누수")"
+
 # 초과 없음 → 무출력
 ONLY_OK="$TMP_DIR/only-ok"
 mkdir "$ONLY_OK"
@@ -67,6 +87,10 @@ QUIET=$(USAGE_LOG_DIR="$ONLY_OK" python3 aggregate-usage.py)
 RC=$?
 assert_eq "초과 없음 무출력" "" "$QUIET"
 assert_eq "exit 0 고정" "0" "$RC"
+
+# 누수 없는 fixture --all → "축별 누수" 라인 미출력
+ALL_ONLY_OK=$(USAGE_LOG_DIR="$ONLY_OK" python3 aggregate-usage.py --all)
+assert_eq "누수 없으면 --all에 축별 누수 라인 미출력" "0" "$(printf '%s' "$ALL_ONLY_OK" | grep -c "축별 누수")"
 
 echo "---"
 echo "PASS: $PASS / FAIL: $FAIL"

--- a/.claude/scripts/usage-thresholds.json
+++ b/.claude/scripts/usage-thresholds.json
@@ -2,5 +2,6 @@
   "correction_count": 3,
   "partial_count": 3,
   "missing_rate": 0.5,
-  "min_invocations_for_missing": 5
+  "min_invocations_for_missing": 5,
+  "axis_leak_count": 3
 }

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -63,3 +63,15 @@ diff 성격·규모에 맞춰 관점 세트를 고른다. 기본 후보 (고정 
 
 - `mcp__github-reviewer__create_pull_request_review`(bot 계정)로 **해당 코드 라인에 인라인 코멘트** — 한 코멘트에 몰아쓰지 않는다. `commit_id`는 full SHA (short SHA는 422).
 - 게시 후 대화로 요약 보고. 반영은 유저 지시 시 **별도 커밋** — PR 공개 후라 리뷰어가 반영분을 추적할 수 있어야 한다 (fixup 흡수 금지).
+
+## 6. 누수 태깅 (#690 채점 4축)
+
+게시 직후, 컨트롤러 검증을 통과한 finding마다 "축1~3 중 어디서 잡혔어야 했나"를 판정해 기록한다 (축 정의 정본은 implement 스킬 §채점 4축 좌표계):
+
+```bash
+python3 .claude/hooks/log-record.py axis_leak --missed-axis <1|2|3> --finding "<한 줄 요약>" --pr <PR번호>
+```
+
+- 판정 기준: 결함이 **TC가 명세를 못 담음**(누락 케이스·false positive test)이면 축1 / **TC가 있는데도 동작 오류가 통과**면 축2 / **구현 구조·효율·역할 분배**면 축3.
+- 축1~3 어디서도 잡을 수 없는 종류(기획 홀·요구사항 자체의 결함)는 태깅하지 않는다 — 관문 누수가 아니다.
+- 집계·임계 판정은 aggregate-usage.py가 축별로 수행하고 pr 스킬 머지 단계에서 출력된다 — 초과 시 해당 축 관문(implement 스킬) 정비를 제안. 정비 반영 후 소비 마킹은 `improvement --name axis:<n>`.


### PR DESCRIPTION
## 문제

PR #705가 implement 스킬에 채점 4축 좌표계(RED=축1·GREEN=축2·리팩터=축3·PR 리뷰=축4)를 선언했지만, 좌표만 있고 기록 수단이 없다. #690 원안의 메타 신호 — "축4에서 잡힌 걸 왜 축1~3이 놓쳤나"(누수 분석) — 가 합류하려면 축4 finding의 누수 태깅 레코드가 쌓여야 한다.

## 접근

- **log-record.py `axis_leak` 이벤트** — `--missed-axis <1|2|3>`·`--finding` 필수, `--pr` 선택. 기존 이벤트(skill_end/correction/improvement)와 같은 JSONL·exit 규약.
- **aggregate-usage.py 축별 집계·임계** — 스킬 stats와 분리된 축별 카운트. 임계(`axis_leak_count: 3`) 초과 축만 "implement 스킬 축N 관문 정비 검토" 경고로 출력돼 기존 pr 스킬 머지 단계 채널에 합류. 정비 소비 마킹은 스킬명과 충돌하지 않는 합성 버킷 `improvement --name axis:<n>` — 기존 marks/is_fresh 패턴 재사용.
- **review 스킬 §6 누수 태깅** — 게시 직후 컨트롤러 검증을 통과한 finding마다 축 판정 후 기록. 판정 기준: TC가 명세를 못 담음(누락 케이스·false positive test)=축1 / TC 있는데 동작 오류 통과=축2 / 구현 구조·효율·역할 분배=축3. 기획 홀·요구사항 자체 결함은 관문 누수가 아니므로 태깅 제외.
- 검증: 회귀 테스트 log-record 18→26·aggregate 10→16 assert 전부 통과. review 스킬 조항은 fresh-context 에이전트 시나리오(false positive test→축1, 효율·중복→축3, 기획 홀·오탐→제외)로 판정 정확성 확인.
- 축1~3 실시간 관문은 여전히 무기록(#705의 기록 밀도 신중론) — 기록은 소비자(누수 분석)가 있는 축4에서만 발생한다.

## 남은 과제

- 누수 레코드가 쌓인 뒤의 실제 누수 분석(축별 추세→관문 개정안 제안)은 improve-skill/메타 루프 소관으로 미구현 — 임계 경고까지가 이 PR.
- `axis_leak_count: 3` 초기값은 실데이터로 튜닝 (기존 임계들과 동일한 이월).
- PR #705(좌표계 선언)와 짝 — 참조하는 축 정의가 그쪽에 있다. 파일 겹침은 없어 머지 순서 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3rfY2j6yrf4TxPfJb2kpf