### PR TITLE
[#631] Siri에서 앱을 열지 않고 AI 커맨드 전송

### DIFF
--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -8,7 +8,12 @@ paths:
 
 # 로컬라이제이션 규칙
 
-지원 언어 31개 (en 원문 + 30개 번역: ko ja zh-Hans zh-Hant vi th es fr it pt-BR ca de nl sv da nb fi pl cs sk hu ru uk ro el hr tr id ms hi — #626). 번역 리소스는 3곳: 메인 `Supports/Extensions/Resources`(Localizable.strings), 위젯 `TodoCalendarApp/AppExtensions/Widget/Resources`, 권한 문구 `TodoCalendarApp/Resources/Localize`(InfoPlist.strings).
+지원 언어 31개 (en 원문 + 30개 번역: ko ja zh-Hans zh-Hant vi th es fr it pt-BR ca de nl sv da nb fi pl cs sk hu ru uk ro el hr tr id ms hi — #626). 번역 리소스는 3곳: 메인 `Supports/Extensions/Resources`(Localizable.strings), 위젯 `TodoCalendarApp/AppExtensions/Widget/Resources`(Localizable.strings), 앱 타겟 `TodoCalendarApp/Resources/Localize`.
+
+앱 타겟 항목은 파일 3개를 담는다 — 각각 용도가 다르니 신규 문구를 아무 파일에나 넣지 말 것:
+- `InfoPlist.strings` — 시스템 권한 요청 문구(카메라·마이크 접근 등).
+- `Localizable.strings` — **AppIntents 라벨·다이얼로그**(`title`·`description`·`IntentDialog` 등). AppIntents 문구는 그 인텐트가 속한 타겟 자신의 번들에서 해석되므로, 공유 리소스인 `Supports/Extensions/Resources`에 넣으면 시스템이 못 찾는다 — 앱 타겟(`TodoCalendarApp`) 소속 인텐트는 반드시 여기. **#722에서 데인 함정**: AppIntents 메타데이터는 이 규칙을 몰라 다른 곳에 두면 조용히 원문(en)으로만 보이거나 라벨이 깨진다.
+- `AppShortcuts.strings` — Siri 발화 phrase(`AppShortcutsProvider`).
 
 ## 1. 전 언어 동기화 짝 (CLAUDE.md §1)
 

--- a/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
@@ -325,8 +325,14 @@ extension AIAgentOrchestrationUsecaseImple {
 
     // 푸시가 특정 job을 지목해 도착. 추적 중인 job일 때만 즉시 조회.
     // 콜드 스타트(구독 없음)는 CalendarViewModel.prepare() → restoreIfNeeded()가 커버한다.
+    // 미추적 job(인텐트·확장이 앱 밖에서 만든 job)의 푸시는 저장소 복원으로 이어받는다 —
+    // 앱이 이미 포그라운드라 refreshProcessingJobIfNeeded(willEnterForeground 트리거)를 못 타는 경우를 메운다.
     public func handleJobStatusChanged(_ jobId: String) {
-        guard self.currentProcessingJobId == jobId else { return }
+        guard self.currentProcessingJobId == jobId else {
+            // 추적 중이 아닌 job — 앱 밖(Siri 인텐트·공유 확장)에서 만들어졌다
+            self.restoreIfNeededWhenIdle()
+            return
+        }
         // 만료된 confirm job은 더 조회하지 않는다 — 로컬 종료(추적 해제)로 push 즉시 조회 대상에서 뺀다.
         if case .confirm(_, _, _, let expireTime) = self.subject.state.value ?? .idle,
            let expireTime, expireTime <= Date() {
@@ -334,6 +340,18 @@ extension AIAgentOrchestrationUsecaseImple {
             return
         }
         self.commandUsecase.refreshJobStatus(jobId)
+    }
+
+    // 복원 근거는 앱 메모리가 아니라 저장소의 ProcessingAICommand다 — 여기서 볼 것은
+    // "지금 화면을 덮어도 되는가" 하나뿐이다. 미방출(prepare의 복원 진행 중)·입력 중·
+    // 결과 표시 중이면 보고 있던 화면이 덮인다. refreshProcessingJobIfNeeded의 .idle 분기와 동일 가드.
+    private func restoreIfNeededWhenIdle() {
+        switch self.subject.state.value {
+        case .idle:
+            self.restoreIfNeeded()
+        default:
+            break
+        }
     }
 
     // 포그라운드 복귀 — 백그라운드에서 폴링 Timer가 멈춘 공백을 메운다.

--- a/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
@@ -725,6 +725,7 @@ private final class StubAICommandUsecase: AICommandUsecase, @unchecked Sendable 
         self.didProcessCommand = commandText
         return self.jobPublisher(self.stubCommandJob)
     }
+
     func processConfirmCommand(_ action: AIConfirmCommandAction) -> AnyPublisher<AIJob, any Error> {
         self.didProcessConfirmToken = action.confirmToken
         return self.jobPublisher(self.stubConfirmJob)
@@ -1138,6 +1139,43 @@ extension AIAgentOrchestrationUsecaseImpleTests {
         usecase.handleJobStatusChanged("other_job")
 
         // then
+        #expect(self.stubCommand.didRefreshJobStatusWith == nil)
+    }
+
+    // 회귀: 인텐트·확장이 앱 밖에서 만든 job은 currentProcessingJobId가 nil이라 위 가드에
+    // 걸려 그냥 버려졌다. 앱이 이미 포그라운드면 refreshProcessingJobIfNeeded(포그라운드
+    // 복귀 트리거)도 안 타서 아무도 못 받는다 — idle 상태에서 온 미추적 푸시는 복원으로 이어받는다.
+    @Test("추적 중이 아닌 job 푸시라도 idle 상태면 저장소에서 복원을 시도한다")
+    func usecase_whenPushReceivedForUntrackedJob_whileIdle_restoresFromStorage() async throws {
+        // given — 인텐트가 만든 job(앱 메모리엔 없음), idle 상태
+        let usecase = self.makeUsecaseInIdle()
+
+        // when
+        usecase.handleJobStatusChanged("intent-made-job")
+
+        // then — 추적 대상이 아니므로 즉시 조회가 아니라 복원 경로를 탄다
+        #expect(self.stubCommand.didRefreshJobStatusWith == nil)
+        #expect(self.stubCommand.didRestore == true)
+    }
+
+    // 복원이 화면 상태를 덮으면 안 되는 구간 — refreshProcessingJobIfNeeded의 가드와 동일 기준.
+    @Test("추적 중이 아닌 job 푸시라도 결과를 보고 있는 중이면 복원하지 않는다")
+    func usecase_whenPushReceivedForUntrackedJob_whileShowingResult_doesNotRestore() async throws {
+        // given — 다른 job(job-1)의 결과를 이미 done으로 보여주고 있는 중
+        let expect = expectConfirm("done 진입")
+        expect.count = 2
+        var done = AIJobResult.DoneResult()
+        done.text = "완료"
+        let usecase = self.makeUsecaseWithCommandJob(self.dummyJob(.done(done)))
+        let _ = try await self.outputs(expect, for: usecase.state) {
+            try? usecase.submit("회의")
+        }
+
+        // when — 추적 중이 아닌 다른 job의 푸시
+        usecase.handleJobStatusChanged("intent-made-job")
+
+        // then — done 화면을 덮지 않는다
+        #expect(self.stubCommand.didRestore == false)
         #expect(self.stubCommand.didRefreshJobStatusWith == nil)
     }
 

--- a/TodoCalendarApp/AppExtensions/Base/AppExtensionBase.swift
+++ b/TodoCalendarApp/AppExtensions/Base/AppExtensionBase.swift
@@ -127,44 +127,6 @@ final class AppExtensionBase {
     }()
 }
 
-// MARK: - NeverRemoveAuthStorage
-
-struct NeverRemoveAuthStorage: AuthStore, APICredentialStore  {
-    
-    private let storage: AuthStoreImple
-    init(storage: AuthStoreImple) {
-        self.storage = storage
-    }
-    
-    func loadCurrentAuth() -> Domain.Auth? {
-        return self.storage.loadCurrentAuth()
-    }
-    
-    func loadCredential() -> APICredential? {
-        return self.loadCurrentAuth().map { .init(auth: $0) }
-    }
-    
-    func saveCredential(_ credential: APICredential) {
-        self.updateCredential(credential)
-    }
-    
-    func saveAuth(_ auth: Domain.Auth) {
-        self.storage.saveAuth(auth)
-    }
-    
-    func removeAuth() {
-        // not remove auth
-    }
-    
-    func updateCredential(_ credential: APICredential) {
-        self.storage.updateCredential(credential)
-    }
-    
-    func removeCredential() {
-        // not remove credential
-    }
-}
-
 // MARK: - dummy
 
 class DummyFirebaseAuthService: FirebaseAuthService {

--- a/TodoCalendarApp/Resources/Localize/ca.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/ca.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Afegeix amb IA a ${applicationName}";
+"Add a schedule in ${applicationName}" = "Afegeix una cita a ${applicationName}";
+"Add a to-do in ${applicationName}" = "Afegeix una tasca a ${applicationName}";
+"Add with AI" = "Afegeix amb IA";

--- a/TodoCalendarApp/Resources/Localize/ca.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/ca.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Afegeix amb IA";
+"Send what you say to AI and let it create your events and to-dos." = "Envieu el que dieu a la IA perquè creï els vostres esdeveniments i tasques.";
+"Command" = "Ordre";
+"What would you like to add?" = "Què voldríeu afegir?";
+"Got it. I'll notify you when it's done." = "Entesos. Us avisaré quan estigui llest.";
+"Sign in to the app first to use AI." = "Inicieu sessió a l'app abans d'utilitzar la IA.";
+"You've used up your AI credits for today." = "Heu esgotat els vostres crèdits d'IA d'avui.";
+"Something went wrong. Please try again." = "S'ha produït un error. Torneu-ho a provar.";
+"A previous request is still pending. Check the app to review it." = "Encara teniu una sol·licitud anterior pendent. Reviseu-la a l'app.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Enviat, però l'aplicació no pot fer el seguiment del resultat. Reviseu el calendari d'aquí a un moment.";

--- a/TodoCalendarApp/Resources/Localize/cs.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/cs.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Přidat pomocí AI v ${applicationName}";
+"Add a schedule in ${applicationName}" = "Přidat termín v ${applicationName}";
+"Add a to-do in ${applicationName}" = "Přidat úkol v ${applicationName}";
+"Add with AI" = "Přidat pomocí AI";

--- a/TodoCalendarApp/Resources/Localize/cs.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/cs.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Přidat pomocí AI";
+"Send what you say to AI and let it create your events and to-dos." = "Pošlete AI to, co řeknete, a nechte ji vytvořit vaše termíny a úkoly.";
+"Command" = "Příkaz";
+"What would you like to add?" = "Co byste chtěli přidat?";
+"Got it. I'll notify you when it's done." = "Rozumím. Dám vám vědět, až to bude hotové.";
+"Sign in to the app first to use AI." = "Nejprve se přihlaste do aplikace, abyste mohli použít AI.";
+"You've used up your AI credits for today." = "Vyčerpali jste dnešní kredity AI.";
+"Something went wrong. Please try again." = "Něco se pokazilo. Zkuste to prosím znovu.";
+"A previous request is still pending. Check the app to review it." = "Stále máte nevyřízený předchozí požadavek. Zkontrolujte ho v aplikaci.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Odesláno, ale aplikace nemůže sledovat výsledek. Za chvíli zkontrolujte kalendář.";

--- a/TodoCalendarApp/Resources/Localize/da.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/da.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Tilføj med AI i ${applicationName}";
+"Add a schedule in ${applicationName}" = "Tilføj en aftale i ${applicationName}";
+"Add a to-do in ${applicationName}" = "Tilføj en opgave i ${applicationName}";
+"Add with AI" = "Tilføj med AI";

--- a/TodoCalendarApp/Resources/Localize/da.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/da.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Tilføj med AI";
+"Send what you say to AI and let it create your events and to-dos." = "Send det, du siger, til AI, så opretter den dine aftaler og opgaver.";
+"Command" = "Kommando";
+"What would you like to add?" = "Hvad vil du gerne tilføje?";
+"Got it. I'll notify you when it's done." = "Modtaget. Jeg giver dig besked, når det er klar.";
+"Sign in to the app first to use AI." = "Log ind i appen først for at bruge AI.";
+"You've used up your AI credits for today." = "Du har brugt alle dine AI-kreditter for i dag.";
+"Something went wrong. Please try again." = "Noget gik galt. Prøv igen.";
+"A previous request is still pending. Check the app to review it." = "Din forrige anmodning afventer stadig. Tjek appen for at se den.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Sendt, men appen kan ikke følge resultatet. Tjek din kalender om lidt.";

--- a/TodoCalendarApp/Resources/Localize/de.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/de.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Mit KI in ${applicationName} hinzufügen";
+"Add a schedule in ${applicationName}" = "Einen Termin in ${applicationName} hinzufügen";
+"Add a to-do in ${applicationName}" = "Eine Aufgabe in ${applicationName} hinzufügen";
+"Add with AI" = "Mit KI hinzufügen";

--- a/TodoCalendarApp/Resources/Localize/de.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/de.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Mit KI hinzufügen";
+"Send what you say to AI and let it create your events and to-dos." = "Senden Sie der KI, was Sie sagen, und lassen Sie sie Ihre Termine und Aufgaben erstellen.";
+"Command" = "Befehl";
+"What would you like to add?" = "Was möchten Sie hinzufügen?";
+"Got it. I'll notify you when it's done." = "Alles klar. Ich benachrichtige Sie, wenn es fertig ist.";
+"Sign in to the app first to use AI." = "Melden Sie sich zuerst in der App an, um die KI zu nutzen.";
+"You've used up your AI credits for today." = "Sie haben Ihr heutiges KI-Guthaben aufgebraucht.";
+"Something went wrong. Please try again." = "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut.";
+"A previous request is still pending. Check the app to review it." = "Ihre vorherige Anfrage ist noch offen. Prüfen Sie sie in der App.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Gesendet, aber die App kann das Ergebnis nicht verfolgen. Prüfen Sie in Kürze Ihren Kalender.";

--- a/TodoCalendarApp/Resources/Localize/el.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/el.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Προσθήκη με AI στο ${applicationName}";
+"Add a schedule in ${applicationName}" = "Προσθήκη ραντεβού στο ${applicationName}";
+"Add a to-do in ${applicationName}" = "Προσθήκη εργασίας στο ${applicationName}";
+"Add with AI" = "Προσθήκη με AI";

--- a/TodoCalendarApp/Resources/Localize/el.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/el.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Προσθήκη με AI";
+"Send what you say to AI and let it create your events and to-dos." = "Στείλτε στο AI αυτό που λέτε για να δημιουργήσει τα ραντεβού και τις εργασίες σας.";
+"Command" = "Εντολή";
+"What would you like to add?" = "Τι θα θέλατε να προσθέσετε;";
+"Got it. I'll notify you when it's done." = "Έγινε. Θα σας ειδοποιήσω όταν ολοκληρωθεί.";
+"Sign in to the app first to use AI." = "Συνδεθείτε πρώτα στην εφαρμογή για να χρησιμοποιήσετε το AI.";
+"You've used up your AI credits for today." = "Έχετε εξαντλήσει τις μονάδες AI για σήμερα.";
+"Something went wrong. Please try again." = "Κάτι πήγε στραβά. Δοκιμάστε ξανά.";
+"A previous request is still pending. Check the app to review it." = "Υπάρχει ακόμη ένα εκκρεμές αίτημα. Ελέγξτε το στην εφαρμογή.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Στάλθηκε, αλλά η εφαρμογή δεν μπορεί να παρακολουθήσει το αποτέλεσμα. Ελέγξτε το ημερολόγιό σας σε λίγο.";

--- a/TodoCalendarApp/Resources/Localize/en.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/en.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Add with AI in ${applicationName}";
+"Add a schedule in ${applicationName}" = "Add a schedule in ${applicationName}";
+"Add a to-do in ${applicationName}" = "Add a to-do in ${applicationName}";
+"Add with AI" = "Add with AI";

--- a/TodoCalendarApp/Resources/Localize/en.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/en.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Add with AI";
+"Send what you say to AI and let it create your events and to-dos." = "Send what you say to AI and let it create your events and to-dos.";
+"Command" = "Command";
+"What would you like to add?" = "What would you like to add?";
+"Got it. I'll notify you when it's done." = "Got it. I'll notify you when it's done.";
+"Sign in to the app first to use AI." = "Sign in to the app first to use AI.";
+"You've used up your AI credits for today." = "You've used up your AI credits for today.";
+"Something went wrong. Please try again." = "Something went wrong. Please try again.";
+"A previous request is still pending. Check the app to review it." = "A previous request is still pending. Check the app to review it.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Sent, but the app can't track the result. Check your calendar after a moment.";

--- a/TodoCalendarApp/Resources/Localize/es.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/es.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Añadir con IA en ${applicationName}";
+"Add a schedule in ${applicationName}" = "Añadir un evento de calendario en ${applicationName}";
+"Add a to-do in ${applicationName}" = "Añadir una tarea en ${applicationName}";
+"Add with AI" = "Añadir con IA";

--- a/TodoCalendarApp/Resources/Localize/es.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/es.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Añadir con IA";
+"Send what you say to AI and let it create your events and to-dos." = "Envía lo que dices a la IA para que cree tus eventos y tareas.";
+"Command" = "Comando";
+"What would you like to add?" = "¿Qué te gustaría añadir?";
+"Got it. I'll notify you when it's done." = "Entendido. Te avisaré cuando esté listo.";
+"Sign in to the app first to use AI." = "Inicia sesión en la app primero para usar la IA.";
+"You've used up your AI credits for today." = "Has agotado tus créditos de IA de hoy.";
+"Something went wrong. Please try again." = "Algo salió mal. Inténtalo de nuevo.";
+"A previous request is still pending. Check the app to review it." = "Todavía tienes una solicitud pendiente. Revísala en la app.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Enviado, pero la app no puede seguir el resultado. Revisa tu calendario en un momento.";

--- a/TodoCalendarApp/Resources/Localize/fi.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/fi.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Lisää AI:lla sovelluksessa ${applicationName}";
+"Add a schedule in ${applicationName}" = "Lisää aikataulutapahtuma sovelluksessa ${applicationName}";
+"Add a to-do in ${applicationName}" = "Lisää tehtävä sovelluksessa ${applicationName}";
+"Add with AI" = "Lisää AI:lla";

--- a/TodoCalendarApp/Resources/Localize/fi.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/fi.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Lisää AI:lla";
+"Send what you say to AI and let it create your events and to-dos." = "Lähetä sanomasi AI:lle, niin se luo tapahtumasi ja tehtäväsi.";
+"Command" = "Komento";
+"What would you like to add?" = "Mitä haluaisit lisätä?";
+"Got it. I'll notify you when it's done." = "Selvä. Ilmoitan sinulle, kun se on valmis.";
+"Sign in to the app first to use AI." = "Kirjaudu ensin sisään sovellukseen käyttääksesi AI:ta.";
+"You've used up your AI credits for today." = "Olet käyttänyt tämän päivän AI-krediitit loppuun.";
+"Something went wrong. Please try again." = "Jokin meni pieleen. Yritä uudelleen.";
+"A previous request is still pending. Check the app to review it." = "Sinulla on yhä käsittelemätön aiempi pyyntö. Tarkista se sovelluksessa.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Lähetetty, mutta sovellus ei voi seurata tulosta. Tarkista kalenterisi hetken kuluttua.";

--- a/TodoCalendarApp/Resources/Localize/fr.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/fr.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Ajouter avec l'IA dans ${applicationName}";
+"Add a schedule in ${applicationName}" = "Ajouter un rendez-vous dans ${applicationName}";
+"Add a to-do in ${applicationName}" = "Ajouter une tâche dans ${applicationName}";
+"Add with AI" = "Ajouter avec l'IA";

--- a/TodoCalendarApp/Resources/Localize/fr.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/fr.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Ajouter avec l'IA";
+"Send what you say to AI and let it create your events and to-dos." = "Envoyez ce que vous dites à l'IA pour créer vos événements et tâches.";
+"Command" = "Commande";
+"What would you like to add?" = "Que souhaitez-vous ajouter ?";
+"Got it. I'll notify you when it's done." = "Compris. Je vous préviendrai une fois terminé.";
+"Sign in to the app first to use AI." = "Connectez-vous d'abord à l'app pour utiliser l'IA.";
+"You've used up your AI credits for today." = "Vous avez épuisé vos crédits IA pour aujourd'hui.";
+"Something went wrong. Please try again." = "Un problème est survenu. Veuillez réessayer.";
+"A previous request is still pending. Check the app to review it." = "Votre demande précédente est toujours en attente. Vérifiez-la dans l'app.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Envoyé, mais l'application ne peut pas suivre le résultat. Consultez votre calendrier dans un instant.";

--- a/TodoCalendarApp/Resources/Localize/hi.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/hi.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "${applicationName} में AI से जोड़ें";
+"Add a schedule in ${applicationName}" = "${applicationName} में अनुसूची जोड़ें";
+"Add a to-do in ${applicationName}" = "${applicationName} में कार्य जोड़ें";
+"Add with AI" = "AI से जोड़ें";

--- a/TodoCalendarApp/Resources/Localize/hi.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/hi.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "AI से जोड़ें";
+"Send what you say to AI and let it create your events and to-dos." = "आप जो कहें उसे AI को भेजें और अपने इवेंट और कार्य बनवाएं।";
+"Command" = "कमांड";
+"What would you like to add?" = "आप क्या जोड़ना चाहेंगे?";
+"Got it. I'll notify you when it's done." = "ठीक है। पूरा होने पर मैं आपको बता दूँगा।";
+"Sign in to the app first to use AI." = "AI इस्तेमाल करने के लिए पहले ऐप में लॉगिन करें।";
+"You've used up your AI credits for today." = "आपने आज के अपने AI क्रेडिट इस्तेमाल कर लिए हैं।";
+"Something went wrong. Please try again." = "कुछ गड़बड़ हो गई। कृपया फिर से कोशिश करें।";
+"A previous request is still pending. Check the app to review it." = "आपका पिछला अनुरोध अभी भी लंबित है। ऐप में देखें।";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "भेज दिया गया, लेकिन ऐप परिणाम ट्रैक नहीं कर सकता। कुछ देर बाद अपना कैलेंडर देखें।";

--- a/TodoCalendarApp/Resources/Localize/hr.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/hr.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Dodaj pomoću AI u ${applicationName}";
+"Add a schedule in ${applicationName}" = "Dodaj termin u ${applicationName}";
+"Add a to-do in ${applicationName}" = "Dodaj zadatak u ${applicationName}";
+"Add with AI" = "Dodaj pomoću AI";

--- a/TodoCalendarApp/Resources/Localize/hr.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/hr.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Dodaj pomoću AI";
+"Send what you say to AI and let it create your events and to-dos." = "Pošaljite AI-ju ono što kažete kako bi stvorio vaše termine i zadatke.";
+"Command" = "Naredba";
+"What would you like to add?" = "Što biste željeli dodati?";
+"Got it. I'll notify you when it's done." = "U redu. Obavijestit ću vas kad bude gotovo.";
+"Sign in to the app first to use AI." = "Najprije se prijavite u aplikaciju da biste koristili AI.";
+"You've used up your AI credits for today." = "Iskoristili ste današnje AI kredite.";
+"Something went wrong. Please try again." = "Nešto je pošlo po zlu. Pokušajte ponovno.";
+"A previous request is still pending. Check the app to review it." = "Prethodni zahtjev još uvijek čeka. Provjerite ga u aplikaciji.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Poslano, ali aplikacija ne može pratiti rezultat. Provjerite kalendar za trenutak.";

--- a/TodoCalendarApp/Resources/Localize/hu.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/hu.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Hozzáadás AI-val itt: ${applicationName}";
+"Add a schedule in ${applicationName}" = "Program hozzáadása itt: ${applicationName}";
+"Add a to-do in ${applicationName}" = "Feladat hozzáadása itt: ${applicationName}";
+"Add with AI" = "Hozzáadás AI-val";

--- a/TodoCalendarApp/Resources/Localize/hu.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/hu.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Hozzáadás AI-val";
+"Send what you say to AI and let it create your events and to-dos." = "Küldje el az AI-nak, amit mond, hogy létrehozza az eseményeit és feladatait.";
+"Command" = "Parancs";
+"What would you like to add?" = "Mit szeretne hozzáadni?";
+"Got it. I'll notify you when it's done." = "Rendben. Szólok, ha elkészült.";
+"Sign in to the app first to use AI." = "Az AI használatához előbb jelentkezzen be az appba.";
+"You've used up your AI credits for today." = "Mára elfogyott az AI kreditkeret.";
+"Something went wrong. Please try again." = "Hiba történt. Kérjük, próbálja újra.";
+"A previous request is still pending. Check the app to review it." = "A korábbi kérése még mindig függőben van. Ellenőrizze az appban.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Elküldve, de az alkalmazás nem tudja követni az eredményt. Nézze meg a naptárát kis idő múlva.";

--- a/TodoCalendarApp/Resources/Localize/id.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/id.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Tambah dengan AI di ${applicationName}";
+"Add a schedule in ${applicationName}" = "Tambah jadwal di ${applicationName}";
+"Add a to-do in ${applicationName}" = "Tambah tugas di ${applicationName}";
+"Add with AI" = "Tambah dengan AI";

--- a/TodoCalendarApp/Resources/Localize/id.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/id.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Tambah dengan AI";
+"Send what you say to AI and let it create your events and to-dos." = "Kirim apa yang Anda katakan ke AI agar ia membuat jadwal dan tugas Anda.";
+"Command" = "Perintah";
+"What would you like to add?" = "Apa yang ingin Anda tambahkan?";
+"Got it. I'll notify you when it's done." = "Baik. Saya akan memberi tahu Anda saat selesai.";
+"Sign in to the app first to use AI." = "Masuk ke aplikasi terlebih dahulu untuk menggunakan AI.";
+"You've used up your AI credits for today." = "Anda sudah menghabiskan kredit AI hari ini.";
+"Something went wrong. Please try again." = "Terjadi kesalahan. Coba lagi.";
+"A previous request is still pending. Check the app to review it." = "Permintaan sebelumnya masih tertunda. Periksa di aplikasi.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Terkirim, tetapi aplikasi tidak dapat melacak hasilnya. Periksa kalender Anda sebentar lagi.";

--- a/TodoCalendarApp/Resources/Localize/it.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/it.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Aggiungi con l'IA in ${applicationName}";
+"Add a schedule in ${applicationName}" = "Aggiungi una pianificazione in ${applicationName}";
+"Add a to-do in ${applicationName}" = "Aggiungi un'attività da fare in ${applicationName}";
+"Add with AI" = "Aggiungi con l'IA";

--- a/TodoCalendarApp/Resources/Localize/it.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/it.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Aggiungi con l'IA";
+"Send what you say to AI and let it create your events and to-dos." = "Invia ciò che dici all'IA per creare i tuoi eventi e le cose da fare.";
+"Command" = "Comando";
+"What would you like to add?" = "Cosa vuoi aggiungere?";
+"Got it. I'll notify you when it's done." = "Ricevuto. Ti avviserò quando sarà fatto.";
+"Sign in to the app first to use AI." = "Accedi prima all'app per usare l'IA.";
+"You've used up your AI credits for today." = "Hai esaurito i crediti IA di oggi.";
+"Something went wrong. Please try again." = "Qualcosa è andato storto. Riprova.";
+"A previous request is still pending. Check the app to review it." = "Hai ancora una richiesta precedente in sospeso. Controllala nell'app.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Inviato, ma l'app non può tracciare il risultato. Controlla il calendario tra poco.";

--- a/TodoCalendarApp/Resources/Localize/ja.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/ja.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "${applicationName}でAIに追加";
+"Add a schedule in ${applicationName}" = "${applicationName}で予定を追加";
+"Add a to-do in ${applicationName}" = "${applicationName}でタスクを追加";
+"Add with AI" = "AIで追加";

--- a/TodoCalendarApp/Resources/Localize/ja.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/ja.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "AIで追加";
+"Send what you say to AI and let it create your events and to-dos." = "話した内容をAIに送って、予定やタスクを作成します。";
+"Command" = "コマンド";
+"What would you like to add?" = "何を追加しますか？";
+"Got it. I'll notify you when it's done." = "了解しました。完了したらお知らせします。";
+"Sign in to the app first to use AI." = "AIを使うには、先にアプリにログインしてください。";
+"You've used up your AI credits for today." = "本日のAIクレジットを使い切りました。";
+"Something went wrong. Please try again." = "問題が発生しました。もう一度お試しください。";
+"A previous request is still pending. Check the app to review it." = "前回のリクエストがまだ保留中です。アプリで確認してください。";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "送信しましたが、アプリで結果を追跡できません。しばらくしてからカレンダーをご確認ください。";

--- a/TodoCalendarApp/Resources/Localize/ko.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/ko.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "${applicationName}에 AI로 추가";
+"Add a schedule in ${applicationName}" = "${applicationName}에 일정 추가";
+"Add a to-do in ${applicationName}" = "${applicationName}에 할일 추가";
+"Add with AI" = "AI로 추가";

--- a/TodoCalendarApp/Resources/Localize/ko.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/ko.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "AI로 추가";
+"Send what you say to AI and let it create your events and to-dos." = "말한 내용을 AI에게 보내 일정과 할일을 만들어요.";
+"Command" = "명령";
+"What would you like to add?" = "무엇을 추가할까요?";
+"Got it. I'll notify you when it's done." = "알겠어요. 완료되면 알려드릴게요.";
+"Sign in to the app first to use AI." = "AI를 사용하려면 먼저 앱에 로그인해주세요.";
+"You've used up your AI credits for today." = "오늘의 AI 크레딧을 모두 사용했어요.";
+"Something went wrong. Please try again." = "문제가 발생했어요. 다시 시도해주세요.";
+"A previous request is still pending. Check the app to review it." = "이전 요청이 아직 처리되지 않았어요. 앱에서 확인해주세요.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "보냈지만 앱에서 결과를 추적할 수 없어요. 잠시 후 캘린더를 확인해 주세요.";

--- a/TodoCalendarApp/Resources/Localize/ms.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/ms.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Tambah dengan AI dalam ${applicationName}";
+"Add a schedule in ${applicationName}" = "Tambah jadual dalam ${applicationName}";
+"Add a to-do in ${applicationName}" = "Tambah tugasan dalam ${applicationName}";
+"Add with AI" = "Tambah dengan AI";

--- a/TodoCalendarApp/Resources/Localize/ms.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/ms.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Tambah dengan AI";
+"Send what you say to AI and let it create your events and to-dos." = "Hantar apa yang anda cakap kepada AI supaya ia mencipta jadual dan tugasan anda.";
+"Command" = "Arahan";
+"What would you like to add?" = "Apa yang anda ingin tambah?";
+"Got it. I'll notify you when it's done." = "Baik. Saya akan maklumkan apabila selesai.";
+"Sign in to the app first to use AI." = "Log masuk ke aplikasi dahulu untuk menggunakan AI.";
+"You've used up your AI credits for today." = "Anda telah menghabiskan kredit AI hari ini.";
+"Something went wrong. Please try again." = "Sesuatu tidak kena. Sila cuba lagi.";
+"A previous request is still pending. Check the app to review it." = "Permintaan sebelumnya masih belum selesai. Sila semak dalam aplikasi.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Dihantar, tetapi aplikasi tidak dapat menjejaki hasilnya. Sila semak kalendar anda sebentar lagi.";

--- a/TodoCalendarApp/Resources/Localize/nb.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/nb.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Legg til med AI i ${applicationName}";
+"Add a schedule in ${applicationName}" = "Legg til en avtale i ${applicationName}";
+"Add a to-do in ${applicationName}" = "Legg til en oppgave i ${applicationName}";
+"Add with AI" = "Legg til med AI";

--- a/TodoCalendarApp/Resources/Localize/nb.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/nb.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Legg til med AI";
+"Send what you say to AI and let it create your events and to-dos." = "Send det du sier til AI, så oppretter den avtalene og oppgavene dine.";
+"Command" = "Kommando";
+"What would you like to add?" = "Hva vil du legge til?";
+"Got it. I'll notify you when it's done." = "Skjønner. Jeg varsler deg når det er ferdig.";
+"Sign in to the app first to use AI." = "Logg inn i appen først for å bruke AI.";
+"You've used up your AI credits for today." = "Du har brukt opp AI-kredittene dine for i dag.";
+"Something went wrong. Please try again." = "Noe gikk galt. Prøv igjen.";
+"A previous request is still pending. Check the app to review it." = "Din forrige forespørsel venter fortsatt. Sjekk appen for å se den.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Sendt, men appen kan ikke følge resultatet. Sjekk kalenderen om en liten stund.";

--- a/TodoCalendarApp/Resources/Localize/nl.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/nl.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Met AI in ${applicationName} toevoegen";
+"Add a schedule in ${applicationName}" = "Een afspraak in ${applicationName} toevoegen";
+"Add a to-do in ${applicationName}" = "Een taak in ${applicationName} toevoegen";
+"Add with AI" = "Toevoegen met AI";

--- a/TodoCalendarApp/Resources/Localize/nl.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/nl.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Toevoegen met AI";
+"Send what you say to AI and let it create your events and to-dos." = "Stuur wat je zegt naar AI en laat het je afspraken en taken aanmaken.";
+"Command" = "Opdracht";
+"What would you like to add?" = "Wat wil je toevoegen?";
+"Got it. I'll notify you when it's done." = "Begrepen. Ik laat het je weten zodra het klaar is.";
+"Sign in to the app first to use AI." = "Log eerst in op de app om AI te gebruiken.";
+"You've used up your AI credits for today." = "Je hebt je AI-credits voor vandaag opgebruikt.";
+"Something went wrong. Please try again." = "Er is iets misgegaan. Probeer het opnieuw.";
+"A previous request is still pending. Check the app to review it." = "Je hebt nog een openstaand verzoek. Controleer dit in de app.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Verzonden, maar de app kan het resultaat niet volgen. Bekijk je agenda over een moment.";

--- a/TodoCalendarApp/Resources/Localize/pl.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/pl.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Dodaj z AI w ${applicationName}";
+"Add a schedule in ${applicationName}" = "Dodaj termin w ${applicationName}";
+"Add a to-do in ${applicationName}" = "Dodaj zadanie w ${applicationName}";
+"Add with AI" = "Dodaj z AI";

--- a/TodoCalendarApp/Resources/Localize/pl.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/pl.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Dodaj z AI";
+"Send what you say to AI and let it create your events and to-dos." = "Wyślij do AI to, co powiesz, aby utworzyć Twoje terminy i zadania.";
+"Command" = "Polecenie";
+"What would you like to add?" = "Co chciałbyś dodać?";
+"Got it. I'll notify you when it's done." = "Rozumiem. Dam Ci znać, gdy będzie gotowe.";
+"Sign in to the app first to use AI." = "Zaloguj się najpierw w aplikacji, aby korzystać z AI.";
+"You've used up your AI credits for today." = "Wykorzystałeś dzisiejsze kredyty AI.";
+"Something went wrong. Please try again." = "Coś poszło nie tak. Spróbuj ponownie.";
+"A previous request is still pending. Check the app to review it." = "Nadal masz oczekującą wcześniejszą prośbę. Sprawdź ją w aplikacji.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Wysłano, ale aplikacja nie może śledzić wyniku. Sprawdź kalendarz za chwilę.";

--- a/TodoCalendarApp/Resources/Localize/pt-BR.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/pt-BR.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Adicionar com IA no ${applicationName}";
+"Add a schedule in ${applicationName}" = "Adicionar um compromisso no ${applicationName}";
+"Add a to-do in ${applicationName}" = "Adicionar uma tarefa no ${applicationName}";
+"Add with AI" = "Adicionar com IA";

--- a/TodoCalendarApp/Resources/Localize/pt-BR.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/pt-BR.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Adicionar com IA";
+"Send what you say to AI and let it create your events and to-dos." = "Envie o que você disser para a IA criar seus eventos e tarefas.";
+"Command" = "Comando";
+"What would you like to add?" = "O que você gostaria de adicionar?";
+"Got it. I'll notify you when it's done." = "Entendido. Vou te avisar quando terminar.";
+"Sign in to the app first to use AI." = "Faça login no app primeiro para usar a IA.";
+"You've used up your AI credits for today." = "Você usou todos os seus créditos de IA hoje.";
+"Something went wrong. Please try again." = "Algo deu errado. Tente novamente.";
+"A previous request is still pending. Check the app to review it." = "Você ainda tem uma solicitação pendente. Verifique no app.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Enviado, mas o app não consegue acompanhar o resultado. Verifique seu calendário em instantes.";

--- a/TodoCalendarApp/Resources/Localize/ro.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/ro.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Adaugă cu AI în ${applicationName}";
+"Add a schedule in ${applicationName}" = "Adaugă o programare în ${applicationName}";
+"Add a to-do in ${applicationName}" = "Adaugă o sarcină în ${applicationName}";
+"Add with AI" = "Adaugă cu AI";

--- a/TodoCalendarApp/Resources/Localize/ro.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/ro.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Adaugă cu AI";
+"Send what you say to AI and let it create your events and to-dos." = "Trimiteți către AI ce spuneți, ca să vă creeze programările și sarcinile.";
+"Command" = "Comandă";
+"What would you like to add?" = "Ce ați dori să adăugați?";
+"Got it. I'll notify you when it's done." = "Am înțeles. Vă anunț când e gata.";
+"Sign in to the app first to use AI." = "Autentificați-vă mai întâi în aplicație ca să folosiți AI.";
+"You've used up your AI credits for today." = "V-ați epuizat creditele AI de azi.";
+"Something went wrong. Please try again." = "Ceva nu a mers bine. Încercați din nou.";
+"A previous request is still pending. Check the app to review it." = "Aveți încă o solicitare anterioară în așteptare. Verificați în aplicație.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Trimis, dar aplicația nu poate urmări rezultatul. Verificați calendarul peste puțin timp.";

--- a/TodoCalendarApp/Resources/Localize/ru.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/ru.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Добавить с помощью ИИ в ${applicationName}";
+"Add a schedule in ${applicationName}" = "Добавить встречу в ${applicationName}";
+"Add a to-do in ${applicationName}" = "Добавить задачу в ${applicationName}";
+"Add with AI" = "Добавить с помощью ИИ";

--- a/TodoCalendarApp/Resources/Localize/ru.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/ru.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Добавить с помощью ИИ";
+"Send what you say to AI and let it create your events and to-dos." = "Отправьте ИИ то, что вы скажете, и он создаст ваши события и задачи.";
+"Command" = "Команда";
+"What would you like to add?" = "Что вы хотите добавить?";
+"Got it. I'll notify you when it's done." = "Понял. Сообщу, когда будет готово.";
+"Sign in to the app first to use AI." = "Сначала войдите в приложение, чтобы использовать ИИ.";
+"You've used up your AI credits for today." = "Вы исчерпали кредиты ИИ на сегодня.";
+"Something went wrong. Please try again." = "Что-то пошло не так. Повторите попытку.";
+"A previous request is still pending. Check the app to review it." = "У вас всё ещё есть незавершённый запрос. Проверьте его в приложении.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Отправлено, но приложение не может отследить результат. Проверьте календарь чуть позже.";

--- a/TodoCalendarApp/Resources/Localize/sk.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/sk.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Pridať pomocou AI v ${applicationName}";
+"Add a schedule in ${applicationName}" = "Pridať termín v ${applicationName}";
+"Add a to-do in ${applicationName}" = "Pridať úlohu v ${applicationName}";
+"Add with AI" = "Pridať pomocou AI";

--- a/TodoCalendarApp/Resources/Localize/sk.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/sk.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Pridať pomocou AI";
+"Send what you say to AI and let it create your events and to-dos." = "Pošlite AI to, čo poviete, a nechajte ju vytvoriť vaše termíny a úlohy.";
+"Command" = "Príkaz";
+"What would you like to add?" = "Čo by ste chceli pridať?";
+"Got it. I'll notify you when it's done." = "Rozumiem. Dám vám vedieť, keď to bude hotové.";
+"Sign in to the app first to use AI." = "Najprv sa prihláste do aplikácie, aby ste mohli používať AI.";
+"You've used up your AI credits for today." = "Vyčerpali ste dnešné kredity AI.";
+"Something went wrong. Please try again." = "Niečo sa pokazilo. Skúste to, prosím, znova.";
+"A previous request is still pending. Check the app to review it." = "Stále máte nevybavenú predchádzajúcu žiadosť. Skontrolujte ju v aplikácii.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Odoslané, ale aplikácia nemôže sledovať výsledok. O chvíľu skontrolujte kalendár.";

--- a/TodoCalendarApp/Resources/Localize/sv.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/sv.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Lägg till med AI i ${applicationName}";
+"Add a schedule in ${applicationName}" = "Lägg till ett möte i ${applicationName}";
+"Add a to-do in ${applicationName}" = "Lägg till en uppgift i ${applicationName}";
+"Add with AI" = "Lägg till med AI";

--- a/TodoCalendarApp/Resources/Localize/sv.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/sv.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Lägg till med AI";
+"Send what you say to AI and let it create your events and to-dos." = "Skicka det du säger till AI så skapar den dina möten och uppgifter.";
+"Command" = "Kommando";
+"What would you like to add?" = "Vad vill du lägga till?";
+"Got it. I'll notify you when it's done." = "Uppfattat. Jag meddelar dig när det är klart.";
+"Sign in to the app first to use AI." = "Logga in i appen först för att använda AI.";
+"You've used up your AI credits for today." = "Du har använt alla dina AI-krediter för idag.";
+"Something went wrong. Please try again." = "Något gick fel. Försök igen.";
+"A previous request is still pending. Check the app to review it." = "Din tidigare begäran väntar fortfarande. Kontrollera den i appen.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Skickat, men appen kan inte följa resultatet. Kolla kalendern om en stund.";

--- a/TodoCalendarApp/Resources/Localize/th.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/th.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "เพิ่มด้วย AI ใน ${applicationName}";
+"Add a schedule in ${applicationName}" = "เพิ่มนัดหมายใน ${applicationName}";
+"Add a to-do in ${applicationName}" = "เพิ่มสิ่งที่ต้องทำใน ${applicationName}";
+"Add with AI" = "เพิ่มด้วย AI";

--- a/TodoCalendarApp/Resources/Localize/th.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/th.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "เพิ่มด้วย AI";
+"Send what you say to AI and let it create your events and to-dos." = "ส่งสิ่งที่คุณพูดให้ AI เพื่อสร้างนัดหมายและสิ่งที่ต้องทำให้คุณ";
+"Command" = "คำสั่ง";
+"What would you like to add?" = "คุณต้องการเพิ่มอะไร?";
+"Got it. I'll notify you when it's done." = "รับทราบ เดี๋ยวแจ้งให้ทราบเมื่อเสร็จ";
+"Sign in to the app first to use AI." = "กรุณาเข้าสู่ระบบแอปก่อนใช้งาน AI";
+"You've used up your AI credits for today." = "คุณใช้เครดิต AI ของวันนี้หมดแล้ว";
+"Something went wrong. Please try again." = "เกิดข้อผิดพลาด กรุณาลองอีกครั้ง";
+"A previous request is still pending. Check the app to review it." = "คำขอก่อนหน้ายังอยู่ระหว่างดำเนินการ กรุณาตรวจสอบในแอป";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "ส่งแล้ว แต่แอปติดตามผลลัพธ์ไม่ได้ กรุณาตรวจสอบปฏิทินในอีกสักครู่";

--- a/TodoCalendarApp/Resources/Localize/tr.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/tr.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "${applicationName} uygulamasında AI ile ekle";
+"Add a schedule in ${applicationName}" = "${applicationName} uygulamasında randevu ekle";
+"Add a to-do in ${applicationName}" = "${applicationName} uygulamasında görev ekle";
+"Add with AI" = "AI ile Ekle";

--- a/TodoCalendarApp/Resources/Localize/tr.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/tr.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "AI ile Ekle";
+"Send what you say to AI and let it create your events and to-dos." = "Söylediklerinizi AI'ya gönderin, o da randevularınızı ve görevlerinizi oluştursun.";
+"Command" = "Komut";
+"What would you like to add?" = "Ne eklemek istersiniz?";
+"Got it. I'll notify you when it's done." = "Anlaşıldı. Tamamlandığında size bildireceğim.";
+"Sign in to the app first to use AI." = "AI kullanmak için önce uygulamaya giriş yapın.";
+"You've used up your AI credits for today." = "Bugünkü AI kredinizi tükettiniz.";
+"Something went wrong. Please try again." = "Bir şeyler ters gitti. Lütfen tekrar deneyin.";
+"A previous request is still pending. Check the app to review it." = "Önceki isteğiniz hâlâ beklemede. Uygulamada kontrol edin.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Gönderildi, ancak uygulama sonucu izleyemiyor. Birazdan takviminizi kontrol edin.";

--- a/TodoCalendarApp/Resources/Localize/uk.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/uk.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Додати за допомогою ШІ в ${applicationName}";
+"Add a schedule in ${applicationName}" = "Додати зустріч в ${applicationName}";
+"Add a to-do in ${applicationName}" = "Додати завдання в ${applicationName}";
+"Add with AI" = "Додати за допомогою ШІ";

--- a/TodoCalendarApp/Resources/Localize/uk.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/uk.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Додати за допомогою ШІ";
+"Send what you say to AI and let it create your events and to-dos." = "Надішліть ШІ те, що ви скажете, і він створить ваші зустрічі та завдання.";
+"Command" = "Команда";
+"What would you like to add?" = "Що б ви хотіли додати?";
+"Got it. I'll notify you when it's done." = "Зрозуміло. Повідомлю, коли буде готово.";
+"Sign in to the app first to use AI." = "Спочатку увійдіть в застосунок, щоб використовувати ШІ.";
+"You've used up your AI credits for today." = "Ви вичерпали кредити ШІ на сьогодні.";
+"Something went wrong. Please try again." = "Щось пішло не так. Спробуйте ще раз.";
+"A previous request is still pending. Check the app to review it." = "У вас усе ще є незавершений запит. Перевірте його в застосунку.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Надіслано, але додаток не може відстежити результат. Перевірте календар за мить.";

--- a/TodoCalendarApp/Resources/Localize/vi.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/vi.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "Thêm bằng AI trong ${applicationName}";
+"Add a schedule in ${applicationName}" = "Thêm lịch trình trong ${applicationName}";
+"Add a to-do in ${applicationName}" = "Thêm việc cần làm trong ${applicationName}";
+"Add with AI" = "Thêm bằng AI";

--- a/TodoCalendarApp/Resources/Localize/vi.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/vi.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "Thêm bằng AI";
+"Send what you say to AI and let it create your events and to-dos." = "Gửi những gì bạn nói cho AI để tạo lịch trình và việc cần làm.";
+"Command" = "Lệnh";
+"What would you like to add?" = "Bạn muốn thêm gì?";
+"Got it. I'll notify you when it's done." = "Đã nhận. Tôi sẽ báo cho bạn khi xong.";
+"Sign in to the app first to use AI." = "Vui lòng đăng nhập vào ứng dụng trước khi dùng AI.";
+"You've used up your AI credits for today." = "Bạn đã dùng hết credit AI hôm nay.";
+"Something went wrong. Please try again." = "Đã xảy ra lỗi. Vui lòng thử lại.";
+"A previous request is still pending. Check the app to review it." = "Yêu cầu trước của bạn vẫn đang chờ xử lý. Vui lòng kiểm tra trong ứng dụng.";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "Đã gửi, nhưng ứng dụng không theo dõi được kết quả. Hãy kiểm tra lịch sau giây lát.";

--- a/TodoCalendarApp/Resources/Localize/zh-Hans.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/zh-Hans.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "在${applicationName}中用AI添加";
+"Add a schedule in ${applicationName}" = "在${applicationName}中添加日程";
+"Add a to-do in ${applicationName}" = "在${applicationName}中添加待办事项";
+"Add with AI" = "用AI添加";

--- a/TodoCalendarApp/Resources/Localize/zh-Hans.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "用AI添加";
+"Send what you say to AI and let it create your events and to-dos." = "把你说的内容发送给AI，让它为你创建日程和待办事项。";
+"Command" = "指令";
+"What would you like to add?" = "你想添加什么？";
+"Got it. I'll notify you when it's done." = "好的，完成后会通知你。";
+"Sign in to the app first to use AI." = "请先登录应用才能使用AI。";
+"You've used up your AI credits for today." = "你今天的AI额度已用完。";
+"Something went wrong. Please try again." = "出了点问题，请重试。";
+"A previous request is still pending. Check the app to review it." = "之前的请求仍在处理中，请在应用内查看。";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "已发送，但应用无法跟踪结果。请稍后查看日历。";

--- a/TodoCalendarApp/Resources/Localize/zh-Hant.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/zh-Hant.lproj/AppShortcuts.strings
@@ -1,0 +1,4 @@
+"Add with AI in ${applicationName}" = "在${applicationName}中用AI新增";
+"Add a schedule in ${applicationName}" = "在${applicationName}中新增行程";
+"Add a to-do in ${applicationName}" = "在${applicationName}中新增待辦事項";
+"Add with AI" = "用AI新增";

--- a/TodoCalendarApp/Resources/Localize/zh-Hant.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/zh-Hant.lproj/Localizable.strings
@@ -1,0 +1,10 @@
+"Add with AI" = "用AI新增";
+"Send what you say to AI and let it create your events and to-dos." = "把你說的內容傳送給AI，讓它為你建立行程和待辦事項。";
+"Command" = "指令";
+"What would you like to add?" = "你想新增什麼？";
+"Got it. I'll notify you when it's done." = "好的，完成後會通知你。";
+"Sign in to the app first to use AI." = "請先登入應用程式才能使用AI。";
+"You've used up your AI credits for today." = "你今天的AI點數已經用完了。";
+"Something went wrong. Please try again." = "發生問題，請重試。";
+"A previous request is still pending. Check the app to review it." = "之前的請求仍在處理中，請在應用程式內查看。";
+"Sent, but the app can't track the result. Check your calendar after a moment." = "已傳送，但應用程式無法追蹤結果。請稍後查看行事曆。";

--- a/TodoCalendarApp/Sources/AppIntents/AICommandIntentFactory.swift
+++ b/TodoCalendarApp/Sources/AppIntents/AICommandIntentFactory.swift
@@ -1,0 +1,115 @@
+//
+//  AICommandIntentFactory.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 8/6/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Domain
+import Repository
+import SQLiteService
+import Alamofire
+
+
+// 앱 라이프사이클(prepareInitialScene → UsecaseFactory)에 의존하지 않는 인텐트 전용 조립.
+// openAppWhenRun = false 는 scene 없이 기동돼 그 경로가 돌지 않는다.
+struct AICommandIntentFactory {
+
+    private let environmentStorage: UserDefaultEnvironmentStorageImple
+    private let authStore: AuthStoreImple
+    private let firebaseAuthService: any FirebaseAuthService
+
+    init() {
+        let environmentStorage = UserDefaultEnvironmentStorageImple(
+            suiteName: AppEnvironment.groupID
+        )
+        let keyChainStorage = KeyChainStorageImple(
+            identifier: AppEnvironment.keyChainStoreName
+        )
+        keyChainStorage.setupSharedGroup(AppEnvironment.groupID)
+
+        // 앱에서 이 setup 은 prepareLaunch 경로가 부른다 — 백그라운드 기동엔 안 도니 직접 부른다
+        let firebaseAuthService = FirebaseAuthServiceImple(
+            appGroupId: AppEnvironment.groupID,
+            useEmulator: AppEnvironment.useEmulator
+        )
+        try? firebaseAuthService.setup()
+
+        self.environmentStorage = environmentStorage
+        self.authStore = AuthStoreImple(
+            keyChainStorage: keyChainStorage,
+            environmentStorage: environmentStorage
+        )
+        self.firebaseAuthService = firebaseAuthService
+    }
+}
+
+extension AICommandIntentFactory {
+
+    func makeSubmitService() -> IntentCommandSubmitService {
+        return IntentCommandSubmitService(
+            repository: self.makeAICommandRepository(),
+            authStore: self.authStore,
+            settingRepository: CalendarSettingRepositoryImple(
+                environmentStorage: self.environmentStorage
+            )
+        )
+    }
+
+    // job 생성 + 처리중 기록 두 가지만 필요하므로 usecase가 아닌 repository를 직접 만든다.
+    private func makeAICommandRepository() -> any AICommandRepository {
+        let auth = self.authStore.loadCurrentAuth()
+        let remoteAPI = self.makeRemoteAPI()
+        // AI 엔드포인트는 인증 필수(CalendarAPIAutenticator.shouldAdapt).
+        // auth를 seed하지 않으면 무인증으로 나간다 — ShareUsecaseFactory와 같은 처리.
+        if let auth {
+            remoteAPI.setup(credential: APICredential(auth: auth))
+        }
+
+        let sqliteService = SQLiteService(openWithReadOnly: false)
+        _ = sqliteService.open(path: AppEnvironment.dbFilePath(for: auth?.uid))
+        return AICommandRepositoryImple(
+            remote: remoteAPI,
+            localStorage: AICommandLocalStorageImple(sqliteService: sqliteService)
+        )
+    }
+
+    private func makeRemoteAPI() -> RemoteAPIImple {
+
+        func readSecret() -> [String: Any] {
+            guard let path = Bundle.main.path(forResource: "secrets", ofType: "json"),
+                  let jsonData = try? Data(contentsOf: URL(fileURLWithPath: path))
+            else { return [:] }
+            return (try? JSONSerialization.jsonObject(
+                with: jsonData, options: .allowFragments
+            ) as? [String: Any]) ?? [:]
+        }
+        let secrets = readSecret()
+        let host = AppEnvironment.useEmulator
+            ? secrets["emulator_caleandar_api_host"] as? String
+            : secrets["caleandar_api_host"] as? String
+        let environment = RemoteEnvironment(
+            calendarAPIHost: host ?? "https://dummy.com",
+            csAPI: secrets["cs_api"] as? String ?? "https://dummy.com",
+            deviceId: AppEnvironment.deviceId(self.environmentStorage),
+            acceptLanguage: { AcceptLanguage.headerValue(from: Locale.preferredLanguages) }
+        )
+        let configure = URLSessionConfiguration.af.default
+        configure.timeoutIntervalForRequest = AppEnvironment.apiDefaultTimeoutSeconds
+        let session = Session(
+            configuration: configure,
+            serializationQueue: DispatchQueue(label: "af.serialization", qos: .utility)
+        )
+        let authenticator = CalendarAPIAutenticator(
+            credentialStore: NeverRemoveAuthStorage(storage: self.authStore),
+            firebaseAuthService: self.firebaseAuthService
+        )
+        return RemoteAPIImple(
+            session: session,
+            environment: environment,
+            interceptor: AuthenticationInterceptorProxy(authenticator: authenticator)
+        )
+    }
+}

--- a/TodoCalendarApp/Sources/AppIntents/AICommandSubmitFailReason.swift
+++ b/TodoCalendarApp/Sources/AppIntents/AICommandSubmitFailReason.swift
@@ -1,0 +1,39 @@
+//
+//  AICommandSubmitFailReason.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 8/6/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Domain
+
+
+enum AICommandSubmitFailReason: Error, Equatable {
+    case notSignedIn
+    case limitExceeded
+    case previousRequestPending
+    /// 서버 job은 만들어졌지만 ProcessingAICommand 기록에 실패했다.
+    /// 재시도를 유도하면 중복 job에 크레딧이 두 번 나간다.
+    case processingCommandRecordFailed
+    case unknown
+}
+
+extension AICommandSubmitFailReason {
+
+    init(_ error: any Error) {
+        switch (error as? ServerErrorModel)?.code {
+        case .dailyLimitExceeded:
+            self = .limitExceeded
+
+        case .unauthorized, .invalidAccessKey:
+            // 로컬 Auth 레코드는 남아있는데 서버 세션이 죽은 경우 — 무한 재시도로
+            // 유저를 몰아넣지 않도록 로그인 유도 문구로 떨어뜨린다.
+            self = .notSignedIn
+
+        default:
+            self = .unknown
+        }
+    }
+}

--- a/TodoCalendarApp/Sources/AppIntents/IntentCommandSubmitService.swift
+++ b/TodoCalendarApp/Sources/AppIntents/IntentCommandSubmitService.swift
@@ -1,0 +1,70 @@
+//
+//  IntentCommandSubmitService.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 8/6/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Domain
+import Repository
+
+
+struct IntentCommandSubmitService: Sendable {
+
+    private let repository: any AICommandRepository
+    private let authStore: any AuthStore
+    private let settingRepository: any CalendarSettingRepository
+
+    init(
+        repository: any AICommandRepository,
+        authStore: any AuthStore,
+        settingRepository: any CalendarSettingRepository
+    ) {
+        self.repository = repository
+        self.authStore = authStore
+        self.settingRepository = settingRepository
+    }
+
+    func submit(_ commandText: String) async throws {
+        guard self.authStore.loadCurrentAuth() != nil
+        else { throw AICommandSubmitFailReason.notSignedIn }
+
+        guard await self.hasNoPendingRequest()
+        else { throw AICommandSubmitFailReason.previousRequestPending }
+
+        let timeZone = self.settingRepository.loadUserSelectedTImeZone() ?? .current
+        let jobId: String
+        do {
+            jobId = try await self.repository.processCommand(
+                commandText, timeZone: timeZone.identifier
+            )
+        } catch {
+            throw AICommandSubmitFailReason(error)
+        }
+
+        try await self.updateProcessingCommand(jobId: jobId)
+    }
+
+    // ProcessingAICommand는 단일 행이라, 앞선 요청이 남았는데 새로 보내면 앱이 이어받을
+    // 근거가 덮여 결과가 유실된다. 유무 확인 자체가 실패해도 보내지 않는다.
+    private func hasNoPendingRequest() async -> Bool {
+        do {
+            return try await self.repository.loadProcessingAICommand() == nil
+        } catch {
+            return false
+        }
+    }
+
+    // 인텐트는 응답 직후 죽으므로 이 기록이 앱으로 넘기는 유일한 인계 채널이다.
+    private func updateProcessingCommand(jobId: String) async throws {
+        do {
+            try await self.repository.updateProcessingAICommand(
+                .init(jobId: jobId, isConfirmJob: false)
+            )
+        } catch {
+            throw AICommandSubmitFailReason.processingCommandRecordFailed
+        }
+    }
+}

--- a/TodoCalendarApp/Sources/AppIntents/SendAICommandIntent.swift
+++ b/TodoCalendarApp/Sources/AppIntents/SendAICommandIntent.swift
@@ -1,0 +1,66 @@
+//
+//  SendAICommandIntent.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 8/5/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import AppIntents
+
+
+struct SendAICommandIntent: AppIntent {
+
+    static let title: LocalizedStringResource = "Add with AI"
+
+    static let description = IntentDescription(
+        "Send what you say to AI and let it create your events and to-dos."
+    )
+
+    // 앱을 열지 않고 백그라운드에서 커맨드만 등록한다. 결과는 푸시로 전달된다.
+    static let openAppWhenRun: Bool = false
+
+    @Parameter(
+        title: "Command",
+        requestValueDialog: IntentDialog("What would you like to add?")
+    )
+    var commandText: String
+
+    init() { }
+
+    init(commandText: String) {
+        self.commandText = commandText
+    }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let service = AICommandIntentFactory().makeSubmitService()
+        do {
+            try await service.submit(self.commandText)
+            return .result(dialog: IntentDialog("Got it. I'll notify you when it's done."))
+        } catch {
+            let reason = error as? AICommandSubmitFailReason ?? .unknown
+            return .result(dialog: reason.dialog)
+        }
+    }
+}
+
+
+extension AICommandSubmitFailReason {
+
+    var dialog: IntentDialog {
+        switch self {
+        case .notSignedIn:
+            return IntentDialog("Sign in to the app first to use AI.")
+        case .limitExceeded:
+            return IntentDialog("You've used up your AI credits for today.")
+        case .previousRequestPending:
+            return IntentDialog("A previous request is still pending. Check the app to review it.")
+        case .processingCommandRecordFailed:
+            // job은 이미 서버에 있다 — 재시도를 유도하면 중복 job에 크레딧이 두 번 나간다.
+            return IntentDialog("Sent, but the app can't track the result. Check your calendar after a moment.")
+        case .unknown:
+            return IntentDialog("Something went wrong. Please try again.")
+        }
+    }
+}

--- a/TodoCalendarApp/Sources/AppIntents/TodoCalendarAppShortcuts.swift
+++ b/TodoCalendarApp/Sources/AppIntents/TodoCalendarAppShortcuts.swift
@@ -1,0 +1,26 @@
+//
+//  TodoCalendarAppShortcuts.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 8/5/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import AppIntents
+
+
+struct TodoCalendarAppShortcuts: AppShortcutsProvider {
+
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: SendAICommandIntent(),
+            phrases: [
+                "Add with AI in \(.applicationName)",
+                "Add a schedule in \(.applicationName)",
+                "Add a to-do in \(.applicationName)"
+            ],
+            shortTitle: "Add with AI",
+            systemImageName: "sparkles"
+        )
+    }
+}

--- a/TodoCalendarApp/Sources/NeverRemoveAuthStorage.swift
+++ b/TodoCalendarApp/Sources/NeverRemoveAuthStorage.swift
@@ -1,0 +1,50 @@
+//
+//  NeverRemoveAuthStorage.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 8/6/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Domain
+import Repository
+
+
+// 유저 없는 백그라운드에서 리프레시가 일시 실패했다고 세션을 지우면 조용히 로그아웃된다.
+struct NeverRemoveAuthStorage: AuthStore, APICredentialStore {
+
+    private let storage: AuthStoreImple
+
+    init(storage: AuthStoreImple) {
+        self.storage = storage
+    }
+
+    func loadCurrentAuth() -> Auth? {
+        return self.storage.loadCurrentAuth()
+    }
+
+    func loadCredential() -> APICredential? {
+        return self.storage.loadCredential()
+    }
+
+    func saveAuth(_ auth: Auth) {
+        self.storage.saveAuth(auth)
+    }
+
+    func saveCredential(_ credential: APICredential) {
+        self.storage.saveCredential(credential)
+    }
+
+    func updateCredential(_ credential: APICredential) {
+        self.storage.updateCredential(credential)
+    }
+
+    func removeAuth() {
+        // not remove auth
+    }
+
+    func removeCredential() {
+        // not remove credential
+    }
+}

--- a/TodoCalendarApp/Sources/Root/ApplicationRootViewModel.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootViewModel.swift
@@ -64,6 +64,10 @@ final class ApplicationRootViewModelImple: @unchecked Sendable {
     private var cancellables: Set<AnyCancellable> = []
 }
 
+private enum Constant {
+    static let processingJobRefreshInterval: TimeInterval = 30
+}
+
 
 // MARK: - handle root routing
 
@@ -184,8 +188,20 @@ extension ApplicationRootViewModelImple {
                 self?.handleWillEnterForeground()
             })
             .store(in: &self.cancellables)
+
+        // didBecomeActive는 제어센터·알림센터 여닫기나 권한 다이얼로그 dismiss로도 매번 온다.
+        NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
+            .throttle(
+                for: .seconds(Constant.processingJobRefreshInterval),
+                scheduler: DispatchQueue.main,
+                latest: false
+            )
+            .sink(receiveValue: { [weak self] _ in
+                self?.handleDidBecomeActive()
+            })
+            .store(in: &self.cancellables)
     }
