### PR TITLE
[#777] 키보드 입력 시트에서 전송 시 present 충돌 크래시 해소

### DIFF
--- a/Presentations/CalendarScenes/Sources/CalendarViewRouter.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewRouter.swift
@@ -32,8 +32,7 @@ final class CalendarViewRouterImple: BaseRouterImple, CalendarViewRouting, @unch
         self.aiAgentCommandSceneBuilder = aiAgentCommandSceneBuilder
     }
     private var currentScene: (any CalendarScene)? { self.scene as? (any CalendarScene) }
-    private weak var presentedAICommandScene: (any Scene)?
-    
+
     @MainActor
     func attachInitialMonths(_ months: [CalendarMonth]) -> [any CalendarPaperSceneInteractor] {
         guard let current = self.currentScene else { return [] }
@@ -53,16 +52,13 @@ final class CalendarViewRouterImple: BaseRouterImple, CalendarViewRouting, @unch
         current.changeFocus(at: index)
     }
 
+    // 진입 시점에 떠 있는 시트는 이전 결과 시트일 수도, 키보드 입력 시트(다른 라우터가 띄운다)일 수도 있다.
+    // 무엇이 떠 있든 닫고 완료 콜백에서 present — 겹쳐 띄우면 UIKit이 예외를 던진다.
+    // 뜬 게 없으면 dismissPresented가 즉시 completion을 부르므로 음성 입력 경로도 그대로 통과한다.
     func routeToAICommand() {
-        Task { @MainActor in
-            // 이미 떠 있는 결과 시트가 있으면 닫고 새로 띄운다.
-            // dismiss 완료 콜백에서 present해 전환 타이밍 충돌을 방지.
-            if self.presentedAICommandScene != nil {
-                self.scene?.dismiss(animated: true) { [weak self] in
-                    self?.presentAICommandScene()
-                }
-            } else {
-                self.presentAICommandScene()
+        self.dismissPresented(animated: true) { [weak self] in
+            Task { @MainActor in
+                self?.presentAICommandScene()
             }
         }
     }
@@ -70,7 +66,6 @@ final class CalendarViewRouterImple: BaseRouterImple, CalendarViewRouting, @unch
     @MainActor
     private func presentAICommandScene() {
         let next = self.aiAgentCommandSceneBuilder.makeCommandScene()
-        self.presentedAICommandScene = next
         self.showBottomSlide(next)
     }
 }

--- a/docs/troubleshooting/2026-08-07-ai-command-sheet-present-while-keyboard-sheet-up.md
+++ b/docs/troubleshooting/2026-08-07-ai-command-sheet-present-while-keyboard-sheet-up.md
@@ -1,0 +1,20 @@
+---
+issue: "#777"
+subdomain: AIAgent
+symptoms: [Attempt to present which is already presenting, 바텀시트 크래시, 키보드 입력 전송 크래시, AIAgentCommandViewController, AIAgentKeyboardInputViewController]
+resolution: fixed
+---
+
+# 키보드 입력 시트에서 커맨드를 전송하면 present 충돌로 크래시
+
+- **증상**: 키보드 입력 시트에서 전송 → `Attempt to present <AIAgentCommandViewController> on <MainViewController> ... which is already presenting <AIAgentKeyboardInputViewController>`. 음성 입력 경로는 무증상.
+
+- **근본 원인**: `AIAgentOrchestrationUsecase.submit(_:)` 이 `.processing` 을 동기 방출하고 `state` 퍼블리셔에 `receive(on:)` 이 없어, `AIAgentKeyboardInputViewModelImple.send(_:)` 가 리턴하기 전에 `CalendarViewModel` sink → `routeToAICommand()` 까지 동기로 진행된다. 키보드 시트를 닫는 `closeScene()` 은 그 뒤라 present 가 항상 앞선다. 막았어야 할 `CalendarViewRouterImple.routeToAICommand()` 의 가드는 자기가 띄운 `presentedAICommandScene` 만 봤고, 키보드 시트는 `DayEventListRouter` 가 띄운 것이라 잡히지 않았다. 두 라우터가 같은 presenting VC 에 각자 present 하면서 서로의 상태를 모르는 구조가 원인.
+
+- **해결**: `routeToAICommand()` 의 조건 분기를 `BaseRouterImple.dismissPresented(animated:_:)` 로 통일. `presentedViewController` 는 조상이 present 한 것도 반환하므로 소유 라우터와 무관하게 떠 있는 시트가 닫히고, 뜬 게 없으면 즉시 completion 이라 음성 경로는 동작이 동일하다. 추적 필드 `presentedAICommandScene` 제거.
+
+- **기각 방향**:
+  - `send()` 순서 뒤집기(closeScene 완료 콜백에서 submit) — keyboard→command 경로만 덮고 `routeToAICommand` 의 기존 분기는 그대로 남는다. 전송 실패 시 showError 를 띄울 scene 도 사라진다.
+  - AI 시트 present 소유를 한 라우터로 일원화 — 근본적이나 CalendarScenes·AIAgentScene 배선을 넓게 뜯어야 해 이번 결함 대비 과대.
+
+- **남은 구멍**: 커맨드 시트가 떠 있는 상태에서 `routeToAIKeyboardInput` 이 키보드 시트를 present 하는 반대 방향은 같은 구조적 구멍이나, 현 동선에선 커맨드 시트가 화면을 덮어 AI 진입 버튼에 닿을 수 없어 재현되지 않는다.

--- a/docs/troubleshooting/INDEX.md
+++ b/docs/troubleshooting/INDEX.md
@@ -6,4 +6,5 @@
 
 <!-- 레코드는 아래에 최신순으로 추가 -->
 
+- [2026-08-07 키보드 입력 시트에서 커맨드를 전송하면 present 충돌로 크래시](2026-08-07-ai-command-sheet-present-while-keyboard-sheet-up.md) — AIAgent / fixed / already presenting, 바텀시트 크래시, 키보드 입력 전송
 - [2026-08-06 Share Extension으로 만든 AI job의 결과 푸시가 안 온다](2026-08-06-share-extension-ai-job-no-push.md) — AIAgent / non-issue / 푸시 안옴, device_id, DailyLimitExceeded, share extension


### PR DESCRIPTION
closes #777

## 문제

키보드 입력 시트에서 커맨드를 전송하면 크래시가 났다.

```
Attempt to present <AIAgentCommandViewController> on <MainViewController>
(from <CalendarViewController>) which is already presenting <AIAgentKeyboardInputViewController>.
```

`AIAgentOrchestrationUsecase.submit(_:)` 은 `.processing` 을 동기로 방출하고 `state` 퍼블리셔에 `receive(on:)` 이 없다. 그래서 `AIAgentKeyboardInputViewModelImple.send(_:)` 가 리턴하기도 전에 `CalendarViewModel` 의 sink → `routeToAICommand()` 까지 동기로 타고 들어간다. 키보드 시트를 닫는 `closeScene()` 은 그 뒤라, 커맨드 시트 present 가 항상 앞선다.

막았어야 할 `CalendarViewRouterImple.routeToAICommand()` 의 가드는 자기가 띄운 `presentedAICommandScene` 하나만 봤다. 키보드 시트는 `DayEventListRouter` 가 띄운 것이라 잡히지 않는다. **두 라우터가 같은 presenting VC 에 각자 present 하면서 서로의 상태를 모르는 구조**가 원인이다. 그 필드가 weak 이라 직전 커맨드 시트 VC 가 살아 있으면 우연히 dismiss→present 경로를 타 살고, 해제됐으면 죽는 비결정적 동작이기도 했다.

음성 입력은 인라인 바에서 바로 submit 이라 닫을 시트가 없어 영향이 없다 — 키보드 경로만 터진다.

## 접근

조건 분기를 없애고 `BaseRouterImple.dismissPresented(animated:_:)` 로 통일했다. `UIViewController.presentedViewController` 는 **조상이 present 한 것도 반환**하므로, 시트를 누가 띄웠는지 몰라도 떠 있는 것이 닫히고 완료 콜백에서 present 된다. 뜬 게 없으면 즉시 completion 이라 음성 경로는 동작이 같다. "내가 띄운 것만 추적하는" `presentedAICommandScene` 필드는 분기와 함께 사라졌다.

규명 결과는 `docs/troubleshooting/2026-08-07-...md` 에 아카이브했다 (기각한 두 방향 포함).

## 남은 과제

- **반대 방향은 그대로다.** 커맨드 시트가 떠 있는 상태에서 `routeToAIKeyboardInput` 이 키보드 시트를 present 하는 경로도 같은 구조적 구멍이다. 현 동선에선 커맨드 시트가 화면을 덮어 AI 진입 버튼에 닿을 수 없어 재현되지 않아 이번 범위에서 뺐다. 근본 해소는 AI 시트 present 소유를 한 라우터로 모으는 것.
- **회귀 테스트 없음.** UIKit presentation 배선이라 유닛테스트로 덮이지 않는다. 실물 재현으로 확인한다.
