### PR TITLE
[#741] D-day 잠금화면 위젯 — circular·rectangular·inline 지원

### DIFF
--- a/Supports/Extensions/Sources/Type+Extensions/Sequence+Extensions.swift
+++ b/Supports/Extensions/Sources/Type+Extensions/Sequence+Extensions.swift
@@ -33,8 +33,18 @@ extension Sequence {
 }
 
 
+extension Sequence where Element == String {
+
+    /// 빈 조각을 빼고 잇는다 — 표시 문구 조각 중 일부가 비었을 때
+    /// 구분자만 덩그러니 남는("· 3/15") 걸 막는다.
+    public func joinedNonEmpty(separator: String) -> String {
+        return self.filter { !$0.isEmpty }.joined(separator: separator)
+    }
+}
+
+
 extension Array {
-    
+
     public subscript(safe index: Int) -> Element? {
         get {
             guard (0..<self.count) ~= index else { return nil }

--- a/Supports/Extensions/Tests/Sequence+ExtensionsTests.swift
+++ b/Supports/Extensions/Tests/Sequence+ExtensionsTests.swift
@@ -64,3 +64,45 @@ struct SequenceRemoveDuplicatesTests {
         #expect(result.isEmpty == true)
     }
 }
+
+
+// MARK: - joinedNonEmpty
+
+struct SequenceJoinedNonEmptyTests {
+
+    @Test("빈 조각은 빼고 잇는다")
+    func joinedNonEmpty_skipsEmptyElements() {
+        // given
+        let texts = ["매주 월", "", "오전 7:00"]
+
+        // when
+        let joined = texts.joinedNonEmpty(separator: " · ")
+
+        // then
+        #expect(joined == "매주 월 · 오전 7:00")
+    }
+
+    @Test("전부 비어 있으면 빈 문자열을 낸다")
+    func joinedNonEmpty_whenAllEmpty_returnsEmpty() {
+        // given
+        let texts = ["", ""]
+
+        // when
+        let joined = texts.joinedNonEmpty(separator: " · ")
+
+        // then
+        #expect(joined == "")
+    }
+
+    @Test("남는 조각이 하나면 구분자가 붙지 않는다")
+    func joinedNonEmpty_whenSingleRemains_hasNoSeparator() {
+        // given
+        let texts = ["", "D-14", ""]
+
+        // when
+        let joined = texts.joinedNonEmpty(separator: " · ")
+
+        // then
+        #expect(joined == "D-14")
+    }
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Intents/DDayTargetSelectIntent.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Intents/DDayTargetSelectIntent.swift
@@ -407,8 +407,7 @@ struct DDayTargetTurnQuery: EntityQuery, @unchecked Sendable {
                     DDayTargetDateFormatter.dateText(of: turn.time, in: timeZone),
                     DDayTargetDateFormatter.timeText(of: turn.time, in: timeZone)
                 ]
-                .filter { !$0.isEmpty }
-                .joined(separator: " ")
+                .joinedNonEmpty(separator: " ")
             )
         }
     }

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidget.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidget.swift
@@ -48,15 +48,13 @@ private extension DDayWidgetViewModel {
     /// 소형 하단 한 줄 — "매주 월 · 3/15 오전 7:00". 빈 조각은 뺀다.
     var compactDetailText: String {
         return [self.repeatText, self.dateText, self.timeText]
-            .filter { !$0.isEmpty }
-            .joined(separator: " · ")
+            .joinedNonEmpty(separator: " · ")
     }
 
     /// 중형 우측 둘째 줄 — "오전 7:00 · 매주 월".
     var detailText: String {
         return [self.timeText, self.repeatText]
-            .filter { !$0.isEmpty }
-            .joined(separator: " · ")
+            .joinedNonEmpty(separator: " · ")
     }
 }
 
@@ -141,6 +139,71 @@ struct DDayMediumWidgetView: View {
 }
 
 
+// MARK: - 잠금화면
+
+/// 잠금화면은 시스템이 단색 렌더링을 적용하므로 색을 직접 지정하지 않는다.
+/// `.primary`/`.secondary`까지만 쓰고, 위젯 배경 설정은 여기서 의미가 없다.
+struct DDayCircularWidgetView: View {
+
+    private let model: DDayWidgetViewModel
+    init(model: DDayWidgetViewModel) {
+        self.model = model
+    }
+
+    var body: some View {
+        ZStack {
+            AccessoryWidgetBackground()
+
+            Text(model.ddayText)
+                .font(.system(size: 17, weight: .bold))
+                .minimumScaleFactor(0.5)
+                .lineLimit(1)
+                .padding(2)
+        }
+    }
+}
+
+struct DDayRectangularWidgetView: View {
+
+    private let model: DDayWidgetViewModel
+    init(model: DDayWidgetViewModel) {
+        self.model = model
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            DDayTitleView(model: model, fontSize: 13, lineLimit: 1)
+
+            Text(model.ddayText)
+                .font(.system(size: 18, weight: .bold))
+                .minimumScaleFactor(0.7)
+                .lineLimit(1)
+                .foregroundStyle(.primary)
+
+            if !model.dateText.isEmpty {
+                Text(model.dateText)
+                    .font(.system(size: 11))
+                    .lineLimit(1)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct DDayInlineWidgetView: View {
+
+    private let model: DDayWidgetViewModel
+    init(model: DDayWidgetViewModel) {
+        self.model = model
+    }
+
+    var body: some View {
+        Text(model.lockScreenInlineText)
+    }
+}
+
+
 // MARK: - EntryView
 
 struct DDayWidgetEntryView: View {
@@ -155,6 +218,19 @@ struct DDayWidgetEntryView: View {
 
     var body: some View {
         switch self.entry.result {
+        // accessory 케이스는 포괄 `.success`보다 앞에 둔다 — 뒤에 두면 소형 뷰가 잠금화면에 나온다
+        case .success(let model) where family == .accessoryCircular:
+            DDayCircularWidgetView(model: model)
+                .widgetURL(model.link)
+
+        case .success(let model) where family == .accessoryRectangular:
+            DDayRectangularWidgetView(model: model)
+                .widgetURL(model.link)
+
+        case .success(let model) where family == .accessoryInline:
+            DDayInlineWidgetView(model: model)
+                .widgetURL(model.link)
+
         case .success(let model) where family == .systemMedium:
             DDayMediumWidgetView(model: model)
                 .widgetURL(model.link)
@@ -185,7 +261,10 @@ struct DDayWidget: Widget {
             DDayWidgetEntryView(entry: entry)
                 .containerBackground(entry.backgroundShape, for: .widget)
         }
-        .supportedFamilies([.systemSmall, .systemMedium])
+        .supportedFamilies([
+            .systemSmall, .systemMedium,
+            .accessoryCircular, .accessoryRectangular, .accessoryInline
+        ])
         .configurationDisplayName("widget.dday::name".localized())
         .description("widget.common::explain".localized())
     }
@@ -207,6 +286,15 @@ struct DDayWidgetView_Provider: PreviewProvider {
             DDayWidgetEntryView(entry: entry)
                 .previewContext(WidgetPreviewContext(family: .systemMedium))
                 .containerBackground(.background, for: .widget)
+
+            DDayWidgetEntryView(entry: entry)
+                .previewContext(WidgetPreviewContext(family: .accessoryCircular))
+
+            DDayWidgetEntryView(entry: entry)
+                .previewContext(WidgetPreviewContext(family: .accessoryRectangular))
+
+            DDayWidgetEntryView(entry: entry)
+                .previewContext(WidgetPreviewContext(family: .accessoryInline))
         }
     }
 }

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidgetViewModelProvider.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/DDayWidget/DDayWidgetViewModelProvider.swift
@@ -31,6 +31,12 @@ struct DDayWidgetViewModel: Sendable {
         return self.repeatText.isEmpty == false
     }
 
+    /// 잠금화면 inline 한 줄. D-n을 앞에 두는 이유 — inline은 폭이 좁아 뒤에서부터 잘리는데,
+    /// 제목이 길 때 남은 일수가 사라지면 이 위젯을 둘 이유가 없어진다.
+    var lockScreenInlineText: String {
+        return [self.ddayText, self.eventTitle].joinedNonEmpty(separator: " · ")
+    }
+
     static var sample: Self {
         return .init(
             eventTitle: "widget.dday.sample::title".localized(),

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/DDayWidgetViewModelProviderTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/DDayWidgetViewModelProviderTests.swift
@@ -314,3 +314,56 @@ extension DDayWidgetViewModelProviderTests {
         #expect(model.link == nil)
     }
 }
+
+
+// MARK: - 잠금화면 표시 문구
+
+extension DDayWidgetViewModelProviderTests {
+
+    private func makeModel(title: String, dday: String) -> DDayWidgetViewModel {
+        return DDayWidgetViewModel(
+            eventTitle: title,
+            ddayText: dday,
+            dateText: "3월 15일 (월)",
+            timeText: "",
+            repeatText: ""
+        )
+    }
+
+    @Test("inline 문구는 D-n으로 시작한다 — 잠금화면은 뒤에서부터 잘린다")
+    func lockScreenInlineText_startsWithDDay() {
+        // given
+        let model = self.makeModel(title: "워크숍", dday: "D-14")
+
+        // when
+        let text = model.lockScreenInlineText
+
+        // then
+        #expect(text.hasPrefix("D-14") == true)
+        #expect(text.contains("워크숍") == true)
+    }
+
+    @Test("제목이 비어 있으면 D-n만 낸다")
+    func lockScreenInlineText_whenTitleIsEmpty_ddayOnly() {
+        // given
+        let model = self.makeModel(title: "", dday: "D-14")
+
+        // when
+        let text = model.lockScreenInlineText
+
+        // then
+        #expect(text == "D-14")
+    }
+
+    @Test("대상이 없으면 안내 문구를 낸다")
+    func lockScreenInlineText_whenNoTarget_usesGuide() {
+        // given
+        let model = DDayWidgetViewModel.noTarget()
+
+        // when
+        let text = model.lockScreenInlineText
+
+        // then
+        #expect(text.contains(model.eventTitle) == true)
+    }
+}


### PR DESCRIPTION
## 문제

D-day는 "항상 보이는 카운트다운"이 본질인데 홈 소·중형에만 있었다. 잠금화면 accessory 계열은 `NextEventWidget`(inline·rectangular) · `NextRemainEventWidget`(rectangular) · `ForemostEventWidget`(inline) 셋뿐이었다. (#721 리스트업 4번에서 D-day 조각을 분리한 #741)

## 접근

**새로 만든 건 뷰뿐이다.** 대상·회차 2단 선택 Intent(`DDayWidgetConfigurationIntent`), D-n 산출·유저 타임존·다음 자정 갱신·탭 링크(`DDayWidgetViewModelProvider`)는 family를 모르는 코드라 그대로 재사용했다. `ForemostEventWidget`이 한 Widget에서 accessory와 system을 함께 지원하는 선례가 있어 별도 위젯을 신설하지 않고 `supportedFamilies`를 넓혔다 — 갤러리 항목과 위젯 kind가 하나로 유지된다.

자리별 표시는 폭에 맞춰 갈랐다. circular은 D-n만(+`AccessoryWidgetBackground`), rectangular은 제목·D-n·날짜(기존 `DDayTitleView` 재사용이라 반복 아이콘도 따라온다), inline은 한 줄.

**inline 문구는 D-n을 앞에 뒀다.** inline은 폭이 좁아 뒤에서부터 잘리는데, 제목이 길면 정작 남은 일수가 사라져 위젯을 둘 이유가 없어진다. `D-14 · 워크숍` 순서를 테스트로 고정했다.

**분기 순서에 함정이 있다.** `DDayWidgetEntryView`는 포괄 `.success` 케이스가 소형 뷰를 잡는 구조라, accessory 케이스를 뒤에 두면 잠금화면에 홈 소형 뷰가 나온다. 앞에 두고 그 이유를 주석으로 남겼다.

**곁다리 리팩터** — 빈 조각을 빼고 구분자로 잇는 표시 문구 조립이 D-day 코드 4곳에 복제돼 있어 `Sequence.joinedNonEmpty(separator:)`로 뽑았다. `Supports/Extensions`가 바뀌어 테스트 스킴이 12개로 늘었고 전부 통과했다.

## 검증

시뮬레이터에서 잠금화면 3종 배치·대상 선택·탭 이동까지 확인했다. 위젯 타깃엔 스냅샷 스위트가 없어 뷰는 실기 확인 대상이고, 유닛 테스트는 inline 문구 규칙(3케이스)과 `joinedNonEmpty`(3케이스)를 덮는다. AppIntents 메타데이터는 유닛 테스트가 못 잡는 계약이라 `.appex/Metadata.appintents/extract.actionsdata`를 직접 열어 회차 노출 조건(`"|repeating|"`)이 온전한지 확인했다.

## 남은 과제

- **오늘 일정 수 잠금화면 위젯** — #721 리스트업 4번의 나머지 조각. 데이터 소스도 표시도 달라 별도 이슈로 뺐다.
- **잠금화면엔 위젯 배경 설정이 반영되지 않는다** — `containerBackground`가 시스템 vibrant로 덮인다. 의도된 동작이며 홈 위젯 배경 설정을 위해 해당 코드는 그대로 뒀다.
- **`impact-check.sh` 갭 2건** — `ALL_SCHEMES`에 `Extensions` 스킴이 빠져 있고(`:12`), `Supports/Extensions/Tests/` 경로엔 매핑 규칙이 없다(`:44`는 Sources만 매칭). 이번엔 수동으로 포함해 돌렸다. 기본 base가 로컬 `develop`이라 GitHub 머지 후 stale ref로 오탐이 나는 것도 함께.

---

closes #741
