### PR TITLE
[#722] D-day 위젯 — 홈스크린 소·중형에 대상 이벤트까지 남은 일수 표시

### DIFF
--- a/Domain/Sources/Usecases/Events/EventRepeatTimeEnumerator.swift
+++ b/Domain/Sources/Usecases/Events/EventRepeatTimeEnumerator.swift
@@ -144,6 +144,32 @@ public final class EventRepeatTimeEnumerator: Sendable {
     }
 }
 
+// MARK: - 기준 시각 이후 첫 회차
+
+extension EventRepeatTimeEnumerator {
+
+    private static var maxAdvanceCount: Int { 3650 }
+
+    public func nextEventTime(
+        after refTime: TimeInterval,
+        from origin: RepeatingTimes,
+        until endTime: TimeInterval?
+    ) -> RepeatingTimes? {
+
+        var current = origin
+        var advanced = 0
+        while current.time.upperBoundWithFixed < refTime {
+            guard advanced < Self.maxAdvanceCount,
+                  let next = self.nextEventTime(from: current, until: endTime)
+            else { return nil }
+            current = next
+            advanced += 1
+        }
+        return current
+    }
+}
+
+
 // MARK: - next date by repeating options
 
 extension EventRepeatTimeEnumerator {

--- a/Domain/Tests/Usecases/EventRepeatTimeEnumeratorNextAfterTests.swift
+++ b/Domain/Tests/Usecases/EventRepeatTimeEnumeratorNextAfterTests.swift
@@ -1,0 +1,68 @@
+//
+//  EventRepeatTimeEnumeratorNextAfterTests.swift
+//  Domain
+//
+//  Created by sudo.park on 7/29/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+
+@testable import Domain
+
+
+struct EventRepeatTimeEnumeratorNextAfterTests {
+
+    private var origin: RepeatingTimes {
+        // 1970-01-01 00:00 ~ 01:00 (UTC)
+        return .init(time: .period(0..<3600), turn: 1)
+    }
+
+    private func makeEnumerator(
+        endOption: EventRepeating.RepeatEndOption? = nil
+    ) -> EventRepeatTimeEnumerator {
+        let option = EventRepeatingOptions.EveryDay()
+        return EventRepeatTimeEnumerator(option, endOption: endOption)!
+    }
+}
+
+// MARK: - 기준 시각 이후 첫 회차 탐색
+
+extension EventRepeatTimeEnumeratorNextAfterTests {
+
+    @Test("기준 시각이 origin 종료 이전이면 origin을 그대로 반환")
+    func nextAfter_whenRefTimeBeforeOriginEnd_returnsOrigin() {
+        // given
+        let enumerator = self.makeEnumerator()
+        // when
+        let next = enumerator.nextEventTime(after: 100, from: self.origin, until: nil)
+        // then
+        #expect(next?.turn == 1)
+        #expect(next?.time == .period(0..<3600))
+    }
+
+    @Test("기준 시각이 3일 뒤면 4번째 회차 반환")
+    func nextAfter_whenRefTimeIsThreeDaysLater_returnsFourthTurn() {
+        // given
+        let enumerator = self.makeEnumerator()
+        let threeDays: TimeInterval = 3600 * 24 * 3
+        // when
+        let next = enumerator.nextEventTime(after: threeDays, from: self.origin, until: nil)
+        // then
+        #expect(next?.turn == 4)
+        #expect(next?.time == .period(threeDays..<threeDays + 3600))
+    }
+
+    @Test("종료 시각을 넘어서면 nil")
+    func nextAfter_whenRefTimeAfterRepeatEnd_returnsNil() {
+        // given
+        let twoDays: TimeInterval = 3600 * 24 * 2
+        let enumerator = self.makeEnumerator(endOption: .until(twoDays))
+        let tenDays: TimeInterval = 3600 * 24 * 10
+        // when
+        let next = enumerator.nextEventTime(after: tenDays, from: self.origin, until: twoDays)
+        // then
+        #expect(next == nil)
+    }
+}

--- a/Presentations/EventDetailScene/Sources/EventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailViewModel.swift
@@ -97,19 +97,3 @@ protocol EventDetailViewModel: Sendable, AnyObject {
     var isSaving: AnyPublisher<Bool, Never> { get }
     var moreActions: AnyPublisher<[[EventDetailMoreAction]], Never> { get }
 }
-
-
-struct DDayText {
-    
-    let text: String
-    init(_ interval: Int) {
-        switch interval {
-        case ..<0:
-            self.text = "D+\(abs(interval))"
-        case 0:
-            self.text = "D-Day"
-        default:
-            self.text = "D-\(interval)"
-        }
-    }
-}

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewModel.swift
@@ -11,6 +11,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
@@ -14,6 +14,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 

--- a/Presentations/EventDetailScene/Tests/HolidayEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/HolidayEventDetailViewModelImpleTests.swift
@@ -11,6 +11,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import UnitTestHelpKit
 import TestDoubles
 

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -501,6 +501,10 @@
 "widget.next.no_events_today" = "No events today";
 "widget.next.no_events" = "No upcoming events";
 
+"widget.dday::name" = "D-Day";
+"widget.dday::noTarget" = "Select an event";
+"widget.dday.sample::title" = "Workshop";
+
 // MARK: - link
 
 "deeplink::invalid_link_message" = "This link format is not supported.\nPlease update the app to the latest version.";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -501,6 +501,10 @@
 "widget.next.no_events_today" = "오늘 이벤트 없음";
 "widget.next.no_events" = "가까운 시일 내\n예정된 이벤트 없음";
 
+"widget.dday::name" = "디데이";
+"widget.dday::noTarget" = "대상을 선택해주세요";
+"widget.dday.sample::title" = "워크숍";
+
 // MARK: - link
 
 "deeplink::invalid_link_message" = "지원하지 않는 형식의 링크입니다.\n앱을 최신 버전으로 업데이트 해주세요.";

--- a/Supports/Extensions/Sources/DDayText.swift
+++ b/Supports/Extensions/Sources/DDayText.swift
@@ -1,0 +1,26 @@
+//
+//  DDayText.swift
+//  Extensions
+//
+//  Created by sudo.park on 7/29/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+
+public struct DDayText {
+
+    public let text: String
+
+    public init(_ interval: Int) {
+        switch interval {
+        case ..<0:
+            self.text = "D+\(abs(interval))"
+        case 0:
+            self.text = "D-Day"
+        default:
+            self.text = "D-\(interval)"
+        }
+    }
+}

--- a/Supports/Extensions/Tests/DDayTextTests.swift
+++ b/Supports/Extensions/Tests/DDayTextTests.swift
@@ -1,0 +1,42 @@
+//
+//  DDayTextTests.swift
+//  Extensions
+//
+//  Created by sudo.park on 7/29/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+
+@testable import Extensions
+
+
+struct DDayTextTests {
+
+    @Test("미래 이벤트는 D-n", arguments: [1, 3, 100])
+    func ddayText_whenFuture_isDMinus(_ interval: Int) {
+        // given
+        // when
+        let text = DDayText(interval).text
+        // then
+        #expect(text == "D-\(interval)")
+    }
+
+    @Test("당일은 D-Day")
+    func ddayText_whenToday_isDDay() {
+        // given
+        // when
+        let text = DDayText(0).text
+        // then
+        #expect(text == "D-Day")
+    }
+
+    @Test("지난 이벤트는 D+n", arguments: [-1, -3, -100])
+    func ddayText_whenPast_isDPlus(_ interval: Int) {
+        // given
+        // when
+        let text = DDayText(interval).text
+        // then
+        #expect(text == "D+\(abs(interval))")
+    }
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Base+Factory/DDayTargetSelectIntentFactory.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Base+Factory/DDayTargetSelectIntentFactory.swift
@@ -1,0 +1,37 @@
+//
+//  DDayTargetSelectIntentFactory.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 7/29/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Domain
+import Repository
+
+
+struct DDayTargetSelectIntentFactory {
+
+    private let base: AppExtensionBase
+    private let usecaseFactory: WidgetUsecaseFactory
+
+    init(base: AppExtensionBase) {
+        self.base = base
+        self.usecaseFactory = .init(base: base)
+    }
+}
+
+extension DDayTargetSelectIntentFactory {
+
+    func makeEventFetchUsecase() -> any CalendarEventFetchUsecase {
+        return self.usecaseFactory.makeEventsFetchUsecase()
+    }
+
+    func loadTimeZone() -> TimeZone {
+        let repository = CalendarSettingRepositoryImple(
+            environmentStorage: self.base.userDefaultEnvironmentStorage
+        )
+        return repository.loadUserSelectedTImeZone() ?? .current
+    }
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Base+Factory/WidgetViewModelProviderBuilder.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Base+Factory/WidgetViewModelProviderBuilder.swift
@@ -323,6 +323,26 @@ extension WidgetViewModelProviderBuilder {
             localeProvider: Locale.current
         )
     }
+
+    func makeDDayWidgetViewModelProvider() async -> DDayWidgetViewModelProvider {
+        await self.checkShouldReset()
+
+        let appSettingRepository = AppSettingLocalRepositoryImple(
+            storage: AppSettingLocalStorage(
+                environmentStorage: base.userDefaultEnvironmentStorage
+            )
+        )
+        let calendarSettingRepository = CalendarSettingRepositoryImple(
+            environmentStorage: base.userDefaultEnvironmentStorage
+        )
+        let eventFetchUsecase = self.usecaseFactory.makeEventsFetchUsecase()
+
+        return DDayWidgetViewModelProvider(
+            eventFetchUsecase: eventFetchUsecase,
+            calendarSettingRepository: calendarSettingRepository,
+            appSettingRepository: appSettingRepository
+        )
+    }
 }
 
 // MARK: - composed

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Intents/DDayTargetSelectIntent.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Intents/DDayTargetSelectIntent.swift
@@ -1,0 +1,183 @@
+//
+//  DDayTargetSelectIntent.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 7/29/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import WidgetKit
+import AppIntents
+import Prelude
+import Optics
+import Domain
+import Extensions
+import CalendarScenes
+
+
+// MARK: - DDayTargetEventId + entity id
+
+extension DDayTargetEventId {
+
+    private static var todoPrefix: String { "todo::" }
+    private static var schedulePrefix: String { "schedule::" }
+
+    var entityId: String {
+        let prefix = self.isTodo ? Self.todoPrefix : Self.schedulePrefix
+        return "\(prefix)\(self.eventId)"
+    }
+
+    init?(entityId: String) {
+        if entityId.hasPrefix(Self.todoPrefix) {
+            self.init(
+                eventId: String(entityId.dropFirst(Self.todoPrefix.count)), isTodo: true
+            )
+        } else if entityId.hasPrefix(Self.schedulePrefix) {
+            self.init(
+                eventId: String(entityId.dropFirst(Self.schedulePrefix.count)), isTodo: false
+            )
+        } else {
+            return nil
+        }
+    }
+}
+
+
+// MARK: - DDayTargetEventEntity
+
+struct DDayTargetEventEntity: AppEntity, Sendable {
+
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Event"
+
+    var id: String
+    var name: String
+    var dateText: String
+
+    static let defaultQuery = DDayTargetEventQuery()
+
+    var displayRepresentation: DisplayRepresentation {
+        return DisplayRepresentation(title: "\(name)", subtitle: "\(dateText)")
+    }
+}
+
+
+// MARK: - DDayTargetEventQuery
+
+struct DDayTargetEventQuery: EntityQuery, @unchecked Sendable {
+
+    private let factory: DDayTargetSelectIntentFactory
+
+    init() {
+        self.factory = .init(base: AppExtensionBase())
+    }
+
+    private static var suggestionDays: Int { 365 }
+    private static var suggestionLimit: Int { 50 }
+
+    func entities(for identifiers: [String]) async throws -> [DDayTargetEventEntity] {
+
+        let usecase = self.factory.makeEventFetchUsecase()
+        let timeZone = self.factory.loadTimeZone()
+        let now = Date()
+
+        let targets = identifiers.compactMap { DDayTargetEventId(entityId: $0) }
+        var entities: [DDayTargetEventEntity] = []
+        for target in targets {
+            guard let event = try? await usecase.fetchDDayTargetEvent(target, after: now)
+            else { continue }
+            entities.append(self.asEntity(event, timeZone))
+        }
+        return entities
+    }
+
+    func suggestedEntities() async throws -> [DDayTargetEventEntity] {
+
+        let usecase = self.factory.makeEventFetchUsecase()
+        let timeZone = self.factory.loadTimeZone()
+        let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
+        let now = Date()
+
+        guard let todayStart = calendar.dayRange(now)?.lowerBound,
+              let until = calendar.addDays(Self.suggestionDays, from: now)
+        else { return [] }
+
+        let events = try await usecase.fetchEvents(
+            in: todayStart..<until.timeIntervalSince1970, timeZone
+        )
+        return self.asSuggestions(events.eventWithTimes, timeZone)
+    }
+
+    private func asSuggestions(
+        _ events: [any CalendarEvent], _ timeZone: TimeZone
+    ) -> [DDayTargetEventEntity] {
+
+        let sorted = events
+            .filter { !($0 is HolidayCalendarEvent) }
+            .compactMap { event -> (DDayTargetEventId, String, EventTime)? in
+                guard let time = event.eventTime else { return nil }
+                switch event {
+                case let todo as TodoCalendarEvent:
+                    return (.init(eventId: todo.eventId, isTodo: true), todo.name, time)
+                case let schedule as ScheduleCalendarEvent:
+                    return (
+                        .init(eventId: schedule.eventIdWithoutTurn, isTodo: false),
+                        schedule.name, time
+                    )
+                default:
+                    return nil
+                }
+            }
+            .sorted { $0.2.lowerBoundWithFixed < $1.2.lowerBoundWithFixed }
+
+        var seen = Set<DDayTargetEventId>()
+        return sorted
+            .filter { seen.insert($0.0).inserted }
+            .prefix(Self.suggestionLimit)
+            .map { targetId, name, time in
+                DDayTargetEventEntity(
+                    id: targetId.entityId,
+                    name: name,
+                    dateText: DDayTargetDateFormatter.text(of: time, in: timeZone)
+                )
+            }
+    }
+
+    private func asEntity(
+        _ event: DDayTargetEvent, _ timeZone: TimeZone
+    ) -> DDayTargetEventEntity {
+        return DDayTargetEventEntity(
+            id: event.targetId.entityId,
+            name: event.name,
+            dateText: DDayTargetDateFormatter.text(of: event.time, in: timeZone)
+        )
+    }
+}
+
+
+// MARK: - DDayTargetDateFormatter
+
+enum DDayTargetDateFormatter {
+
+    static func text(of time: EventTime, in timeZone: TimeZone) -> String {
+        let date = Date(
+            timeIntervalSince1970: time.rangeWithShifttingifNeed(on: timeZone).lowerBound
+        )
+        let formatter = DateFormatter()
+        formatter.timeZone = timeZone
+        formatter.locale = .current
+        formatter.setLocalizedDateFormatFromTemplate("yMMMdEEE")
+        return formatter.string(from: date)
+    }
+}
+
+
+// MARK: - Intent
+
+struct DDayWidgetConfigurationIntent: WidgetConfigurationIntent {
+
+    static let title: LocalizedStringResource = ""
+
+    @Parameter(title: "Event", default: nil)
+    var target: DDayTargetEventEntity?
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/TodoCalendarWidgetBundle.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/TodoCalendarWidgetBundle.swift
@@ -28,6 +28,7 @@ struct BaseWidgetBundle: WidgetBundle {
         ForemostEventWidget()
         NextEventWidget()
         NextRemainEventWidget()
+        DDayWidget()
     }
 }
 

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Usecases/CalendarEventFetchUsecase.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Usecases/CalendarEventFetchUsecase.swift
@@ -72,6 +72,17 @@ struct TodayNextEvents {
     let customTags: [CustomEventTag]
 }
 
+struct DDayTargetEventId: Sendable, Hashable {
+    let eventId: String
+    let isTodo: Bool
+}
+
+struct DDayTargetEvent: Sendable {
+    let targetId: DDayTargetEventId
+    let name: String
+    let time: EventTime
+}
+
 protocol CalendarEventFetchUsecase {
     
     func fetchEvents(
@@ -89,6 +100,10 @@ protocol CalendarEventFetchUsecase {
     func fetchNextEvents(
         _ refTime: Date, withIn todayRange: Range<TimeInterval>, _ timeZone: TimeZone
     ) async throws -> TodayNextEvents
+
+    func fetchDDayTargetEvent(
+        _ target: DDayTargetEventId, after refTime: Date
+    ) async throws -> DDayTargetEvent?
 }
 
 extension CalendarEventFetchUsecase {
@@ -465,8 +480,88 @@ extension CalendarEventFetchUsecaseImple {
     }
 }
 
+// MARK: - D-day 대상 조회
+
+extension CalendarEventFetchUsecaseImple {
+
+    func fetchDDayTargetEvent(
+        _ target: DDayTargetEventId, after refTime: Date
+    ) async throws -> DDayTargetEvent? {
+
+        return target.isTodo
+            ? try await self.fetchDDayTargetTodo(target, after: refTime)
+            : try await self.fetchDDayTargetSchedule(target, after: refTime)
+    }
+
+    private func fetchDDayTargetTodo(
+        _ target: DDayTargetEventId, after refTime: Date
+    ) async throws -> DDayTargetEvent? {
+
+        guard let todo = try? await self.todoRepository.todoEvent(target.eventId)
+            .values.first(where: { _ in true }),
+              let time = todo.time
+        else { return nil }
+
+        guard let nextTime = Self.resolveTargetTime(
+            time: time,
+            repeating: todo.repeating,
+            startTurn: todo.repeatingTurn ?? 1,
+            excludeTimeKeys: [],
+            after: refTime
+        )
+        else { return nil }
+
+        return DDayTargetEvent(targetId: target, name: todo.name, time: nextTime)
+    }
+
+    private func fetchDDayTargetSchedule(
+        _ target: DDayTargetEventId, after refTime: Date
+    ) async throws -> DDayTargetEvent? {
+
+        guard let schedule = try? await self.scheduleRepository.scheduleEvent(target.eventId)
+            .values.first(where: { _ in true })
+        else { return nil }
+
+        guard let nextTime = Self.resolveTargetTime(
+            time: schedule.time,
+            repeating: schedule.repeating,
+            startTurn: 1,
+            excludeTimeKeys: schedule.repeatingTimeToExcludes,
+            after: refTime
+        )
+        else { return nil }
+
+        return DDayTargetEvent(targetId: target, name: schedule.name, time: nextTime)
+    }
+
+    private static func resolveTargetTime(
+        time: EventTime,
+        repeating: EventRepeating?,
+        startTurn: Int,
+        excludeTimeKeys: Set<String>,
+        after refTime: Date
+    ) -> EventTime? {
+
+        guard let repeating else { return time }
+
+        guard let enumerator = EventRepeatTimeEnumerator(
+            repeating.repeatOption,
+            endOption: repeating.repeatingEndOption,
+            without: excludeTimeKeys
+        )
+        else { return time }
+
+        return enumerator.nextEventTime(
+            after: refTime.timeIntervalSince1970,
+            from: .init(time: time, turn: startTurn),
+            until: repeating.repeatingEndOption?.endTime
+        )?.time
+    }
+}
+
+
 private extension Array where Element == CalendarEvent {
-    
+
     func sorted() -> Array {
         return self.sorted(by: { lhs, rhs in
             switch (lhs.eventTime?.lowerBoundWithFixed, rhs.eventTime?.lowerBoundWithFixed) {

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidget.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidget.swift
@@ -1,0 +1,142 @@
+//
+//  DDayWidget.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 7/29/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import WidgetKit
+import SwiftUI
+import Prelude
+import Optics
+import Domain
+import Extensions
+
+
+// MARK: - DDayWidgetView
+
+struct DDaySmallWidgetView: View {
+
+    private let model: DDayWidgetViewModel
+    init(model: DDayWidgetViewModel) {
+        self.model = model
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(model.eventTitle)
+                .font(.system(size: 13, weight: .semibold))
+                .lineLimit(2)
+                .foregroundStyle(.primary)
+
+            Spacer(minLength: 0)
+
+            Text(model.ddayText)
+                .font(.system(size: 32, weight: .bold))
+                .minimumScaleFactor(0.6)
+                .lineLimit(1)
+                .foregroundStyle(.primary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct DDayMediumWidgetView: View {
+
+    private let model: DDayWidgetViewModel
+    init(model: DDayWidgetViewModel) {
+        self.model = model
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(model.eventTitle)
+                .font(.system(size: 15, weight: .semibold))
+                .lineLimit(1)
+                .foregroundStyle(.primary)
+
+            Spacer(minLength: 0)
+
+            HStack(alignment: .lastTextBaseline) {
+                Text(model.ddayText)
+                    .font(.system(size: 36, weight: .bold))
+                    .minimumScaleFactor(0.6)
+                    .lineLimit(1)
+                    .foregroundStyle(.primary)
+
+                Spacer()
+
+                Text(model.targetDateText)
+                    .font(.system(size: 12))
+                    .lineLimit(1)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct DDayWidgetEntryView: View {
+
+    private let entry: ResultTimelineEntry<DDayWidgetViewModel>
+
+    @Environment(\.widgetFamily) var family: WidgetFamily
+
+    init(entry: ResultTimelineEntry<DDayWidgetViewModel>) {
+        self.entry = entry
+    }
+
+    var body: some View {
+        switch self.entry.result {
+        case .success(let model) where family == .systemMedium:
+            DDayMediumWidgetView(model: model)
+
+        case .success(let model):
+            DDaySmallWidgetView(model: model)
+
+        case .failure(let error):
+            FailView(errorModel: error)
+        }
+    }
+}
+
+
+// MARK: - DDayWidget
+
+struct DDayWidget: Widget {
+
+    nonisolated static let kind: String = "DDayWidget"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: Self.kind,
+            intent: DDayWidgetConfigurationIntent.self,
+            provider: DDayWidgetTimeLineProvider()
+        ) { entry in
+            DDayWidgetEntryView(entry: entry)
+                .containerBackground(entry.backgroundShape, for: .widget)
+        }
+        .supportedFamilies([.systemSmall, .systemMedium])
+        .configurationDisplayName("widget.dday::name".localized())
+        .description("widget.common::explain".localized())
+    }
+}
+
+
+struct DDayWidgetView_Provider: PreviewProvider {
+
+    static var previews: some View {
+        let entry = ResultTimelineEntry(date: Date(), result: .success(DDayWidgetViewModel.sample))
+
+        return Group {
+            DDayWidgetEntryView(entry: entry)
+                .previewContext(WidgetPreviewContext(family: .systemSmall))
+                .containerBackground(.background, for: .widget)
+
+            DDayWidgetEntryView(entry: entry)
+                .previewContext(WidgetPreviewContext(family: .systemMedium))
+                .containerBackground(.background, for: .widget)
+        }
+    }
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidgetTimeLineProvider.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidgetTimeLineProvider.swift
@@ -1,0 +1,68 @@
+//
+//  DDayWidgetTimeLineProvider.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 7/29/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import WidgetKit
+import Prelude
+import Optics
+import Domain
+import Extensions
+
+
+struct DDayWidgetTimeLineProvider: AppIntentTimelineProvider {
+
+    typealias Intent = DDayWidgetConfigurationIntent
+    typealias Entry = ResultTimelineEntry<DDayWidgetViewModel>
+
+    init() { }
+}
+
+extension DDayWidgetTimeLineProvider {
+
+    func placeholder(in context: Context) -> Entry {
+        return .init(date: Date(), result: .success(.sample))
+    }
+
+    func snapshot(
+        for configuration: DDayWidgetConfigurationIntent, in context: Context
+    ) async -> Entry {
+
+        guard context.isPreview == false
+        else {
+            return self.placeholder(in: context)
+        }
+        return await self.loadEntry(configuration.target)
+    }
+
+    func timeline(
+        for configuration: DDayWidgetConfigurationIntent, in context: Context
+    ) async -> Timeline<Entry> {
+
+        let entry = await self.loadEntry(configuration.target)
+        let refreshAfter = (try? entry.result.get())?.refreshAfter
+        return Timeline(
+            entries: [entry],
+            policy: .after(refreshAfter ?? Date().nextUpdateTime)
+        )
+    }
+
+    private func loadEntry(_ selected: DDayTargetEventEntity?) async -> Entry {
+
+        let target = selected.flatMap { DDayTargetEventId(entityId: $0.id) }
+        let builder = WidgetViewModelProviderBuilder(base: .init())
+        let viewModelProvider = await builder.makeDDayWidgetViewModelProvider()
+        let now = Date()
+        do {
+            let model = try await viewModelProvider.getDDayModel(for: now, target: target)
+            return .init(date: now, result: .success(model))
+                |> \.background .~ model.widgetSetting.background
+        } catch {
+            return .init(date: now, result: .failure(.init(error: error)))
+        }
+    }
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidgetViewModelProvider.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidgetViewModelProvider.swift
@@ -1,0 +1,104 @@
+//
+//  DDayWidgetViewModelProvider.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 7/29/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Prelude
+import Optics
+import Domain
+import Extensions
+
+
+// MARK: - DDayWidgetViewModel
+
+struct DDayWidgetViewModel: Sendable {
+
+    let eventTitle: String
+    let ddayText: String
+    let targetDateText: String
+    var refreshAfter: Date?
+    var widgetSetting: WidgetAppearanceSettings = .init()
+
+    static var sample: Self {
+        return .init(
+            eventTitle: "widget.dday.sample::title".localized(),
+            ddayText: "D-14",
+            targetDateText: DDayTargetDateFormatter.text(
+                of: .at(Date().timeIntervalSince1970 + 3600 * 24 * 14), in: .current
+            )
+        )
+    }
+
+    static func noTarget() -> Self {
+        return .init(
+            eventTitle: "widget.dday::noTarget".localized(),
+            ddayText: "–",
+            targetDateText: ""
+        )
+    }
+}
+
+
+// MARK: - DDayWidgetViewModelProvider
+
+final class DDayWidgetViewModelProvider {
+
+    private let eventFetchUsecase: any CalendarEventFetchUsecase
+    private let calendarSettingRepository: any CalendarSettingRepository
+    private let appSettingRepository: any AppSettingRepository
+
+    init(
+        eventFetchUsecase: any CalendarEventFetchUsecase,
+        calendarSettingRepository: any CalendarSettingRepository,
+        appSettingRepository: any AppSettingRepository
+    ) {
+        self.eventFetchUsecase = eventFetchUsecase
+        self.calendarSettingRepository = calendarSettingRepository
+        self.appSettingRepository = appSettingRepository
+    }
+}
+
+extension DDayWidgetViewModelProvider {
+
+    func getDDayModel(
+        for now: Date, target: DDayTargetEventId?
+    ) async throws -> DDayWidgetViewModel {
+
+        let timeZone = self.calendarSettingRepository.loadUserSelectedTImeZone() ?? .current
+        let setting = self.appSettingRepository.loadWidgetAppearanceSetting()
+        let refreshAfter = Self.nextMidnight(after: now, in: timeZone)
+
+        guard let target,
+              let event = try await self.eventFetchUsecase.fetchDDayTargetEvent(target, after: now)
+        else {
+            return DDayWidgetViewModel.noTarget()
+                |> \.refreshAfter .~ refreshAfter
+                |> \.widgetSetting .~ setting
+        }
+
+        let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
+        let targetDate = Date(
+            timeIntervalSince1970: event.time.rangeWithShifttingifNeed(on: timeZone).lowerBound
+        )
+        let interval = calendar.diffDays(now, targetDate) ?? 0
+
+        return DDayWidgetViewModel(
+            eventTitle: event.name,
+            ddayText: DDayText(interval).text,
+            targetDateText: DDayTargetDateFormatter.text(of: event.time, in: timeZone)
+        )
+        |> \.refreshAfter .~ refreshAfter
+        |> \.widgetSetting .~ setting
+    }
+
+    private static func nextMidnight(after now: Date, in timeZone: TimeZone) -> Date {
+        let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
+        let startOfToday = calendar.startOfDay(for: now)
+        return calendar.date(byAdding: .day, value: 1, to: startOfToday)
+            ?? now.addingTimeInterval(3600)
+    }
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/Doubles/StubCalendarEventsFetchUescase.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/Doubles/StubCalendarEventsFetchUescase.swift
@@ -88,4 +88,14 @@ class StubCalendarEventsFetchUescase: CalendarEventFetchUsecase {
     ) async throws -> TodayNextEvents {
         return try self.stubNextEvents.unwrap()
     }
+
+    var stubDDayTarget: DDayTargetEvent?
+    var didRequestDDayTarget: DDayTargetEventId?
+
+    func fetchDDayTargetEvent(
+        _ target: DDayTargetEventId, after refTime: Date
+    ) async throws -> DDayTargetEvent? {
+        self.didRequestDDayTarget = target
+        return self.stubDDayTarget
+    }
 }

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/Usecases/CalendarEventFetchUsecaseImpleTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/Usecases/CalendarEventFetchUsecaseImpleTests.swift
@@ -514,7 +514,88 @@ extension CalendarEventFetchUsecaseImpleTests {
     }
 }
 
+
+// MARK: - D-day 대상 조회
+
+extension CalendarEventFetchUsecaseImpleTests {
+
+    func testUsecase_fetchDDayTarget_whenNotRepeating_returnsOriginTime() async throws {
+        // given
+        self.stubScheduleRepository.stubEvent = ScheduleEvent(
+            uuid: "s1", name: "워크숍", time: .at(1000)
+        )
+        let usecase = self.makeUsecase()
+
+        // when
+        let target = try await usecase.fetchDDayTargetEvent(
+            .init(eventId: "s1", isTodo: false), after: Date(timeIntervalSince1970: 0)
+        )
+
+        // then
+        XCTAssertEqual(target?.name, "워크숍")
+        XCTAssertEqual(target?.time, .at(1000))
+    }
+
+    func testUsecase_fetchDDayTarget_whenEventNotExists_returnsNil() async throws {
+        // given
+        let usecase = self.makeUsecase()
+
+        // when
+        let target = try await usecase.fetchDDayTargetEvent(
+            .init(eventId: "not-exists", isTodo: false), after: Date(timeIntervalSince1970: 0)
+        )
+
+        // then
+        XCTAssertNil(target)
+    }
+
+    func testUsecase_fetchDDayTarget_whenTodoHasNoTime_returnsNil() async throws {
+        // given
+        self.stubTodoRepository.singleTodoMocking = TodoEvent(uuid: "t1", name: "언젠가")
+        let usecase = self.makeUsecase()
+
+        // when
+        let target = try await usecase.fetchDDayTargetEvent(
+            .init(eventId: "t1", isTodo: true), after: Date(timeIntervalSince1970: 0)
+        )
+
+        // then
+        XCTAssertNil(target)
+    }
+
+    func testUsecase_fetchDDayTarget_whenRepeating_returnsNextTurnTime() async throws {
+        // given
+        let day: TimeInterval = 3600 * 24
+        let repeating = EventRepeating(
+            repeatingStartTime: 0, repeatOption: EventRepeatingOptions.EveryDay()
+        )
+        self.stubScheduleRepository.stubEvent = ScheduleEvent(
+            uuid: "s2", name: "스탠드업", time: .period(0..<3600)
+        )
+        |> \.repeating .~ repeating
+        let usecase = self.makeUsecase()
+
+        // when
+        let target = try await usecase.fetchDDayTargetEvent(
+            .init(eventId: "s2", isTodo: false), after: Date(timeIntervalSince1970: day * 3)
+        )
+
+        // then
+        XCTAssertEqual(target?.time, .period(day * 3..<day * 3 + 3600))
+    }
+}
+
 private final class PrivateStubTodoRepository: StubTodoEventRepository, @unchecked Sendable {
+
+    var singleTodoMocking: TodoEvent?
+
+    override func todoEvent(_ id: String) -> AnyPublisher<TodoEvent, any Error> {
+        guard let mocking = self.singleTodoMocking, mocking.uuid == id
+        else {
+            return Empty().eraseToAnyPublisher()
+        }
+        return Just(mocking).mapAsAnyError().eraseToAnyPublisher()
+    }
     
     override func loadCurrentTodoEvents() -> AnyPublisher<[TodoEvent], any Error> {
         

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/DDayWidgetViewModelProviderTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/DDayWidgetViewModelProviderTests.swift
@@ -1,0 +1,116 @@
+//
+//  DDayWidgetViewModelProviderTests.swift
+//  TodoCalendarAppWidget
+//
+//  Created by sudo.park on 7/29/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Prelude
+import Optics
+import Domain
+import TestDoubles
+
+@testable import TodoCalendarApp
+
+
+struct DDayWidgetViewModelProviderTests {
+
+    private var utc: TimeZone { TimeZone(abbreviation: "UTC")! }
+
+    // 2026-07-27 00:00 UTC
+    private var now: Date { Date(timeIntervalSince1970: 1785110400) }
+
+    private func makeProvider(
+        target: DDayTargetEvent? = nil
+    ) -> DDayWidgetViewModelProvider {
+
+        let usecase = StubCalendarEventsFetchUescase()
+        usecase.stubDDayTarget = target
+
+        let calendarSettingRepository = StubCalendarSettingRepository()
+        calendarSettingRepository.saveTimeZone(self.utc)
+
+        return DDayWidgetViewModelProvider(
+            eventFetchUsecase: usecase,
+            calendarSettingRepository: calendarSettingRepository,
+            appSettingRepository: StubAppSettingRepository()
+        )
+    }
+}
+
+// MARK: - 대상이 있을 때
+
+extension DDayWidgetViewModelProviderTests {
+
+    @Test("14일 뒤 이벤트는 D-14")
+    func provider_whenTargetIsFuture_showsDMinus() async throws {
+        // given
+        let after14Days = self.now.addingTimeInterval(3600 * 24 * 14)
+        let target = DDayTargetEvent(
+            targetId: .init(eventId: "s1", isTodo: false),
+            name: "워크숍",
+            time: .at(after14Days.timeIntervalSince1970)
+        )
+        let provider = self.makeProvider(target: target)
+        // when
+        let model = try await provider.getDDayModel(
+            for: self.now, target: .init(eventId: "s1", isTodo: false)
+        )
+        // then
+        #expect(model.eventTitle == "워크숍")
+        #expect(model.ddayText == "D-14")
+    }
+
+    @Test("오늘 이벤트는 D-Day")
+    func provider_whenTargetIsToday_showsDDay() async throws {
+        // given
+        let target = DDayTargetEvent(
+            targetId: .init(eventId: "s1", isTodo: false),
+            name: "오늘",
+            time: .at(self.now.timeIntervalSince1970 + 3600)
+        )
+        let provider = self.makeProvider(target: target)
+        // when
+        let model = try await provider.getDDayModel(
+            for: self.now, target: .init(eventId: "s1", isTodo: false)
+        )
+        // then
+        #expect(model.ddayText == "D-Day")
+    }
+
+    @Test("갱신 시각은 유저 타임존 기준 다음 자정")
+    func provider_refreshAfterIsNextMidnightInUserTimeZone() async throws {
+        // given
+        let target = DDayTargetEvent(
+            targetId: .init(eventId: "s1", isTodo: false),
+            name: "워크숍",
+            time: .at(self.now.timeIntervalSince1970 + 3600 * 24 * 14)
+        )
+        let provider = self.makeProvider(target: target)
+        // when
+        let model = try await provider.getDDayModel(
+            for: self.now.addingTimeInterval(3600 * 5), target: .init(eventId: "s1", isTodo: false)
+        )
+        // then
+        #expect(model.refreshAfter == self.now.addingTimeInterval(3600 * 24))
+    }
+}
+
+// MARK: - 대상이 없을 때
+
+extension DDayWidgetViewModelProviderTests {
+
+    @Test("대상 미지정이면 안내 문구")
+    func provider_whenNoTarget_showsGuideText() async throws {
+        // given
+        let provider = self.makeProvider(target: nil)
+        // when
+        let model = try await provider.getDDayModel(for: self.now, target: nil)
+        // then
+        #expect(model.ddayText == "–")
+        #expect(model.targetDateText.isEmpty)
+    }
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/EventListWidgetViewModelProviderTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/EventListWidgetViewModelProviderTests.swift
@@ -538,8 +538,14 @@ extension EventListWidgetViewModelProviderTests {
         func fetchNextEvents(_ refTime: Date, withIn todayRange: Range<TimeInterval>, _ timeZone: TimeZone) async throws -> TodayNextEvents {
             return .init(nextEvents: [], customTags: [])
         }
+
+        func fetchDDayTargetEvent(
+            _ target: DDayTargetEventId, after refTime: Date
+        ) async throws -> DDayTargetEvent? {
+            return nil
+        }
     }
-    
+
     private func makeProviderWithStubUnsortedEvents() -> EventListWidgetViewModelProvider {
         
         let fetchUsecase = UnSortedStubEventsFetchUsecase(refDate: self.refDate)
@@ -616,8 +622,14 @@ extension EventListWidgetViewModelProviderTests {
             func fetchNextEvents(_ refTime: Date, withIn todayRange: Range<TimeInterval>, _ timeZone: TimeZone) async throws -> TodayNextEvents {
                 return .init(nextEvents: [], customTags: [])
             }
+
+            func fetchDDayTargetEvent(
+                _ target: DDayTargetEventId, after refTime: Date
+            ) async throws -> DDayTargetEvent? {
+                return nil
+            }
         }
-        
+
         let fetchUsecase = EventsWithTagFetchUescase()
         let calendarSettingRepository = StubCalendarSettingRepository()
         let appSettingRepository = StubAppSettingRepository()


### PR DESCRIPTION
## 문제

`#721` 프리미엄 위젯 팩의 선봉. 홈스크린에서 "그 날까지 며칠 남았나"를 보여주는 위젯이 없었다.

D-day 계산 자체는 이미 있었지만(`DaysIntervalCountUsecase`, `Calendar.diffDays`) 위젯에서 쓸 수 없는 상태였다:
- 표시 포맷 `DDayText`가 `EventDetailScene` 프레임워크에 internal로 갇혀 있음
- 위젯 전용 `CalendarEventFetchUsecase`에 "ID로 이벤트 하나 조회"가 없음 — 기간 조회만 가능
- 반복 이벤트의 "지금 기준 다음 회차"를 한 번에 구하는 수단이 없음 (`nextEventTime(from:until:)`은 한 칸만 전진)

## 접근

**대상은 기존 이벤트 연결만.** 임의 날짜+제목 직접 입력은 제외했다 — 위젯 config에만 사는 데이터가 되어 앱에서 조회·편집이 안 되고, 종일 일정으로 대체 가능하다. 반복 이벤트는 ForemostEvent처럼 차단하지 않고 **다음 회차 기준**으로 허용한다.

**대상 저장은 ID만, 본문은 매 타임라인마다 조회.** 위젯 config에 `todo::<id>` / `schedule::<id>` 문자열만 남기고, 렌더 시점에 read-only SQLite에서 이벤트를 읽는다. 이벤트가 삭제되면 조회가 nil이 되어 "대상을 선택해주세요" 안내로 폴백한다.

**반복 회차는 enumerator로 정확히 계산.** 기간 조회로 다음 회차를 찾으면 먼 미래 회차를 놓치므로, 원본 이벤트를 ID로 가져와 `EventRepeatTimeEnumerator`를 기준 시각 넘을 때까지 전진시킨다. 무한 루프 방어로 최대 3650회.

**자정 갱신은 D-day 위젯만 자체 계산.** 공통 `Date.nextUpdateTime`은 유저 타임존 미반영 TODO가 달려 있는데, 이걸 고치면 기존 18종 위젯이 전부 영향받는다. 이번엔 건드리지 않고 D-day 타임라인 프로바이더가 유저 타임존 기준 다음 자정을 직접 산출한다.

**커스터마이징 확장 대비 2가지를 미리 고정.** 배경 이미지·테마는 이후 `#721` 커스터마이징 이슈에서 같은 Intent에 파라미터로 붙는다. AppIntent는 파라미터 추가는 안전하지만 삭제·개명은 기존 위젯 설정을 깨므로 ① Intent 타입명을 이벤트 선택에 한정하지 않고 `DDayWidgetConfigurationIntent`로 두고, ② View 배경을 처음부터 `containerBackground(for: .widget)`로 선언했다.

## 커밋 단위

1. `DDayText`를 Extensions로 승격 — 위젯 공용화
2. `EventRepeatTimeEnumerator.nextEventTime(after:from:until:)` — 기준 시각 이후 첫 회차
3. `CalendarEventFetchUsecase.fetchDDayTargetEvent(_:after:)` — 단건 조회 + 반복 해석
4. AppIntents 3층 — Entity·Query·Intent
5. `DDayWidgetViewModelProvider` — D-n 산출 + 자정 갱신 시각
6. TimelineProvider·View·번들 등록

## 검증

- `TodoCalendarAppWidget` / `Domain` / `Extensions` / `EventDetailScene` 4개 스킴 테스트 통과
- `TodoCalendarApp` 빌드 성공

## 남은 과제

- **시뮬레이터 수동 확인 미완** — 위젯 갤러리에서 추가 → 편집 시트의 Event 파라미터 목록 표시 → 선택 후 D-n 표시. `suggestedEntities()`의 1년 fetch 범위는 자동 검증이 불가능한 자리다.
- **Pro 게이팅·결제** — `#721` 별도 트랙
- **위젯 커스터마이징(배경 이미지·테마)** — `#721` 리스트업 3번. 위젯 편집 시트는 사진 피커를 띄울 수 없어, 앱에서 등록 → App Group 저장 → AppEntity 목록으로 선택하는 구조가 된다
- **잠금화면 위젯 / 위젯 갤러리** — `#721` 리스트업 4·5번
- **공통 `Date.nextUpdateTime`의 timeZone 미반영 TODO** — 18종 위젯 전체에 영향이라 별도 판단 필요

Closes #722
