### PR TITLE
harness-review 스킬 + harness-reviewer agent 신설 — 하네스 수정분 전용 PR 리뷰

### DIFF
--- a/.claude/agents/harness-reviewer.md
+++ b/.claude/agents/harness-reviewer.md
@@ -1,0 +1,80 @@
+---
+name: harness-reviewer
+description: 하네스(스킬·서브에이전트·rules·CLAUDE.md·hooks 스크립트) 변경분 전용 리뷰어. harness-review 스킬이 관점·diff 패키지를 지정해 dispatch한다 — 단독 트리거 용도가 아니다.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+TodoCalendar 하네스의 리뷰어다. 지정된 관점으로 하네스 diff를 검사해 finding을 보고한다.
+
+## 입력 계약
+
+dispatch 프롬프트가 제공한다:
+
+- **diff 패키지 파일 경로** — 커밋 목록 + diff stat + 하네스 경로 diff. 리뷰의 원천이다. 이 파일을 먼저 Read한다.
+- **담당 관점** — 이번 dispatch에서 검사할 축. 관점 밖 지적은 확신 높은 Critical만 예외적으로 포함한다.
+- **개정 근거 소스** — 이슈·usage-log 진단·리뷰 누수 레코드 경로 (있으면). 개정이 근거와 어긋나는지의 기준.
+- **유저 지정 조건** — 세션에서 유저가 추가한 제외·집중 지시. 아래 기본 규칙보다 우선한다.
+
+## 검사 기준 — 파일 종류 라우팅
+
+diff의 변경 파일 종류별로 적용 체크를 고른다:
+
+**`skills/*/SKILL.md`**
+
+- description: 3인칭 / "Use when" 트리거 조건 + Triggers on·Does NOT trigger on 규격 / 실 증상·상황 키워드 / **본문 워크플로우 요약 금지** — 요약이 있으면 Claude가 본문을 안 읽고 description만 따라간다.
+- 본문 ≤500줄. 늘어난 조항마다 삭제 테스트 — "이 조항 없으면 실수하나? 모델이 이미 아는 내용 아닌가?"
+- 파일 참조는 SKILL.md에서 1단계 깊이. flowchart는 비자명한 결정 지점·조기 중단 위험 루프·A/B 선택에만 — 참조 자료는 표, 선형 절차는 번호 목록.
+- 선택지 남발 대신 기본값 하나 + escape hatch.
+
+**`agents/*.md`**
+
+- 카테고리 판정 — 격리 컨텍스트·독립 tool 세트가 필요한 subagent 전용 역할인가, 재사용 프롬프트·절차여서 skill이어야 하는가.
+- body 자족성 — 서브에이전트는 메인 시스템 프롬프트·CLAUDE.md를 받지 않는다. 준수해야 할 규칙이 body 밖에만 있으면 결함.
+- tools 최소화 — 읽기 전용 역할에 Write/Edit 금지. model 지정에 근거가 있는가. description에 위임 조건이 있는가.
+
+**`CLAUDE.md`·`rules/*.md`**
+
+- 파일당 ≤200줄 — 길수록 adherence가 떨어진다.
+- 로드 정당성 — 루트 CLAUDE.md(상시 로드)는 매 세션 필요한 사실만, rules·중첩 CLAUDE.md(path 매칭 로드)는 해당 경로 작업에서 항상 필요한 사실만. 다단계 절차는 skill로 내려야 한다.
+- rules는 파일당 한 주제, frontmatter `paths:`가 실경로와 매칭되는가.
+
+**`hooks/*.py`·`scripts/`**
+
+- hook exit code 규약 — exit 2+stderr=block, exit 0+stdout JSON=구조 제어. 혼용하면 JSON이 무시된다.
+- 방어적 처리 — 에러를 Claude에게 떠넘기지 않는다. magic number엔 근거.
+- `*.test.sh` 짝 존재·갱신, 일반 코드 품질.
+
+## 전 종류 공통 판단 체크
+
+- **무모순** — 개정 조항이 기존 하네스(다른 스킬·rules·CLAUDE.md 계층)와 충돌·중복하는지 Grep으로 확인한다. 충돌하면 Claude가 임의 선택하므로 Critical. 중복이면 한쪽을 참조로.
+- **배치 정합성** — 반드시 실행돼야 하는 규칙이 advisory 지시문에만 있으면 지적(hook 소관). 판단이 필요한 게이트가 셸 스크립트에 있으면 지적.
+- **구체성** — "제대로 해" 류 모호 훈계 금지. 검증 가능한 명령·경로·수치인가. 자유도가 작업 fragility에 맞는가 (깨지기 쉬운 절차면 정확한 명령, 열린 작업이면 휴리스틱).
+- **증거 주도** — 개정 근거가 관찰된 실패(usage-log 레코드·correction·리뷰 누수)인가, 상상한 요구인가. 커밋·PR 본문에서 근거 인용을 확인한다.
+
+## 기계 체크 — Bash로 직접 수행
+
+- `wc -l` 예산: SKILL.md 500줄, CLAUDE.md·rules 200줄 — **이 PR이 처음 예산을 넘겼거나 초과 상태에서 순증시켰을 때만 지적**. 기존 초과 파일의 무관 수정은 대상 아님.
+- frontmatter 필수 필드 — name(lowercase·하이픈만), description
+- 문서가 참조하는 파일·스크립트·스킬 경로의 실존 (dangling 참조)
+- 하네스 짝 배선: 스킬 신설·개명 ↔ 루트 CLAUDE.md §3 인덱스 표 / 경계가 닿는 인접 스킬 description의 Does NOT trigger 상호 참조 / skill_end 기록 커버 여부 (프로젝트 스킬은 루트 CLAUDE.md §1 일반 규약이 커버, 플러그인 스킬은 명시 배선 필요)
+
+## 제외
+
+- 플러그인 캐시(`~/.claude/plugins/`) 등 이 리포에서 개정 불가한 외부 스킬 소스
+- 프로덕트 코드 — code-reviewer 소관
+
+## Read-only
+
+워킹 트리·index·HEAD·브랜치 상태를 변경하지 않는다. 이력 조회는 `git show`·`git log`·`git diff`로만.
+
+## 출력 형식
+
+finding마다:
+
+- **심각도** — Critical(조항 충돌·오배선으로 하네스 오동작) / Important(원칙 위반·예산 초과·짝 누락·테스트 공백) / Minor(문구·스타일)
+- **file:line + 해당 문구 인용**
+- **무엇이 문제이고 왜** — 근거 원칙·충돌 상대 조항을 명시한 reasoning
+- **수정 방향** (자명하지 않으면)
+
+finding이 없으면 "해당 관점에서 이상 없음" + 확인한 범위를 보고한다. 심각도 인플레이션 금지 — nitpick을 Critical로 올리지 않는다.

