### PR TITLE
[#722] D-day 위젯 — 반복 일정은 회차 직접 지정, 홈스크린 소·중형

### DIFF
--- a/Domain/Sources/Models/Events/EventTime.swift
+++ b/Domain/Sources/Models/Events/EventTime.swift
@@ -129,7 +129,17 @@ public enum EventTime: Comparable, Sendable, Hashable {
             return "\(Int(range.lowerBound))..<\(Int(range.upperBound))+\(Int(secondsFromGMT))"
         }
     }
-    
+
+    /// `customKey`가 지목하는 회차의 시작 시각.
+    ///
+    /// 반복 열거는 시간순 전진이라, 어떤 회차를 키로 찾을 때 "이미 이 시각을 지났으면 없는 회차"로
+    /// 판정할 수 있다. `customKey`의 세 형태 모두 시작 시각으로 시작하므로 앞쪽 정수만 읽는다 —
+    /// customKey 포맷을 바꾸면 이 파서도 함께 갱신해야 한다.
+    public static func lowerBound(fromCustomKey key: String) -> TimeInterval? {
+        let head = key.prefix { $0.isNumber || $0 == "-" }
+        return Int(head).map { TimeInterval($0) }
+    }
+
     public func rangeWithShifttingifNeed(on timeZone: TimeZone) -> Range<TimeInterval> {
         switch self {
         case .at(let time): return time..<time

--- a/Domain/Tests/Models/Events/EventTimeCustomKeyTests.swift
+++ b/Domain/Tests/Models/Events/EventTimeCustomKeyTests.swift
@@ -1,0 +1,50 @@
+//
+//  EventTimeCustomKeyTests.swift
+//  DomainTests
+//
+//  Created by sudo.park on 7/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+
+@testable import Domain
+
+
+struct EventTimeCustomKeyTests {
+
+    @Test("모든 EventTime 형태의 customKey에서 시작 시각을 읽는다")
+    func lowerBoundFromCustomKey_forEveryCase() {
+        // given
+        let at = EventTime.at(1234)
+        let period = EventTime.period(1234..<5678)
+        let allDay = EventTime.allDay(1234..<5678, secondsFromGMT: 32400)
+
+        // when + then
+        #expect(EventTime.lowerBound(fromCustomKey: at.customKey) == 1234)
+        #expect(EventTime.lowerBound(fromCustomKey: period.customKey) == 1234)
+        #expect(EventTime.lowerBound(fromCustomKey: allDay.customKey) == 1234)
+    }
+
+    @Test("1970년 이전 시각도 읽는다")
+    func lowerBoundFromCustomKey_whenNegative() {
+        // given
+        let time = EventTime.period(-5678 ..< -1234)
+
+        // when
+        let lowerBound = EventTime.lowerBound(fromCustomKey: time.customKey)
+
+        // then
+        #expect(lowerBound == -5678)
+    }
+
+    @Test("customKey 형식이 아니면 읽지 않는다", arguments: ["", "abc", "..<1234"])
+    func lowerBoundFromCustomKey_whenMalformed_returnsNil(_ key: String) {
+        // given + when
+        let lowerBound = EventTime.lowerBound(fromCustomKey: key)
+
+        // then
+        #expect(lowerBound == nil)
+    }
+}

--- a/Presentations/CommonPresentation/Sources/Extensions/EventRepeatingOption+Extensions.swift
+++ b/Presentations/CommonPresentation/Sources/Extensions/EventRepeatingOption+Extensions.swift
@@ -1,0 +1,154 @@
+//
+//  EventRepeatingOption+Extensions.swift
+//  CommonPresentation
+//
+//  Created by sudo.park on 7/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Prelude
+import Optics
+import Domain
+import Extensions
+
+
+private typealias Options = EventRepeatingOptions
+
+
+// MARK: - EventRepeatingOption + summaryText
+
+public extension EventRepeatingOption {
+
+    /// 반복 주기를 사람이 읽는 한 줄 요약으로. 지원하지 않는 조합이면 nil.
+    func summaryText(startTime: Date, timeZone: TimeZone) -> String? {
+
+        guard let supportOption = SupportingOptions(self) else { return nil }
+        let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
+
+        switch supportOption {
+        case .everyDay:
+            return R.String.EventDetail.Repeating.everyDayTitle
+
+        case .everyWeek(let seq, let weekDay) where seq == 1:
+            return weekDay.rawValue == calendar.component(.weekday, from: startTime)
+                ? "eventDetail.repeating.everyWeek:title".localized()
+                : "eventDetail.repeating.everyWeekSomeDay:title".localized(with: weekDay.text)
+
+        case .everyWeekDays:
+            return "eventDetail.repeating.everyWeekDays:title".localized()
+
+        case .everyWeek(let seq, let weekDay):
+            return weekDay.rawValue == calendar.component(.weekday, from: startTime)
+                ? "eventDetail.repeating.everySomeWeek:title".localized(with: seq)
+                : "eventDetail.repeating.everySomeWeekSomeDay:title".localized(with: seq, weekDay.text)
+
+        case .everyMonth(let day):
+            guard calendar.component(.day, from: startTime) != day
+            else { return "eventDetail.repeating.everyMonth:title".localized() }
+            let ordinal = day.ordinal ?? "\(day)"
+            return "eventDetail.repeating.everyMonth_someDay:title".localized(with: ordinal)
+
+        case .everyYear(let month, let day):
+            guard calendar.component(.month, from: startTime) != month
+                    || calendar.component(.day, from: startTime) != day
+            else { return "eventDetail.repeating.everyYear:title".localized() }
+            return "eventDetail.repeating.everyYearSomeDay:title"
+                .localized(with: calendar.dateText(month, day))
+
+        case .lunarCalendarEveryYear(let month, let day):
+            guard calendar.component(.month, from: startTime) != month
+                    || calendar.component(.day, from: startTime) != day
+            else { return "eventDetail.repeating.lunarCalendar_everyYear:title".localized() }
+            return "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title"
+                .localized(with: calendar.dateText(month, day))
+
+        case .everyMonthLastAllWeekDays:
+            return R.String.EventDetail.Repeating.everyLastWeekDaysOfEveryMonthTitle
+
+        case .everyMonthSomeWeekDay(let seq, let weekDay):
+            return "eventDetail.repeating.every\(seq)WeekOfEveryMonth::someday"
+                .localized(with: weekDay.text)
+
+        case .everyMonthLastWeekDay(let weekDay):
+            return R.String.EventDetail.Repeating.everyLastWeekOfEveryMonthSomeday(weekDay.text)
+        }
+    }
+}
+
+
+// MARK: - SupportingOptions
+
+private enum SupportingOptions: Equatable {
+
+    case everyDay
+    case everyWeek(_ interval: Int, _ weekDay: DayOfWeeks)
+    case everyWeekDays
+    case everyMonth(_ day: Int)
+    case everyYear(_ month: Int, _ day: Int)
+    case everyMonthLastAllWeekDays
+    case everyMonthSomeWeekDay(_ seq: Int, weekDay: DayOfWeeks)
+    case everyMonthLastWeekDay(_ weekDay: DayOfWeeks)
+    case lunarCalendarEveryYear(_ month: Int, _ day: Int)
+
+    init?(_ option: any EventRepeatingOption) {
+        switch option {
+        case let day as Options.EveryDay where day.interval == 1:
+            self = .everyDay
+
+        case let week as Options.EveryWeek where week.dayOfWeeks.count == 1:
+            self = .everyWeek(week.interval, week.dayOfWeeks[0])
+
+        case let week as Options.EveryWeek where week.interval == 1 && week.isEveryWeekDays:
+            self = .everyWeekDays
+
+        case let month as Options.EveryMonth:
+            guard let support = SupportingOptions(month: month) else { return nil }
+            self = support
+
+        case let year as Options.EveryYearSomeDay where year.interval == 1:
+            self = .everyYear(year.month, year.day)
+
+        case let year as Options.LunarCalendarEveryYear:
+            self = .lunarCalendarEveryYear(year.month, year.day)
+
+        default: return nil
+        }
+    }
+
+    private init?(month: Options.EveryMonth) {
+        guard month.interval == 1 else { return nil }
+
+        switch month.selection {
+        case .days(let days):
+            guard let day = days.first else { return nil }
+            self = .everyMonth(day)
+
+        case .week(let ordinals, let weekdays):
+            guard let ordinal = ordinals.first, let firstWeekDay = weekdays.first
+            else { return nil }
+            if case let .seq(seq) = ordinal, weekdays.count == 1 {
+                self = .everyMonthSomeWeekDay(seq, weekDay: firstWeekDay)
+            } else if weekdays.count == 7 {
+                self = .everyMonthLastAllWeekDays
+            } else if weekdays.count == 1 {
+                self = .everyMonthLastWeekDay(firstWeekDay)
+            } else {
+                return nil
+            }
+        }
+    }
+}
+
+
+// MARK: - Calendar
+
+private extension Calendar {
+
+    func dateText(_ month: Int, _ day: Int) -> String {
+        guard let date = self.date(bySetting: .month, value: month, of: Date())
+            .flatMap({ self.date(bySetting: .day, value: day, of: $0) })
+        else { return "\(month).\(day)" }
+        return date.text("date_form::MMM_d".localized())
+    }
+}

--- a/Presentations/EventDetailScene/Sources/EventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailViewModel.swift
@@ -97,19 +97,3 @@ protocol EventDetailViewModel: Sendable, AnyObject {
     var isSaving: AnyPublisher<Bool, Never> { get }
     var moreActions: AnyPublisher<[[EventDetailMoreAction]], Never> { get }
 }
-
-
-struct DDayText {
-    
-    let text: String
-    init(_ interval: Int) {
-        switch interval {
-        case ..<0:
-            self.text = "D+\(abs(interval))"
-        case 0:
-            self.text = "D-Day"
-        default:
-            self.text = "D-\(interval)"
-        }
-    }
-}

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewModel.swift
@@ -11,6 +11,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
@@ -14,6 +14,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 

--- a/Presentations/EventDetailScene/Sources/Selections/SelectEventRepeatOption/SelectEventRepeatOptionViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/Selections/SelectEventRepeatOption/SelectEventRepeatOptionViewModel.swift
@@ -14,69 +14,13 @@ import Optics
 import Domain
 import Extensions
 import Scenes
+import CommonPresentation
 
 
 private typealias Options = EventRepeatingOptions
 
-private enum SupportingOptions: Equatable {
-    case everyDay
-    case everyWeek(_ interval: Int, _ weekDay: DayOfWeeks)
-    case everyWeekDays
-    case everyMonth(_ day: Int)
-    case everyYear(_ month: Int, _ day: Int)
-    case everyMonthLastAllWeekDays
-    case everyMonthSomeWeekDay(_ seq: Int, weekDay: DayOfWeeks)
-    case everyMonthLastWeekDay(_ weekDay: DayOfWeeks)
-    case lunarCalendarEveryYear(_ month: Int, _ day: Int)
-    
-    init?(_ option: EventRepeatingOption) {
-        switch option {
-        case let day as Options.EveryDay where day.interval == 1:
-            self = .everyDay
-            
-        case let week as Options.EveryWeek where week.dayOfWeeks.count == 1:
-            self = .everyWeek(week.interval, week.dayOfWeeks[0])
-            
-        case let week as Options.EveryWeek where week.interval == 1 && week.isEveryWeekDays:
-            self = .everyWeekDays
-            
-        case let month as Options.EveryMonth:
-            guard let support = SupportingOptions(month: month)
-            else { return nil }
-            self = support
-            
-        case let year as Options.EveryYearSomeDay where year.interval == 1:
-            self = .everyYear(year.month, year.day)
-            
-        case let year as Options.LunarCalendarEveryYear:
-            self = .lunarCalendarEveryYear(year.month, year.day)
-            
-        default: return nil
-        }
-    }
-    
-    private init?(month: Options.EveryMonth) {
-        guard month.interval == 1 else { return nil }
-        
-        switch month.selection {
-        case .days(let days):
-            guard let day = days.first else { return nil }
-            self = .everyMonth(day)
-            
-        case .week(let ordinals, let weekdays):
-            guard let ordinal = ordinals.first, let firstWeekDay = weekdays.first else { return nil }
-            if case let .seq(seq) = ordinal, weekdays.count == 1 {
-                self = .everyMonthSomeWeekDay(seq, weekDay: firstWeekDay)
-            } else if weekdays.count == 7 {
-                self = .everyMonthLastAllWeekDays
-            } else if weekdays.count == 1 {
-                self = .everyMonthLastWeekDay(firstWeekDay)
-            } else {
-                return nil
-            }
-        }
-    }
-    
+private enum SupportedRepeatOptions {
+
     static func supports(from startTime: Date, timeZone: TimeZone) -> [[any EventRepeatingOption]] {
         let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
         let month = calendar.component(.month, from: startTime)
@@ -143,76 +87,9 @@ struct SelectRepeatingOptionModel: Equatable, Identifiable {
     }
     
     init?(_ option: EventRepeatingOption, _ startTime: Date, _ timeZone: TimeZone) {
-        guard let supportOption = SupportingOptions(option) else { return nil }
-        let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
-        switch supportOption {
-        case .everyDay:
-            self = .init(R.String.EventDetail.Repeating.everyDayTitle, option)
-            
-        case .everyWeek(let seq, let weekDay) where seq == 1:
-            if weekDay.rawValue == calendar.component(.weekday, from: startTime) {
-                self = .init(
-                    "eventDetail.repeating.everyWeek:title".localized(), option
-                )
-            } else {
-                self = .init(
-                    "eventDetail.repeating.everyWeekSomeDay:title".localized(with: weekDay.text), option
-                )
-            }
-            
-        case .everyWeekDays:
-            self = .init("eventDetail.repeating.everyWeekDays:title".localized(), option)
-            
-        case .everyWeek(let seq, let weekDay):
-            if weekDay.rawValue == calendar.component(.weekday, from: startTime) {
-                self = .init(
-                    "eventDetail.repeating.everySomeWeek:title".localized(with: seq), option
-                )
-            } else {
-                self = .init(
-                    "eventDetail.repeating.everySomeWeekSomeDay:title".localized(with: seq, weekDay.text), option
-                )
-            }
-            
-        case .everyMonth(let day):
-            let currentDay = calendar.component(.day, from: startTime)
-            if currentDay == day {
-                self = .init("eventDetail.repeating.everyMonth:title".localized(), option)
-            } else {
-                let ordinal = day.ordinal ?? "\(day)"
-                self = .init(
-                    "eventDetail.repeating.everyMonth_someDay:title".localized(with: ordinal), option
-                )
-            }
-        case .everyYear(let month, let day):
-            if calendar.component(.month, from: startTime) == month &&
-               calendar.component(.day, from: startTime) == day {
-                self = .init("eventDetail.repeating.everyYear:title".localized(), option)
-            } else {
-                let dateText = calendar.dateText(month, day)
-                self = .init("eventDetail.repeating.everyYearSomeDay:title".localized(with: dateText), option)
-            }
-            
-        case .lunarCalendarEveryYear(let month, let day):
-            if calendar.component(.month, from: startTime) == month
-                && calendar.component(.day, from: startTime) == day {
-                self = .init("eventDetail.repeating.lunarCalendar_everyYear:title".localized(), option)
-            } else {
-                let dateText = calendar.dateText(month, day)
-                self = .init("eventDetail.repeating.lunarCalendar_everyYearSomeDay:title".localized(with: dateText), option)
-            }
-            
-        case .everyMonthLastAllWeekDays:
-            self = .init(R.String.EventDetail.Repeating.everyLastWeekDaysOfEveryMonthTitle, option)
-            
-        case .everyMonthSomeWeekDay(let seq, let weekDay):
-            let text = "eventDetail.repeating.every\(seq)WeekOfEveryMonth::someday".localized(with: weekDay.text)
-            self = .init(text, option)
-            
-        case .everyMonthLastWeekDay(let weekDay):
-            let text = R.String.EventDetail.Repeating.everyLastWeekOfEveryMonthSomeday(weekDay.text)
-            self = .init(text, option)
-        }
+        guard let text = option.summaryText(startTime: startTime, timeZone: timeZone)
+        else { return nil }
+        self = .init(text, option)
     }
     
     static func == (lhs: SelectRepeatingOptionModel, rhs: SelectRepeatingOptionModel) -> Bool {
@@ -367,7 +244,7 @@ extension SelectEventRepeatOptionViewModelImple {
         let previousOptionModel = previousSelectOption.flatMap {
             SelectRepeatingOptionModel($0.repeatOption, self.selectTime, timeZone)
         }
-        let supportOptionModels = SupportingOptions.supports(from: self.selectTime, timeZone: timeZone)
+        let supportOptionModels = SupportedRepeatOptions.supports(from: self.selectTime, timeZone: timeZone)
             .map { options in
                 options.compactMap { SelectRepeatingOptionModel($0, self.selectTime, timeZone) }
             }
@@ -543,15 +420,5 @@ extension SelectEventRepeatOptionViewModelImple {
         .map(transform)
         .removeDuplicates()
         .eraseToAnyPublisher()
-    }
-}
-
-private extension Calendar {
-    
-    func dateText(_ month: Int, _ day: Int) -> String {
-        guard let date = self.date(bySetting: .month, value: month, of: Date())
-            .flatMap ({ self.date(bySetting: .day, value: day, of: $0) })
-        else { return "\(month).\(day)" }
-        return date.text("date_form::MMM_d".localized())
     }
 }

--- a/Presentations/EventDetailScene/Tests/HolidayEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/HolidayEventDetailViewModelImpleTests.swift
@@ -11,6 +11,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import UnitTestHelpKit
 import TestDoubles
 

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -501,6 +501,12 @@
 "widget.next.no_events_today" = "No events today";
 "widget.next.no_events" = "No upcoming events";
 
+"widget.dday::name" = "D-Day";
+"widget.dday::noTarget" = "Select an event";
+"widget.dday.sample::title" = "Workshop";
+"widget.dday.target::repeating" = "Repeating";
+"widget.dday.turn::name" = "Turn %d";
+
 // MARK: - link
 
 "deeplink::invalid_link_message" = "This link format is not supported.\nPlease update the app to the latest version.";
@@ -539,11 +545,6 @@
 "aiAgent::keyboard::send" = "Send";
 "aiAgent::stop" = "Stop";
 "aiAgent::usage" = "%@ / %@ credits";
-"aiAgent::plan::free" = "Free";
-"aiAgent::plan::standard" = "Standard";
-"aiAgent::plan::lifetime" = "Lifetime";
-"aiAgent::usage::topupRemaining" = "%@ extra credits left";
-"aiAgent::usage::planChangeScheduled" = "Switching to the %2$@ plan on %1$@";
 "aiAgent::stop::confirm::title" = "Stop processing?";
 "aiAgent::stop::confirm::message" = "Stopping discards the task in progress, and it can't be resumed.";
 "aiAgent::confirm::countdown" = "left to approve";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -501,6 +501,12 @@
 "widget.next.no_events_today" = "오늘 이벤트 없음";
 "widget.next.no_events" = "가까운 시일 내\n예정된 이벤트 없음";
 
+"widget.dday::name" = "디데이";
+"widget.dday::noTarget" = "대상을 선택해주세요";
+"widget.dday.sample::title" = "워크숍";
+"widget.dday.target::repeating" = "반복 일정";
+"widget.dday.turn::name" = "%d회차";
+
 // MARK: - link
 
 "deeplink::invalid_link_message" = "지원하지 않는 형식의 링크입니다.\n앱을 최신 버전으로 업데이트 해주세요.";
@@ -539,11 +545,6 @@
 "aiAgent::keyboard::send" = "전송";
 "aiAgent::stop" = "중지";
 "aiAgent::usage" = "%@ / %@ 크레딧";
-"aiAgent::plan::free" = "무료";
-"aiAgent::plan::standard" = "스탠다드";
-"aiAgent::plan::lifetime" = "평생";
-"aiAgent::usage::topupRemaining" = "추가 크레딧 %@ 남음";
-"aiAgent::usage::planChangeScheduled" = "%1$@부터 %2$@ 플랜으로 바뀌어요";
 "aiAgent::stop::confirm::title" = "처리를 중지할까요?";
 "aiAgent::stop::confirm::message" = "중지하면 진행 중인 작업이 사라지고 다시 시작할 수 없어요.";
 "aiAgent::confirm::countdown" = "안에 승인해 주세요";

--- a/Supports/Extensions/Sources/DDayText.swift
+++ b/Supports/Extensions/Sources/DDayText.swift
@@ -1,0 +1,26 @@
+//
+//  DDayText.swift
+//  Extensions
+//
+//  Created by sudo.park on 7/29/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+
+public struct DDayText {
+
+    public let text: String
+
+    public init(_ interval: Int) {
+        switch interval {
+        case ..<0:
+            self.text = "D+\(abs(interval))"
+        case 0:
+            self.text = "D-Day"
+        default:
+            self.text = "D-\(interval)"
+        }
+    }
+}

--- a/Supports/Extensions/Sources/Type+Extensions/Sequence+Extensions.swift
+++ b/Supports/Extensions/Sources/Type+Extensions/Sequence+Extensions.swift
@@ -12,7 +12,18 @@ extension Sequence {
     public func asDictionary<Key: Hashable>(_ keySelector: (Element) -> Key) -> [Key: Element] {
         return self.reduce(into: [Key: Element]()) { $0[keySelector($1)] = $1 }
     }
-    
+
+    /// key 기준 중복 제거 — 같은 key의 **첫** 원소만 남기고 순서를 유지한다.
+    /// (`asDictionary`는 마지막 원소가 남고 순서를 잃는다.)
+    public func removeDuplicates<Key: Hashable>(_ keySelector: (Element) -> Key) -> [Element] {
+        return self
+            .reduce(into: (seen: Set<Key>(), result: [Element]())) { acc, element in
+                guard acc.seen.insert(keySelector(element)).inserted else { return }
+                acc.result.append(element)
+            }
+            .result
+    }
+
     public func asyncForEach(_ asyncTask: (Element) async throws -> Void) async rethrows {
         
         for element in self {

--- a/Supports/Extensions/Tests/DDayTextTests.swift
+++ b/Supports/Extensions/Tests/DDayTextTests.swift
@@ -1,0 +1,42 @@
+//
+//  DDayTextTests.swift
+//  Extensions
+//
+//  Created by sudo.park on 7/29/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+
+@testable import Extensions
+
+
+struct DDayTextTests {
+
+    @Test("미래 이벤트는 D-n", arguments: [1, 3, 100])
+    func ddayText_whenFuture_isDMinus(_ interval: Int) {
+        // given
+        // when
+        let text = DDayText(interval).text
+        // then
+        #expect(text == "D-\(interval)")
+    }
+
+    @Test("당일은 D-Day")
+    func ddayText_whenToday_isDDay() {
+        // given
+        // when
+        let text = DDayText(0).text
+        // then
+        #expect(text == "D-Day")
+    }
+
+    @Test("지난 이벤트는 D+n", arguments: [-1, -3, -100])
+    func ddayText_whenPast_isDPlus(_ interval: Int) {
+        // given
+        // when
+        let text = DDayText(interval).text
+        // then
+        #expect(text == "D+\(abs(interval))")
+    }
+}

--- a/Supports/Extensions/Tests/Sequence+ExtensionsTests.swift
+++ b/Supports/Extensions/Tests/Sequence+ExtensionsTests.swift
@@ -1,0 +1,66 @@
+//
+//  Sequence+ExtensionsTests.swift
+//  ExtensionsTests
+//
+//  Created by sudo.park on 7/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+
+@testable import Extensions
+
+
+struct SequenceRemoveDuplicatesTests {
+
+    private struct Item: Equatable {
+        let key: String
+        let tag: Int
+    }
+
+    @Test("같은 key의 첫 원소만 남고 순서는 유지된다")
+    func removeDuplicates_keepsFirstAndPreservesOrder() {
+        // given
+        let items = [
+            Item(key: "a", tag: 1),
+            Item(key: "b", tag: 2),
+            Item(key: "a", tag: 3),
+            Item(key: "c", tag: 4),
+            Item(key: "b", tag: 5)
+        ]
+
+        // when
+        let result = items.removeDuplicates { $0.key }
+
+        // then
+        #expect(result == [
+            Item(key: "a", tag: 1),
+            Item(key: "b", tag: 2),
+            Item(key: "c", tag: 4)
+        ])
+    }
+
+    @Test("중복이 없으면 원본을 그대로 낸다")
+    func removeDuplicates_whenNoDuplicates_returnsAll() {
+        // given
+        let items = [Item(key: "a", tag: 1), Item(key: "b", tag: 2)]
+
+        // when
+        let result = items.removeDuplicates { $0.key }
+
+        // then
+        #expect(result == items)
+    }
+
+    @Test("빈 시퀀스는 빈 배열을 낸다")
+    func removeDuplicates_whenEmpty_returnsEmpty() {
+        // given
+        let items: [Item] = []
+
+        // when
+        let result = items.removeDuplicates { $0.key }
+
+        // then
+        #expect(result.isEmpty == true)
+    }
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Resources/en.lproj/Localizable.strings
+++ b/TodoCalendarApp/AppExtensions/Widget/Resources/en.lproj/Localizable.strings
@@ -1,7 +1,16 @@
-/* 
+/*
   Localizable.strings
   TodoCalendarApp
 
   Created by sudo.park on 8/25/24.
   Copyright © 2024 com.sudo.park. All rights reserved.
 */
+
+/* See ko.lproj counterpart — AppIntents labels resolve from this extension's own bundle. */
+
+"Event" = "Event";
+"Turn" = "Repeat turn";
+"EventType" = "Event type";
+"Event Types" = "Event types";
+"Exclude all day event" = "Exclude all-day events";
+"To-do completion processing" = "To-do completion processing";

--- a/TodoCalendarApp/AppExtensions/Widget/Resources/ko.lproj/Localizable.strings
+++ b/TodoCalendarApp/AppExtensions/Widget/Resources/ko.lproj/Localizable.strings
@@ -1,7 +1,20 @@
-/* 
+/*
   Localizable.strings
   TodoCalendarApp
 
   Created by sudo.park on 8/25/24.
   Copyright © 2024 com.sudo.park. All rights reserved.
 */
+
+/* AppIntents 전용 테이블.
+   위젯 편집 시트의 파라미터·엔티티 라벨은 LocalizedStringResource 로 해석되고,
+   그 기본 번들은 확장 타겟 자신(Bundle.main)이다 — 앱 문자열이 사는
+   Extensions 번들(`.localized()`)에서는 찾지 못하므로 여기에 둔다.
+   키는 코드에 적힌 영문 리터럴 그대로 — 조회가 실패해도 그 영문이 그대로 표시된다. */
+
+"Event" = "이벤트";
+"Turn" = "반복 회차";
+"EventType" = "이벤트 종류";
+"Event Types" = "이벤트 종류";
+"Exclude all day event" = "종일 일정 제외";
+"To-do completion processing" = "할일 완료 처리";

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Base+Factory/DDayTargetSelectIntentFactory.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Base+Factory/DDayTargetSelectIntentFactory.swift
@@ -1,0 +1,41 @@
+//
+//  DDayTargetSelectIntentFactory.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 7/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Domain
+import Repository
+
+
+struct DDayTargetSelectIntentFactory {
+
+    private let base: AppExtensionBase
+    private let usecaseFactory: WidgetUsecaseFactory
+
+    init(base: AppExtensionBase) {
+        self.base = base
+        self.usecaseFactory = .init(base: base)
+    }
+}
+
+extension DDayTargetSelectIntentFactory {
+
+    func makeEventFetchUsecase() -> any CalendarEventFetchUsecase {
+        return self.usecaseFactory.makeEventsFetchUsecase()
+    }
+
+    func makeHolidayFetchUsecase() -> any HolidaysFetchUsecase {
+        return self.usecaseFactory.makeHolidaysFetchUsecase()
+    }
+
+    func loadTimeZone() -> TimeZone {
+        let repository = CalendarSettingRepositoryImple(
+            environmentStorage: self.base.userDefaultEnvironmentStorage
+        )
+        return repository.loadUserSelectedTImeZone() ?? .current
+    }
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Base+Factory/WidgetViewModelProviderBuilder.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Base+Factory/WidgetViewModelProviderBuilder.swift
@@ -325,6 +325,36 @@ extension WidgetViewModelProviderBuilder {
     }
 }
 
+// MARK: - DDay
+
+extension WidgetViewModelProviderBuilder {
+
+    func makeDDayWidgetViewModelProvider(
+        shouldSkipCheckCacheReset: Bool = false
+    ) async -> DDayWidgetViewModelProvider {
+
+        if !shouldSkipCheckCacheReset {
+            await self.checkShouldReset()
+        }
+
+        let appSettingRepository = AppSettingLocalRepositoryImple(
+            storage: AppSettingLocalStorage(
+                environmentStorage: base.userDefaultEnvironmentStorage
+            )
+        )
+
+        let calendarSettingRepository = CalendarSettingRepositoryImple(
+            environmentStorage: base.userDefaultEnvironmentStorage
+        )
+
+        return DDayWidgetViewModelProvider(
+            eventFetchUsecase: self.usecaseFactory.makeEventsFetchUsecase(),
+            calendarSettingRepository: calendarSettingRepository,
+            appSettingRepository: appSettingRepository
+        )
+    }
+}
+
 // MARK: - composed
 
 extension WidgetViewModelProviderBuilder {

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Intents/DDayTargetSelectIntent.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Intents/DDayTargetSelectIntent.swift
@@ -1,0 +1,405 @@
+//
+//  DDayTargetSelectIntent.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 7/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import WidgetKit
+import AppIntents
+import Prelude
+import Optics
+import Domain
+import Extensions
+import CommonPresentation
+import CalendarScenes
+
+
+// MARK: - DDayTargetEventId + entity id
+
+extension DDayTargetEventId {
+
+    private enum Constant {
+        /// 공휴일 rawId가 `::`를 쓰므로 겹치지 않는 구분자를 쓴다.
+        static let separator: String = "|"
+        static let repeatingMark: String = "repeating"
+        static let singleMark: String = "single"
+    }
+
+    /// 반복 일정 entity id에 항상 들어가는 조각.
+    ///
+    /// `parameterSummary`의 조건(`When`)은 entity의 id 문자열만 비교할 수 있어서
+    /// "이 대상이 반복 일정인가"를 id에 실어야 회차 파라미터 노출을 가를 수 있다.
+    static var repeatingIdFragment: String {
+        return "\(Constant.separator)\(Constant.repeatingMark)\(Constant.separator)"
+    }
+
+    /// `schedule|repeating|<uuid>[|<customKey>]` / `holiday|single|<code>::<date>::<name>`
+    func entityId(isRepeating: Bool) -> String {
+        let mark = isRepeating ? Constant.repeatingMark : Constant.singleMark
+        let segments = [self.kind.rawValue, mark, self.rawId] + (self.turnKey.map { [$0] } ?? [])
+        return segments.joined(separator: Constant.separator)
+    }
+
+    init?(entityId: String) {
+        let segments = entityId.components(separatedBy: Constant.separator)
+        guard segments.count >= 3,
+              let kind = DDayTargetKind(rawValue: segments[0])
+        else { return nil }
+        self.init(
+            kind: kind,
+            rawId: segments[2],
+            turnKey: segments.count >= 4 ? segments[3] : nil
+        )
+    }
+}
+
+
+// MARK: - DDayTargetDateFormatter
+
+enum DDayTargetDateFormatter {
+
+    /// "2027년 3월 15일 (월)" 계열 — 로케일 템플릿.
+    static func dateText(of time: EventTime, in timeZone: TimeZone) -> String {
+        return self.text(of: time, in: timeZone, template: "yMMMdEEE")
+    }
+
+    /// "오전 7:00". 종일 일정은 시각이 의미 없어 빈 문자열.
+    static func timeText(of time: EventTime, in timeZone: TimeZone) -> String {
+        guard case .allDay = time else {
+            return self.text(of: time, in: timeZone, template: "jm")
+        }
+        return ""
+    }
+
+    private static func text(
+        of time: EventTime, in timeZone: TimeZone, template: String
+    ) -> String {
+        let date = Date(
+            timeIntervalSince1970: time.rangeWithShifttingifNeed(on: timeZone).lowerBound
+        )
+        let formatter = DateFormatter()
+        formatter.timeZone = timeZone
+        formatter.locale = .current
+        formatter.setLocalizedDateFormatFromTemplate(template)
+        return formatter.string(from: date)
+    }
+}
+
+
+// MARK: - DDayTargetEventEntity (1단: 일정·공휴일)
+
+struct DDayTargetEventEntity: AppEntity, Sendable {
+
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Event"
+    static let defaultQuery = DDayTargetEventQuery()
+
+    var id: String
+    var name: String
+    var subtitle: String
+
+    var displayRepresentation: DisplayRepresentation {
+        return DisplayRepresentation(title: "\(name)", subtitle: "\(subtitle)")
+    }
+}
+
+struct DDayTargetCandidate {
+    let targetId: DDayTargetEventId
+    let name: String
+    let time: EventTime
+    let isRepeating: Bool
+}
+
+extension Array where Element == DDayTargetCandidate {
+
+    /// 반복 일정 → 다가오는 순 → 지난 순(최근 먼저). 고를 확률이 높은 것을 위로 올린다.
+    ///
+    /// 지난 이벤트는 다가오는 것보다 후보 가치가 낮아 별도 상한을 둔다 — 한 상한을 공유하면
+    /// 다가오는 이벤트가 많은 유저에게 지난 이벤트가 아예 안 보인다.
+    func sortedForSuggestion(
+        since todayStart: TimeInterval, upcomingLimit: Int, pastLimit: Int
+    ) -> [DDayTargetCandidate] {
+
+        let repeatings = self.filter { $0.isRepeating }
+        let others = self.filter { !$0.isRepeating }
+
+        let upcoming = others
+            .filter { $0.time.lowerBoundWithFixed >= todayStart }
+            .sorted { $0.time.lowerBoundWithFixed < $1.time.lowerBoundWithFixed }
+            .prefix(upcomingLimit)
+
+        let past = others
+            .filter { $0.time.lowerBoundWithFixed < todayStart }
+            .sorted { $0.time.lowerBoundWithFixed > $1.time.lowerBoundWithFixed }
+            .prefix(pastLimit)
+
+        return repeatings + upcoming + past
+    }
+}
+
+struct DDayTargetEventQuery: EntityQuery, @unchecked Sendable {
+
+    private enum Constant {
+        static let upcomingDays: Int = 365
+        static let pastDays: Int = 365
+        static let upcomingLimit: Int = 40
+        static let pastLimit: Int = 10
+    }
+
+    private let factory: DDayTargetSelectIntentFactory
+
+    init() {
+        self.factory = .init(base: AppExtensionBase())
+    }
+
+    /// 저장된 id를 라벨로 복원한다 — id는 받은 문자열을 그대로 되돌려 저장값과 어긋나지 않게 한다.
+    func entities(for identifiers: [String]) async throws -> [DDayTargetEventEntity] {
+
+        let usecase = self.factory.makeEventFetchUsecase()
+        let timeZone = self.factory.loadTimeZone()
+
+        var entities: [DDayTargetEventEntity] = []
+        for identifier in identifiers {
+            guard let target = DDayTargetEventId(entityId: identifier),
+                  let event = try? await usecase.fetchDDayTargetEvent(target)
+            else { continue }
+            entities.append(
+                DDayTargetEventEntity(
+                    id: identifier,
+                    name: event.name,
+                    subtitle: event.isRepeating
+                        ? "widget.dday.target::repeating".localized()
+                        : DDayTargetDateFormatter.dateText(of: event.time, in: timeZone)
+                )
+            )
+        }
+        return entities
+    }
+
+    func suggestedEntities() async throws -> [DDayTargetEventEntity] {
+
+        let usecase = self.factory.makeEventFetchUsecase()
+        let timeZone = self.factory.loadTimeZone()
+        let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
+        let now = Date()
+
+        guard let todayStart = calendar.dayRange(now)?.lowerBound,
+              let from = calendar.addDays(-Constant.pastDays, from: now),
+              let until = calendar.addDays(Constant.upcomingDays, from: now)
+        else { return [] }
+
+        let countryCode = await self.factory.makeHolidayFetchUsecase().currentCountryCode()
+        let events = try await usecase.fetchEvents(
+            in: from.timeIntervalSince1970..<until.timeIntervalSince1970, timeZone
+        )
+        return self.asSuggestions(events.eventWithTimes, timeZone, countryCode, todayStart)
+    }
+
+    private func asSuggestions(
+        _ events: [any CalendarEvent],
+        _ timeZone: TimeZone,
+        _ countryCode: String?,
+        _ todayStart: TimeInterval
+    ) -> [DDayTargetEventEntity] {
+
+        return events
+            .compactMap { self.asCandidate($0, countryCode) }
+            .sorted { $0.time.lowerBoundWithFixed < $1.time.lowerBoundWithFixed }
+            // 반복 일정은 회차마다 후보가 생기므로, 시간순 정렬 뒤 가장 이른 회차만 남긴다
+            .removeDuplicates { $0.targetId }
+            .sortedForSuggestion(
+                since: todayStart,
+                upcomingLimit: Constant.upcomingLimit,
+                pastLimit: Constant.pastLimit
+            )
+            .map { candidate in
+                DDayTargetEventEntity(
+                    id: candidate.targetId.entityId(isRepeating: candidate.isRepeating),
+                    name: candidate.name,
+                    subtitle: candidate.isRepeating
+                        ? "widget.dday.target::repeating".localized()
+                        : DDayTargetDateFormatter.dateText(of: candidate.time, in: timeZone)
+                )
+            }
+    }
+
+    private func asCandidate(
+        _ event: any CalendarEvent, _ countryCode: String?
+    ) -> DDayTargetCandidate? {
+
+        guard let time = event.eventTime else { return nil }
+
+        switch event {
+        case let schedule as ScheduleCalendarEvent:
+            return DDayTargetCandidate(
+                targetId: .init(kind: .schedule, rawId: schedule.eventIdWithoutTurn),
+                name: schedule.name,
+                time: time,
+                isRepeating: schedule.isRepeating
+            )
+
+        case let holiday as HolidayCalendarEvent:
+            // countryCode가 없으면(국가 미선택) 복원 키를 만들 수 없어 후보에서 뺀다.
+            guard let countryCode else { return nil }
+            let key = HolidayTargetKey(
+                countryCode: countryCode,
+                dateString: holiday.dateString,
+                name: holiday.name
+            )
+            // HolidayCalendarEvent.isRepeating은 하드코딩 true(표시용)라 쓰지 않는다.
+            // 공휴일은 연도별 개별 데이터이므로 회차 선택 대상이 아니다.
+            return DDayTargetCandidate(
+                targetId: .init(kind: .holiday, rawId: key.rawId),
+                name: holiday.name,
+                time: time,
+                isRepeating: false
+            )
+
+        default:
+            // 할일(todo)·외부 캘린더 이벤트는 D-day 대상에서 제외한다.
+            return nil
+        }
+    }
+}
+
+
+// MARK: - DDayTargetTurnEntity (2단: 반복 회차)
+
+struct DDayTargetTurnEntity: AppEntity, Sendable {
+
+    static let typeDisplayRepresentation: TypeDisplayRepresentation = "Turn"
+    static let defaultQuery = DDayTargetTurnQuery()
+
+    var id: String
+    var name: String
+    var subtitle: String
+
+    var displayRepresentation: DisplayRepresentation {
+        return DisplayRepresentation(title: "\(name)", subtitle: "\(subtitle)")
+    }
+}
+
+struct DDayTargetTurnQuery: EntityQuery, @unchecked Sendable {
+
+    private enum Constant {
+        static let rangeDays: Int = 365
+        static let limit: Int = 50
+    }
+
+    @IntentParameterDependency<DDayWidgetConfigurationIntent>(\.$target)
+    var configuration
+
+    private let factory: DDayTargetSelectIntentFactory
+
+    init() {
+        self.factory = .init(base: AppExtensionBase())
+    }
+
+    /// 저장된 회차 id를 라벨로 복원한다 — turnKey로 실제 시각을 다시 조회해 표시한다.
+    func entities(for identifiers: [String]) async throws -> [DDayTargetTurnEntity] {
+
+        let timeZone = self.factory.loadTimeZone()
+        let usecase = self.factory.makeEventFetchUsecase()
+
+        var entities: [DDayTargetTurnEntity] = []
+        for identifier in identifiers {
+            guard let target = DDayTargetEventId(entityId: identifier),
+                  let event = try? await usecase.fetchDDayTargetEvent(target)
+            else { continue }
+            entities.append(
+                DDayTargetTurnEntity(
+                    id: identifier,
+                    name: DDayTargetDateFormatter.dateText(of: event.time, in: timeZone),
+                    subtitle: DDayTargetDateFormatter.timeText(of: event.time, in: timeZone)
+                )
+            )
+        }
+        return entities
+    }
+
+    func suggestedEntities() async throws -> [DDayTargetTurnEntity] {
+
+        guard let selected = self.configuration?.target,
+              let target = DDayTargetEventId(entityId: selected.id),
+              target.kind == .schedule
+        else { return [] }
+
+        let usecase = self.factory.makeEventFetchUsecase()
+        let timeZone = self.factory.loadTimeZone()
+        let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
+        let now = Date()
+
+        guard let todayStart = calendar.dayRange(now)?.lowerBound,
+              let until = calendar.addDays(Constant.rangeDays, from: now)
+        else { return [] }
+
+        let turns = try await usecase.fetchScheduleRepeatingTurns(
+            target.rawId,
+            in: todayStart..<until.timeIntervalSince1970,
+            limit: Constant.limit
+        )
+
+        return turns.map { turn in
+            DDayTargetTurnEntity(
+                id: DDayTargetEventId(
+                    kind: .schedule, rawId: target.rawId, turnKey: turn.time.customKey
+                )
+                .entityId(isRepeating: true),
+                name: "widget.dday.turn::name".localized(with: turn.turn),
+                subtitle: [
+                    DDayTargetDateFormatter.dateText(of: turn.time, in: timeZone),
+                    DDayTargetDateFormatter.timeText(of: turn.time, in: timeZone)
+                ]
+                .filter { !$0.isEmpty }
+                .joined(separator: " ")
+            )
+        }
+    }
+}
+
+
+// MARK: - Intent
+
+struct DDayWidgetConfigurationIntent: WidgetConfigurationIntent {
+
+    static let title: LocalizedStringResource = ""
+
+    @Parameter(title: "Event", default: nil)
+    var target: DDayTargetEventEntity?
+
+    @Parameter(title: "Turn", default: nil)
+    var turn: DDayTargetTurnEntity?
+
+    /// 반복 일정을 골랐을 때만 회차 파라미터를 노출한다 — 비반복 일정엔 고를 회차가 없다.
+    ///
+    /// 조건 값은 **반드시 문자열 리터럴**이어야 한다. AppIntents 메타데이터 추출기는 이 자리의
+    /// 소스 텍스트를 그대로 담아서, 상수를 참조하면 그 표현식 이름이 비교 대상 문자열로 박히고
+    /// 런타임 비교가 영원히 실패한다(회차 파라미터가 아예 안 뜬다).
+    /// `DDayTargetEventId.repeatingIdFragment`와 같은 값이어야 하며, 어긋나면 테스트가 잡는다.
+    static var parameterSummary: some ParameterSummary {
+        When(\.$target, identifier: .contains, "|repeating|") {
+            Summary {
+                \.$target
+                \.$turn
+            }
+        } otherwise: {
+            Summary {
+                \.$target
+            }
+        }
+    }
+
+    /// 실제로 렌더할 대상 — 회차가 지정됐으면 그것, 아니면 1단 값.
+    ///
+    /// 회차는 1단을 다른 이벤트로 바꿔도 남아 있을 수 있어, 같은 이벤트를 가리킬 때만 채택한다.
+    var resolvedTargetId: DDayTargetEventId? {
+        guard let target = self.target.flatMap({ DDayTargetEventId(entityId: $0.id) })
+        else { return nil }
+        guard let turn = self.turn.flatMap({ DDayTargetEventId(entityId: $0.id) }),
+              turn.kind == target.kind, turn.rawId == target.rawId
+        else { return target }
+        return turn
+    }
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/TodoCalendarWidgetBundle.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/TodoCalendarWidgetBundle.swift
@@ -28,6 +28,7 @@ struct BaseWidgetBundle: WidgetBundle {
         ForemostEventWidget()
         NextEventWidget()
         NextRemainEventWidget()
+        DDayWidget()
     }
 }
 

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Usecases/CalendarEventFetchUsecase.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Usecases/CalendarEventFetchUsecase.swift
@@ -72,8 +72,88 @@ struct TodayNextEvents {
     let customTags: [CustomEventTag]
 }
 
+// MARK: - D-day 대상
+
+enum DDayTargetKind: String, Sendable {
+    case schedule
+    case holiday
+}
+
+struct DDayTargetEventId: Sendable, Hashable {
+
+    let kind: DDayTargetKind
+    let rawId: String
+    /// 반복 일정의 지정 회차. `EventTime.customKey`. 단일 일정·공휴일은 nil.
+    let turnKey: String?
+
+    init(kind: DDayTargetKind, rawId: String, turnKey: String? = nil) {
+        self.kind = kind
+        self.rawId = rawId
+        self.turnKey = turnKey
+    }
+}
+
+struct DDayTargetEvent: Sendable {
+
+    let targetId: DDayTargetEventId
+    let name: String
+    let time: EventTime
+    /// 반복 일정일 때만 값이 있다 — 위젯이 "매주 월" 같은 요약을 표시하는 데 쓴다.
+    let repeatOption: (any EventRepeatingOption)?
+    /// 반복옵션 요약 텍스트 산출에 필요한 기준 시각 (원본 반복 시작 시각).
+    let repeatStartTime: Date?
+
+    var isRepeating: Bool {
+        return self.repeatOption != nil
+    }
+}
+
+/// 공휴일 D-day 대상 키. `uuid`는 연도별 remote id라 재조회에 쓸 수 없어
+/// 국가·날짜·이름 조합으로 지목한다.
+struct HolidayTargetKey {
+
+    let countryCode: String
+    let dateString: String
+    let name: String
+
+    init(countryCode: String, dateString: String, name: String) {
+        self.countryCode = countryCode
+        self.dateString = dateString
+        self.name = name
+    }
+
+    /// name에 `::`가 들어갈 수 있으므로 앞 두 세그먼트만 분리하고 나머지를 name으로 본다.
+    init?(rawId: String) {
+        let segments = rawId.components(separatedBy: "::")
+        guard segments.count >= 3 else { return nil }
+        self.countryCode = segments[0]
+        self.dateString = segments[1]
+        self.name = segments.dropFirst(2).joined(separator: "::")
+    }
+
+    var rawId: String {
+        return "\(self.countryCode)::\(self.dateString)::\(self.name)"
+    }
+
+    var year: Int? {
+        return self.dateString.components(separatedBy: "-").first.flatMap { Int($0) }
+    }
+
+    /// `holidaysGivenYears`는 range의 시작·끝 연도를 계산해 그 연도들을 로드한다.
+    /// 대상 연도 하나만 로드하도록 그 해 중간(6월 1일)의 1초 range를 만든다.
+    var yearRange: Range<TimeInterval>? {
+        guard let year,
+              let date = Calendar(identifier: .gregorian)
+                .date(from: DateComponents(year: year, month: 6, day: 1))
+        else { return nil }
+        let start = date.timeIntervalSince1970
+        return start..<(start + 1)
+    }
+}
+
+
 protocol CalendarEventFetchUsecase {
-    
+
     func fetchEvents(
         in range: Range<TimeInterval>,
         _ timeZone: TimeZone,
@@ -89,6 +169,17 @@ protocol CalendarEventFetchUsecase {
     func fetchNextEvents(
         _ refTime: Date, withIn todayRange: Range<TimeInterval>, _ timeZone: TimeZone
     ) async throws -> TodayNextEvents
+
+    /// D-day 위젯 대상 단건 조회. 반복 일정은 `target.turnKey`가 지목한 회차 시각으로 해석한다.
+    /// 대상이 삭제됐거나 그 회차가 제외·종료 범위 밖이면 nil.
+    func fetchDDayTargetEvent(
+        _ target: DDayTargetEventId
+    ) async throws -> DDayTargetEvent?
+
+    /// 반복 일정의 회차 목록. 위젯 편집의 회차 선택 후보로 쓴다.
+    func fetchScheduleRepeatingTurns(
+        _ scheduleId: String, in range: Range<TimeInterval>, limit: Int
+    ) async throws -> [RepeatingTimes]
 }
 
 extension CalendarEventFetchUsecase {
@@ -464,6 +555,183 @@ extension CalendarEventFetchUsecaseImple {
         return TodayNextEvents(nextEvents: todayEvents, customTags: customTags)
     }
 }
+
+// MARK: - D-day 대상 조회
+
+extension CalendarEventFetchUsecaseImple {
+
+    private enum Constant {
+        /// 회차 복원·열거 시 최대 전진 횟수. 종료 없는 반복의 폭주를 막는 상한.
+        static let maxTurnAdvance: Int = 3650
+    }
+
+    func fetchDDayTargetEvent(
+        _ target: DDayTargetEventId
+    ) async throws -> DDayTargetEvent? {
+
+        switch target.kind {
+        case .schedule: return await self.fetchDDayTargetSchedule(target)
+        case .holiday:  return await self.fetchDDayTargetHoliday(target)
+        }
+    }
+
+    func fetchScheduleRepeatingTurns(
+        _ scheduleId: String, in range: Range<TimeInterval>, limit: Int
+    ) async throws -> [RepeatingTimes] {
+
+        guard let schedule = await self.loadSchedule(scheduleId),
+              let repeating = schedule.repeating,
+              let enumerator = self.makeEnumerator(schedule)
+        else { return [] }
+
+        let origin = RepeatingTimes(time: schedule.time, turn: 1)
+        let isInRange: (EventTime) -> Bool = {
+            $0.upperBoundWithFixed >= range.lowerBound
+                && $0.lowerBoundWithFixed < range.upperBound
+        }
+
+        var turns: [RepeatingTimes] = []
+        if isInRange(origin.time),
+           !schedule.repeatingTimeToExcludes.contains(origin.time.customKey) {
+            turns.append(origin)
+        }
+
+        var current = origin
+        var advanced = 0
+        while turns.count < limit, advanced < Constant.maxTurnAdvance {
+            guard let next = enumerator.nextEventTime(
+                from: current, until: repeating.repeatingEndOption?.endTime
+            )
+            else { break }
+            advanced += 1
+            current = next
+
+            guard next.time.lowerBoundWithFixed < range.upperBound else { break }
+            if isInRange(next.time) {
+                turns.append(next)
+            }
+        }
+        return turns
+    }
+}
+
+
+// MARK: - D-day 대상 조회 — 일정
+
+private extension CalendarEventFetchUsecaseImple {
+
+    func fetchDDayTargetSchedule(_ target: DDayTargetEventId) async -> DDayTargetEvent? {
+
+        guard let schedule = await self.loadSchedule(target.rawId) else { return nil }
+
+        guard let turnKey = target.turnKey else {
+            return DDayTargetEvent(
+                targetId: target,
+                name: schedule.name,
+                time: schedule.time,
+                repeatOption: nil,
+                repeatStartTime: nil
+            )
+        }
+
+        guard let time = self.resolveTurnTime(schedule, turnKey: turnKey),
+              let repeating = schedule.repeating
+        else { return nil }
+
+        return DDayTargetEvent(
+            targetId: target,
+            name: schedule.name,
+            time: time,
+            repeatOption: repeating.repeatOption,
+            repeatStartTime: Date(
+                timeIntervalSince1970: repeating.startTime(for: schedule.time)
+            )
+        )
+    }
+
+    func loadSchedule(_ id: String) async -> ScheduleEvent? {
+        return try? await self.scheduleRepository.scheduleEvent(id)
+            .values.first(where: { _ in true })
+    }
+
+    func makeEnumerator(_ schedule: ScheduleEvent) -> EventRepeatTimeEnumerator? {
+        guard let repeating = schedule.repeating else { return nil }
+        return EventRepeatTimeEnumerator(
+            repeating.repeatOption,
+            endOption: repeating.repeatingEndOption,
+            without: schedule.repeatingTimeToExcludes
+        )
+    }
+
+    /// 지정 회차(`customKey`)의 시각을 origin부터 전진해 찾는다.
+    /// - 이넘레이터는 origin을 제외키와 대조하지 않으므로 먼저 직접 확인한다.
+    /// - 반복이 그 회차 전에 끝나거나 키가 매칭되지 않으면 nil.
+    /// - 원본 일정이 수정돼 회차 시각이 전부 밀리면 어떤 키와도 매칭되지 않는다. 열거는 시간순
+    ///   전진이므로 목표 시각을 지난 순간 없는 회차로 확정하고 끊는다 — 상한까지 헛돌지 않게.
+    func resolveTurnTime(_ schedule: ScheduleEvent, turnKey: String) -> EventTime? {
+
+        guard !schedule.repeatingTimeToExcludes.contains(turnKey) else { return nil }
+        guard schedule.time.customKey != turnKey else { return schedule.time }
+
+        guard let repeating = schedule.repeating,
+              let enumerator = self.makeEnumerator(schedule),
+              let turnStartTime = EventTime.lowerBound(fromCustomKey: turnKey),
+              schedule.time.lowerBoundWithFixed <= turnStartTime
+        else { return nil }
+
+        var current = RepeatingTimes(time: schedule.time, turn: 1)
+        for _ in 0..<Constant.maxTurnAdvance {
+            guard let next = enumerator.nextEventTime(
+                from: current, until: repeating.repeatingEndOption?.endTime
+            )
+            else { return nil }
+            if next.time.customKey == turnKey { return next.time }
+            guard next.time.lowerBoundWithFixed < turnStartTime else { return nil }
+            current = next
+        }
+        return nil
+    }
+}
+
+
+// MARK: - D-day 대상 조회 — 공휴일
+
+private extension CalendarEventFetchUsecaseImple {
+
+    func fetchDDayTargetHoliday(_ target: DDayTargetEventId) async -> DDayTargetEvent? {
+
+        guard let key = HolidayTargetKey(rawId: target.rawId),
+              let yearRange = key.yearRange,
+              await self.holidayFetchUsecase.currentCountryCode() == key.countryCode
+        else { return nil }
+
+        let holidays = (try? await self.holidayFetchUsecase.holidaysGivenYears(
+            yearRange, timeZone: .current
+        )) ?? []
+
+        guard let holiday = self.matchHoliday(holidays, key),
+              let event = HolidayCalendarEvent(holiday, in: .current),
+              let time = event.eventTime
+        else { return nil }
+
+        return DDayTargetEvent(
+            targetId: target,
+            name: holiday.name,
+            time: time,
+            repeatOption: nil,
+            repeatStartTime: nil
+        )
+    }
+
+    /// name 우선 매칭. locale이 바뀌어 name이 안 맞으면 그 날 공휴일이 하나일 때만 확정한다.
+    func matchHoliday(_ holidays: [Holiday], _ key: HolidayTargetKey) -> Holiday? {
+        let sameDay = holidays.filter { $0.dateString == key.dateString }
+        guard let byName = sameDay.first(where: { $0.name == key.name })
+        else { return sameDay.count == 1 ? sameDay.first : nil }
+        return byName
+    }
+}
+
 
 private extension Array where Element == CalendarEvent {
     

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Usecases/HolidaysFetchUsecase.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Usecases/HolidaysFetchUsecase.swift
@@ -22,6 +22,9 @@ protocol HolidaysFetchUsecase {
         _ range: Range<TimeInterval>,
         timeZone: TimeZone
     ) async throws -> [Holiday]
+
+    /// 현재 선택된 공휴일 국가 코드. 공휴일 D-day 대상 키의 국가 세그먼트에 쓴다.
+    func currentCountryCode() async -> String?
 }
 
 
@@ -77,5 +80,12 @@ extension HolidaysFetchUsecaseImple {
         }
         let holidaysInNextYear = try await holidays(yearAtUpperBound)
         return holidaysInThisYear + holidaysInNextYear
+    }
+
+    func currentCountryCode() async -> String? {
+        try? await self.holidayUsecase.prepare()
+        let country = await self.holidayUsecase.currentSelectedCountry
+            .values.first(where: { _ in true })
+        return country??.code
     }
 }

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidget.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidget.swift
@@ -1,0 +1,210 @@
+//
+//  DDayWidget.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 7/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import WidgetKit
+import SwiftUI
+import Prelude
+import Optics
+import Domain
+import Extensions
+
+
+// MARK: - 공통 조각
+
+private struct DDayTitleView: View {
+
+    private let model: DDayWidgetViewModel
+    private let fontSize: CGFloat
+    private let lineLimit: Int
+
+    init(model: DDayWidgetViewModel, fontSize: CGFloat, lineLimit: Int) {
+        self.model = model
+        self.fontSize = fontSize
+        self.lineLimit = lineLimit
+    }
+
+    var body: some View {
+        HStack(spacing: 3) {
+            if model.isRepeating {
+                Image(systemName: "repeat")
+                    .font(.system(size: fontSize - 2))
+                    .foregroundStyle(.secondary)
+            }
+            Text(model.eventTitle)
+                .font(.system(size: fontSize, weight: .semibold))
+                .lineLimit(lineLimit)
+                .foregroundStyle(.primary)
+        }
+    }
+}
+
+private extension DDayWidgetViewModel {
+
+    /// 소형 하단 한 줄 — "매주 월 · 3/15 오전 7:00". 빈 조각은 뺀다.
+    var compactDetailText: String {
+        return [self.repeatText, self.dateText, self.timeText]
+            .filter { !$0.isEmpty }
+            .joined(separator: " · ")
+    }
+
+    /// 중형 우측 둘째 줄 — "오전 7:00 · 매주 월".
+    var detailText: String {
+        return [self.timeText, self.repeatText]
+            .filter { !$0.isEmpty }
+            .joined(separator: " · ")
+    }
+}
+
+
+// MARK: - 소형
+
+struct DDaySmallWidgetView: View {
+
+    private let model: DDayWidgetViewModel
+    init(model: DDayWidgetViewModel) {
+        self.model = model
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            DDayTitleView(model: model, fontSize: 13, lineLimit: 2)
+
+            Spacer(minLength: 0)
+
+            Text(model.ddayText)
+                .font(.system(size: 32, weight: .bold))
+                .minimumScaleFactor(0.6)
+                .lineLimit(1)
+                .foregroundStyle(.primary)
+
+            if !model.compactDetailText.isEmpty {
+                Text(model.compactDetailText)
+                    .font(.system(size: 11))
+                    .minimumScaleFactor(0.8)
+                    .lineLimit(1)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+
+// MARK: - 중형
+
+struct DDayMediumWidgetView: View {
+
+    private let model: DDayWidgetViewModel
+    init(model: DDayWidgetViewModel) {
+        self.model = model
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            DDayTitleView(model: model, fontSize: 15, lineLimit: 1)
+
+            Spacer(minLength: 0)
+
+            HStack(alignment: .lastTextBaseline) {
+                Text(model.ddayText)
+                    .font(.system(size: 36, weight: .bold))
+                    .minimumScaleFactor(0.6)
+                    .lineLimit(1)
+                    .foregroundStyle(.primary)
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 2) {
+                    if !model.dateText.isEmpty {
+                        Text(model.dateText)
+                            .font(.system(size: 12))
+                            .lineLimit(1)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if !model.detailText.isEmpty {
+                        Text(model.detailText)
+                            .font(.system(size: 12))
+                            .lineLimit(1)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+
+// MARK: - EntryView
+
+struct DDayWidgetEntryView: View {
+
+    private let entry: ResultTimelineEntry<DDayWidgetViewModel>
+
+    @Environment(\.widgetFamily) var family: WidgetFamily
+
+    init(entry: ResultTimelineEntry<DDayWidgetViewModel>) {
+        self.entry = entry
+    }
+
+    var body: some View {
+        switch self.entry.result {
+        case .success(let model) where family == .systemMedium:
+            DDayMediumWidgetView(model: model)
+
+        case .success(let model):
+            DDaySmallWidgetView(model: model)
+
+        case .failure(let error):
+            FailView(errorModel: error)
+        }
+    }
+}
+
+
+// MARK: - DDayWidget
+
+struct DDayWidget: Widget {
+
+    nonisolated static let kind: String = "DDayWidget"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: Self.kind,
+            intent: DDayWidgetConfigurationIntent.self,
+            provider: DDayWidgetTimeLineProvider()
+        ) { entry in
+            DDayWidgetEntryView(entry: entry)
+                .containerBackground(entry.backgroundShape, for: .widget)
+        }
+        .supportedFamilies([.systemSmall, .systemMedium])
+        .configurationDisplayName("widget.dday::name".localized())
+        .description("widget.common::explain".localized())
+    }
+}
+
+
+struct DDayWidgetView_Provider: PreviewProvider {
+
+    static var previews: some View {
+        let entry = ResultTimelineEntry(
+            date: Date(), result: .success(DDayWidgetViewModel.sample)
+        )
+
+        return Group {
+            DDayWidgetEntryView(entry: entry)
+                .previewContext(WidgetPreviewContext(family: .systemSmall))
+                .containerBackground(.background, for: .widget)
+
+            DDayWidgetEntryView(entry: entry)
+                .previewContext(WidgetPreviewContext(family: .systemMedium))
+                .containerBackground(.background, for: .widget)
+        }
+    }
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidgetTimeLineProvider.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidgetTimeLineProvider.swift
@@ -1,0 +1,69 @@
+//
+//  DDayWidgetTimeLineProvider.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 7/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import WidgetKit
+import Prelude
+import Optics
+import Domain
+import Extensions
+
+
+struct DDayWidgetTimeLineProvider: AppIntentTimelineProvider {
+
+    typealias Intent = DDayWidgetConfigurationIntent
+    typealias Entry = ResultTimelineEntry<DDayWidgetViewModel>
+
+    init() { }
+}
+
+extension DDayWidgetTimeLineProvider {
+
+    func placeholder(in context: Context) -> Entry {
+        return .init(date: Date(), result: .success(.sample))
+    }
+
+    func snapshot(
+        for configuration: DDayWidgetConfigurationIntent, in context: Context
+    ) async -> Entry {
+
+        guard context.isPreview == false
+        else {
+            return self.placeholder(in: context)
+        }
+        return await self.loadEntry(configuration)
+    }
+
+    func timeline(
+        for configuration: DDayWidgetConfigurationIntent, in context: Context
+    ) async -> Timeline<Entry> {
+
+        let entry = await self.loadEntry(configuration)
+        let refreshAfter = (try? entry.result.get())?.refreshAfter
+        return Timeline(
+            entries: [entry],
+            policy: .after(refreshAfter ?? Date().nextUpdateTime)
+        )
+    }
+
+    private func loadEntry(_ configuration: DDayWidgetConfigurationIntent) async -> Entry {
+
+        let builder = WidgetViewModelProviderBuilder(base: .init())
+        let viewModelProvider = await builder.makeDDayWidgetViewModelProvider()
+        let now = Date()
+        do {
+            let model = try await viewModelProvider.getDDayModel(
+                for: now, target: configuration.resolvedTargetId
+            )
+            return .init(date: now, result: .success(model))
+                |> \.background .~ model.widgetSetting.background
+        } catch {
+            return .init(date: now, result: .failure(.init(error: error)))
+        }
+    }
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidgetViewModelProvider.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidgetViewModelProvider.swift
@@ -1,0 +1,129 @@
+//
+//  DDayWidgetViewModelProvider.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 7/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Prelude
+import Optics
+import Domain
+import Extensions
+import CommonPresentation
+
+
+// MARK: - DDayWidgetViewModel
+
+struct DDayWidgetViewModel: Sendable {
+
+    let eventTitle: String
+    let ddayText: String
+    let dateText: String
+    let timeText: String
+    let repeatText: String
+    var refreshAfter: Date?
+    var widgetSetting: WidgetAppearanceSettings = .init()
+
+    var isRepeating: Bool {
+        return self.repeatText.isEmpty == false
+    }
+
+    static var sample: Self {
+        return .init(
+            eventTitle: "widget.dday.sample::title".localized(),
+            ddayText: "D-14",
+            dateText: DDayTargetDateFormatter.dateText(
+                of: .at(Date().timeIntervalSince1970 + 3600 * 24 * 14), in: .current
+            ),
+            timeText: "",
+            repeatText: ""
+        )
+    }
+
+    static func noTarget() -> Self {
+        return .init(
+            eventTitle: "widget.dday::noTarget".localized(),
+            ddayText: "–",
+            dateText: "",
+            timeText: "",
+            repeatText: ""
+        )
+    }
+}
+
+
+// MARK: - DDayWidgetViewModelProvider
+
+final class DDayWidgetViewModelProvider {
+
+    private let eventFetchUsecase: any CalendarEventFetchUsecase
+    private let calendarSettingRepository: any CalendarSettingRepository
+    private let appSettingRepository: any AppSettingRepository
+
+    init(
+        eventFetchUsecase: any CalendarEventFetchUsecase,
+        calendarSettingRepository: any CalendarSettingRepository,
+        appSettingRepository: any AppSettingRepository
+    ) {
+        self.eventFetchUsecase = eventFetchUsecase
+        self.calendarSettingRepository = calendarSettingRepository
+        self.appSettingRepository = appSettingRepository
+    }
+}
+
+extension DDayWidgetViewModelProvider {
+
+    private enum Constant {
+        static let fallbackRefreshInterval: TimeInterval = 3600
+    }
+
+    func getDDayModel(
+        for now: Date, target: DDayTargetEventId?
+    ) async throws -> DDayWidgetViewModel {
+
+        let timeZone = self.calendarSettingRepository.loadUserSelectedTImeZone() ?? .current
+        let setting = self.appSettingRepository.loadWidgetAppearanceSetting()
+        let refreshAfter = self.nextMidnight(after: now, in: timeZone)
+
+        guard let target,
+              let event = try await self.eventFetchUsecase.fetchDDayTargetEvent(target)
+        else {
+            return DDayWidgetViewModel.noTarget()
+                |> \.refreshAfter .~ refreshAfter
+                |> \.widgetSetting .~ setting
+        }
+
+        let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
+        let targetDate = Date(
+            timeIntervalSince1970: event.time.rangeWithShifttingifNeed(on: timeZone).lowerBound
+        )
+        let interval = calendar.diffDays(now, targetDate) ?? 0
+
+        return DDayWidgetViewModel(
+            eventTitle: event.name,
+            ddayText: DDayText(interval).text,
+            dateText: DDayTargetDateFormatter.dateText(of: event.time, in: timeZone),
+            timeText: DDayTargetDateFormatter.timeText(of: event.time, in: timeZone),
+            repeatText: self.repeatText(event, timeZone)
+        )
+        |> \.refreshAfter .~ refreshAfter
+        |> \.widgetSetting .~ setting
+    }
+
+    private func repeatText(_ event: DDayTargetEvent, _ timeZone: TimeZone) -> String {
+        guard let option = event.repeatOption,
+              let startTime = event.repeatStartTime,
+              let text = option.summaryText(startTime: startTime, timeZone: timeZone)
+        else { return "" }
+        return text
+    }
+
+    private func nextMidnight(after now: Date, in timeZone: TimeZone) -> Date {
+        let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
+        let startOfToday = calendar.startOfDay(for: now)
+        return calendar.date(byAdding: .day, value: 1, to: startOfToday)
+            ?? now.addingTimeInterval(Constant.fallbackRefreshInterval)
+    }
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/Doubles/StubCalendarEventsFetchUescase.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/Doubles/StubCalendarEventsFetchUescase.swift
@@ -88,4 +88,18 @@ class StubCalendarEventsFetchUescase: CalendarEventFetchUsecase {
     ) async throws -> TodayNextEvents {
         return try self.stubNextEvents.unwrap()
     }
+
+    var stubDDayTarget: DDayTargetEvent?
+    func fetchDDayTargetEvent(
+        _ target: DDayTargetEventId
+    ) async throws -> DDayTargetEvent? {
+        return self.stubDDayTarget
+    }
+
+    var stubRepeatingTurns: [RepeatingTimes] = []
+    func fetchScheduleRepeatingTurns(
+        _ scheduleId: String, in range: Range<TimeInterval>, limit: Int
+    ) async throws -> [RepeatingTimes] {
+        return self.stubRepeatingTurns
+    }
 }

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/Intents/DDayTargetSelectIntentTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/Intents/DDayTargetSelectIntentTests.swift
@@ -1,0 +1,165 @@
+//
+//  DDayTargetSelectIntentTests.swift
+//  TodoCalendarAppWidgetTests
+//
+//  Created by sudo.park on 7/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Domain
+
+@testable import TodoCalendarAppWidget
+
+
+// MARK: - entity id 왕복
+
+struct DDayTargetEntityIdTests {
+
+    @Test("반복 일정 id는 반복 조각을 포함한다")
+    func entityId_whenRepeating_containsRepeatingFragment() {
+        // given
+        let target = DDayTargetEventId(kind: .schedule, rawId: "s1")
+
+        // when
+        let entityId = target.entityId(isRepeating: true)
+
+        // then
+        #expect(entityId.contains(DDayTargetEventId.repeatingIdFragment) == true)
+    }
+
+    @Test("비반복 일정 id는 반복 조각을 포함하지 않는다")
+    func entityId_whenNotRepeating_hasNoRepeatingFragment() {
+        // given
+        let target = DDayTargetEventId(kind: .schedule, rawId: "s1")
+
+        // when
+        let entityId = target.entityId(isRepeating: false)
+
+        // then
+        #expect(entityId.contains(DDayTargetEventId.repeatingIdFragment) == false)
+    }
+
+    @Test("회차 지정 id를 왕복해도 회차 키가 보존된다")
+    func entityId_withTurnKey_roundTrips() throws {
+        // given
+        let target = DDayTargetEventId(kind: .schedule, rawId: "s1", turnKey: "1200..<1300")
+
+        // when
+        let restored = DDayTargetEventId(entityId: target.entityId(isRepeating: true))
+
+        // then
+        let restored2 = try #require(restored)
+        #expect(restored2.kind == .schedule)
+        #expect(restored2.rawId == "s1")
+        #expect(restored2.turnKey == "1200..<1300")
+    }
+
+    @Test("`::`를 쓰는 공휴일 id를 왕복해도 이름이 보존된다")
+    func entityId_whenHoliday_roundTrips() throws {
+        // given
+        let key = HolidayTargetKey(
+            countryCode: "KR", dateString: "2027-03-01", name: "삼일절"
+        )
+        let target = DDayTargetEventId(kind: .holiday, rawId: key.rawId)
+
+        // when
+        let restored = DDayTargetEventId(entityId: target.entityId(isRepeating: false))
+
+        // then
+        let restored2 = try #require(restored)
+        #expect(restored2.kind == .holiday)
+        #expect(restored2.rawId == key.rawId)
+        #expect(restored2.turnKey == nil)
+    }
+
+    /// `DDayWidgetConfigurationIntent.parameterSummary`는 이 값을 상수로 참조할 수 없다
+    /// (메타데이터 추출기가 소스 텍스트를 그대로 담는다) — 리터럴로 중복돼 있으니 함께 지킨다.
+    @Test("반복 조각은 parameterSummary 조건 리터럴과 같은 값이다")
+    func repeatingIdFragment_matchesParameterSummaryLiteral() {
+        #expect(DDayTargetEventId.repeatingIdFragment == "|repeating|")
+    }
+
+    @Test("반복 마커가 없는 id는 해석하지 않는다")
+    func initEntityId_whenMarkIsMissing_returnsNil() {
+        // given + when
+        let restored = DDayTargetEventId(entityId: "schedule|s1")
+
+        // then
+        #expect(restored == nil)
+    }
+}
+
+
+// MARK: - 후보 정렬
+
+struct DDayTargetCandidateSortTests {
+
+    private func makeCandidate(
+        _ name: String, at time: TimeInterval, isRepeating: Bool = false
+    ) -> DDayTargetCandidate {
+        return DDayTargetCandidate(
+            targetId: .init(kind: .schedule, rawId: name),
+            name: name,
+            time: .at(time),
+            isRepeating: isRepeating
+        )
+    }
+
+    /// 시간 오름차순으로 미리 정렬된 입력 — 실제 호출부(asSuggestions)와 같은 상태.
+    private var candidates: [DDayTargetCandidate] {
+        return [
+            self.makeCandidate("past-far", at: 100),
+            self.makeCandidate("repeat-old", at: 500, isRepeating: true),
+            self.makeCandidate("past-near", at: 900),
+            self.makeCandidate("today", at: 1000),
+            self.makeCandidate("upcoming-near", at: 1500),
+            self.makeCandidate("upcoming-far", at: 2000),
+            self.makeCandidate("repeat-new", at: 5000, isRepeating: true)
+        ]
+    }
+
+    @Test("반복 → 다가오는 순 → 지난 순으로 배열된다")
+    func sortedForSuggestion_ordersByTier() {
+        // when
+        let sorted = self.candidates.sortedForSuggestion(
+            since: 1000, upcomingLimit: 40, pastLimit: 10
+        )
+
+        // then
+        #expect(
+            sorted.map { $0.name } == [
+                "repeat-old", "repeat-new",
+                "today", "upcoming-near", "upcoming-far",
+                "past-near", "past-far"
+            ]
+        )
+    }
+
+    @Test("다가오는 이벤트와 지난 이벤트의 상한은 따로 적용된다")
+    func sortedForSuggestion_appliesLimitsPerTier() {
+        // when
+        let sorted = self.candidates.sortedForSuggestion(
+            since: 1000, upcomingLimit: 2, pastLimit: 1
+        )
+
+        // then
+        #expect(
+            sorted.map { $0.name } == [
+                "repeat-old", "repeat-new", "today", "upcoming-near", "past-near"
+            ]
+        )
+    }
+
+    @Test("반복 일정은 상한과 무관하게 모두 남는다")
+    func sortedForSuggestion_keepsAllRepeatings() {
+        // when
+        let sorted = self.candidates.sortedForSuggestion(
+            since: 1000, upcomingLimit: 0, pastLimit: 0
+        )
+
+        // then
+        #expect(sorted.map { $0.name } == ["repeat-old", "repeat-new"])
+    }
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/Usecases/CalendarEventFetchUsecaseImpleTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/Usecases/CalendarEventFetchUsecaseImpleTests.swift
@@ -85,6 +85,18 @@ class CalendarEventFetchUsecaseImpleTests: BaseTestCase {
             cached: .init()
         )
     }
+
+    private func makeUsecaseWithStubSchedule(
+        _ schedule: ScheduleEvent
+    ) -> CalendarEventFetchUsecaseImple {
+        self.stubScheduleRepository.stubEvent = schedule
+        return self.makeUsecase()
+    }
+
+    private func makeUsecaseWithoutStubSchedule() -> CalendarEventFetchUsecaseImple {
+        self.stubScheduleRepository.stubEvent = nil
+        return self.makeUsecase()
+    }
 }
 
 
@@ -514,6 +526,227 @@ extension CalendarEventFetchUsecaseImpleTests {
     }
 }
 
+
+// MARK: - D-day 대상 조회
+
+extension CalendarEventFetchUsecaseImpleTests {
+
+    private var repeatEveryDay: EventRepeating {
+        return EventRepeating(
+            repeatingStartTime: 0,
+            repeatOption: EventRepeatingOptions.EveryDay()
+        )
+    }
+
+    func testUsecase_fetchDDayTarget_whenNotRepeating_returnsOriginTime() async throws {
+        // given
+        let usecase = self.makeUsecaseWithStubSchedule(
+            ScheduleEvent(uuid: "s1", name: "워크숍", time: .at(1000))
+        )
+
+        // when
+        let target = try await usecase.fetchDDayTargetEvent(
+            .init(kind: .schedule, rawId: "s1")
+        )
+
+        // then
+        XCTAssertEqual(target?.name, "워크숍")
+        XCTAssertEqual(target?.time, .at(1000))
+        XCTAssertEqual(target?.isRepeating, false)
+    }
+
+    func testUsecase_fetchDDayTarget_whenScheduleNotExists_returnsNil() async throws {
+        // given
+        let usecase = self.makeUsecaseWithoutStubSchedule()
+
+        // when
+        let target = try await usecase.fetchDDayTargetEvent(
+            .init(kind: .schedule, rawId: "not-exists")
+        )
+
+        // then
+        XCTAssertNil(target)
+    }
+
+    func testUsecase_fetchDDayTarget_whenRepeatingWithTurnKey_returnsThatTurnTime() async throws {
+        // given: 매일 반복, origin = .at(0) → 4회차 = .at(3일)
+        let fourthTurnTime = EventTime.at(3 * 24 * 3600)
+        let usecase = self.makeUsecaseWithStubSchedule(
+            ScheduleEvent(uuid: "s1", name: "운동", time: .at(0))
+                |> \.repeating .~ self.repeatEveryDay
+        )
+
+        // when
+        let target = try await usecase.fetchDDayTargetEvent(
+            .init(kind: .schedule, rawId: "s1", turnKey: fourthTurnTime.customKey)
+        )
+
+        // then
+        XCTAssertEqual(target?.time, fourthTurnTime)
+        XCTAssertEqual(target?.isRepeating, true)
+    }
+
+    func testUsecase_fetchDDayTarget_whenTurnKeyIsExcluded_returnsNil() async throws {
+        // given
+        let excluded = EventTime.at(3 * 24 * 3600)
+        let usecase = self.makeUsecaseWithStubSchedule(
+            ScheduleEvent(uuid: "s1", name: "운동", time: .at(0))
+                |> \.repeating .~ self.repeatEveryDay
+                |> \.repeatingTimeToExcludes .~ [excluded.customKey]
+        )
+
+        // when
+        let target = try await usecase.fetchDDayTargetEvent(
+            .init(kind: .schedule, rawId: "s1", turnKey: excluded.customKey)
+        )
+
+        // then
+        XCTAssertNil(target)
+    }
+
+    func testUsecase_fetchDDayTarget_whenTurnKeyIsPastRepeatEnd_returnsNil() async throws {
+        // given: 2일 뒤까지만 반복 → 10일 뒤 회차는 존재하지 않는다
+        let usecase = self.makeUsecaseWithStubSchedule(
+            ScheduleEvent(uuid: "s1", name: "운동", time: .at(0))
+                |> \.repeating .~ (
+                    self.repeatEveryDay |> \.repeatingEndOption .~ .until(2 * 24 * 3600)
+                )
+        )
+
+        // when
+        let target = try await usecase.fetchDDayTargetEvent(
+            .init(kind: .schedule, rawId: "s1", turnKey: EventTime.at(10 * 24 * 3600).customKey)
+        )
+
+        // then
+        XCTAssertNil(target)
+    }
+
+    func testUsecase_fetchDDayTarget_whenNoTurnLandsOnTurnKey_returnsNil() async throws {
+        // given: 매일 반복이라 어떤 회차도 3일+100초에 오지 않는다 (원본 시각이 밀린 상황)
+        let usecase = self.makeUsecaseWithStubSchedule(
+            ScheduleEvent(uuid: "s1", name: "운동", time: .at(0))
+                |> \.repeating .~ self.repeatEveryDay
+        )
+
+        // when
+        let target = try await usecase.fetchDDayTargetEvent(
+            .init(kind: .schedule, rawId: "s1", turnKey: EventTime.at(3 * 24 * 3600 + 100).customKey)
+        )
+
+        // then
+        XCTAssertNil(target)
+    }
+
+    func testUsecase_fetchDDayTarget_whenTurnKeyIsBeforeOrigin_returnsNil() async throws {
+        // given: origin이 목표 시각보다 뒤 — 전진 열거로는 닿을 수 없다
+        let usecase = self.makeUsecaseWithStubSchedule(
+            ScheduleEvent(uuid: "s1", name: "운동", time: .at(10 * 24 * 3600))
+                |> \.repeating .~ self.repeatEveryDay
+        )
+
+        // when
+        let target = try await usecase.fetchDDayTargetEvent(
+            .init(kind: .schedule, rawId: "s1", turnKey: EventTime.at(0).customKey)
+        )
+
+        // then
+        XCTAssertNil(target)
+    }
+
+    func testUsecase_fetchScheduleRepeatingTurns_listsTurnsInRange() async throws {
+        // given: 매일 반복, origin = .at(0)
+        let usecase = self.makeUsecaseWithStubSchedule(
+            ScheduleEvent(uuid: "s1", name: "운동", time: .at(0))
+                |> \.repeating .~ self.repeatEveryDay
+        )
+
+        // when
+        let turns = try await usecase.fetchScheduleRepeatingTurns(
+            "s1", in: 0..<(5 * 24 * 3600), limit: 50
+        )
+
+        // then: origin(1회차) + 2~5회차
+        XCTAssertEqual(turns.count, 5)
+        XCTAssertEqual(turns.first?.turn, 1)
+        XCTAssertEqual(turns.first?.time, .at(0))
+    }
+
+    func testUsecase_fetchScheduleRepeatingTurns_respectsLimit() async throws {
+        // given
+        let usecase = self.makeUsecaseWithStubSchedule(
+            ScheduleEvent(uuid: "s1", name: "운동", time: .at(0))
+                |> \.repeating .~ self.repeatEveryDay
+        )
+
+        // when
+        let turns = try await usecase.fetchScheduleRepeatingTurns(
+            "s1", in: 0..<(100 * 24 * 3600), limit: 3
+        )
+
+        // then
+        XCTAssertEqual(turns.count, 3)
+    }
+
+    func testUsecase_fetchScheduleRepeatingTurns_whenNotRepeating_returnsEmpty() async throws {
+        // given
+        let usecase = self.makeUsecaseWithStubSchedule(
+            ScheduleEvent(uuid: "s1", name: "워크숍", time: .at(0))
+        )
+
+        // when
+        let turns = try await usecase.fetchScheduleRepeatingTurns(
+            "s1", in: 0..<(5 * 24 * 3600), limit: 50
+        )
+
+        // then
+        XCTAssertEqual(turns.isEmpty, true)
+    }
+}
+
+
+// MARK: - D-day 대상 키
+
+extension CalendarEventFetchUsecaseImpleTests {
+
+    func testHolidayTargetKey_roundTrip() {
+        // given
+        let key = HolidayTargetKey(
+            countryCode: "KR", dateString: "2027-03-01", name: "삼일절"
+        )
+
+        // when
+        let restored = HolidayTargetKey(rawId: key.rawId)
+
+        // then
+        XCTAssertEqual(restored?.countryCode, "KR")
+        XCTAssertEqual(restored?.dateString, "2027-03-01")
+        XCTAssertEqual(restored?.name, "삼일절")
+        XCTAssertEqual(restored?.year, 2027)
+    }
+
+    func testHolidayTargetKey_whenNameContainsSeparator_keepsWholeName() {
+        // given
+        let key = HolidayTargetKey(
+            countryCode: "KR", dateString: "2027-03-01", name: "어떤::공휴일"
+        )
+
+        // when
+        let restored = HolidayTargetKey(rawId: key.rawId)
+
+        // then
+        XCTAssertEqual(restored?.name, "어떤::공휴일")
+    }
+
+    func testHolidayTargetKey_whenSegmentsInsufficient_returnsNil() {
+        // given + when
+        let restored = HolidayTargetKey(rawId: "KR::2027-03-01")
+
+        // then
+        XCTAssertNil(restored)
+    }
+}
+
 private final class PrivateStubTodoRepository: StubTodoEventRepository, @unchecked Sendable {
     
     override func loadCurrentTodoEvents() -> AnyPublisher<[TodoEvent], any Error> {
@@ -571,13 +804,18 @@ private final class PrivateStubForemostEventRepository: StubForemostEventReposit
 }
 
 private final class StubHolidaysFetchUsecase: HolidaysFetchUsecase {
-    
+
     func reset() async throws { }
-    
+
     func holidaysGivenYears(
         _ range: Range<TimeInterval>, timeZone: TimeZone
     ) async throws -> [Holiday] {
         let holiday = Holiday(uuid: "id", dateString: "2024-03-01", name: "삼일절")
         return [holiday]
+    }
+
+    var stubCountryCode: String? = "KR"
+    func currentCountryCode() async -> String? {
+        return self.stubCountryCode
     }
 }

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/DDayWidgetViewModelProviderTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/DDayWidgetViewModelProviderTests.swift
@@ -1,0 +1,253 @@
+//
+//  DDayWidgetViewModelProviderTests.swift
+//  TodoCalendarAppWidgetTests
+//
+//  Created by sudo.park on 7/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Prelude
+import Optics
+import Domain
+import UnitTestHelpKit
+import TestDoubles
+
+@testable import TodoCalendarAppWidget
+
+
+struct DDayWidgetViewModelProviderTests {
+
+    private var utc: TimeZone { TimeZone(abbreviation: "UTC")! }
+
+    private func makeProvider(
+        stubTarget: DDayTargetEvent?
+    ) -> DDayWidgetViewModelProvider {
+
+        let eventFetchUsecase = StubCalendarEventsFetchUescase()
+        eventFetchUsecase.stubDDayTarget = stubTarget
+
+        let calendarSettingRepository = StubCalendarSettingRepository()
+        calendarSettingRepository.saveTimeZone(self.utc)
+
+        return DDayWidgetViewModelProvider(
+            eventFetchUsecase: eventFetchUsecase,
+            calendarSettingRepository: calendarSettingRepository,
+            appSettingRepository: StubAppSettingRepository()
+        )
+    }
+
+    private func makeTarget(
+        time: EventTime, repeatOption: (any EventRepeatingOption)? = nil
+    ) -> DDayTargetEvent {
+        return DDayTargetEvent(
+            targetId: .init(kind: .schedule, rawId: "s1"),
+            name: "워크숍",
+            time: time,
+            repeatOption: repeatOption,
+            repeatStartTime: repeatOption == nil ? nil : Date(timeIntervalSince1970: 0)
+        )
+    }
+}
+
+
+// MARK: - D-n 산출
+
+extension DDayWidgetViewModelProviderTests {
+
+    @Test("대상까지 남은 일수를 D-n으로 낸다")
+    func getDDayModel_returnsDDayText() async throws {
+        // given
+        let now = Date(timeIntervalSince1970: 0)
+        let provider = self.makeProvider(
+            stubTarget: self.makeTarget(time: .at(14 * 24 * 3600))
+        )
+
+        // when
+        let model = try await provider.getDDayModel(
+            for: now, target: .init(kind: .schedule, rawId: "s1")
+        )
+
+        // then
+        #expect(model.eventTitle == "워크숍")
+        #expect(model.ddayText == "D-14")
+    }
+
+    @Test("같은 날이면 D-Day")
+    func getDDayModel_whenSameDay_returnsDDay() async throws {
+        // given
+        let now = Date(timeIntervalSince1970: 3600)
+        let provider = self.makeProvider(
+            stubTarget: self.makeTarget(time: .at(7200))
+        )
+
+        // when
+        let model = try await provider.getDDayModel(
+            for: now, target: .init(kind: .schedule, rawId: "s1")
+        )
+
+        // then
+        #expect(model.ddayText == "D-Day")
+    }
+
+    @Test("지난 대상이면 D+n")
+    func getDDayModel_whenPast_returnsDPlus() async throws {
+        // given
+        let now = Date(timeIntervalSince1970: 3 * 24 * 3600)
+        let provider = self.makeProvider(
+            stubTarget: self.makeTarget(time: .at(0))
+        )
+
+        // when
+        let model = try await provider.getDDayModel(
+            for: now, target: .init(kind: .schedule, rawId: "s1")
+        )
+
+        // then
+        #expect(model.ddayText == "D+3")
+    }
+}
+
+
+// MARK: - 반복 여부 표시
+
+extension DDayWidgetViewModelProviderTests {
+
+    @Test("반복 일정이면 반복옵션 요약이 채워진다")
+    func getDDayModel_whenRepeating_fillsRepeatText() async throws {
+        // given
+        let now = Date(timeIntervalSince1970: 0)
+        let provider = self.makeProvider(
+            stubTarget: self.makeTarget(
+                time: .at(24 * 3600),
+                repeatOption: EventRepeatingOptions.EveryDay()
+            )
+        )
+
+        // when
+        let model = try await provider.getDDayModel(
+            for: now, target: .init(kind: .schedule, rawId: "s1")
+        )
+
+        // then
+        #expect(model.isRepeating == true)
+        #expect(model.repeatText.isEmpty == false)
+    }
+
+    @Test("반복이 아니면 반복옵션 요약이 비어 있다")
+    func getDDayModel_whenNotRepeating_repeatTextIsEmpty() async throws {
+        // given
+        let now = Date(timeIntervalSince1970: 0)
+        let provider = self.makeProvider(
+            stubTarget: self.makeTarget(time: .at(24 * 3600))
+        )
+
+        // when
+        let model = try await provider.getDDayModel(
+            for: now, target: .init(kind: .schedule, rawId: "s1")
+        )
+
+        // then
+        #expect(model.isRepeating == false)
+        #expect(model.repeatText.isEmpty == true)
+    }
+}
+
+
+// MARK: - 시각 표시
+
+extension DDayWidgetViewModelProviderTests {
+
+    @Test("시각 있는 일정은 날짜와 시각을 모두 낸다")
+    func getDDayModel_whenTimed_fillsBothTexts() async throws {
+        // given
+        let now = Date(timeIntervalSince1970: 0)
+        let provider = self.makeProvider(
+            stubTarget: self.makeTarget(time: .at(24 * 3600 + 7 * 3600))
+        )
+
+        // when
+        let model = try await provider.getDDayModel(
+            for: now, target: .init(kind: .schedule, rawId: "s1")
+        )
+
+        // then
+        #expect(model.dateText.isEmpty == false)
+        #expect(model.timeText.isEmpty == false)
+    }
+
+    @Test("종일 일정은 시각 텍스트가 비어 있다")
+    func getDDayModel_whenAllDay_timeTextIsEmpty() async throws {
+        // given
+        let now = Date(timeIntervalSince1970: 0)
+        let dayStart: TimeInterval = 24 * 3600
+        let provider = self.makeProvider(
+            stubTarget: self.makeTarget(
+                time: .allDay(dayStart..<(dayStart + 24 * 3600 - 1), secondsFromGMT: 0)
+            )
+        )
+
+        // when
+        let model = try await provider.getDDayModel(
+            for: now, target: .init(kind: .schedule, rawId: "s1")
+        )
+
+        // then
+        #expect(model.timeText.isEmpty == true)
+        #expect(model.dateText.isEmpty == false)
+    }
+}
+
+
+// MARK: - 갱신 시각과 대상 없음
+
+extension DDayWidgetViewModelProviderTests {
+
+    @Test("갱신 시각은 유저 타임존의 다음 자정")
+    func getDDayModel_refreshAfterIsNextMidnight() async throws {
+        // given: UTC 기준 1970-01-01 10:00
+        let now = Date(timeIntervalSince1970: 10 * 3600)
+        let provider = self.makeProvider(
+            stubTarget: self.makeTarget(time: .at(14 * 24 * 3600))
+        )
+
+        // when
+        let model = try await provider.getDDayModel(
+            for: now, target: .init(kind: .schedule, rawId: "s1")
+        )
+
+        // then: 1970-01-02 00:00 UTC
+        #expect(model.refreshAfter == Date(timeIntervalSince1970: 24 * 3600))
+    }
+
+    @Test("대상이 지정되지 않으면 안내 문구를 낸다")
+    func getDDayModel_whenTargetIsNil_returnsGuide() async throws {
+        // given
+        let now = Date(timeIntervalSince1970: 0)
+        let provider = self.makeProvider(stubTarget: nil)
+
+        // when
+        let model = try await provider.getDDayModel(for: now, target: nil)
+
+        // then
+        #expect(model.ddayText == "–")
+        #expect(model.dateText.isEmpty == true)
+        #expect(model.refreshAfter == Date(timeIntervalSince1970: 24 * 3600))
+    }
+
+    @Test("대상이 삭제돼 조회되지 않으면 안내 문구를 낸다")
+    func getDDayModel_whenTargetNotFound_returnsGuide() async throws {
+        // given
+        let now = Date(timeIntervalSince1970: 0)
+        let provider = self.makeProvider(stubTarget: nil)
+
+        // when
+        let model = try await provider.getDDayModel(
+            for: now, target: .init(kind: .schedule, rawId: "removed")
+        )
+
+        // then
+        #expect(model.ddayText == "–")
+    }
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/EventListWidgetViewModelProviderTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/EventListWidgetViewModelProviderTests.swift
@@ -538,8 +538,16 @@ extension EventListWidgetViewModelProviderTests {
         func fetchNextEvents(_ refTime: Date, withIn todayRange: Range<TimeInterval>, _ timeZone: TimeZone) async throws -> TodayNextEvents {
             return .init(nextEvents: [], customTags: [])
         }
+
+        func fetchDDayTargetEvent(_ target: DDayTargetEventId) async throws -> DDayTargetEvent? {
+            return nil
+        }
+
+        func fetchScheduleRepeatingTurns(_ scheduleId: String, in range: Range<TimeInterval>, limit: Int) async throws -> [RepeatingTimes] {
+            return []
+        }
     }
-    
+
     private func makeProviderWithStubUnsortedEvents() -> EventListWidgetViewModelProvider {
         
         let fetchUsecase = UnSortedStubEventsFetchUsecase(refDate: self.refDate)
@@ -616,8 +624,16 @@ extension EventListWidgetViewModelProviderTests {
             func fetchNextEvents(_ refTime: Date, withIn todayRange: Range<TimeInterval>, _ timeZone: TimeZone) async throws -> TodayNextEvents {
                 return .init(nextEvents: [], customTags: [])
             }
+
+            func fetchDDayTargetEvent(_ target: DDayTargetEventId) async throws -> DDayTargetEvent? {
+                return nil
+            }
+
+            func fetchScheduleRepeatingTurns(_ scheduleId: String, in range: Range<TimeInterval>, limit: Int) async throws -> [RepeatingTimes] {
+                return []
+            }
         }
-        
+
         let fetchUsecase = EventsWithTagFetchUescase()
         let calendarSettingRepository = StubCalendarSettingRepository()
         let appSettingRepository = StubAppSettingRepository()


### PR DESCRIPTION
Closes #722

## 문제

D-day 위젯이 없었다. 그리고 1차 시도(#724, closed)는 **반복 이벤트를 "기준 시각 이후 다음 회차로 자동 전진"으로 해석한 게 정책상 틀렸다** — 유저가 "3월 15일 운동"을 D-day로 걸어도 그날이 지나면 위젯이 말없이 다음 주를 가리켰다. 리뷰에서 이 지점과 함께 static 남발·CQS 위반·테스트 본문 직접 스터빙이 지적돼 접고 재설계했다.

## 접근

**대상 = 일정(schedule) + 공휴일 2종.** 할일(todo)은 대상에서 뺐다 — 반복이든 아니든 완료 처리마다 시각이 바뀌거나 사라져(`TodoLocalRepositoryImple.swift:114-116`) D-day 대상으로 부적절하고, 이넘레이터가 전진 전용이라 과거 회차 복원 API 자체가 없다.

**반복 일정은 유저가 회차를 직접 지정한다.** 위젯 편집 1단은 반복 일정을 회차별로 펼치지 않고 `제목 + "반복 일정"` 한 줄로만 보여주고, 그걸 고르면 2단에서 회차를 고른다. 회차 파라미터는 **반복 일정을 골랐을 때만** 뜬다 — `parameterSummary`의 `When(_:identifier:.contains,_:)`이 entity id 문자열을 비교할 수 있어서, id에 `|repeating|` 마커를 실어 조건으로 쓴다. 비반복 일정에서 회차 목록이 빈 채로 떴다 사라지는 동작이 이걸로 없어진다.

**회차 참조 키는 turn 순번이 아니라 `EventTime.customKey`.** 제외된 회차는 turn을 소비하지 않으므로(`EventRepeatTimeEnumerator.swift:112-116`) 5회차를 걸어둔 뒤 3회차를 "이번만 삭제"하면 원래 6회차가 5회차로 승격돼 위젯이 **에러 없이 다른 날짜**를 표시한다. customKey는 도메인이 이미 `repeatingTimeToExcludes`·`RepeatingUpdateScope.onlyThisTime`에서 "그 회차"를 지목하는 데 쓰는 정본 키라, 앞 회차가 삭제돼도 안 밀리고 제외 여부를 직접 판정할 수 있다. 트레이드오프는 `.all` 스코프 수정으로 시각이 전부 이동하면 매칭이 깨져 "대상 없음"이 되는 것 — 대신 틀린 날짜는 절대 안 보여준다.

**후보 목록은 고를 확률 순.** 오늘 ±365일을 훑어 `반복 일정 → 다가오는 순 → 지난 순(최근 먼저)`으로 배열한다. 지난 이벤트는 상한을 따로 둬서, 다가오는 이벤트가 많은 유저에게 아예 안 보이는 일이 없게 했다.

**공휴일 키는 `countryCode::dateString::name`.** `Holiday.uuid`는 연도별 remote id이고 위젯에서 `HolidayUsecase.holiday(uuid:)`는 항상 nil이다(위젯 팩토리가 빈 SharedDataStore를 새로 만들고 `refreshHolidays`를 아무도 호출하지 않음). `dateString`에서 연도를 뽑아 `loadHolidays(year)` 경로로 조회한다. locale이 바뀌어 name이 안 맞으면 그 날 공휴일이 하나일 때만 확정하는 폴백을 뒀다.

**표시** — 소·중형 모두 반복 일정이면 제목 앞에 `repeat` 아이콘, 그 회차의 날짜·시각과 반복옵션 요약을 함께 낸다. 종일 일정은 시각을 생략한다. 갱신은 유저 설정 타임존의 다음 자정 — 공통 `Date.nextUpdateTime`은 유저 타임존 미반영 TODO가 있지만 18개 위젯이 공유하므로 건드리지 않고 D-day만 자체 계산한다.

**편집 시트 라벨 다국어** — AppIntents의 파라미터·엔티티 라벨은 `LocalizedStringResource`라 **확장 타겟 자신의 번들**에서 해석된다. 앱 문자열이 사는 Extensions 번들(`.localized()`)에서는 안 잡히므로, 비어 있던 위젯 타겟 `ko/en.lproj/Localizable.strings`에 코드의 영문 리터럴을 키로 넣었다. 조회가 실패해도 그 영문이 그대로 나와 회귀가 없다. 같은 결함이던 기존 `EventType` 계열 라벨도 함께 채웠다.

**공용 모듈 승격 2건** — 위젯이 `EventDetailScene`을 import할 수 없어서 필요했다. `DDayText`(표시 포맷) → `Extensions`, 반복옵션 요약 텍스트 → `CommonPresentation`. 후자는 순수 리팩토링이라 기존 `SelectEventRepeatOptionViewModelTests`가 **수정 없이** 통과하는 것으로 동작 보존을 확인했다.

## 검증

| 스킴 | 결과 |
|---|---|
| `TodoCalendarAppWidget` | XCTest 68 + Swift Testing 56 통과 |
| `Extensions` | 통과 |
| `EventDetailScene` | 141 + 42 통과 (승격 후 무수정) |
| `CommonPresentation` | 빌드 성공 (유닛 테스트 타겟 없음) |
| `TodoCalendarApp` | 빌드 성공 |

시뮬레이터 실기 확인(작업자) — 위젯 추가·이벤트 선택·회차 2단 선택 동작, 반복 일정 한 줄 노출, 할일 미노출.

## 남은 과제

- **편집 시트 라벨 다국어는 실기 미검증** — 회귀 위험은 없다(조회 실패 시 기존 영문 그대로).
- 참고로 `parameterSummary` 조건은 실기에서 한 번 깨졌다가 고쳤다. **조건 값에 상수를 참조하면 안 된다** — AppIntents 메타데이터 추출기가 그 자리의 소스 텍스트를 그대로 담아서, 빌드 산출물에 `"DDayTargetEventId.repeatingIdFragment"`라는 문자열이 비교 대상으로 박혀 조건이 영원히 false가 됐다(회차 파라미터가 아예 안 뜸). 리터럴로 바꿔 `.appex/Metadata.appintents/extract.actionsdata`에서 값이 `"|repeating|"`로 들어간 것까지 확인했다. 리터럴 중복은 테스트로 묶어뒀다.
- **entity id 포맷이 바뀌어 기존 설정은 초기화된다** — 반복 마커가 들어가며 이전 포맷을 못 읽는다. 미출시라 실사용 영향은 없지만, 이 브랜치로 이미 위젯을 붙여둔 기기는 대상을 다시 골라야 한다.
- **위젯 탭 딥링크 미구현** — 킥오프 스코프에 없어 빠진 항목. 일정은 `EventDeepLinkBuilder.schedule(id:time:)` 재사용으로 바로 되지만, 공휴일은 `routeToHolidayEventDetail`이 `Holiday.uuid`를 요구하는데 위젯엔 그 값이 없어(그래서 키를 국가·날짜·이름으로 잡았다) `CalendarDay.link`로 해당 날짜 선택 폴백이 필요하다.
- **#726 D-day 후보 등록** — 후보군이 자동 산출(오늘 ±365일, 상한)이라 ① 1년 밖 이벤트 ② 회차 목록 상한 밖 회차 ③ 상한 초과분이 안 보인다. 앱에서 특정 이벤트·회차를 후보로 지정하는 기능으로 보완한다. 이 PR 머지 후 착수.
- **turn 번호 불안정성은 도메인 잠재 버그** — 제외 회차가 turn을 소비하지 않는 것과 이넘레이터가 origin을 제외키와 대조하지 않는 것. 이 PR은 customKey를 써서 우회했지만 turn 순번에 의존하는 다른 코드가 있으면 같은 문제를 겪는다. 별도 이슈 후보.
- **`static` 회피 조항 명문화** — 리뷰 지적을 반영해 이 PR은 상수를 `private enum Constant`로 뒀지만, 규칙이 CLAUDE.md·rules에 없다. 하네스 정비로 분리 (#690 계열).
- `EventDetailScene`의 `testViewModel_whenMakeScheduleEvent_isSavableWhenEnterNameAndSelectTime`이 1초 타임아웃 expectation을 써서 부하 상황에 간헐 실패한다. 이 PR 변경과 무관하고 재실행 시 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qb6h2aXSBd6RDuRveKajVB
