### PR TITLE
[#690] flywheel 경고에서 정비 경로 없는 글로벌 스킬 제외

### DIFF
--- a/.claude/scripts/aggregate-usage.py
+++ b/.claude/scripts/aggregate-usage.py
@@ -8,6 +8,8 @@
 - (미귀속) 버킷은 --all 진단 표에만 노출 — 스킬이 아니라 정비(improvement 마킹) 소비 경로가 없어 임계 판정에서 제외.
 - plugin_prefixes 매칭 스킬(superpowers: 등)은 조항이 이 레포 밖이라 개정 불가 → partial·correction 임계만 제외.
   누락률은 유지한다 — 종료 레코드 배선은 프로젝트 스킬 소관이라 여전히 고칠 수 있는 신호다.
+- excluded_skills 는 임계 판정에서 통째로 뺀다. 글로벌 스킬(~/.claude/skills)처럼 이 레포가 정본을
+  갖지 않아 정비 경로 자체가 없는 대상용. --all 진단 표에는 그대로 남는다.
 - axis_leak 이벤트는 missed_axis(1/2/3)별로 별도 집계하며, improvement name이 합성 버킷 "axis:<n>" 형식이면 그 ts 이후만 신선 처리(소비 마킹) — 스킬 stats와 섞지 않는다.
 - exit 0 고정: 게이트가 아니라 제안이다. 임계는 usage-thresholds.json.
 """
@@ -100,8 +102,9 @@ def missing_rate(entry):
 def violations(stats, axis_stats, thresholds):
     lines = []
     plugin_prefixes = tuple(thresholds.get("plugin_prefixes", []))
+    excluded = set(thresholds.get("excluded_skills", []))
     for name, entry in sorted(stats.items()):
-        if name == UNATTRIBUTED:
+        if name == UNATTRIBUTED or name in excluded:
             continue
         is_plugin = bool(plugin_prefixes) and name.startswith(plugin_prefixes)
         if not is_plugin and entry["corrections"] >= thresholds["correction_count"]:

--- a/.claude/scripts/aggregate-usage.test.sh
+++ b/.claude/scripts/aggregate-usage.test.sh
@@ -61,6 +61,14 @@ cat > "$FIXTURE" << 'JSONL'
 {"ts":"2026-01-01T16:04:00+09:00","event":"skill","session_id":"t5","name":"superpowers:brainstorming"}
 {"ts":"2026-01-01T16:05:00+09:00","event":"skill_end","session_id":"t1","name":"superpowers:brainstorming","compliance":"full","deviations":[]}
 {"ts":"2026-01-01T16:06:00+09:00","event":"skill_end","session_id":"t2","name":"superpowers:brainstorming","compliance":"full","deviations":[]}
+{"ts":"2026-01-01T17:00:00+09:00","event":"skill","session_id":"u1","name":"handoff-prepare"}
+{"ts":"2026-01-01T17:01:00+09:00","event":"skill","session_id":"u2","name":"handoff-prepare"}
+{"ts":"2026-01-01T17:02:00+09:00","event":"skill","session_id":"u3","name":"handoff-prepare"}
+{"ts":"2026-01-01T17:03:00+09:00","event":"skill","session_id":"u4","name":"handoff-prepare"}
+{"ts":"2026-01-01T17:04:00+09:00","event":"skill","session_id":"u5","name":"handoff-prepare"}
+{"ts":"2026-01-01T17:05:00+09:00","event":"correction","session_id":"u1","skills":["handoff-prepare"],"summary":"c1","gist":""}
+{"ts":"2026-01-01T17:06:00+09:00","event":"correction","session_id":"u2","skills":["handoff-prepare"],"summary":"c2","gist":""}
+{"ts":"2026-01-01T17:07:00+09:00","event":"correction","session_id":"u3","skills":["handoff-prepare"],"summary":"c3","gist":""}
 JSONL
 
 OUT=$(python3 aggregate-usage.py)
@@ -90,6 +98,12 @@ assert_eq "플러그인 partial·correction 임계 제외" "0" "$(printf '%s' "$
 assert_contains "플러그인 누락률은 유지" "superpowers:brainstorming — 종료 레코드 누락률 60%" "$OUT"
 # 제외된 버킷도 --all 진단 표에는 남는다
 assert_contains "--all에 플러그인 버킷" "superpowers:writing-skills" "$ALL"
+
+# --- excluded_skills: 이 레포가 정본을 안 가져 정비 경로가 없는 대상은 임계 판정 통째 제외 ---
+# handoff-prepare — 발동 5·종료 0(누락률 100%)·correction 3이어도 violations 미노출
+assert_eq "excluded_skills 임계 판정 전체 제외" "0" "$(printf '%s' "$OUT" | grep -c "handoff-prepare")"
+# 제외해도 --all 진단 표에는 남는다
+assert_contains "--all에 excluded_skills 버킷" "handoff-prepare" "$ALL"
 
 # --- 축별 누수 집계 ---
 # 축1: 3건 ≥ 임계 3 → 초과, 축2: 2건 < 임계 3 → 미검출, 축3: 0건

--- a/.claude/scripts/usage-thresholds.json
+++ b/.claude/scripts/usage-thresholds.json
@@ -6,5 +6,9 @@
   "axis_leak_count": 3,
   "plugin_prefixes": [
     "superpowers:"
+  ],
+  "excluded_skills": [
+    "handoff-prepare",
+    "open-external"
   ]
 }


### PR DESCRIPTION
## 문제

`aggregate-usage.py` 가 `handoff-prepare`·`open-external` 의 종료 레코드 누락률을 경고로 띄운다. 둘 다 글로벌 스킬(`~/.claude/skills`)이라 **이 레포가 정본을 갖지 않는다** — 종료 레코드 배선을 넣을 수도, improve-skill 로 정비할 수도 없다. 소비 경로가 없는 신호가 매 머지마다 반복 출력되는 상태였다.

기존 `plugin_prefixes` 는 이 용도로 못 쓴다. 설계상 partial·correction 만 빼고 **누락률은 일부러 유지**한다 (종료 레코드 배선은 프로젝트 스킬 소관이라는 전제).

## 접근

`excluded_skills` 를 추가해 해당 이름을 임계 판정에서 통째로 뺀다. `--all` 진단 표에는 그대로 남으므로 관측은 유지되고, 억제한 사실도 config 한 곳에서 드러난다.

회귀 테스트 1건 추가 — 발동 5·종료 0(누락률 100%)·correction 3 인 fixture 가 violations 에 안 뜨고 `--all` 에는 뜨는지. 수정 전 fixture 로 RED 확인했다.

## 남은 과제

없음. 다른 글로벌 스킬이 임계에 걸리면 config 에 이름만 추가한다.