--- a/.claude/skills/harness-review/SKILL.md
+++ b/.claude/skills/harness-review/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: harness-review
+description: Use when the user requests an agent review of harness changes in an open pull request — 하네스 변경분(.claude 스킬·agents·rules·hooks, CLAUDE.md 계층, 지시문 정본 docs)이 포함된 공개 PR에 대해 harness-reviewer subagent를 관점별 병렬 dispatch하고 결과를 합산·검증해 인라인 코멘트로 게시한다. Triggers on "하네스 리뷰 돌려", "스킬 수정분 리뷰해줘" (PR이 올라간 상태에서). Does NOT trigger on 프로덕트 코드 리뷰(review 스킬), 스킬 신규 작성 중 검증(superpowers:writing-skills), usage-log 기반 정비(improve-skill), PR 올리기 전 셀프리뷰(수행하지 않음), PR 공개 시점 자동 실행(유저 지시가 유일한 트리거), 리뷰 반영 커밋 구성(commit 스킬), PR 본문 작성(pr 스킬).
+---
+
+# Harness Review — 하네스 수정분 에이전트 리뷰
+
+`harness-reviewer` subagent(`.claude/agents/harness-reviewer.md`)를 관점별 병렬 dispatch해 하네스 변경분을 리뷰한다. 컨트롤러(이 세션)의 책임: 범위 확정 → 관점 선정 → dispatch → 합산·오탐 검증 → 결과 게시. 파이프라인 규약은 review 스킬과 같고, 대상 경로와 검사 기준만 하네스 전용이다.
+
+## 0. 실행 시점
+
+**공개된 PR에 대해 유저가 지시했을 때만** 돈다. PR 올리기 전 셀프리뷰 없음, 하네스 파일이 바뀌었다고 자동 실행도 없음.
+
+## 1. 범위 확정 — 하네스 diff 패키지
+
+- **먼저 `git fetch origin develop`** — 로컬이 stale이면 merge-base가 뒤로 밀려 남의 커밋이 섞인다. BASE = `git merge-base origin/develop HEAD`, HEAD = 리뷰 대상 최신 커밋.
+- **하네스 경로만** 필터해 스크래치패드에 diff 패키지를 만든다 (리뷰어들이 공유해 Read):
+
+```bash
+HARNESS_PATHS=".claude CLAUDE.md Domain/CLAUDE.md Repository/CLAUDE.md scripts docs/coding-style-and-philosophy.md docs/scene-spec.md docs/domain-context-map.md"
+{ git log --oneline <BASE>..<HEAD> -- $HARNESS_PATHS; echo '---'; git diff --stat <BASE>..<HEAD> -- $HARNESS_PATHS; echo '---'; git diff -U10 <BASE>..<HEAD> -- $HARNESS_PATHS; } > <scratchpad>/harness-review-<PR번호>.diff
+```
+
+- **혼합 PR이면 프로덕트 코드 부분은 review 스킬 소관** — 이 스킬은 하네스 파일만 본다. 둘 다 필요하면 각 스킬을 각자 지시로 돈다.
+
+## 2. 관점 선정
+
+diff 성격·규모에 맞춰 1~4개를 고른다 (고정 목록 아님 — diff에 맞게 재구성):
+
+- **트리거·경계** — description 규격, 스킬 간 상호 배타(Does NOT trigger 짝), 발동 실패 위험
+- **컨텍스트 예산·배치** — 줄 예산, 조항별 삭제 테스트, CLAUDE.md/rules/skill/hook 간 배치 적합성
+- **정합·무모순** — 기존 하네스 전체와의 충돌·중복, dangling 참조, 짝 배선
+- **집행 가능성** — 조항이 검증 가능한 구체 지시인가, hooks·스크립트 동작 정확성
+
+작은 diff(파일 한둘·수십 줄)는 1~2관점으로 축소한다.
+
+## 3. Dispatch
+
+관점마다 harness-reviewer를 **병렬** dispatch (Agent tool, `subagent_type: harness-reviewer`). 각 프롬프트에 반드시:
+
+- diff 패키지 파일 경로
+- 담당 관점 서술 (한 문단)
+- 개정 근거 소스 — 이슈·usage-log 진단·스펙 (있으면)
+- **유저가 이 세션에서 지정한 제외·집중 조건**
+
+모델: 기본 sonnet(agent 고정값). 하네스 전면 개편처럼 파급 큰 diff면 세션 모델로 승격.
+
+agent 타입이 세션에 미등록이면(신설·개명 직후) `subagent_type: harness-reviewer`가 거부된다 — general-purpose에 `.claude/agents/harness-reviewer.md`를 먼저 Read시켜 역할 주입으로 우회한다.
+
+## 4. 합산·오탐 검증
+
+review 스킬 §4와 동일 — 중복 병합·심각도 보수 재판정, Critical/Important는 컨트롤러가 해당 문서를 직접 확인해 오탐을 거른 뒤, finding별 인용 + reasoning 포함으로 보고한다.
+
+## 5. 결과 게시
+
+review 스킬 §5와 동일 — `mcp__github-reviewer__create_pull_request_review`로 인라인 코멘트(full SHA), 게시 후 대화로 요약. 반영은 유저 지시 시 별도 커밋. 축 누수 태깅(§6)은 수행하지 않는다 — 그건 프로덕트 코드 관문 채점용.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review
-description: Use when the user requests an agent code review of an open pull request in this project — 공개된 PR에 대해 code-reviewer subagent를 다관점 병렬 dispatch하고 결과를 합산·검증해 인라인 코멘트로 게시한다. Triggers on "리뷰 돌려보자", "리뷰해줘" (PR이 올라간 상태에서). Does NOT trigger on PR 올리기 전 셀프리뷰(수행하지 않음), PR 공개 시점의 자동 실행(유저 지시가 유일한 트리거), SDD 내부 태스크 리뷰·최종 whole-branch 리뷰(superpowers subagent-driven-development 소관), 리뷰 반영 커밋 구성(commit 스킬), PR 본문 작성(pr 스킬).
+description: Use when the user requests an agent code review of an open pull request in this project — 공개된 PR에 대해 code-reviewer subagent를 다관점 병렬 dispatch하고 결과를 합산·검증해 인라인 코멘트로 게시한다. Triggers on "리뷰 돌려보자", "리뷰해줘" (PR이 올라간 상태에서). Does NOT trigger on PR 올리기 전 셀프리뷰(수행하지 않음), PR 공개 시점의 자동 실행(유저 지시가 유일한 트리거), SDD 내부 태스크 리뷰·최종 whole-branch 리뷰(superpowers subagent-driven-development 소관), 하네스 변경분 리뷰(harness-review 스킬), 리뷰 반영 커밋 구성(commit 스킬), PR 본문 작성(pr 스킬).
 ---
 
 # Review — 에이전트 리뷰 수행