-    
+
     private func handleDidEnterBackground() {
         self.prepareUsecase.prepareEnterBackground()
         self.backgroundEventSyncUsecase.scheduleTask()
@@ -194,6 +210,11 @@ extension ApplicationRootViewModelImple {
 
     private func handleWillEnterForeground() {
         self.appUpdateCheckUsecase.checkUpdateIsNeed()
+    }
+
+    // Siri 인텐트는 앱을 background로 내리지 않아 포그라운드 복귀 이벤트가 오지 않는다.
+    // active 전환은 그 경우까지 덮는다.
+    private func handleDidBecomeActive() {
         self.aiJobRefreshUsecase.refreshProcessingJobIfNeeded()
     }
 

--- a/TodoCalendarApp/TodoCalendarAppTests/AppIntents/IntentCommandSubmitServiceTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/AppIntents/IntentCommandSubmitServiceTests.swift
@@ -1,0 +1,273 @@
+//
+//  IntentCommandSubmitServiceTests.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 8/4/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Testing
+import Prelude
+import Optics
+import Domain
+import Repository
+import Extensions
+import TestDoubles
+
+@testable import TodoCalendarApp
+
+
+final class IntentCommandSubmitServiceTests {
+
+    private func makeService(
+        hasAuth: Bool = true,
+        stubRepository: StubAICommandRepository = .init()
+    ) -> (IntentCommandSubmitService, StubAICommandRepository) {
+        let settingRepository = StubCalendarSettingRepository()
+        settingRepository.saveTimeZone(TimeZone(identifier: "Asia/Seoul")!)
+        let service = IntentCommandSubmitService(
+            repository: stubRepository,
+            authStore: StubAuthStore(
+                auth: hasAuth ? Auth(uid: "uid", accessToken: "token") : nil
+            ),
+            settingRepository: settingRepository
+        )
+        return (service, stubRepository)
+    }
+
+    private func makeRepository(
+        processFailWith error: (any Error)? = nil,
+        pending: ProcessingAICommand? = nil,
+        shouldFailLoadPending: Bool = false,
+        shouldFailUpdatePending: Bool = false
+    ) -> StubAICommandRepository {
+        let repository = StubAICommandRepository()
+        repository.stubProcessError = error
+        repository.stubPendingCommand = pending
+        repository.shouldFailLoadPending = shouldFailLoadPending
+        repository.shouldFailUpdatePending = shouldFailUpdatePending
+        return repository
+    }
+
+    private func failReason(
+        of submit: () async throws -> Void
+    ) async -> AICommandSubmitFailReason? {
+        do {
+            try await submit()
+            return nil
+        } catch {
+            return error as? AICommandSubmitFailReason
+        }
+    }
+}
+
+// MARK: - 로그인 상태
+
+extension IntentCommandSubmitServiceTests {
+
+    @Test("로그인 상태면 커맨드를 전송하고 처리중으로 기록한다")
+    func submit_whenSignedIn_submits() async {
+        // given
+        let (service, repository) = self.makeService()
+
+        // when
+        let reason = await self.failReason { try await service.submit("내일 3시 회의") }
+
+        // then
+        #expect(reason == nil)
+        #expect(repository.didProcessCommandText == "내일 3시 회의")
+        #expect(repository.didProcessTimeZone == "Asia/Seoul")
+        #expect(repository.didUpdatePendingJobId == "some_job")
+    }
+
+    @Test("미로그인이면 전송하지 않고 notSignedIn으로 실패한다")
+    func submit_whenNotSignedIn_notSubmits() async {
+        // given
+        let (service, repository) = self.makeService(hasAuth: false)
+
+        // when
+        let reason = await self.failReason { try await service.submit("내일 3시 회의") }
+
+        // then
+        #expect(reason == .notSignedIn)
+        #expect(repository.didProcessCommandText == nil)
+    }
+}
+
+// MARK: - 미확인 요청 가드
+
+extension IntentCommandSubmitServiceTests {
+
+    // ProcessingAICommand는 단일 행이다. 통과시켜 제출하면 앱이 추적 중인 job의 기록이
+    // 덮여 앞선 결과가 유실된다.
+    @Test("앞선 요청이 남아있으면 서버로 보내지 않는다")
+    func submit_whenPreviousRequestPending_notSubmits() async {
+        // given
+        let repository = self.makeRepository(
+            pending: ProcessingAICommand(jobId: "previous_job", isConfirmJob: false)
+        )
+        let (service, _) = self.makeService(stubRepository: repository)
+
+        // when
+        let reason = await self.failReason { try await service.submit("내일 3시 회의") }
+
+        // then
+        #expect(reason == .previousRequestPending)
+        #expect(repository.didProcessCommandText == nil)
+    }
+
+    // fail-closed — 유무를 확인 못 했는데 통과시키면 위와 같은 유실이 난다.
+    @Test("앞선 요청 유무 조회가 실패하면 서버로 보내지 않는다")
+    func submit_whenLoadPendingFails_notSubmits() async {
+        // given
+        let repository = self.makeRepository(shouldFailLoadPending: true)
+        let (service, _) = self.makeService(stubRepository: repository)
+
+        // when
+        let reason = await self.failReason { try await service.submit("내일 3시 회의") }
+
+        // then
+        #expect(reason == .previousRequestPending)
+        #expect(repository.didProcessCommandText == nil)
+    }
+}
+
+// MARK: - 전송 실패 분류
+
+extension IntentCommandSubmitServiceTests {
+
+    @Test("한도 초과 서버 에러는 limitExceeded로 분류한다")
+    func submit_whenDailyLimitExceeded_returnsLimitExceeded() async {
+        // given
+        let error = ServerErrorModel()
+            |> \.code .~ ServerErrorModel.ErrorCode.dailyLimitExceeded
+        let (service, _) = self.makeService(
+            stubRepository: self.makeRepository(processFailWith: error)
+        )
+
+        // when
+        let reason = await self.failReason { try await service.submit("내일 3시 회의") }
+
+        // then
+        #expect(reason == .limitExceeded)
+    }
+
+    @Test("그 외 에러는 unknown으로 분류한다")
+    func submit_whenOtherError_returnsUnknown() async {
+        // given
+        let (service, _) = self.makeService(
+            stubRepository: self.makeRepository(processFailWith: RuntimeError("network down"))
+        )
+
+        // when
+        let reason = await self.failReason { try await service.submit("내일 3시 회의") }
+
+        // then
+        #expect(reason == .unknown)
+    }
+
+    @Test(
+        "로컬 Auth는 남아있지만 서버 세션이 죽은 에러는 notSignedIn으로 분류한다",
+        arguments: [ServerErrorModel.ErrorCode.unauthorized, .invalidAccessKey]
+    )
+    func submit_whenServerSessionDead_returnsNotSignedIn(_ code: ServerErrorModel.ErrorCode) async {
+        // given
+        let error = ServerErrorModel() |> \.code .~ code
+        let (service, _) = self.makeService(
+            stubRepository: self.makeRepository(processFailWith: error)
+        )
+
+        // when
+        let reason = await self.failReason { try await service.submit("내일 3시 회의") }
+
+        // then
+        #expect(reason == .notSignedIn)
+    }
+
+    // job은 서버에 만들어졌지만 로컬 기록에 실패한 경우 — unknown으로 떨어지면 유저가
+    // "다시 시도"를 믿고 재전송해 중복 job이 생긴다. 별도 케이스로 분류돼야 한다.
+    @Test("job은 만들어졌지만 기록에 실패하면 processingCommandRecordFailed로 분류한다")
+    func submit_whenRecordFails_returnsRecordFailed() async {
+        // given
+        let (service, _) = self.makeService(
+            stubRepository: self.makeRepository(shouldFailUpdatePending: true)
+        )
+
+        // when
+        let reason = await self.failReason { try await service.submit("내일 3시 회의") }
+
+        // then
+        #expect(reason == .processingCommandRecordFailed)
+    }
+}
+
+
+private final class StubAuthStore: AuthStore, @unchecked Sendable {
+
+    private var auth: Auth?
+    init(auth: Auth?) {
+        self.auth = auth
+    }
+
+    func loadCurrentAuth() -> Auth? {
+        return self.auth
+    }
+
+    func saveAuth(_ auth: Auth) {
+        self.auth = auth
+    }
+
+    func removeAuth() {
+        self.auth = nil
+    }
+}
+
+private final class StubAICommandRepository: AICommandRepository, @unchecked Sendable {
+
+    var stubProcessError: (any Error)?
+    var stubPendingCommand: ProcessingAICommand?
+    var shouldFailLoadPending: Bool = false
+    var shouldFailUpdatePending: Bool = false
+
+    var didProcessCommandText: String?
+    var didProcessTimeZone: String?
+    var didUpdatePendingJobId: String?
+
+    func processCommand(_ commandText: String, timeZone: String) async throws -> String {
+        if let stubProcessError { throw stubProcessError }
+        self.didProcessCommandText = commandText
+        self.didProcessTimeZone = timeZone
+        return "some_job"
+    }
+
+    func loadProcessingAICommand() async throws -> ProcessingAICommand? {
+        guard !self.shouldFailLoadPending
+        else { throw RuntimeError("failed to load processing command") }
+        return self.stubPendingCommand
+    }
+
+    func updateProcessingAICommand(_ cmd: ProcessingAICommand) async throws {
+        guard !self.shouldFailUpdatePending
+        else { throw RuntimeError("failed to update processing command") }
+        self.didUpdatePendingJobId = cmd.jobId
+    }
+
+    func clearProcessingAICommand() async throws { }
+
+    func processConfirmCommand(_ action: AIConfirmCommandAction, timeZone: String) async throws -> String {
+        throw RuntimeError("not imple")
+    }
+
+    func rejectConfirmCommand(_ action: AIConfirmCommandAction) async throws { }
+
+    func cancelCommand(_ jobId: String) async throws { }
+
+    func loadJob(_ jobId: String) async throws -> AIJob {
+        throw RuntimeError("not imple")
+    }
+
+    func loadUsage() async throws -> AIAgentUsageLoadResult {
+        throw RuntimeError("not imple")
+    }
+}

--- a/TodoCalendarApp/TodoCalendarAppTests/ApplicationRootViewModelImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/ApplicationRootViewModelImpleTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2026 com.sudo.park. All rights reserved.
 //
 
+import UIKit
 import Testing
 import Combine
 import Domain
@@ -19,6 +20,7 @@ import UnitTestHelpKit
 final class ApplicationRootViewModelImpleTests {
 
     private let spyAIJobRefreshUsecase = SpyAIJobRefreshUsecase()
+    private let spyAppUpdateCheckUsecase = SpyAppUpdateCheckUsecase()
 
     private func makeViewModel() -> ApplicationRootViewModelImple {
         return ApplicationRootViewModelImple(
@@ -30,7 +32,7 @@ final class ApplicationRootViewModelImpleTests {
             userNotificationUsecase: StubUserNotificationUsecase(),
             backgroundEventSyncUsecase: StubBackgroundEventSyncUsecase(),
             aiJobRefreshUsecase: self.spyAIJobRefreshUsecase,
-            appUpdateCheckUsecase: StubAppUpdateCheckUsecase()
+            appUpdateCheckUsecase: self.spyAppUpdateCheckUsecase
         )
     }
 }
@@ -70,6 +72,65 @@ extension ApplicationRootViewModelImpleTests {
 }
 
 
+// MARK: - 앱 활성 상태 전환
+
+extension ApplicationRootViewModelImpleTests {
+
+    @Test("앱이 활성 상태가 되면 처리중인 AI job을 이어받는다")
+    func viewModel_whenDidBecomeActive_refreshProcessingJob() async {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        NotificationCenter.default.post(
+            name: UIApplication.didBecomeActiveNotification, object: nil
+        )
+        try? await Task.sleep(for: .milliseconds(100))
+
+        // then
+        #expect(self.spyAIJobRefreshUsecase.didRefreshProcessingJobTimes == 1)
+        withExtendedLifetime(viewModel) { }
+    }
+
+    // didBecomeActive는 제어센터·알림센터 여닫기, 권한 다이얼로그 dismiss 등에서도 매번 온다.
+    // 그때마다 재조회하면 job 진행 중 구간에 불필요한 서버 조회가 반복된다.
+    @Test("짧은 간격의 연속 활성 전환은 한 번만 이어받는다")
+    func viewModel_whenDidBecomeActiveRepeatedly_refreshOnlyOnce() async {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        (0..<3).forEach { _ in
+            NotificationCenter.default.post(
+                name: UIApplication.didBecomeActiveNotification, object: nil
+            )
+        }
+        try? await Task.sleep(for: .milliseconds(100))
+
+        // then
+        #expect(self.spyAIJobRefreshUsecase.didRefreshProcessingJobTimes == 1)
+        withExtendedLifetime(viewModel) { }
+    }
+
+    @Test("포그라운드 복귀는 업데이트 체크만 하고 AI job은 이어받지 않는다")
+    func viewModel_whenWillEnterForeground_onlyCheckUpdate() async {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        NotificationCenter.default.post(
+            name: UIApplication.willEnterForegroundNotification, object: nil
+        )
+        try? await Task.sleep(for: .milliseconds(100))
+
+        // then
+        #expect(self.spyAppUpdateCheckUsecase.didCheckUpdateIsNeed == true)
+        #expect(self.spyAIJobRefreshUsecase.didRefreshProcessingJobTimes == 0)
+        withExtendedLifetime(viewModel) { }
+    }
+}
+
+
 // MARK: - doubles
 
 private final class SpyAIJobRefreshUsecase: AIJobRefreshUsecase, @unchecked Sendable {
@@ -79,9 +140,9 @@ private final class SpyAIJobRefreshUsecase: AIJobRefreshUsecase, @unchecked Send
         self.didHandleJobStatusChangedWith = jobId
     }
 
-    var didRefreshProcessingJob: Bool?
+    var didRefreshProcessingJobTimes: Int = 0
     func refreshProcessingJobIfNeeded() {
-        self.didRefreshProcessingJob = true
+        self.didRefreshProcessingJobTimes += 1
     }
 
     var didChangeFactory: Bool?
@@ -127,9 +188,12 @@ private final class StubBackgroundEventSyncUsecase: BackgroundEventSyncUsecase, 
     func registerTask() { }
 }
 
-private final class StubAppUpdateCheckUsecase: AppUpdateCheckUsecase, @unchecked Sendable {
+private final class SpyAppUpdateCheckUsecase: AppUpdateCheckUsecase, @unchecked Sendable {
 
-    func checkUpdateIsNeed() { }
+    var didCheckUpdateIsNeed: Bool?
+    func checkUpdateIsNeed() {
+        self.didCheckUpdateIsNeed = true
+    }
 
     var updateRequirement: AnyPublisher<AppUpdateRequirement, Never> {
         return Empty().eraseToAnyPublisher()

--- a/TodoCalendarApp/TodoCalendarAppTests/NeverRemoveAuthStorageTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/NeverRemoveAuthStorageTests.swift
@@ -1,0 +1,139 @@
+//
+//  NeverRemoveAuthStorageTests.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 8/5/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Testing
+import Domain
+import Repository
+
+@testable import TodoCalendarApp
+
+
+final class NeverRemoveAuthStorageTests {
+
+    private func makeSUT(
+        seedAuth: Auth? = Auth(uid: "uid", accessToken: "old_token", refreshToken: "old_refresh")
+    ) -> (NeverRemoveAuthStorage, AuthStoreImple) {
+        let authStore = AuthStoreImple(
+            keyChainStorage: FakeKeyChainStore(),
+            environmentStorage: FakeEnvironmentStorage()
+        )
+        if let seedAuth {
+            authStore.saveAuth(seedAuth)
+        }
+        let sut = NeverRemoveAuthStorage(storage: authStore)
+        return (sut, authStore)
+    }
+}
+
+// MARK: - 세션 보존 (삭제 무력화)
+
+extension NeverRemoveAuthStorageTests {
+
+    @Test("removeCredential을 호출해도 저장된 로그인 세션이 지워지지 않는다")
+    func removeCredential_keepsSessionAlive() {
+        // given
+        let (sut, authStore) = self.makeSUT()
+
+        // when
+        sut.removeCredential()
+
+        // then
+        #expect(authStore.loadCurrentAuth()?.uid == "uid")
+    }
+
+    @Test("removeAuth를 호출해도 저장된 로그인 세션이 지워지지 않는다")
+    func removeAuth_keepsSessionAlive() {
+        // given
+        let (sut, authStore) = self.makeSUT()
+
+        // when
+        sut.removeAuth()
+
+        // then
+        #expect(authStore.loadCurrentAuth()?.uid == "uid")
+    }
+}
+
+// MARK: - 나머지 동작은 authStore에 위임
+
+extension NeverRemoveAuthStorageTests {
+
+    @Test("loadCredential은 authStore에 저장된 인증 정보를 그대로 반환한다")
+    func loadCredential_returnsUnderlyingCredential() {
+        // given
+        let (sut, _) = self.makeSUT()
+
+        // when
+        let credential = sut.loadCredential()
+
+        // then
+        #expect(credential?.accessToken == "old_token")
+    }
+
+    @Test("updateCredential은 authStore에 반영된다")
+    func updateCredential_updatesUnderlyingStore() {
+        // given
+        let (sut, authStore) = self.makeSUT()
+
+        // when
+        var newCredential = APICredential(accessToken: "new_token")
+        newCredential.refreshToken = "new_refresh"
+        sut.updateCredential(newCredential)
+
+        // then
+        #expect(authStore.loadCurrentAuth()?.accessToken == "new_token")
+    }
+}
+
+
+private final class FakeKeyChainStore: KeyChainStorage, @unchecked Sendable {
+
+    private var dataMap: [String: Data] = [:]
+
+    func setupSharedGroup(_ identifier: String) { }
+
+    func load<T>(_ key: String) -> T? where T: Decodable {
+        return self.dataMap[key]
+            .flatMap { try? JSONDecoder().decode(T.self, from: $0) }
+    }
+
+    func update<T>(_ key: String, _ value: T) where T: Encodable {
+        guard let data = try? JSONEncoder().encode(value)
+        else { return }
+        self.dataMap[key] = data
+    }
+
+    func remove(_ key: String) {
+        self.dataMap[key] = nil
+    }
+}
+
+private final class FakeEnvironmentStorage: EnvironmentStorage, @unchecked Sendable {
+
+    private var storage: [String: String] = [:]
+
+    func load<T>(_ key: String) -> T? where T: Decodable {
+        return self.storage[key]
+            .flatMap { $0.data(using: .utf8) }
+            .flatMap { try? JSONDecoder().decode(T.self, from: $0) }
+    }
+
+    func update<T>(_ key: String, _ value: T) where T: Encodable {
+        guard let data = try? JSONEncoder().encode(value),
+              let dataText = String(data: data, encoding: .utf8)
+        else { return }
+        self.storage[key] = dataText
+    }
+
+    func remove(_ key: String) {
+        self.storage.removeValue(forKey: key)
+    }
+
+    func synchronize() { }
+}

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -324,6 +324,7 @@ extension Project {
                 "AppExtensions/Base/**",
                 "AppExtensions/\(extensionName)/Sources/**",
                 "Sources/AppEnvironment.swift",
+                "Sources/NeverRemoveAuthStorage.swift",
                 .glob("Intents/TodoCalendarWidgetIntents.intentdefinition", codeGen: .public)
             ],
             resources: [
@@ -356,6 +357,7 @@ extension Project {
                 "AppExtensions/Base/**",
                 "AppExtensions/\(extensionName)/Sources/**",
                 "Sources/AppEnvironment.swift",
+                "Sources/NeverRemoveAuthStorage.swift",
                 .glob("Intents/TodoCalendarWidgetIntents.intentdefinition", codeGen: .public),
                 "AppExtensions/\(extensionName)/Tests/**"
             ],

--- a/scripts/check-localization-parity.py
+++ b/scripts/check-localization-parity.py
@@ -18,6 +18,8 @@ PAIRS = [
     "Supports/Extensions/Resources/{}.lproj/Localizable.strings",
     "TodoCalendarApp/AppExtensions/Widget/Resources/{}.lproj/Localizable.strings",
     "TodoCalendarApp/Resources/Localize/{}.lproj/InfoPlist.strings",
+    "TodoCalendarApp/Resources/Localize/{}.lproj/Localizable.strings",
+    "TodoCalendarApp/Resources/Localize/{}.lproj/AppShortcuts.strings",
 ]
 ENTRY = re.compile(r'"((?:[^"\\]|\\.)+)"\s*=\s*"((?:[^"\\]|\\.)*)"\s*;')
 SPEC = re.compile(r'%(?:\d+\$)?[-#0+ ]*\d*(?:\.\d+)?(?:hh?|ll?|q|z|t|L)?[@dDuUxXoOfeEgGcsSaAF]')


### PR DESCRIPTION
앱을 열지 않고 **Siri 발화만으로 AI 커맨드를 서버에 등록**한다. 결과는 기존 푸시·복원 경로가 처리한다.

closes #631

## 문제

AI 커맨드를 보내려면 앱을 열고 시트를 띄워야 했다. #630이 공유 확장을 열었고, 이번엔 Siri다.

여기서 두 가지가 걸렸다.

**1. 인텐트는 앱의 조립을 쓸 수 없다.** `UsecaseFactory`를 세우는 `prepareInitialScene()`이 `SceneDelegate`에서만 호출되는데, `openAppWhenRun = false`는 scene 없이 기동된다. 앱 라이프사이클과 무관한 전용 조립이 필요했다.

**2. Siri는 앱을 백그라운드로 내리지 않고 job을 만드는 첫 진입점이다.** 앱을 띄워둔 채 발화하면 포그라운드 복귀도 콜드 스타트도 일어나지 않아, 그 job을 앱에 알리는 기존 트리거가 하나도 돌지 않는다. 캘린더엔 이벤트가 생겼는데 화면은 계속 idle이다.

## 접근

**전송 게이트를 인텐트 진입점에 둔다.** `ProcessingAICommand`가 단일 행이라, 유저가 아직 확인하지 않은 요청이 있는데 새로 보내면 앱이 이어받을 근거가 덮여 앞선 결과가 유실된다. 제출 전에 그 유무를 확인하고, 확인 자체가 실패해도 보내지 않는다(fail-closed).

**실패를 유저가 행동할 수 있는 결과로 분류한다.** 미로그인 / 한도초과 / 앞선 요청 남음 / 기록 실패 / 일반 실패. 401은 미로그인으로 본다 — 로컬 인증만 남고 서버 세션이 죽은 상태라 "다시 시도"로 안내하면 무한 재시도가 된다. 기록 실패도 전송 실패와 구분한다 — job은 이미 만들어져서 재시도를 유도하면 중복 job에 크레딧이 두 번 나간다.

**앱 밖에서 만들어진 job의 푸시를 앱이 이어받게 한다.** `handleJobStatusChanged`의 guard 실패 경로를 "버림"에서 "복원 시도"로 바꿨다. 복원 근거는 앱 메모리가 아니라 저장소의 `ProcessingAICommand`라, 여기서 판단할 것은 화면을 덮어도 되는지 하나뿐이다.

**이어받을 계기 자체도 만든다.** `refreshProcessingJobIfNeeded`를 `willEnterForeground`에서 `didBecomeActive`로 옮겼다. 앱을 띄워둔 채 발화하면 앱은 inactive까지만 가고 포그라운드 복귀 이벤트가 오지 않아, 푸시가 도착할 때까지 화면이 비어 있었다. 포그라운드 복귀 뒤엔 항상 `didBecomeActive`가 뒤따르므로 기존 경로도 중복 없이 그대로 덮인다.

## 검증

`Domain` `TodoCalendarApp` `AIAgentScene` 포함 12개 스킴 그린. `check-localization-parity.py` 통과. AppIntents 메타데이터는 `extract.actionsdata`를 직접 열어 인텐트·발화·`${applicationName}` 토큰을 확인했다.

**사람 확인이 남았다** — 실기기 Siri 발화 동작, 시뮬레이터 언어별 문구 노출. 절차는 아래.

## 테스트 방법

**실기기가 필요하다.** 시뮬레이터는 Siri 발화를 받지 못한다 — 언어별 문구 노출만 시뮬레이터로 확인한다.

### 1. 기본 동선 — 앱이 꺼진 상태

1. 앱을 완전히 종료(앱스위처에서 밀어 내리기)
2. Siri 호출 → **"To-do Calendar에 일정 추가"**
3. Siri가 **"무엇을 추가할까요?"** 로 되묻는지 확인
4. **"내일 오후 두시에 팀 미팅"** 발화
5. **"알겠어요. 완료되면 알려드릴게요"** 응답 확인 — 이때 **앱이 열리지 않아야 한다** (`openAppWhenRun = false`)
6. 완료 푸시 도착 → 탭 → 앱에서 결과 확인
7. 캘린더에 이벤트가 생성됐는지 확인

### 2. 앱을 띄워둔 채 발화 — `didBecomeActive` 경로

앱이 포그라운드에 있으면 background로 내려가지 않아 `willEnterForeground`가 오지 않는다. 이 경로가 이번에 새로 배선된 부분이다.

1. 앱을 포그라운드에 띄운 상태로 Siri 호출 → 위 2~5 반복
2. Siri가 닫히고 앱으로 돌아왔을 때, **푸시를 기다리지 않고** 화면이 처리중 상태로 전환되는지 확인
   - 전환되지 않고 idle로 남아 있으면 `didBecomeActive` 배선이 동작하지 않은 것

### 3. 응답 문구 분기

| 결과 | 재현 방법 |
|---|---|
| `submitted` | 위 기본 동선 |
| `notSignedIn` | 로그아웃 상태에서 발화 |
| `previousRequestPending` | 앱에서 AI 커맨드를 보낸 뒤 **결과를 확인하지 않은 채** 시트를 닫고, 이어서 Siri로 발화 |
| `limitExceeded` | 일일 한도를 소진한 계정으로 발화 |
| `failed` | 비행기 모드에서 발화 |
| `sentButUntracked` | 자연 재현 불가 — 서버 job 생성은 성공하고 로컬 기록만 실패해야 한다. 유닛 테스트로 커버 |

`previousRequestPending`은 조회 자체가 실패했을 때도 나온다(fail-closed) — 이쪽은 자연 재현이 어려워 유닛 테스트로 본다.

### 4. 언어별 문구

시뮬레이터 언어를 바꾼 뒤 **Shortcuts 앱 → To-do Calendar** 액션 목록에서 인텐트 라벨과 발화 문구가 해당 언어로 노출되는지 확인한다. 31개 전수는 과하니 ko / ja / en 위주로 보고, 나머지는 `check-localization-parity.py`와 `extract.actionsdata` 확인으로 갈음한다.

## 의도적으로 뺀 것

**발화에 명령 본문을 인라인하는 방식**(`"To-do Calendar에 내일 두시 회의 잡아줘"`를 한 번에)은 불가능해서 뺐다. App Shortcuts phrase의 파라미터는 `AppEnum`·`AppEntity`만 허용돼 자유 텍스트 `String`을 못 넣고, `AppEntity`로 감싸도 Siri 온디바이스 모델이 슬롯에 긴 자유 문장을 담지 못한다. 되묻기 턴(`requestValueDialog`)이 Siri가 파싱 없이 raw string을 넘겨주는 유일한 경로다. 발화를 짧게 만드는 후속은 #762로 분리했다.

## 관련

- #630 공유 확장 (develop 머지 완료)
- #762 Siri 발화 짧게 — Shortcuts 커스텀 문구 지정 안내 (후속)
- #629 앱 내 AI 플로우 / #708 한도 초과 실패 사유 / #722 AppIntents 메타데이터·로컬라이즈 함정
