### PR TITLE
[#741] D-day 위젯 배포 보류 — 위젯 갤러리·후보 등록 메뉴에서 감춤

### DIFF
--- a/Domain/Sources/Utils/FeatureFlag.swift
+++ b/Domain/Sources/Utils/FeatureFlag.swift
@@ -13,6 +13,9 @@ public final class FeatureFlag: @unchecked Sendable {
     
     public enum Flags: Sendable {
         case reservedFlag
+        /// D-day 위젯(#741) — 배포 보류 중. 켜면 일정 상세에 후보 등록 메뉴가 다시 노출된다.
+        /// 위젯 갤러리 노출은 `TodoCalendarWidgetBundle`에서 별도로 막혀 있다.
+        case ddayWidget
     }
     
     private var enableFlags: Set<Flags> = []

--- a/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
@@ -91,7 +91,10 @@ extension EditScheduleEventDetailViewModelImple: EventDetailInputListener {
     func prepare() {
         
         self.subject.isLoading.send(true)
-        self.ddayCandidateUsecase.refresh()
+        // 플래그가 꺼져 있으면 후보 목록을 읽지 않는다 (#741 배포 보류)
+        if FeatureFlag.isEnable(.ddayWidget) {
+            self.ddayCandidateUsecase.refresh()
+        }
 
         let handlePrepared: (EventDetailBasicData, EventDetailData) -> Void = { [weak self] basic, addition in
             self?.subject.basicData.send(
@@ -543,36 +546,45 @@ extension EditScheduleEventDetailViewModelImple {
     var moreActions: AnyPublisher<[[EventDetailMoreAction]], Never> {
         let scheduleId = self.scheduleId
         let targetTime = self.repeatingEventTargetTime
+        // #741 D-day 위젯이 배포 보류라 플래그가 꺼진 동안은 후보 등록 메뉴를 감춘다 —
+        // 위젯 없이 후보만 등록하게 두면 갈 곳 없는 기능이 된다. 처리 로직은 살아 있다
+        let isDDayWidgetEnabled = FeatureFlag.isEnable(.ddayWidget)
         let transform: (
             EventDetailBasicData, (any ForemostMarkableEvent)?, [DDayCandidate]
         ) -> [[EventDetailMoreAction]] = { basic, foremostEvent, candidates in
             let isRepeating = basic.isRepeatingEvent
             let isForemost = foremostEvent?.eventId == scheduleId
-            let isDDayCandidate = candidates.contains(
-                DDayCandidate(
-                    scheduleId: scheduleId, targetTime: targetTime, isRepeating: isRepeating
-                )
-            )
             let removeActions: [EventDetailMoreAction] = isRepeating
                 ? [.remove(onlyThisEvent: true), .remove(onlyThisEvent: false)]
                 : [.remove(onlyThisEvent: false)]
+            let ddayActions: [EventDetailMoreAction] = isDDayWidgetEnabled
+                ? [
+                    .toggleDDayCandidate(
+                        isRegistered: candidates.contains(
+                            DDayCandidate(
+                                scheduleId: scheduleId,
+                                targetTime: targetTime,
+                                isRepeating: isRepeating
+                            )
+                        )
+                    )
+                ]
+                : []
             // TODO: share 기능 일단 비활성화
             let otherActions: [EventDetailMoreAction] = isRepeating
 //                ? [.share]
 //                : [.toggleTo(isForemost: !isForemost), .share]
-                ? [.toggleDDayCandidate(isRegistered: isDDayCandidate), .copy, .transformToTodo]
-                : [
-                    .toggleTo(isForemost: !isForemost),
-                    .toggleDDayCandidate(isRegistered: isDDayCandidate),
-                    .copy,
-                    .transformToTodo
-                ]
+                ? ddayActions + [.copy, .transformToTodo]
+                : [.toggleTo(isForemost: !isForemost)] + ddayActions + [.copy, .transformToTodo]
             return [removeActions, otherActions]
         }
         return Publishers.CombineLatest3(
             self.subject.basicData.compactMap { $0?.origin },
             self.foremostEventUsecase.foremostEvent,
-            self.ddayCandidateUsecase.candidates
+            // 플래그가 꺼져 있으면 후보 목록을 조회·구독하지 않는다
+            isDDayWidgetEnabled
+                ? self.ddayCandidateUsecase.candidates
+                : Just<[DDayCandidate]>([]).eraseToAnyPublisher()
         )
         .map(transform)
         .removeDuplicates()

--- a/Presentations/EventDetailScene/Tests/EditScheduleEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/EditScheduleEventDetailViewModelImpleTests.swift
@@ -41,6 +41,7 @@ class EditScheduleEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitabl
         self.spyEventDetailDataUsecase = nil
         self.stubForemostEventUsecase = nil
         self.stubDDayCandidateUsecase = nil
+        FeatureFlag.disable(.ddayWidget)
         self.spyRouter = nil
         self.spyListener = nil
     }
@@ -57,8 +58,14 @@ class EditScheduleEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitabl
         shouldFailToTransformToTodo: Bool = false,
         shouldFailToSaveDetail: Bool = false,
         shouldFailToRemoveSchedule: Bool = false,
-        registeredCandidates: [DDayCandidate] = []
+        registeredCandidates: [DDayCandidate] = [],
+        isDDayWidgetEnabled: Bool = false
     ) -> EditScheduleEventDetailViewModelImple {
+
+        // 배포 기본값은 off — 후보 액션을 보려는 케이스만 켠다 (tearDown에서 원복)
+        isDDayWidgetEnabled
+            ? FeatureFlag.enable(.ddayWidget)
+            : FeatureFlag.disable(.ddayWidget)
 
         let (schedule, detail) = (customSchedule ?? self.dummyRepeatingSchedule, self.dummyDetail)
         self.spyScheduleUsecase.stubEvent = schedule
@@ -239,14 +246,14 @@ extension EditScheduleEventDetailViewModelImpleTests {
             self.makeViewModel(customSchedule: schedule),
             expect: [
                 [.remove(onlyThisEvent: true), .remove(onlyThisEvent: false)],
-                [.toggleDDayCandidate(isRegistered: false), .copy, .transformToTodo]
+                [.copy, .transformToTodo]
             ]
         )
         parameterizeTest(
             self.makeViewModel(customSchedule: schedule, isForemost: true),
             expect: [
                 [.remove(onlyThisEvent: true), .remove(onlyThisEvent: false)],
-                [.toggleDDayCandidate(isRegistered: false), .copy, .transformToTodo]
+                [.copy, .transformToTodo]
             ]
         )
         let scheduleNotRepeating = schedule |> \.repeating .~ nil
@@ -254,32 +261,44 @@ extension EditScheduleEventDetailViewModelImpleTests {
             self.makeViewModel(customSchedule: scheduleNotRepeating),
             expect: [
                 [.remove(onlyThisEvent: false)],
-                [
-                    .toggleTo(isForemost: true),
-                    .toggleDDayCandidate(isRegistered: false),
-                    .copy,
-                    .transformToTodo
-                ]
+                [.toggleTo(isForemost: true), .copy, .transformToTodo]
             ]
         )
         parameterizeTest(
             self.makeViewModel(customSchedule: scheduleNotRepeating, isForemost: true),
             expect: [
                 [.remove(onlyThisEvent: false)],
-                [
-                    .toggleTo(isForemost: false),
-                    .toggleDDayCandidate(isRegistered: false),
-                    .copy,
-                    .transformToTodo
-                ]
+                [.toggleTo(isForemost: false), .copy, .transformToTodo]
             ]
         )
+    }
+
+    // #741 배포 보류 — 플래그가 꺼진 동안 후보 등록 메뉴가 새어나가면 안 된다
+    func testViewModel_whenDDayWidgetDisabled_hideDDayCandidateAction() {
+        // given
+        let expect = expectation(description: "플래그 off면 후보 액션 없음")
+        let viewModel = self.makeViewModel(customSchedule: self.dummyRepeatingSchedule)
+
+        // when
+        let actions = self.waitFirstOutput(expect, for: viewModel.moreActions) {
+            viewModel.prepare()
+        }
+
+        // then
+        let hasDDayAction = actions?.flatMap { $0 }.contains {
+            if case .toggleDDayCandidate = $0 { return true } else { return false }
+        }
+        XCTAssertEqual(hasDDayAction, false)
+        // 메뉴만 감추는 게 아니라 후보 목록 조회 자체를 안 한다
+        XCTAssertEqual(self.stubDDayCandidateUsecase.didRefresh, false)
     }
 
     func testViewModel_whenRepeatingSchedule_provideDDayCandidateAction() {
         // given
         let expect = expectation(description: "반복 일정에도 후보 액션이 제공된다")
-        let viewModel = self.makeViewModel(customSchedule: self.dummyRepeatingSchedule)
+        let viewModel = self.makeViewModel(
+            customSchedule: self.dummyRepeatingSchedule, isDDayWidgetEnabled: true
+        )
 
         // when
         let actions = self.waitFirstOutput(expect, for: viewModel.moreActions) {
@@ -301,7 +320,8 @@ extension EditScheduleEventDetailViewModelImpleTests {
             repeatingEventTargetTime: targetTime,
             registeredCandidates: [
                 .init(scheduleId: "dummy_schedule", turnKey: targetTime.customKey)
-            ]
+            ],
+            isDDayWidgetEnabled: true
         )
 
         // when
@@ -375,7 +395,8 @@ extension EditScheduleEventDetailViewModelImpleTests {
         let viewModel = self.makeViewModel(
             customSchedule: self.dummyRepeatingSchedule |> \.repeating .~ nil,
             repeatingEventTargetTime: .at(300),
-            registeredCandidates: [.init(scheduleId: "dummy_schedule", turnKey: nil)]
+            registeredCandidates: [.init(scheduleId: "dummy_schedule", turnKey: nil)],
+            isDDayWidgetEnabled: true
         )
 
         // when
@@ -1100,7 +1121,10 @@ private final class PrivateStubDDayCandidateUsecase: DDayCandidateUsecase, @unch
         self.subject = .init(candidates)
     }
 
-    func refresh() { }
+    private(set) var didRefresh: Bool = false
+    func refresh() {
+        self.didRefresh = true
+    }
 
     func append(_ candidate: DDayCandidate) {
         self.subject.send(self.subject.value + [candidate])

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/TodoCalendarWidgetBundle.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/TodoCalendarWidgetBundle.swift
@@ -28,7 +28,11 @@ struct BaseWidgetBundle: WidgetBundle {
         ForemostEventWidget()
         NextEventWidget()
         NextRemainEventWidget()
-        DDayWidget()
+        // #741 D-day 위젯 배포 보류 — 갤러리 노출을 끈다.
+        // 여기만 FeatureFlag가 아닌 주석인 이유: @WidgetBundleBuilder는 런타임 조건(`if`)을
+        // 받지 못한다(컴파일 실패). 앱 쪽 후보 등록 메뉴는 FeatureFlag.ddayWidget이 가린다.
+        // 재개 시 이 줄과 그 플래그를 함께 되살릴 것.
+//        DDayWidget()
     }
 }
 


### PR DESCRIPTION
## 문제

현재 develop 기준으로 배포가 나가는데 D-day 위젯(#722·#726·#731·#741)은 아직 내보내지 않기로 했다.

**진입점이 두 곳이다.** 위젯 갤러리 등록(`TodoCalendarWidgetBundle`)만 막으면 일정 상세 more 메뉴의 "D-day 위젯 후보로 추가"(#726)가 배포판에 그대로 남아, 존재하지 않는 위젯의 후보를 등록하라는 메뉴가 된다.

## 접근

**앱 쪽은 피처 플래그.** 기존 `FeatureFlag`(`Domain/Sources/Utils/FeatureFlag.swift`)에 `.ddayWidget`을 추가했다. `enableFlags`가 빈 Set으로 시작하므로 아무도 `enable`을 부르지 않는 한 off다. `EditScheduleEventDetailViewModelImple.moreActions`가 이 플래그로 후보 등록 메뉴를 가린다.

**위젯 번들만 주석이다.** 같은 플래그로 처리하려고 `if FeatureFlag.isEnable(.ddayWidget) { DDayWidget() }`를 실제로 넣어봤으나 `@WidgetBundleBuilder`가 런타임 조건을 받지 못한다 — 컴파일러가 진단조차 내지 못하고 실패한다(`failed to produce diagnostic for expression`). 그래서 등록 줄을 주석 처리하고, **왜 여기만 방식이 다른지**를 코드 주석으로 남겼다.

**처리 로직은 살려둔다.** 토글 핸들러·`DDayCandidateUsecase` 배선·App Group 저장·위젯 뷰와 Intent는 그대로다. 재개는 번들 한 줄 주석 해제 + 플래그 켜기 두 가지면 된다.

## 검증

테스트 기대값을 배포 기본값(플래그 off)에 맞췄다. 후보 액션을 확인하는 케이스 3개는 `makeViewModel(isDDayWidgetEnabled: true)`로 켜서 돌리고, 전역 상태라 `tearDown`에서 원복한다. **플래그가 꺼진 동안 메뉴가 새지 않는지 확인하는 회귀 테스트를 추가했다** — 이번 배포에서 실제로 지켜야 하는 계약이 그것이라서다.

Domain · EventDetailScene · TodoCalendarAppWidget 테스트와 앱 타깃 빌드 통과.

## 남은 과제

- **재개 시점** — 릴리즈 정책(#721의 Pro 게이팅·선출시 여부)이 정해지면 되돌린다. 되돌릴 두 지점은 코드 주석에 서로를 가리키게 적어뒀다.
- `DDayWidgetConfigurationIntent`는 바이너리에 그대로 컴파일된다. `WidgetConfigurationIntent`는 Shortcuts에 노출되는 종류가 아니라 유저 눈에는 띄지 않는다.