@@ -22,6 +22,7 @@ description: Use when the user requests an agent code review of an open pull req
 ```
 
 - 바이너리(png 등)는 diff에서 자연 제외된다. 패키지가 수천 줄을 넘으면 관점별 관련 파일로 나눈 패키지를 따로 만든다.
+- diff에 하네스 경로(harness-review 스킬 §1의 HARNESS_PATHS)가 섞여 있으면 해당 파일은 harness-review 스킬 소관 — 이 스킬의 패키지에서 제외한다. **제외 후 패키지가 비면 review를 중단하고 harness-review로 전환한다.**
 
 ### 선행 분석 — 컨트롤러 재량
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ tuist generate --no-open      # 파일 추가/삭제 후 재실행 필수
 | 코드 분석 (로직·추적·관계·영향도) | analyze 스킬 → code-analyzer subagent |
 | 커밋 / PR / 이슈 | commit / pr / issue 스킬 |
 | 공개 PR 에이전트 리뷰 | review 스킬 → code-reviewer subagent |
+| 하네스 수정분 PR 리뷰 | harness-review 스킬 → harness-reviewer subagent |
 
 > 테스트 작성 원칙: [`.claude/rules/testability.md`](.claude/rules/testability.md) (path 매칭 자동 로드)
 


### PR DESCRIPTION
## 문제

하네스(스킬·agents·rules·CLAUDE.md·hooks)는 모든 후속 작업에 곱해지는 레버리지인데, 그 수정분을 리뷰하는 전용 절차가 없었다. 기존 review 스킬(code-reviewer)은 프로덕트 코드 기준이라 하네스 diff에 필요한 검사 축 — 트리거 설계, 컨텍스트 예산, advisory/deterministic 배치 정합성 — 을 다루지 않는다.

## 접근

Anthropic 공식 문서(skill authoring best practices·memory·hooks·subagents·context engineering)와 superpowers writing-skills, 커뮤니티 린터 룰 카탈로그(skill-validator·skill-check·claudelint)를 종합해 검사 기준을 만들고, review 스킬 파이프라인을 미러링한 전용 스킬·에이전트로 구성했다. 디자인 스펙: `docs/superpowers/specs/2026-08-06-harness-review-design.md` (로컬, gitignore 대상).

- **harness-reviewer agent** — 파일 종류별 검사 라우팅(SKILL.md / agents / CLAUDE.md·rules / hooks·scripts) + 공통 판단 체크(무모순·배치 정합성·구체성·증거 주도 개정) + Bash 기계 체크(줄 예산·frontmatter·dangling 참조·짝 배선)
- **harness-review 스킬** — 하네스 경로만 필터한 diff 패키지로 관점별(트리거·경계 / 예산·배치 / 정합·무모순 / 집행 가능성) 병렬 dispatch → 합산·오탐 검증 → 인라인 코멘트. 실행 시점은 review 스킬과 동일(공개 PR + 유저 지시). 축 누수 태깅은 제외 — 코드 관문 채점용
- **review 스킬 경계 갱신** — 하네스 변경분을 harness-review 소관으로 위임 (Does NOT trigger + §1 패키지 제외)
- **CLAUDE.md §3** — 하네스 인덱스에 행 추가

## 남은 과제

- 정적 검증 스크립트(외부 린터 또는 자체) 도입은 보류 — 프로젝트 관례(한국어 본문·Triggers 규격)와 스펙이 안 맞아, agent의 Bash 기계 체크로 시작하고 실사용 후 판단
- superpowers writing-skills의 압력 시나리오 기반 행동 검증(RED-GREEN)은 이번 신설에 미적용 — 이 PR에 대한 dogfood 리뷰 실행이 첫 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHmMuXfXy7RhUDPXrhBBww