### PR TITLE
[#746] AI Agent 기능 피처플래그 게이팅

### DIFF
--- a/Domain/Sources/Utils/FeatureFlag.swift
+++ b/Domain/Sources/Utils/FeatureFlag.swift
@@ -16,6 +16,9 @@ public final class FeatureFlag: @unchecked Sendable {
         /// D-day 위젯(#741) — 배포 보류 중. 켜면 일정 상세에 후보 등록 메뉴가 다시 노출된다.
         /// 위젯 갤러리 노출은 `TodoCalendarWidgetBundle`에서 별도로 막혀 있다.
         case ddayWidget
+        /// AI Agent(#746) — 배포 보류 중. 켜면 캘린더 일별 리스트에 AI 진입 버튼이 노출되고
+        /// 앱 시작 시 orchestration prepare(usage 로드·job 복원)가 재개된다.
+        case aiAgent
     }
     
     private var enableFlags: Set<Flags> = []

--- a/Presentations/CalendarScenes/Snapshots/CalendarScenesSnapshots.swift
+++ b/Presentations/CalendarScenes/Snapshots/CalendarScenesSnapshots.swift
@@ -215,6 +215,9 @@ private final class FakeDayEventListViewModel: DayEventListViewModel, @unchecked
         self.stubAIAgentState = aiAgentState
     }
 
+    // 스냅샷 카탈로그는 AI 상태 화면까지 캡처해야 하므로 항상 노출
+    var isAIAgentEnabled: Bool { true }
+
     var foremostEventModel: AnyPublisher<(any EventCellViewModel)?, Never> {
         Just(self.foremostModel).eraseToAnyPublisher()
     }

