### PR TITLE
[#726][#731] D-day 위젯 후보 등록·해제 + 위젯 탭 딥링크

### DIFF
--- a/Domain/Sources/Models/Events/DDayCandidate.swift
+++ b/Domain/Sources/Models/Events/DDayCandidate.swift
@@ -1,0 +1,25 @@
+//
+//  DDayCandidate.swift
+//  Domain
+//
+//  Created by sudo.park on 7/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+
+/// 유저가 D-day 위젯 후보로 지정한 일정.
+///
+/// 자동 산출 후보군(오늘 ±365일·상한)이 못 담는 이벤트를 유저 지정으로 보완한다.
+/// 반복 일정은 `turnKey`(`EventTime.customKey`)로 회차를 지목한다 — nil이면 원본 시각.
+public struct DDayCandidate: Sendable, Hashable {
+
+    public let scheduleId: String
+    public var turnKey: String?
+
+    public init(scheduleId: String, turnKey: String? = nil) {
+        self.scheduleId = scheduleId
+        self.turnKey = turnKey
+    }
+}

--- a/Domain/Sources/Repositories/DDayCandidateRepository.swift
+++ b/Domain/Sources/Repositories/DDayCandidateRepository.swift
@@ -1,0 +1,22 @@
+//
+//  DDayCandidateRepository.swift
+//  Domain
+//
+//  Created by sudo.park on 7/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+
+/// 동기 API인 이유 — 구현이 App Group UserDefaults 단독이다
+/// (`CalendarSettingRepository.loadUserSelectedTImeZone()` 과 같은 계열).
+/// 추가·제거가 갱신 후 전체 목록을 돌려주는 이유 — 병합을 저장소 안에 가둔다.
+/// 밖에서 읽고 합쳐 통째로 덮어쓰면, 앱과 위젯이 같은 App Group suite를 보는 구조에서
+/// 한쪽이 읽은 뒤 다른 쪽이 쓴 변경이 지워진다.
+public protocol DDayCandidateRepository: Sendable {
+
+    func loadCandidates() -> [DDayCandidate]
+    func append(_ candidate: DDayCandidate) -> [DDayCandidate]
+    func remove(_ candidate: DDayCandidate) -> [DDayCandidate]
+}

--- a/Domain/Sources/Usecases/Events/DDayCandidateUsecase.swift
+++ b/Domain/Sources/Usecases/Events/DDayCandidateUsecase.swift
@@ -1,0 +1,74 @@
+//
+//  DDayCandidateUsecase.swift
+//  Domain
+//
+//  Created by sudo.park on 7/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+
+public protocol DDayCandidateUsecase: Sendable {
+
+    func refresh()
+    func append(_ candidate: DDayCandidate)
+    func remove(_ candidate: DDayCandidate)
+
+    var candidates: AnyPublisher<[DDayCandidate], Never> { get }
+}
+
+
+/// 등록·해제는 command, `candidates`는 query — 한 흐름에 섞지 않는다.
+public final class DDayCandidateUsecaseImple: DDayCandidateUsecase, @unchecked Sendable {
+
+    private let repository: any DDayCandidateRepository
+    private let sharedDataStore: SharedDataStore
+
+    public init(
+        repository: any DDayCandidateRepository,
+        sharedDataStore: SharedDataStore
+    ) {
+        self.repository = repository
+        self.sharedDataStore = sharedDataStore
+    }
+
+    private var shareKey: String { ShareDataKeys.ddayCandidates.rawValue }
+}
+
+
+// MARK: - command
+
+extension DDayCandidateUsecaseImple {
+
+    public func refresh() {
+        self.put(self.repository.loadCandidates())
+    }
+
+    public func append(_ candidate: DDayCandidate) {
+        self.put(self.repository.append(candidate))
+    }
+
+    public func remove(_ candidate: DDayCandidate) {
+        self.put(self.repository.remove(candidate))
+    }
+
+    /// 병합은 저장소가 한다 — 여기선 그 결과를 공유 상태에 반영만 한다.
+    private func put(_ candidates: [DDayCandidate]) {
+        self.sharedDataStore.put([DDayCandidate].self, key: self.shareKey, candidates)
+    }
+}
+
+
+// MARK: - query
+
+extension DDayCandidateUsecaseImple {
+
+    public var candidates: AnyPublisher<[DDayCandidate], Never> {
+        return self.sharedDataStore
+            .observe([DDayCandidate].self, key: self.shareKey)
+            .map { $0 ?? [] }
+            .eraseToAnyPublisher()
+    }
+}

--- a/Domain/Sources/Utils/SharedDataStore.swift
+++ b/Domain/Sources/Utils/SharedDataStore.swift
@@ -35,6 +35,7 @@ public enum ShareDataKeys: String {
     case appleCalendarEvents
     case aiAgentUsage
     case billingUserPlan
+    case ddayCandidates
 }
 
 

--- a/Domain/Tests/Usecases/DDayCandidateUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/DDayCandidateUsecaseImpleTests.swift
@@ -1,0 +1,160 @@
+//
+//  DDayCandidateUsecaseImpleTests.swift
+//  DomainTests
+//
+//  Created by sudo.park on 7/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Combine
+import Foundation
+import UnitTestHelpKit
+
+@testable import Domain
+
+
+final class DDayCandidateUsecaseImpleTests: PublisherWaitable {
+
+    var cancelBag: Set<AnyCancellable>! = .init()
+
+    private final class StubRepository: DDayCandidateRepository, @unchecked Sendable {
+
+        private var candidates: [DDayCandidate]
+        init(_ candidates: [DDayCandidate] = []) {
+            self.candidates = candidates
+        }
+
+        func loadCandidates() -> [DDayCandidate] {
+            return self.candidates
+        }
+
+        func append(_ candidate: DDayCandidate) -> [DDayCandidate] {
+            guard !self.candidates.contains(candidate) else { return self.candidates }
+            self.candidates = self.candidates + [candidate]
+            return self.candidates
+        }
+
+        func remove(_ candidate: DDayCandidate) -> [DDayCandidate] {
+            self.candidates = self.candidates.filter { $0 != candidate }
+            return self.candidates
+        }
+    }
+
+    /// `candidates`는 구독 즉시 refresh 전 공유 상태(`[]`)를 한 번 방출한다.
+    /// 그래서 기대 방출 수는 "빈 첫 방출 + 실제 변화 수"다.
+    private func makeUsecase(
+        stubCandidates: [DDayCandidate] = []
+    ) -> DDayCandidateUsecaseImple {
+        return DDayCandidateUsecaseImple(
+            repository: StubRepository(stubCandidates),
+            sharedDataStore: .init()
+        )
+    }
+}
+
+
+// MARK: - 목록 조회
+
+extension DDayCandidateUsecaseImpleTests {
+
+    @Test("refresh하면 저장된 후보를 방출한다")
+    func refresh_emitsStoredCandidates() async throws {
+        // given
+        let expect = expectConfirm("저장된 후보 방출")
+        expect.count = 2
+        let usecase = self.makeUsecase(
+            stubCandidates: [.init(scheduleId: "s1"), .init(scheduleId: "s2", turnKey: "300")]
+        )
+
+        // when
+        let outputs = try await self.outputs(expect, for: usecase.candidates) {
+            usecase.refresh()
+        }
+
+        // then
+        #expect(outputs.last == [.init(scheduleId: "s1"), .init(scheduleId: "s2", turnKey: "300")])
+    }
+}
+
+
+// MARK: - 등록
+
+extension DDayCandidateUsecaseImpleTests {
+
+    @Test("등록하면 목록에 추가된다")
+    func append_addsCandidate() async throws {
+        // given
+        let expect = expectConfirm("등록 후 목록 방출")
+        expect.count = 3
+        let usecase = self.makeUsecase()
+
+        // when
+        let outputs = try await self.outputs(expect, for: usecase.candidates) {
+            usecase.refresh()
+            usecase.append(.init(scheduleId: "s1", turnKey: "300"))
+        }
+
+        // then
+        #expect(outputs.last == [.init(scheduleId: "s1", turnKey: "300")])
+    }
+
+    @Test("같은 회차를 다시 등록해도 중복되지 않는다")
+    func append_whenAlreadyRegistered_doesNotDuplicate() async throws {
+        // given
+        let expect = expectConfirm("중복 등록 방지")
+        expect.count = 3
+        let usecase = self.makeUsecase(stubCandidates: [.init(scheduleId: "s1", turnKey: "300")])
+
+        // when
+        let outputs = try await self.outputs(expect, for: usecase.candidates) {
+            usecase.refresh()
+            usecase.append(.init(scheduleId: "s1", turnKey: "300"))
+        }
+
+        // then
+        #expect(outputs.last == [.init(scheduleId: "s1", turnKey: "300")])
+    }
+
+    @Test("같은 일정의 다른 회차는 별개로 등록된다")
+    func append_whenSameScheduleDifferentTurn_addsBoth() async throws {
+        // given
+        let expect = expectConfirm("회차별 등록")
+        expect.count = 3
+        let usecase = self.makeUsecase(stubCandidates: [.init(scheduleId: "s1", turnKey: "300")])
+
+        // when
+        let outputs = try await self.outputs(expect, for: usecase.candidates) {
+            usecase.refresh()
+            usecase.append(.init(scheduleId: "s1", turnKey: "900"))
+        }
+
+        // then
+        #expect(outputs.last?.count == 2)
+    }
+}
+
+
+// MARK: - 해제
+
+extension DDayCandidateUsecaseImpleTests {
+
+    @Test("해제하면 목록에서 빠진다")
+    func remove_dropsCandidate() async throws {
+        // given
+        let expect = expectConfirm("해제 후 목록 방출")
+        expect.count = 3
+        let usecase = self.makeUsecase(
+            stubCandidates: [.init(scheduleId: "s1"), .init(scheduleId: "s2")]
+        )
+
+        // when
+        let outputs = try await self.outputs(expect, for: usecase.candidates) {
+            usecase.refresh()
+            usecase.remove(.init(scheduleId: "s1"))
+        }
+
+        // then
+        #expect(outputs.last == [.init(scheduleId: "s2")])
+    }
+}

--- a/Presentations/EventDetailScene/Sources/EventDetailSceneBuilderImple.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailSceneBuilderImple.swift
@@ -88,12 +88,13 @@ extension EventDetailSceneBuilderImple: EventDetailSceneBuilder {
             eventDetailDataUsecase: self.usecaseFactory.makeEventDetailDataUsecase(),
             todoEventUsecase: self.usecaseFactory.makeTodoEventUsecase(),
             calendarSettingUsecase: self.usecaseFactory.makeCalendarSettingUsecase(),
-            foremostEventUsecase: self.usecaseFactory.makeForemostEventUsecase()
+            foremostEventUsecase: self.usecaseFactory.makeForemostEventUsecase(),
+            ddayCandidateUsecase: self.usecaseFactory.makeDDayCandidateUsecase()
         )
         viewModel.listener = listener
         return self.makeEventDetailScene(viewModel)
     }
