### PR TITLE
[#639] 전 프레임워크 static 전환 — 내부 15개 + 외부 SPM, 임베드 dylib 0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,23 +5,7 @@ import PackageDescription
 import ProjectDescription
 
 let packageSettings = PackageSettings(
-    productTypes: [
-        "Alamofire": .framework,
-        "Kingfisher": .framework,
-        "Prelude": .framework,
-        "Optics": .framework,
-        "Pulse": .framework,
-        "PulseUI": .framework,
-        "CombineCocoa": .framework,
-        "AsyncAlgorithms": .framework,
-        "AsyncFlatMap": .framework,
-        "SQLiteService": .framework,
-        "Toaster": .framework,
-        "KeychainSwift": .framework,
-        "CombineExt": .framework,
-        "SwiftLinkPreview": .framework,
-        "SnapshotTesting": .framework,
-    ]
+    productTypes: [:]
 )
 #endif
 

--- a/Supports/Common3rdParty/Project.swift
+++ b/Supports/Common3rdParty/Project.swift
@@ -25,6 +25,5 @@ let project = Project.framework(
         .external(name: "KeychainSwift"),
         .external(name: "CombineExt"),
         .external(name: "SwiftLinkPreview")
-    ],
-    customSetting: .init().otherLinkerFlags(["-ObjC"])
+    ]
 )

--- a/Supports/Extensions/Sources/Type+Extensions/String+Extensions.swift
+++ b/Supports/Extensions/Sources/Type+Extensions/String+Extensions.swift
@@ -10,26 +10,17 @@ import Foundation
 
 // MARK: - localizing
 
-extension Bundle {
-    
-    private final class Resource { }
-    
-    static var thisBundle: Bundle {
-        return Bundle(for: Resource.self)
-    }
-}
-
 public enum R {
     public typealias String = ExtensionsStrings
 }
 
 extension String {
-    
+
     public func localized() -> String {
-        
+
         return NSLocalizedString(
-            self, 
-            bundle: Bundle.thisBundle, 
+            self,
+            bundle: Bundle.module,
             comment: ""
         )
     }

--- a/Supports/Extensions/Tests/String+LocalizedTests.swift
+++ b/Supports/Extensions/Tests/String+LocalizedTests.swift
@@ -1,0 +1,30 @@
+//
+//  String+LocalizedTests.swift
+//  ExtensionsTests
+//
+//  Created by sudo.park on 7/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import XCTest
+@testable import Extensions
+
+final class StringLocalizedTests: XCTestCase {
+
+    // 로컬라이즈 번들을 못 찾으면 key가 그대로 반환된다 — static 전환 회귀 가드
+    func testLocalized_resolveKeyToTranslation() {
+        // given
+        let key = "common::back"
+
+        // when
+        let localized = key.localized()
+
+        // then
+        XCTAssertEqual(localized, "Back")
+    }
+
+    func testSynthesizedStrings_resolveViaModuleBundle() {
+        // then
+        XCTAssertEqual(R.String.commonAnd, " and")
+    }
+}

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -139,7 +139,7 @@ extension Project {
     {
         let sources = Target.target(name: name,
                              destinations: destinations,
-                             product: .framework,
+                             product: .staticFramework,
                              bundleId: "\(organizationName).\(name)",
                              deploymentTargets: .iOS(iOSTargetVersion),
                              infoPlist: .default,
@@ -182,7 +182,7 @@ extension Project {
         let settingDict = customSetting.swiftVersion("6.0")
         let sources = Target.target(name: name,
                              destinations: destinations,
-                             product: .framework,
+                             product: .staticFramework,
                              bundleId: "\(organizationName).\(name)",
                              deploymentTargets: .iOS(iOSTargetVersion),
                              infoPlist: .default,
@@ -332,7 +332,9 @@ extension Project {
             entitlements: Entitlements.file(path: "./AppExtensions/\(extensionName)/\(targetName).entitlements"),
             dependencies: dependencies,
             settings: .settings(
-                base: .init().swiftVersion("6.0"),
+                base: .init()
+                    .swiftVersion("6.0")
+                    .otherLinkerFlags(["-ObjC"]),
                 configurations: signingConfigures + [
 
                 ]


### PR DESCRIPTION
## 문제

내부 프레임워크 15개가 전부 dynamic(`.framework`)이고 외부 SPM 15개도 루트 `Package.swift`의 `productTypes`로 dynamic 강제돼 있어, 앱 실행 시 30개+ dylib을 로딩하는 구조였다. #639 항목 1 — 전부 static으로 전환한다. 여기서 정립한 형태가 이후 신규 프레임워크(#707 등)의 컨벤션이 된다.

## 접근

**1. 로컬라이즈 번들 교체 (선행)** — static 전환 시 깨지는 유일한 리소스 참조가 `Bundle.thisBundle`(수기 `Bundle(for:)`)이었다. static이 되면 소비자 바이너리 번들을 반환해 분리 리소스 번들의 `.lproj`를 못 찾는다 (`.localized()` 호출 파일 127개 영향). Tuist 합성 `Bundle.module`로 교체하고 — dynamic·static 양쪽에서 동작 — 키가 번역으로 해석되는지 회귀 테스트를 심어 전환의 가드로 삼았다.

**2. 내부 15개 static 전환** — product 결정 지점은 `Project+Templates.swift` 하드코딩 2곳(framework/frameworkWithTest)뿐이라 `.staticFramework`로 교체. product 파라미터화는 하지 않았다 — 전부 static이라 dynamic 소비자가 없다 (YAGNI). Common3rdParty(dynamic)가 흡수하던 Firebase static 심볼이 최종 바이너리로 전파되기 시작하므로 위젯·인텐트 타겟에 `-ObjC` 추가 (앱은 기존 보유), static 타겟에선 사문화되는 Common3rdParty의 `-ObjC`는 제거.

**3. 외부 SPM static 전환** — `productTypes` dynamic 강제 15개를 걷어내 Tuist 기본(static)으로. Firebase·GoogleSignIn은 원래 미지정(static)이라 무변화.

**검증**: 전 11스킴 테스트 통과(1,053+), 앱·위젯·인텐트 빌드 성공, 앱 번들 임베드 dylib 0 (시스템 shim 제외)·`.appex` 임베드 0, 로컬라이즈 회귀 가드 GREEN.

## 남은 과제

- **테스트 번들 `-ObjC` 미커버 (이론적 잠복)** — 테스트 타겟도 Common3rdParty를 직접 링크해 Firebase static 심볼이 전파되지만 `-ObjC`가 없다. 현재 테스트는 Firebase category를 안 타서 비발현 (전 스킴 GREEN). 단 호스티드 테스트 번들(TodoCalendarAppTests)은 `-ObjC` 추가 시 앱과 중복 클래스 리스크가 있어 무조건 추가가 답이 아님 — Firebase를 타는 테스트가 생기는 시점에 별도 검토.
- **#639 항목 2** — Domain 내 service 구현체(Notification·Speech·OAuth2) 별도 프레임워크 분리. 이 PR 머지 후 착수.
- **수동 QA** — 시뮬레이터에서 화면 텍스트(키 노출 없음)·위젯 렌더링 확인, 바이너리 용량 변화 참고 측정 (3개 바이너리 코드 복제는 감수 확정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