--- a/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
@@ -279,8 +279,10 @@ extension CalendarViewModelImple {
         
         self.bindUncompletedTodoRefresh()
 
-        self.aiAgentOrchestrationUsecase.prepare()
-        self.bindShowAICommandResultIfNeed()
+        if FeatureFlag.isEnable(.aiAgent) {
+            self.aiAgentOrchestrationUsecase.prepare()
+            self.bindShowAICommandResultIfNeed()
+        }
     }
     
     private func prepareInitialMonths(around today: CalendarComponent.Day) {

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListView.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListView.swift
@@ -42,6 +42,7 @@ private enum AICommandBadge: Equatable {
     fileprivate var dayModel: SelectedDayModel?
     fileprivate var cellViewModels: [any EventCellViewModel] = []
     fileprivate var foremostEventMarkingStatus: ForemostMarkingStatus = .idle
+    fileprivate var isAIAgentEnabled: Bool = false
     fileprivate var aiAgentState: AIAgentState = .idle
     fileprivate var recognizingText: String = ""
     fileprivate var voiceLevel: Float = 0
@@ -74,6 +75,8 @@ private enum AICommandBadge: Equatable {
 
         guard self.didBind == false else { return }
         self.didBind = true
+
+        self.isAIAgentEnabled = viewModel.isAIAgentEnabled
 
         viewModel.foremostEventModel
             .receive(on: RunLoop.main)
@@ -511,9 +514,11 @@ private struct QuickAddNewTodoView: View {
             }
             .opacity(self.inputDimOpacity)
 
-            AIAgentEntryButton(badge: self.state.aiCommandBadge) {
-                self.isFocusInput = false
-                self.eventHandler.handleAIEntryButtonTap()
+            if self.state.isAIAgentEnabled {
+                AIAgentEntryButton(badge: self.state.aiCommandBadge) {
+                    self.isFocusInput = false
+                    self.eventHandler.handleAIEntryButtonTap()
+                }
             }
         }
     }

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListViewModel.swift
@@ -68,6 +68,7 @@ protocol DayEventListViewModel: AnyObject, Sendable, DayEventListSceneInteractor
     func attachListener(_ listener: any DayEventListSceneListener)
 
     // presenter
+    var isAIAgentEnabled: Bool { get }
     var foremostEventModel: AnyPublisher<(any EventCellViewModel)?, Never> { get }
     var uncompletedTodoEventModels: AnyPublisher<[TodoEventCellViewModel], Never> { get }
     var selectedDay: AnyPublisher<SelectedDayModel, Never> { get }
@@ -393,6 +394,11 @@ extension DayEventListViewModelImple {
 
     var foremostEventMarkingStatus: AnyPublisher<ForemostMarkingStatus, Never> {
         return self.foremostEventUsecase.foremostEventMarkingStatus
+    }
+
+    // 세션 중 불변 플래그라 publisher가 아닌 스냅샷 Bool로 노출
+    var isAIAgentEnabled: Bool {
+        return FeatureFlag.isEnable(.aiAgent)
     }
 
     var aiAgentState: AnyPublisher<AIAgentState, Never> {

--- a/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
@@ -74,6 +74,7 @@ class CalendarViewModelImpleTests: BaseTestCase, PublisherWaitable {
         self.spyEventSyncUsecase = nil
         self.spyEventUploadService = nil
         self.stubOrchestration = nil
+        FeatureFlag.disable(.aiAgent)
     }
     
     private func makeViewModel(
@@ -195,8 +196,9 @@ extension CalendarViewModelImpleTests {
         XCTAssertEqual(isForemostEventPrepared, [false, true])
     }
 
-    func testViewModel_whenPrepare_callsOrchestrationPrepare() async throws {
+    func testViewModel_whenAIAgentFlagOn_prepareCallsOrchestrationPrepare() async throws {
         // given
+        FeatureFlag.enable(.aiAgent)
         let viewModel = self.makeViewModel()
 
         // when
@@ -205,6 +207,18 @@ extension CalendarViewModelImpleTests {
         // then
         try await Task.sleep(for: .milliseconds(10))
         XCTAssertEqual(self.stubOrchestration.didPrepare, true)
+    }
+
+    func testViewModel_whenAIAgentFlagOff_prepareNotCallsOrchestrationPrepare() async throws {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        viewModel.prepare()
+
+        // then
+        try await Task.sleep(for: .milliseconds(10))
+        XCTAssertNil(self.stubOrchestration.didPrepare)
     }
 
     private func makeViewModelWithInitialSetup(_ today: CalendarComponent.Day) -> CalendarViewModelImple {
@@ -969,6 +983,7 @@ extension CalendarViewModelImpleTests {
 
     func testViewModel_whenAIEntersCommandPhase_routesToAICommand() {
         // given
+        FeatureFlag.enable(.aiAgent)
         let viewModel = self.makeViewModel()
         viewModel.prepare()
 
@@ -982,6 +997,7 @@ extension CalendarViewModelImpleTests {
 
     func testViewModel_whenStayInCommandPhase_routesOnlyOncePerEntry() {
         // given
+        FeatureFlag.enable(.aiAgent)
         let viewModel = self.makeViewModel()
         viewModel.prepare()
 

--- a/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
@@ -51,6 +51,7 @@ class DayEventListViewModelImpleTests: BaseTestCase, PublisherWaitable {
         self.spyRouter = nil
         self.spyListener = nil
         self.stubOrchestrationUsecase = nil
+        FeatureFlag.disable(.aiAgent)
     }
 
     private var stubOrchestrationUsecase: StubAIAgentOrchestrationUsecase!
@@ -1059,6 +1060,30 @@ extension DayEventListViewModelImpleTests {
 // MARK: - AI agent entry mode
 
 extension DayEventListViewModelImpleTests {
+
+    // 피처플래그 off(릴리즈 기본값): AI 진입 버튼 비노출
+    func testViewModel_whenAIAgentFlagOff_aiAgentEntryIsNotEnabled() {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        let isEnabled = viewModel.isAIAgentEnabled
+
+        // then
+        XCTAssertEqual(isEnabled, false)
+    }
+
+    func testViewModel_whenAIAgentFlagOn_aiAgentEntryIsEnabled() {
+        // given
+        FeatureFlag.enable(.aiAgent)
+        let viewModel = self.makeViewModel()
+
+        // when
+        let isEnabled = viewModel.isAIAgentEnabled
+
+        // then
+        XCTAssertEqual(isEnabled, true)
+    }
 
     func testViewModel_whenAgentNotifiesListeningMode_emitsListeningState() {
         // given


### PR DESCRIPTION
## 문제

배포 전 점검에서 AI Agent 기능이 피처플래그 없이 전 유저에게 노출됨을 확인했다 (#746). `FeatureFlag`는 콜사이트 0건의 스캐폴드였고, 유일한 게이트는 액션 시점 로그인 체크(#629)뿐 — 미로그인 유저에게도 AI 버튼·로그인 유도 문구가 보이고, 앱 시작 시 `aiAgentOrchestrationUsecase.prepare()`가 무조건 돌아 AI 백엔드 트래픽이 발생했다.

## 접근

**릴리즈·DEBUG 모두 기본 off, 활성 배선 없음** — 켤 땐 코드로 `FeatureFlag.enable(.aiAgent)` (킥오프에서 확정). #741의 `ddayWidget`과 같은 보류 패턴.

- `FeatureFlag.aiAgent` 신설 — 스캐폴드 첫 실사용
- `DayEventListViewModelImple.isAIAgentEnabled` — off면 quick-add 행에서 AI 진입 버튼 자체가 빠진다. 진입점이 이 버튼 하나뿐이라(위젯·AppIntents·딥링크에 AI 경로 없음) 파생 시트(키보드 입력·command 결과)도 도달 불가
- `CalendarViewModelImple.prepare` — off면 orchestration prepare(usage 로드·job 복원)와 command 결과 시트 자동 표시 바인딩을 생략 → 앱 시작 시 AI 트래픽 차단
- 플래그는 세션 중 불변이라 publisher가 아닌 스냅샷 Bool로 노출. 스냅샷 카탈로그의 `FakeDayEventListViewModel`은 항상 true로 AI 상태 화면 캡처 유지

검증: 게이팅 테스트 4건(on/off × VM 2) + Domain·CalendarScenes 스킴 그린. impact-check가 찍은 전 스킴 중 나머지는 enum 케이스 추가(exhaustive switch 부재)라 영향 없음으로 판단하고 생략.

## 남은 과제

- **재개 시**: `FeatureFlag.enable(.aiAgent)` 배선 한 줄 (위치는 그 시점 결정 — composition root)
- **원격 게이팅(Remote Config 등)** — 범위 밖. 현 플래그는 in-memory 코드 상수
- **미로그인 pre-warm(loadUsage/restore) 후속** — #629 계열 잔여 과제, 이번 게이팅과 별개

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApiKrQijieZCpyGLpg683V
