### PR TITLE
[#740] 사용량 게이지 플랜 칩·top-up 잔량·하향 예약 문구 복구

### DIFF
--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -551,6 +551,11 @@
 "aiAgent::keyboard::send" = "Send";
 "aiAgent::stop" = "Stop";
 "aiAgent::usage" = "%@ / %@ credits";
+"aiAgent::plan::free" = "Free";
+"aiAgent::plan::standard" = "Standard";
+"aiAgent::plan::lifetime" = "Lifetime";
+"aiAgent::usage::topupRemaining" = "%@ extra credits left";
+"aiAgent::usage::planChangeScheduled" = "Switching to the %2$@ plan on %1$@";
 "aiAgent::stop::confirm::title" = "Stop processing?";
 "aiAgent::stop::confirm::message" = "Stopping discards the task in progress, and it can't be resumed.";
 "aiAgent::confirm::countdown" = "left to approve";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -551,6 +551,11 @@
 "aiAgent::keyboard::send" = "전송";
 "aiAgent::stop" = "중지";
 "aiAgent::usage" = "%@ / %@ 크레딧";
+"aiAgent::plan::free" = "무료";
+"aiAgent::plan::standard" = "스탠다드";
+"aiAgent::plan::lifetime" = "평생";
+"aiAgent::usage::topupRemaining" = "추가 크레딧 %@ 남음";
+"aiAgent::usage::planChangeScheduled" = "%1$@부터 %2$@ 플랜으로 바뀌어요";
 "aiAgent::stop::confirm::title" = "처리를 중지할까요?";
 "aiAgent::stop::confirm::message" = "중지하면 진행 중인 작업이 사라지고 다시 시작할 수 없어요.";
 "aiAgent::confirm::countdown" = "안에 승인해 주세요";


### PR DESCRIPTION
closes #740

## 문제

`1c9a1cb9 [#722] D-day 대상 선택 Intent 도입` 이 merge 해소 중 `aabf641f [#720]` 이 넣은 로컬라이즈 키 5개를 ko/en 양쪽에서 지웠다.

소비처인 `AIAgentUsageGaugeView` 는 그대로 살아 있고, `.localized()` 는 키가 없으면 **키 문자열을 그대로 반환**한다. 그래서 AI 사용량 게이지의 플랜 칩·top-up 잔량·하향 예약 안내가 `aiAgent::plan::free` 같은 원문을 화면에 그리고 있었다 — #720 이 만든 표시 셋이 통째로 깨진 상태.

## 접근

지워진 5쌍을 원문 그대로, 원래 자리(`aiAgent::usage` 바로 아래)에 되돌렸다. 소비 코드는 멀쩡하므로 손대지 않았다.

**`test_commandDoneWithPlanInfo` 스냅샷이 검증기 역할을 한다.** 이 케이스가 세 표시(플랜 칩 `.standard` / top-up 잔량 12,300 / 하향 예약)를 모두 덮는데, `ec2b5e90 [#720]` 에 기록된 뒤 재기록된 적이 없어 커밋된 png 는 문자열이 정상이던 시점의 모습이다. 그래서 재기록 결과가 그대로 판정기가 된다:

- 이 커밋 **없이** 재기록 → 두 png 가 변한다 (RED)
- 이 커밋 **적용 후** 재기록 → 기록본과 바이트 동일 (GREEN)

둘 다 실측했다. `AIAgentSceneSnapshots` 8 케이스 전부 통과하고 png diff 없음.

## 남은 과제

소비 키 410개를 ko/en 전수 대조해 이번 5개 외 유실은 없음을 확인했다. 다만 이런 유실을 **커밋 시점에 잡는 수단이 없다** — 스냅샷은 로컬 전용이고 CI 게이트가 아니다. 키 존재 여부를 검사하는 lint 를 붙일지는 별도 판단거리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013p9MHjaSFFVHKk8D3SQJf8