### PR TITLE
[#773] 키보드 입력 시트에 사용량 게이지·플랜 칩 노출 — stateBinding 배선 누락 수정

### DIFF
--- a/Presentations/AIAgentScene/Sources/AIAgentKeyboardInput/AIAgentKeyboardInputViewController.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentKeyboardInput/AIAgentKeyboardInputViewController.swift
@@ -26,10 +26,11 @@ final class AIAgentKeyboardInputViewController: UIHostingController<AIAgentKeybo
 
         let eventHandler = AIAgentKeyboardInputEventHandler()
         eventHandler.bind(viewModel)
-        let containerView = AIAgentKeyboardInputContainerView(
+        var containerView = AIAgentKeyboardInputContainerView(
             viewAppearance: viewAppearance,
             eventHandler: eventHandler
         )
+        containerView.stateBinding = { $0.bind(viewModel) }
         super.init(rootView: containerView)
         self.view.backgroundColor = .clear
     }


### PR DESCRIPTION
closes #773

## 문제

키보드 입력 시트에 사용량 게이지·플랜 칩이 뜨지 않았다. 게이지 마크업(#713)도, `usage`/`currentUserPlan` publisher 도, `ViewState.bind(viewModel)` 도 이미 다 있었는데 **`AIAgentKeyboardInputViewController` 가 `containerView.stateBinding` 을 안 걸어서** `bind` 가 끝내 호출되지 않았다. 그래서 `state.usage`·`state.userPlan` 이 계속 nil 이고, 게이지 블록이 통째로 스킵됐다. 같은 자리를 거는 `AIAgentCommandViewController` 는 정상이라 커맨드 시트만 게이지가 보이던 상태.

이슈의 두 번째 요구(플랜 정보가 크레딧 초과일 때만 노출되는지)도 같은 원인이었다. 클라에는 초과 게이팅이 없다 — 게이지의 플랜 칩은 `userPlan != nil` 이면 항상 그린다. 초과 조건이 걸린 건 "플랜 보기" CTA(`AIAgentCommandStageView`) 뿐이고 그건 #739 의도라 그대로 뒀다.

## 접근

`AIAgentKeyboardInputViewController.init` 에서 `containerView.stateBinding = { $0.bind(viewModel) }` 배선. 형제 Scene(`AIAgentCommandViewController`, `SelectDayDialogViewController`, `CalendarPaperViewController`)이 전부 쓰는 관례를 그대로 따랐다.

## 남은 과제

- **회귀 테스트 없음.** 스냅샷 스위트는 `stateBinding` 을 테스트가 직접 주입해 캡처하는 구조라(`AIAgentSceneSnapshots.swift:52`) 이 배선 누락을 구조적으로 못 잡는다. ViewController 배선 검증 테스트는 프로젝트에 선례가 없어 이번엔 실물 확인으로 갈음했다. 같은 유형(ContainerView 를 쓰는 Scene 의 `stateBinding` 누락)을 잡을 장치는 후속 과제로 남는다.