-    
+
     @MainActor
     private func makeEventDetailScene(
         _ viewModel: any EventDetailViewModel

--- a/Presentations/EventDetailScene/Sources/EventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailView.swift
@@ -1132,6 +1132,8 @@ extension EventDetailMoreAction: Identifiable {
         case .remove(let onlyThisEvent): return "remove:\(onlyThisEvent)"
         case .toggleTo(let isForemost):
             return "toggleTo:\(isForemost)"
+        case .toggleDDayCandidate(let isRegistered):
+            return "toggleDDayCandidate:\(isRegistered)"
         case .copy: return "copy"
         case .addToTemplate: return "addToTemplate"
         case .share: return "share"
@@ -1151,6 +1153,10 @@ extension EventDetailMoreAction: Identifiable {
             return isForemost
                 ? "calendar::event::more_action:foremost:mark:item_name".localized()
                 : "calendar::event::more_action:foremost:unmark:item_name".localized()
+        case .toggleDDayCandidate(let isRegistered):
+            return isRegistered
+                ? "calendar::event::more_action:dday_candidate:unregister:item_name".localized()
+                : "calendar::event::more_action:dday_candidate:register:item_name".localized()
         case .copy: return "calendar::event::more_action:copy:item_name".localized()
         case .addToTemplate: return "add to template".localized()
         case .share: return "share".localized()
@@ -1163,6 +1169,7 @@ extension EventDetailMoreAction: Identifiable {
         switch self {
         case .remove: return "trash"
         case .toggleTo: return "exclamationmark.circle"
+        case .toggleDDayCandidate: return "calendar.badge.clock"
         case .copy: return "doc.on.doc"
         case .addToTemplate: return "doc.plaintext"
         case .share: return "square.and.arrow.up"

--- a/Presentations/EventDetailScene/Sources/EventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailViewModel.swift
@@ -72,6 +72,7 @@ enum EventDetailMoreAction: Equatable {
     case transformToTodo
     case addToTemplate  // 이후 구현 예정
     case toggleTo(isForemost: Bool)
+    case toggleDDayCandidate(isRegistered: Bool)
     case share
 }
 

--- a/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
@@ -24,6 +24,7 @@ final class EditScheduleEventDetailViewModelImple: EventDetailViewModel, @unchec
     private let todoEventUsecase: any TodoEventUsecase
     private let calendarSettingUsecase: any CalendarSettingUsecase
     private let foremostEventUsecase: any ForemostEventUsecase
+    private let ddayCandidateUsecase: any DDayCandidateUsecase
     var router: (any EventDetailRouting)?
     weak var listener: EventDetailSceneListener?
     
@@ -35,7 +36,8 @@ final class EditScheduleEventDetailViewModelImple: EventDetailViewModel, @unchec
         eventDetailDataUsecase: any EventDetailDataUsecase,
         todoEventUsecase: any TodoEventUsecase,
         calendarSettingUsecase: any CalendarSettingUsecase,
-        foremostEventUsecase: any ForemostEventUsecase
+        foremostEventUsecase: any ForemostEventUsecase,
+        ddayCandidateUsecase: any DDayCandidateUsecase
     ) {
         self.scheduleId = scheduleId
         self.repeatingEventTargetTime = repeatingEventTargetTime
@@ -45,7 +47,8 @@ final class EditScheduleEventDetailViewModelImple: EventDetailViewModel, @unchec
         self.todoEventUsecase = todoEventUsecase
         self.calendarSettingUsecase = calendarSettingUsecase
         self.foremostEventUsecase = foremostEventUsecase
-        
+        self.ddayCandidateUsecase = ddayCandidateUsecase
+
         self.internalBinding()
     }
     
@@ -88,7 +91,8 @@ extension EditScheduleEventDetailViewModelImple: EventDetailInputListener {
     func prepare() {
         
         self.subject.isLoading.send(true)
-        
+        self.ddayCandidateUsecase.refresh()
+
         let handlePrepared: (EventDetailBasicData, EventDetailData) -> Void = { [weak self] basic, addition in
             self?.subject.basicData.send(
                 .init(origin: basic)
@@ -141,7 +145,10 @@ extension EditScheduleEventDetailViewModelImple: EventDetailInputListener {
             
         case .toggleTo(let isForemost):
             self.toggleForemostAfterConfirm(toForemost: isForemost)
-            
+
+        case .toggleDDayCandidate(let isRegistered):
+            self.toggleDDayCandidateAfterConfirm(isRegistered: isRegistered)
+
         case .copy:
             self.copyEvent()
             
@@ -228,7 +235,39 @@ extension EditScheduleEventDetailViewModelImple: EventDetailInputListener {
             .store(in: &self.cancellables)
         }
     }
-    
+
+    private func toggleDDayCandidateAfterConfirm(isRegistered: Bool) {
+
+        let message = isRegistered
+            ? "calendar::event::more_action:dday_candidate:unregister:message".localized()
+            : "calendar::event::more_action:dday_candidate:register:message".localized()
+        let info = ConfirmDialogInfo()
+            |> \.title .~ "calendar::event::more_action:dday_candidate:title".localized()
+            |> \.message .~ pure(message)
+            |> \.confirmText .~ R.String.Common.confirm
+            |> \.confirmed .~ pure(self.toggleDDayCandidate(isRegistered))
+            |> \.withCancel .~ true
+            |> \.cancelText .~ R.String.Common.cancel
+        self.router?.showConfirm(dialog: info)
+    }
+
+    private func toggleDDayCandidate(_ isRegistered: Bool) -> () -> Void {
+        let candidate = self.currentCandidate
+        return { [weak self] in
+            guard let usecase = self?.ddayCandidateUsecase else { return }
+            isRegistered ? usecase.remove(candidate) : usecase.append(candidate)
+        }
+    }
+
+    /// 상세가 열린 회차가 곧 등록 대상이다 — 반복이면 그 회차, 아니면 원본.
+    private var currentCandidate: DDayCandidate {
+        return DDayCandidate(
+            scheduleId: self.scheduleId,
+            targetTime: self.repeatingEventTargetTime,
+            isRepeating: self.subject.basicData.value?.origin.isRepeatingEvent ?? false
+        )
+    }
+
     private func transformToTodoAfterConfirm() {
         
         guard let basic = self.subject.basicData.value,
@@ -503,9 +542,17 @@ extension EditScheduleEventDetailViewModelImple {
     
     var moreActions: AnyPublisher<[[EventDetailMoreAction]], Never> {
         let scheduleId = self.scheduleId
-        let transform: (EventDetailBasicData, (any ForemostMarkableEvent)?) -> [[EventDetailMoreAction]] = { basic, foremostEvent in
-            let isRepeating = basic.selectedTime != nil && basic.eventRepeating != nil
+        let targetTime = self.repeatingEventTargetTime
+        let transform: (
+            EventDetailBasicData, (any ForemostMarkableEvent)?, [DDayCandidate]
+        ) -> [[EventDetailMoreAction]] = { basic, foremostEvent, candidates in
+            let isRepeating = basic.isRepeatingEvent
             let isForemost = foremostEvent?.eventId == scheduleId
+            let isDDayCandidate = candidates.contains(
+                DDayCandidate(
+                    scheduleId: scheduleId, targetTime: targetTime, isRepeating: isRepeating
+                )
+            )
             let removeActions: [EventDetailMoreAction] = isRepeating
                 ? [.remove(onlyThisEvent: true), .remove(onlyThisEvent: false)]
                 : [.remove(onlyThisEvent: false)]
@@ -513,13 +560,19 @@ extension EditScheduleEventDetailViewModelImple {
             let otherActions: [EventDetailMoreAction] = isRepeating
 //                ? [.share]
 //                : [.toggleTo(isForemost: !isForemost), .share]
-                ? [.copy, .transformToTodo]
-                : [.toggleTo(isForemost: !isForemost), .copy, .transformToTodo]
+                ? [.toggleDDayCandidate(isRegistered: isDDayCandidate), .copy, .transformToTodo]
+                : [
+                    .toggleTo(isForemost: !isForemost),
+                    .toggleDDayCandidate(isRegistered: isDDayCandidate),
+                    .copy,
+                    .transformToTodo
+                ]
             return [removeActions, otherActions]
         }
-        return Publishers.CombineLatest(
+        return Publishers.CombineLatest3(
             self.subject.basicData.compactMap { $0?.origin },
-            self.foremostEventUsecase.foremostEvent
+            self.foremostEventUsecase.foremostEvent,
+            self.ddayCandidateUsecase.candidates
         )
         .map(transform)
         .removeDuplicates()
@@ -528,7 +581,11 @@ extension EditScheduleEventDetailViewModelImple {
 }
 
 private extension EventDetailBasicData {
-    
+
+    var isRepeatingEvent: Bool {
+        return self.selectedTime != nil && self.eventRepeating != nil
+    }
+
     init(
         _ schedule: ScheduleEvent,
         _ repeatingEventTargetTime: EventTime?,
@@ -563,5 +620,21 @@ private extension ScheduleMakeParams {
         self.eventTagId = basic.eventTagId
         self.repeating = basic.eventRepeating?.repeating
         self.notificationOptions = basic.eventNotifications
+    }
+}
+
+
+private extension DDayCandidate {
+
+    /// 회차 키는 **반복 일정일 때만** 싣는다.
+    ///
+    /// 진입점(`EventListCellEventHanleViewModel.selectEvent`)이 비반복 일정에도 셀의 시각을
+    /// 그대로 넘겨서 `repeatingEventTargetTime`은 비반복에도 채워져 있다. 이걸 그대로 회차 키로
+    /// 쓰면 위젯이 반복 회차로 해석해(`fetchDDayTargetSchedule`) 조회에 실패하고 후보가 사라진다.
+    init(scheduleId: String, targetTime: EventTime?, isRepeating: Bool) {
+        self.init(
+            scheduleId: scheduleId,
+            turnKey: isRepeating ? targetTime?.customKey : nil
+        )
     }
 }

--- a/Presentations/EventDetailScene/Tests/EditScheduleEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/EditScheduleEventDetailViewModelImpleTests.swift
@@ -23,6 +23,7 @@ class EditScheduleEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitabl
     private var spyScheduleUsecase: PrivateStubScheduleEventUsecase!
     private var spyEventDetailDataUsecase: StubEventDetailDataUsecase!
     private var stubForemostEventUsecase: StubForemostEventUsecase!
+    private var stubDDayCandidateUsecase: PrivateStubDDayCandidateUsecase!
     private var spyRouter: SpyEventDetailRouter!
     private var spyListener: SpyEventDetailListener!
     
@@ -39,6 +40,7 @@ class EditScheduleEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitabl
         self.spyScheduleUsecase = nil
         self.spyEventDetailDataUsecase = nil
         self.stubForemostEventUsecase = nil
+        self.stubDDayCandidateUsecase = nil
         self.spyRouter = nil
         self.spyListener = nil
     }
@@ -54,9 +56,10 @@ class EditScheduleEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitabl
         isForemost: Bool = false,
         shouldFailToTransformToTodo: Bool = false,
         shouldFailToSaveDetail: Bool = false,
-        shouldFailToRemoveSchedule: Bool = false
+        shouldFailToRemoveSchedule: Bool = false,
+        registeredCandidates: [DDayCandidate] = []
     ) -> EditScheduleEventDetailViewModelImple {
-        
+
         let (schedule, detail) = (customSchedule ?? self.dummyRepeatingSchedule, self.dummyDetail)
         self.spyScheduleUsecase.stubEvent = schedule
         self.spyEventDetailDataUsecase.stubDetail = detail
@@ -76,7 +79,9 @@ class EditScheduleEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitabl
         
         let todoUsecase = StubTodoEventUsecase()
         todoUsecase.shouldFailMakeTodo = shouldFailToTransformToTodo
-        
+
+        self.stubDDayCandidateUsecase = .init(registeredCandidates)
+
         let viewModel = EditScheduleEventDetailViewModelImple(
             scheduleId: schedule.uuid,
             repeatingEventTargetTime: repeatingEventTargetTime,
@@ -85,7 +90,8 @@ class EditScheduleEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitabl
             eventDetailDataUsecase: self.spyEventDetailDataUsecase,
             todoEventUsecase: todoUsecase,
             calendarSettingUsecase: calendarSettingUsecase,
-            foremostEventUsecase: self.stubForemostEventUsecase
+            foremostEventUsecase: self.stubForemostEventUsecase,
+            ddayCandidateUsecase: self.stubDDayCandidateUsecase
         )
         viewModel.router = self.spyRouter
         viewModel.listener = self.spyListener
@@ -233,33 +239,156 @@ extension EditScheduleEventDetailViewModelImpleTests {
             self.makeViewModel(customSchedule: schedule),
             expect: [
                 [.remove(onlyThisEvent: true), .remove(onlyThisEvent: false)],
-                [.copy, .transformToTodo]
+                [.toggleDDayCandidate(isRegistered: false), .copy, .transformToTodo]
             ]
         )
         parameterizeTest(
             self.makeViewModel(customSchedule: schedule, isForemost: true),
             expect: [
                 [.remove(onlyThisEvent: true), .remove(onlyThisEvent: false)],
-                [.copy, .transformToTodo]
+                [.toggleDDayCandidate(isRegistered: false), .copy, .transformToTodo]
             ]
         )
         let scheduleNotRepeating = schedule |> \.repeating .~ nil
         parameterizeTest(
             self.makeViewModel(customSchedule: scheduleNotRepeating),
             expect: [
-                [.remove(onlyThisEvent: false)], 
-                [.toggleTo(isForemost: true), .copy, .transformToTodo]
+                [.remove(onlyThisEvent: false)],
+                [
+                    .toggleTo(isForemost: true),
+                    .toggleDDayCandidate(isRegistered: false),
+                    .copy,
+                    .transformToTodo
+                ]
             ]
         )
         parameterizeTest(
             self.makeViewModel(customSchedule: scheduleNotRepeating, isForemost: true),
             expect: [
                 [.remove(onlyThisEvent: false)],
-                [.toggleTo(isForemost: false), .copy, .transformToTodo]
+                [
+                    .toggleTo(isForemost: false),
+                    .toggleDDayCandidate(isRegistered: false),
+                    .copy,
+                    .transformToTodo
+                ]
             ]
         )
     }
-    
+
+    func testViewModel_whenRepeatingSchedule_provideDDayCandidateAction() {
+        // given
+        let expect = expectation(description: "반복 일정에도 후보 액션이 제공된다")
+        let viewModel = self.makeViewModel(customSchedule: self.dummyRepeatingSchedule)
+
+        // when
+        let actions = self.waitFirstOutput(expect, for: viewModel.moreActions) {
+            viewModel.prepare()
+        }
+
+        // then
+        XCTAssertEqual(
+            actions?.flatMap { $0 }.contains(.toggleDDayCandidate(isRegistered: false)), true
+        )
+    }
+
+    func testViewModel_whenAlreadyRegistered_provideUnregisterAction() {
+        // given
+        let expect = expectation(description: "등록된 회차면 해제 액션")
+        let targetTime = EventTime.at(300)
+        let viewModel = self.makeViewModel(
+            customSchedule: self.dummyRepeatingSchedule,
+            repeatingEventTargetTime: targetTime,
+            registeredCandidates: [
+                .init(scheduleId: "dummy_schedule", turnKey: targetTime.customKey)
+            ]
+        )
+
+        // when
+        let actions = self.waitFirstOutput(expect, for: viewModel.moreActions) {
+            viewModel.prepare()
+        }
+
+        // then
+        XCTAssertEqual(
+            actions?.flatMap { $0 }.contains(.toggleDDayCandidate(isRegistered: true)), true
+        )
+    }
+
+    func testViewModel_whenToggleDDayCandidate_registerOpenedTurn() {
+        // given
+        let targetTime = EventTime.at(300)
+        let viewModel = self.makeViewModelWithPrepare(
+            repeatingEventTargetTime: targetTime
+        )
+
+        // when
+        viewModel.handleMoreAction(.toggleDDayCandidate(isRegistered: false))
+
+        // then: BaseSpyRouter가 shouldConfirmNotCancel 기본값(true)으로 confirmed를 즉시 호출한다
+        XCTAssertNotNil(self.spyRouter.didShowConfirmWith)
+        XCTAssertEqual(
+            self.stubDDayCandidateUsecase.currentCandidates,
+            [.init(scheduleId: "dummy_schedule", turnKey: targetTime.customKey)]
+        )
+    }
+
+    func testViewModel_whenToggleDDayCandidateOff_unregister() {
+        // given
+        let targetTime = EventTime.at(300)
+        let candidate = DDayCandidate(
+            scheduleId: "dummy_schedule", turnKey: targetTime.customKey
+        )
+        let viewModel = self.makeViewModelWithPrepare(
+            repeatingEventTargetTime: targetTime,
+            registeredCandidates: [candidate]
+        )
+
+        // when
+        viewModel.handleMoreAction(.toggleDDayCandidate(isRegistered: true))
+
+        // then
+        XCTAssertEqual(self.stubDDayCandidateUsecase.currentCandidates, [])
+    }
+
+    // 진입점이 비반복 일정에도 셀 시각을 넘기므로, 회차 키가 섞이면 위젯 조회가 실패한다
+    func testViewModel_whenNotRepeatingSchedule_registerWithoutTurnKey() {
+        // given
+        let viewModel = self.makeViewModelWithPrepare(
+            isNotRepeating: true,
+            repeatingEventTargetTime: .at(300)
+        )
+
+        // when
+        viewModel.handleMoreAction(.toggleDDayCandidate(isRegistered: false))
+
+        // then
+        XCTAssertEqual(
+            self.stubDDayCandidateUsecase.currentCandidates,
+            [.init(scheduleId: "dummy_schedule", turnKey: nil)]
+        )
+    }
+
+    func testViewModel_whenNotRepeatingAndRegistered_provideUnregisterAction() {
+        // given
+        let expect = expectation(description: "비반복 일정도 등록 상태가 라벨에 반영된다")
+        let viewModel = self.makeViewModel(
+            customSchedule: self.dummyRepeatingSchedule |> \.repeating .~ nil,
+            repeatingEventTargetTime: .at(300),
+            registeredCandidates: [.init(scheduleId: "dummy_schedule", turnKey: nil)]
+        )
+
+        // when
+        let actions = self.waitFirstOutput(expect, for: viewModel.moreActions) {
+            viewModel.prepare()
+        }
+
+        // then
+        XCTAssertEqual(
+            actions?.flatMap { $0 }.contains(.toggleDDayCandidate(isRegistered: true)), true
+        )
+    }
+
     func testViewModel_whenAfterRemoveSchedule_closeScene() {
         // given
         let expect = expectation(description: "Schedule 삭제 이후에 화면 닫음")
@@ -452,7 +581,8 @@ extension EditScheduleEventDetailViewModelImpleTests {
         repeatingEventTargetTime: EventTime? = nil,
         shouldFailToTransformToTodo: Bool = false,
         shouldFailToSaveDetail: Bool = false,
-        shouldFailToRemoveSchedule: Bool = false
+        shouldFailToRemoveSchedule: Bool = false,
+        registeredCandidates: [DDayCandidate] = []
     ) -> EditScheduleEventDetailViewModelImple {
         // given
         let expect = expectation(description: "wait prepared")
@@ -469,9 +599,10 @@ extension EditScheduleEventDetailViewModelImpleTests {
             shouldFailSave: shouldFailEdit,
             shouldFailToTransformToTodo: shouldFailToTransformToTodo,
             shouldFailToSaveDetail: shouldFailToSaveDetail,
-            shouldFailToRemoveSchedule: shouldFailToRemoveSchedule
+            shouldFailToRemoveSchedule: shouldFailToRemoveSchedule,
+            registeredCandidates: registeredCandidates
         )
-        
+
         // when
         let _ = self.waitOutputs(expect, for: viewModel.isLoading) {
             viewModel.prepare()
@@ -959,6 +1090,32 @@ extension EditScheduleEventDetailViewModelImpleTests {
         // then
         self.wait(for: [expect], timeout: 0.1)
     }
+}
+
+private final class PrivateStubDDayCandidateUsecase: DDayCandidateUsecase, @unchecked Sendable {
+
+    private let subject: CurrentValueSubject<[DDayCandidate], Never>
+
+    init(_ candidates: [DDayCandidate] = []) {
+        self.subject = .init(candidates)
+    }
+
+    func refresh() { }
+
+    func append(_ candidate: DDayCandidate) {
+        self.subject.send(self.subject.value + [candidate])
+    }
+
+    func remove(_ candidate: DDayCandidate) {
+        self.subject.send(self.subject.value.filter { $0 != candidate })
+    }
+
+    var candidates: AnyPublisher<[DDayCandidate], Never> {
+        return self.subject.eraseToAnyPublisher()
+    }
+
+    /// 테스트 케이스가 직접 검사하는 raw 기록 — 검증은 케이스 책임(stub은 기록만).
+    var currentCandidates: [DDayCandidate] { self.subject.value }
 }
 
 private final class PrivateStubScheduleEventUsecase: StubScheduleEventUsecase, @unchecked Sendable {

--- a/Presentations/Scenes/Sources/Factories.swift
+++ b/Presentations/Scenes/Sources/Factories.swift
@@ -33,6 +33,7 @@ public protocol EventUsecaseFactory {
     func makeDoneTodoDetailDataUsecase() -> any EventDetailDataUsecase
     func makeDoneTodoPagingUsecase() -> any DoneTodoEventsPagingUsecase
     func makeForemostEventUsecase() -> any ForemostEventUsecase
+    func makeDDayCandidateUsecase() -> any DDayCandidateUsecase
     func makeDaysIntervalCountUsecase() -> any DaysIntervalCountUsecase
     var eventSyncUsecase: any EventSyncUsecase { get }
     var eventUploadService: any EventUploadService { get }

--- a/Repository/Sources/Repository+Imple/Event/DDayCandidate/DDayCandidate+Mapping.swift
+++ b/Repository/Sources/Repository+Imple/Event/DDayCandidate/DDayCandidate+Mapping.swift
@@ -1,0 +1,39 @@
+//
+//  DDayCandidate+Mapping.swift
+//  Repository
+//
+//  Created by sudo.park on 7/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Domain
+
+
+struct DDayCandidateMapper: Codable {
+
+    let candidate: DDayCandidate
+
+    init(candidate: DDayCandidate) {
+        self.candidate = candidate
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case scheduleId = "schedule_id"
+        case turnKey = "turn_key"
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.candidate = DDayCandidate(
+            scheduleId: try container.decode(String.self, forKey: .scheduleId),
+            turnKey: try container.decodeIfPresent(String.self, forKey: .turnKey)
+        )
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.candidate.scheduleId, forKey: .scheduleId)
+        try container.encodeIfPresent(self.candidate.turnKey, forKey: .turnKey)
+    }
+}

--- a/Repository/Sources/Repository+Imple/Event/DDayCandidate/DDayCandidateLocalRepositoryImple.swift
+++ b/Repository/Sources/Repository+Imple/Event/DDayCandidate/DDayCandidateLocalRepositoryImple.swift
@@ -1,0 +1,56 @@
+//
+//  DDayCandidateLocalRepositoryImple.swift
+//  Repository
+//
+//  Created by sudo.park on 7/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Domain
+import Extensions
+
+
+public final class DDayCandidateLocalRepositoryImple: DDayCandidateRepository {
+
+    private let environmentStorage: any EnvironmentStorage
+
+    public init(environmentStorage: any EnvironmentStorage) {
+        self.environmentStorage = environmentStorage
+    }
+
+    private enum Constant {
+        static let key: String = "dday_candidates"
+    }
+}
+
+extension DDayCandidateLocalRepositoryImple {
+
+    public func loadCandidates() -> [DDayCandidate] {
+        let mappers: [DDayCandidateMapper]? = self.environmentStorage.load(Constant.key)
+        return mappers?.map { $0.candidate } ?? []
+    }
+
+    public func append(_ candidate: DDayCandidate) -> [DDayCandidate] {
+        let current = self.loadCandidates()
+        guard !current.contains(candidate) else { return current }
+        return self.save(current + [candidate])
+    }
+
+    public func remove(_ candidate: DDayCandidate) -> [DDayCandidate] {
+        return self.save(self.loadCandidates().filter { $0 != candidate })
+    }
+
+    /// 빈 목록이면 키를 지운다 — 빈 배열을 남겨두면 "없음"을 두 형태로 표현하게 된다.
+    private func save(_ candidates: [DDayCandidate]) -> [DDayCandidate] {
+        guard !candidates.isEmpty
+        else {
+            self.environmentStorage.remove(Constant.key)
+            return []
+        }
+        self.environmentStorage.update(
+            Constant.key, candidates.map { DDayCandidateMapper(candidate: $0) }
+        )
+        return candidates
+    }
+}

--- a/Repository/Tests/Event/DDayCandidate/DDayCandidateLocalRepositoryImpleTests.swift
+++ b/Repository/Tests/Event/DDayCandidate/DDayCandidateLocalRepositoryImpleTests.swift
@@ -1,0 +1,122 @@
+//
+//  DDayCandidateLocalRepositoryImpleTests.swift
+//  RepositoryTests
+//
+//  Created by sudo.park on 7/30/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Domain
+
+@testable import Repository
+
+
+struct DDayCandidateLocalRepositoryImpleTests {
+
+    private func makeRepository(
+        storage: FakeEnvironmentStorage = .init()
+    ) -> DDayCandidateLocalRepositoryImple {
+        return DDayCandidateLocalRepositoryImple(environmentStorage: storage)
+    }
+
+    @Test("등록한 후보를 그대로 읽는다")
+    func appendThenLoad_roundTrips() {
+        // given
+        let repository = self.makeRepository()
+        let candidates: [DDayCandidate] = [
+            .init(scheduleId: "s1"),
+            .init(scheduleId: "s2", turnKey: "1200..<1300")
+        ]
+
+        // when
+        candidates.forEach { _ = repository.append($0) }
+        let loaded = repository.loadCandidates()
+
+        // then
+        #expect(loaded == candidates)
+    }
+
+    @Test("등록 결과로 갱신된 전체 목록을 낸다")
+    func append_returnsWholeList() {
+        // given
+        let repository = self.makeRepository()
+        _ = repository.append(.init(scheduleId: "s1"))
+
+        // when
+        let appended = repository.append(.init(scheduleId: "s2"))
+
+        // then
+        #expect(appended == [.init(scheduleId: "s1"), .init(scheduleId: "s2")])
+    }
+
+    @Test("같은 후보를 다시 등록해도 중복되지 않는다")
+    func append_whenAlreadyStored_doesNotDuplicate() {
+        // given
+        let repository = self.makeRepository()
+        let candidate = DDayCandidate(scheduleId: "s1", turnKey: "300")
+        _ = repository.append(candidate)
+
+        // when
+        let appended = repository.append(candidate)
+
+        // then
+        #expect(appended == [candidate])
+        #expect(repository.loadCandidates() == [candidate])
+    }
+
+    @Test("같은 일정의 다른 회차는 별개로 등록된다")
+    func append_whenSameScheduleDifferentTurn_keepsBoth() {
+        // given
+        let repository = self.makeRepository()
+        _ = repository.append(.init(scheduleId: "s1", turnKey: "300"))
+
+        // when
+        let appended = repository.append(.init(scheduleId: "s1", turnKey: "900"))
+
+        // then
+        #expect(appended.count == 2)
+    }
+
+    @Test("제거 결과로 남은 전체 목록을 낸다")
+    func remove_returnsRemaining() {
+        // given
+        let repository = self.makeRepository()
+        _ = repository.append(.init(scheduleId: "s1"))
+        _ = repository.append(.init(scheduleId: "s2"))
+
+        // when
+        let remain = repository.remove(.init(scheduleId: "s1"))
+
+        // then
+        #expect(remain == [.init(scheduleId: "s2")])
+        #expect(repository.loadCandidates() == [.init(scheduleId: "s2")])
+    }
+
+    @Test("저장된 게 없으면 빈 배열을 낸다")
+    func loadCandidates_whenEmpty_returnsEmpty() {
+        // given
+        let repository = self.makeRepository()
+
+        // when
+        let loaded = repository.loadCandidates()
+
+        // then
+        #expect(loaded.isEmpty == true)
+    }
+
+    @Test("마지막 후보를 제거하면 전부 비워진다")
+    func remove_whenLastOne_clearsAll() {
+        // given
+        let repository = self.makeRepository()
+        _ = repository.append(.init(scheduleId: "s1"))
+
+        // when
+        let remain = repository.remove(.init(scheduleId: "s1"))
+
+        // then
+        #expect(remain.isEmpty == true)
+        #expect(repository.loadCandidates().isEmpty == true)
+    }
+}

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -130,6 +130,11 @@
 "calendar::event::more_action:remove:item_name" = "Remove event";
 "calendar::event::more_action:foremost:mark:item_name" = "Mark as foremost";
 "calendar::event::more_action:foremost:unmark:item_name" = "Unmark as foremost";
+"calendar::event::more_action:dday_candidate:register:item_name" = "Add to D-day widget";
+"calendar::event::more_action:dday_candidate:unregister:item_name" = "Remove from D-day widget";
+"calendar::event::more_action:dday_candidate:title" = "D-day widget candidate";
+"calendar::event::more_action:dday_candidate:register:message" = "Add this event as a D-day widget candidate? It will appear at the top of the list when you edit the widget.";
+"calendar::event::more_action:dday_candidate:unregister:message" = "Remove this event from D-day widget candidates?";
 "calendar::event::more_action:copy:item_name" = "Copy event";
 "calendar::event::more_action:transform_to::schedule" = "Convert to schedule";
 "calendar::event::more_action:transform_to::todo" = "Convert to to-do";

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -510,6 +510,7 @@
 "widget.dday::noTarget" = "Select an event";
 "widget.dday.sample::title" = "Workshop";
 "widget.dday.target::repeating" = "Repeating";
+"widget.dday.target::registered" = "Pinned";
 "widget.dday.turn::name" = "Turn %d";
 
 // MARK: - link

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -130,6 +130,11 @@
 "calendar::event::more_action:remove:item_name" = "이벤트 삭제";
 "calendar::event::more_action:foremost:mark:item_name" = "제일 중요 이벤트 등록";
 "calendar::event::more_action:foremost:unmark:item_name" = "제일 중요 이벤트 해제";
+"calendar::event::more_action:dday_candidate:register:item_name" = "D-day 위젯 후보로 추가";
+"calendar::event::more_action:dday_candidate:unregister:item_name" = "D-day 위젯 후보에서 제거";
+"calendar::event::more_action:dday_candidate:title" = "D-day 위젯 후보";
+"calendar::event::more_action:dday_candidate:register:message" = "이 일정을 D-day 위젯 후보로 추가할까요? 위젯을 편집할 때 목록 맨 위에 표시됩니다.";
+"calendar::event::more_action:dday_candidate:unregister:message" = "이 일정을 D-day 위젯 후보에서 제거할까요?";
 "calendar::event::more_action:copy:item_name" = "이벤트 복사";
 "calendar::event::more_action:transform_to::schedule" = "일정으로 전환";
 "calendar::event::more_action:transform_to::todo" = "할일로 전환";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -510,6 +510,7 @@
 "widget.dday::noTarget" = "대상을 선택해주세요";
 "widget.dday.sample::title" = "워크숍";
 "widget.dday.target::repeating" = "반복 일정";
+"widget.dday.target::registered" = "지정한 후보";
 "widget.dday.turn::name" = "%d회차";
 
 // MARK: - link

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Base+Factory/DDayTargetSelectIntentFactory.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Base+Factory/DDayTargetSelectIntentFactory.swift
@@ -32,6 +32,13 @@ extension DDayTargetSelectIntentFactory {
         return self.usecaseFactory.makeHolidaysFetchUsecase()
     }
 
+    /// 앱이 쓴 후보를 같은 App Group suite에서 읽는다.
+    func makeCandidateRepository() -> any DDayCandidateRepository {
+        return DDayCandidateLocalRepositoryImple(
+            environmentStorage: self.base.userDefaultEnvironmentStorage
+        )
+    }
+
     func loadTimeZone() -> TimeZone {
         let repository = CalendarSettingRepositoryImple(
             environmentStorage: self.base.userDefaultEnvironmentStorage

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Intents/DDayTargetSelectIntent.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Intents/DDayTargetSelectIntent.swift
@@ -137,6 +137,15 @@ extension Array where Element == DDayTargetCandidate {
 
         return repeatings + upcoming + past
     }
+
+    /// 지정 후보를 앞에 붙이고, 같은 일정의 자동 산출분을 걷어낸다.
+    ///
+    /// dedupe 키가 `targetId`가 아니라 `rawId`인 이유 — 회차가 지정된 후보(turnKey 있음)와
+    /// 자동 산출 반복 행(turnKey 없음)은 targetId가 달라 둘 다 살아남는다. 회차를 다시 고르는
+    /// 길은 2단 파라미터에 남아 있으므로 자동 행을 숨겨도 잃는 기능이 없다.
+    func mergingPinned(_ pinned: [DDayTargetCandidate]) -> [DDayTargetCandidate] {
+        return (pinned + self).removeDuplicates { $0.targetId.rawId }
+    }
 }
 
 struct DDayTargetEventQuery: EntityQuery, @unchecked Sendable {
@@ -191,18 +200,49 @@ struct DDayTargetEventQuery: EntityQuery, @unchecked Sendable {
         else { return [] }
 
         let countryCode = await self.factory.makeHolidayFetchUsecase().currentCountryCode()
+        let pinned = await self.pinnedCandidates()
         let events = try await usecase.fetchEvents(
             in: from.timeIntervalSince1970..<until.timeIntervalSince1970, timeZone
         )
-        return self.asSuggestions(events.eventWithTimes, timeZone, countryCode, todayStart)
+        return self.asSuggestions(
+            events.eventWithTimes, timeZone, countryCode, todayStart, pinned
+        )
+    }
+
+    /// 유저가 지정한 후보. 삭제된 일정은 조회 실패로 자연히 빠진다.
+    private func pinnedCandidates() async -> [DDayTargetCandidate] {
+
+        let usecase = self.factory.makeEventFetchUsecase()
+        let stored = self.factory.makeCandidateRepository().loadCandidates()
+
+        var candidates: [DDayTargetCandidate] = []
+        for candidate in stored {
+            let targetId = DDayTargetEventId(
+                kind: .schedule, rawId: candidate.scheduleId, turnKey: candidate.turnKey
+            )
+            guard let event = try? await usecase.fetchDDayTargetEvent(targetId)
+            else { continue }
+            candidates.append(
+                DDayTargetCandidate(
+                    targetId: targetId,
+                    name: event.name,
+                    time: event.time,
+                    isRepeating: event.isRepeating
+                )
+            )
+        }
+        return candidates
     }
 
     private func asSuggestions(
         _ events: [any CalendarEvent],
         _ timeZone: TimeZone,
         _ countryCode: String?,
-        _ todayStart: TimeInterval
+        _ todayStart: TimeInterval,
+        _ pinned: [DDayTargetCandidate]
     ) -> [DDayTargetEventEntity] {
+
+        let pinnedIds = Set(pinned.map { $0.targetId })
 
         return events
             .compactMap { self.asCandidate($0, countryCode) }
@@ -214,15 +254,30 @@ struct DDayTargetEventQuery: EntityQuery, @unchecked Sendable {
                 upcomingLimit: Constant.upcomingLimit,
                 pastLimit: Constant.pastLimit
             )
+            // 지정 후보는 티어 상한 뒤에 합친다 — 상한에 걸려 잘리면 지정한 의미가 없다.
+            .mergingPinned(pinned)
             .map { candidate in
                 DDayTargetEventEntity(
                     id: candidate.targetId.entityId(isRepeating: candidate.isRepeating),
                     name: candidate.name,
-                    subtitle: candidate.isRepeating
-                        ? "widget.dday.target::repeating".localized()
-                        : DDayTargetDateFormatter.dateText(of: candidate.time, in: timeZone)
+                    subtitle: self.subtitle(
+                        of: candidate,
+                        in: timeZone,
+                        isPinned: pinnedIds.contains(candidate.targetId)
+                    )
                 )
             }
+    }
+
+    /// "지정한 후보 · 2027년 3월 15일 (월)" 계열. 반복 일정은 날짜 대신 반복 표시.
+    private func subtitle(
+        of candidate: DDayTargetCandidate, in timeZone: TimeZone, isPinned: Bool
+    ) -> String {
+        let base = candidate.isRepeating
+            ? "widget.dday.target::repeating".localized()
+            : DDayTargetDateFormatter.dateText(of: candidate.time, in: timeZone)
+        guard isPinned else { return base }
+        return "\("widget.dday.target::registered".localized()) · \(base)"
     }
 
     private func asCandidate(

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidget.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidget.swift
@@ -157,9 +157,11 @@ struct DDayWidgetEntryView: View {
         switch self.entry.result {
         case .success(let model) where family == .systemMedium:
             DDayMediumWidgetView(model: model)
+                .widgetURL(model.link)
 
         case .success(let model):
             DDaySmallWidgetView(model: model)
+                .widgetURL(model.link)
 
         case .failure(let error):
             FailView(errorModel: error)

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidgetViewModelProvider.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidgetViewModelProvider.swift
@@ -24,6 +24,7 @@ struct DDayWidgetViewModel: Sendable {
     let timeText: String
     let repeatText: String
     var refreshAfter: Date?
+    var link: URL?
     var widgetSetting: WidgetAppearanceSettings = .init()
 
     var isRepeating: Bool {
@@ -109,7 +110,32 @@ extension DDayWidgetViewModelProvider {
             repeatText: self.repeatText(event, timeZone)
         )
         |> \.refreshAfter .~ refreshAfter
+        |> \.link .~ self.link(for: event, in: timeZone)
         |> \.widgetSetting .~ setting
+    }
+
+    /// 일정은 그 회차 상세로, 공휴일은 해당 날짜 선택으로 보낸다.
+    /// 공휴일 상세는 Holiday.uuid를 요구하는데 위젯엔 그 값이 없다 — 상세에 날짜·이름·D-day뿐이라
+    /// 날짜 선택으로 보내도 정보 손실이 없다.
+    private func link(for event: DDayTargetEvent, in timeZone: TimeZone) -> URL? {
+        switch event.targetId.kind {
+        case .schedule:
+            return EventDeepLinkBuilder
+                .schedule(id: event.targetId.rawId, time: event.time)
+                .build()
+
+        case .holiday:
+            let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
+            let date = Date(
+                timeIntervalSince1970: event.time.rangeWithShifttingifNeed(on: timeZone).lowerBound
+            )
+            let components = calendar.dateComponents([.year, .month, .day], from: date)
+            guard let year = components.year,
+                  let month = components.month,
+                  let day = components.day
+            else { return nil }
+            return CalendarDay(year, month, day).link
+        }
     }
 
     private func repeatText(_ event: DDayTargetEvent, _ timeZone: TimeZone) -> String {

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/Intents/DDayTargetSelectIntentTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/Intents/DDayTargetSelectIntentTests.swift
@@ -163,3 +163,61 @@ struct DDayTargetCandidateSortTests {
         #expect(sorted.map { $0.name } == ["repeat-old", "repeat-new"])
     }
 }
+
+
+// MARK: - 지정 후보 티어
+
+struct DDayTargetPinnedTierTests {
+
+    private func makeCandidate(
+        _ name: String, at time: TimeInterval,
+        isRepeating: Bool = false, turnKey: String? = nil
+    ) -> DDayTargetCandidate {
+        return DDayTargetCandidate(
+            targetId: .init(kind: .schedule, rawId: name, turnKey: turnKey),
+            name: name,
+            time: .at(time),
+            isRepeating: isRepeating
+        )
+    }
+
+    @Test("지정 후보가 자동 산출분보다 앞에 온다")
+    func mergingPinned_putsPinnedFirst() {
+        // given
+        let pinned = [self.makeCandidate("pinned", at: 5000)]
+        let auto = [self.makeCandidate("auto", at: 1000)]
+
+        // when
+        let merged = auto.mergingPinned(pinned)
+
+        // then
+        #expect(merged.map { $0.name } == ["pinned", "auto"])
+    }
+
+    @Test("같은 일정이 양쪽에 있으면 지정 후보만 남는다")
+    func mergingPinned_whenSameSchedule_dropsAuto() {
+        // given: 지정은 5회차(turnKey 있음), 자동은 회차 없는 반복 행 — targetId는 다르다
+        let pinned = [self.makeCandidate("운동", at: 5000, isRepeating: true, turnKey: "5000")]
+        let auto = [self.makeCandidate("운동", at: 1000, isRepeating: true)]
+
+        // when
+        let merged = auto.mergingPinned(pinned)
+
+        // then
+        #expect(merged.count == 1)
+        #expect(merged.first?.targetId.turnKey == "5000")
+    }
+
+    @Test("다른 일정은 함께 남는다")
+    func mergingPinned_keepsDifferentSchedules() {
+        // given
+        let pinned = [self.makeCandidate("a", at: 5000)]
+        let auto = [self.makeCandidate("b", at: 1000)]
+
+        // when
+        let merged = auto.mergingPinned(pinned)
+
+        // then
+        #expect(merged.map { $0.name } == ["a", "b"])
+    }
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/DDayWidgetViewModelProviderTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/DDayWidgetViewModelProviderTests.swift
@@ -39,10 +39,12 @@ struct DDayWidgetViewModelProviderTests {
     }
 
     private func makeTarget(
-        time: EventTime, repeatOption: (any EventRepeatingOption)? = nil
+        time: EventTime,
+        repeatOption: (any EventRepeatingOption)? = nil,
+        targetId: DDayTargetEventId = .init(kind: .schedule, rawId: "s1")
     ) -> DDayTargetEvent {
         return DDayTargetEvent(
-            targetId: .init(kind: .schedule, rawId: "s1"),
+            targetId: targetId,
             name: "워크숍",
             time: time,
             repeatOption: repeatOption,
@@ -249,5 +251,66 @@ extension DDayWidgetViewModelProviderTests {
 
         // then
         #expect(model.ddayText == "–")
+    }
+}
+
+
+// MARK: - 탭 링크
+
+extension DDayWidgetViewModelProviderTests {
+
+    @Test("일정은 해당 회차 상세 링크를 낸다")
+    func getDDayModel_whenSchedule_linksToScheduleDetail() async throws {
+        // given
+        let now = Date(timeIntervalSince1970: 0)
+        let provider = self.makeProvider(
+            stubTarget: self.makeTarget(time: .at(14 * 24 * 3600))
+        )
+
+        // when
+        let model = try await provider.getDDayModel(
+            for: now, target: .init(kind: .schedule, rawId: "s1")
+        )
+
+        // then
+        let link = try #require(model.link)
+        #expect(link.absoluteString.contains("calendar/event/schedule") == true)
+        #expect(link.absoluteString.contains("event_id=s1") == true)
+    }
+
+    @Test("공휴일은 해당 날짜 선택 링크를 낸다")
+    func getDDayModel_whenHoliday_linksToCalendarDay() async throws {
+        // given: UTC 기준 1970-01-15 00:00 = 14일 * 86400
+        let now = Date(timeIntervalSince1970: 0)
+        let dayStart: TimeInterval = 14 * 24 * 3600
+        let holidayId = DDayTargetEventId(
+            kind: .holiday, rawId: "KR::1970-01-15::테스트공휴일"
+        )
+        let provider = self.makeProvider(
+            stubTarget: self.makeTarget(
+                time: .period(dayStart..<(dayStart + 24 * 3600 - 1)),
+                targetId: holidayId
+            )
+        )
+
+        // when
+        let model = try await provider.getDDayModel(for: now, target: holidayId)
+
+        // then
+        let link = try #require(model.link)
+        #expect(link.absoluteString.contains("select=1970_01_15") == true)
+    }
+
+    @Test("대상이 지정되지 않으면 링크가 없다")
+    func getDDayModel_whenTargetIsNil_hasNoLink() async throws {
+        // given
+        let now = Date(timeIntervalSince1970: 0)
+        let provider = self.makeProvider(stubTarget: nil)
+
+        // when
+        let model = try await provider.getDDayModel(for: now, target: nil)
+
+        // then
+        #expect(model.link == nil)
     }
 }

--- a/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
+++ b/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
@@ -228,7 +228,16 @@ extension NonLoginUsecaseFactoryImple {
             eventNotifyService: applicationBase.eventNotifyService
         )
     }
-    
+
+    func makeDDayCandidateUsecase() -> any DDayCandidateUsecase {
+        return DDayCandidateUsecaseImple(
+            repository: DDayCandidateLocalRepositoryImple(
+                environmentStorage: applicationBase.userDefaultEnvironmentStorage
+            ),
+            sharedDataStore: applicationBase.sharedDataStore
+        )
+    }
+
     func makeDaysIntervalCountUsecase() -> any DaysIntervalCountUsecase {
         let repository = CalendarSettingRepositoryImple(
             environmentStorage: applicationBase.userDefaultEnvironmentStorage
@@ -668,12 +677,22 @@ extension LoginUsecaseFactoryImple {
             cacheStorage: cache
         )
         return ForemostEventUsecaseImple(
-            repository: repository, 
+            repository: repository,
             sharedDataStore: applicationBase.sharedDataStore,
             eventNotifyService: applicationBase.eventNotifyService
         )
     }
-    
+
+    /// 후보는 로컬(App Group) 전용이라 로그인 여부와 무관하게 같은 조립이다.
+    func makeDDayCandidateUsecase() -> any DDayCandidateUsecase {
+        return DDayCandidateUsecaseImple(
+            repository: DDayCandidateLocalRepositoryImple(
+                environmentStorage: applicationBase.userDefaultEnvironmentStorage
+            ),
+            sharedDataStore: applicationBase.sharedDataStore
+        )
+    }
+
     func makeDaysIntervalCountUsecase() -> any DaysIntervalCountUsecase {
         let repository = CalendarSettingRepositoryImple(
             environmentStorage: applicationBase.userDefaultEnvironmentStorage


### PR DESCRIPTION
## 문제

#722의 위젯 편집 후보군은 자동 산출(오늘 ±365일 · 다가오는 40 / 지난 10)이라 세 군데가 누락된다 — ① 1년 밖 이벤트, ② 상한 밖 반복 회차, ③ 다가오는 이벤트가 상한을 넘을 때 잘린 것. 유저가 원하는 대상이 목록에 아예 없으면 위젯을 쓸 수 없다. (#726)

그리고 D-day 위젯은 탭해도 아무 데도 가지 않았다. 위젯 9종 중 유일하게 링크가 없었다. (#731)

## 접근

**후보 등록(#726)** — 일정 상세의 more-action 토글 하나로 끝낸다. 별도 회차 선택 UI를 만들지 않은 이유는 상세 화면이 이미 자기가 열린 회차(`repeatingEventTargetTime`)를 알고 있어서다. 그 값의 `customKey`가 #722의 회차 키 체계와 같아 그대로 후보 키가 된다.

저장은 Foremost 선례를 따라 **id만 App Group `EnvironmentStorage`에** 두고 상세는 조회 시점에 복원한다. 앱과 위젯이 같은 suite를 보므로 동기화 장치가 필요 없고, 삭제된 일정은 조회 실패로 목록에서 자연히 빠져 청소 로직도 없다. 서버 동기화는 하지 않는다 — 위젯 설정은 기기 종속이라.

**딥링크(#731)** — 일정은 기존 `EventDeepLinkBuilder.schedule(id:time:)`로 해당 회차 상세까지, 공휴일은 `CalendarDay.link`로 그 날짜 선택까지 보낸다. 공휴일 상세 경로를 쓰지 않은 이유는 `routeToHolidayEventDetail`이 위젯에 없는 `Holiday.uuid`를 요구하기 때문이다. 공휴일 상세엔 날짜·이름·D-day뿐이라 날짜 선택으로 보내도 잃는 정보가 없다.

**설계 판단 둘**

- **`DDayTargetEventId`를 Domain으로 올리지 않았다.** 킥오프 브리프엔 "승격"으로 적었지만 그 타입은 `kind` + 공휴일용 복합 rawId(`countryCode::dateString::name`)를 담은 위젯 편집 UI 종속 인코딩이다. 후보 대상은 일정뿐이라 Domain엔 `DDayCandidate(scheduleId, turnKey)`만 두고 위젯이 변환한다.
- **자동 산출분 제거 키는 `targetId`가 아니라 `rawId`.** 회차가 지정된 후보(turnKey 있음)와 회차 없는 자동 반복 행은 `targetId`가 달라 `targetId`로 걸면 같은 일정이 두 번 뜬다. 회차를 다시 고르는 길은 2단 파라미터에 남아 있어 자동 행을 숨겨도 기능 손실이 없다. 합치는 시점도 정렬·상한 **뒤** — 지정 후보가 상한에 걸려 잘리면 이 기능의 목적 자체가 무너진다.

## 검증

시뮬레이터에서 등록 → 위젯 편집 목록 최상단 "지정한 후보" 노출 → 위젯 탭 이동까지 확인했다.

구현 중 잡은 버그 하나 — 진입점(`EventListCellEventHanleViewModel.selectEvent`)이 **비반복 일정에도** 셀 시각을 넘겨서, 그 값을 무조건 회차 키로 실으면 위젯이 반복 회차로 해석해 조회에 실패하고 후보가 통째로 사라졌다. 반복일 때만 회차 키를 싣도록 고쳤고 회귀 테스트로 고정했다.

## 남은 과제

- **후보 목록 관리 화면 없음** — 등록·해제는 상세 화면 토글만. 어떤 일정을 등록해뒀는지 한눈에 보려면 설정 화면이 필요하다.
- **Todo는 후보 대상이 아니다** — 일정만. Todo도 D-day 대상으로 삼을지는 별도 판단.
- **반복이던 일정이 비반복으로 수정되면** 저장된 회차 키가 더는 해석되지 않아 후보에서 빠진다. 드문 경로라 그대로 뒀다.
- **후보 개수 상한 없음** — 유저가 손으로 등록한 것이라 폭주하지 않는다는 전제.

---

closes #726, closes #731
