### PR TITLE
[#780] 이미지 텍스트 추출 서비스 신설 — Vision OCR 온디바이스 인식

### DIFF
--- a/Domain/Sources/Usecases/ImageText/ImageTextRecognizeService.swift
+++ b/Domain/Sources/Usecases/ImageText/ImageTextRecognizeService.swift
@@ -1,0 +1,20 @@
+//
+//  ImageTextRecognizeService.swift
+//  Domain
+//
+//  Created by sudo.park on 8/7/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+
+// MARK: - ImageTextRecognizeService
+
+public protocol ImageTextRecognizeService: Sendable {
+
+    /// 이미지에서 인식한 텍스트를 줄 단위로 반환 (빈 줄 제외).
+    /// 단순 레이아웃에서는 대체로 위→아래 순서지만, 다중 컬럼·영수증 등에서는 순서를 보장하지 않는다.
+    /// 호출 Task가 취소되면 진행 중인 인식을 중단하고 `CancellationError`를 던진다.
+    func recognizeTextLines(in imageData: Data) async throws -> [String]
+}

--- a/Services/FirstPartyServices/Sources/ImageText/ImageTextRecognizeServiceImple.swift
+++ b/Services/FirstPartyServices/Sources/ImageText/ImageTextRecognizeServiceImple.swift
@@ -1,0 +1,134 @@
+//
+//  ImageTextRecognizeServiceImple.swift
+//  FirstPartyServices
+//
+//  Created by sudo.park on 8/7/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Vision
+import ImageIO
+import Extensions
+import Domain
+
+
+public final class ImageTextRecognizeServiceImple: ImageTextRecognizeService, Sendable {
+
+    public init() { }
+}
+
+extension ImageTextRecognizeServiceImple {
+
+    private enum Constant {
+        // share extension 메모리 제한 대비 다운샘플 상한
+        static let maxPixelSize: CGFloat = 2048
+    }
+
+    public func recognizeTextLines(in imageData: Data) async throws -> [String] {
+        let cancelHandle = TextRecognizeCancelHandle()
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                // 디코드·다운샘플·OCR 모두 수십~수백 ms CPU 작업이라
+                // cooperative pool 스레드를 점유하지 않도록 GCD로 내린다.
+                DispatchQueue.global(qos: .userInitiated).async {
+                    do {
+                        let lines = try self.recognizedLines(
+                            in: imageData, cancelHandle: cancelHandle
+                        )
+                        continuation.resume(returning: lines)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
+        } onCancel: {
+            cancelHandle.cancel()
+        }
+    }
+
+    private func downsampledImage(from imageData: Data) throws -> CGImage {
+        guard let source = CGImageSourceCreateWithData(imageData as CFData, nil) else {
+            throw RuntimeError(key: "invalidImageData", "failed to decode image data")
+        }
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: Constant.maxPixelSize,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true
+        ]
+        guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+            throw RuntimeError(key: "invalidImageData", "failed to downsample image")
+        }
+        return thumbnail
+    }
+
+    private func recognizedLines(
+        in imageData: Data,
+        cancelHandle: TextRecognizeCancelHandle
+    ) throws -> [String] {
+        let cgImage = try self.downsampledImage(from: imageData)
+
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.automaticallyDetectsLanguage = true
+        request.usesLanguageCorrection = true
+        try cancelHandle.register(request)
+
+        // completionHandler를 쓰면 perform의 throw 경로와 겹쳐 이중 resume 위험이 생긴다.
+        // 동기 perform 후 results를 직접 읽어 결과 경로를 하나로 유지.
+        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+        do {
+            try handler.perform([request])
+        } catch {
+            // 취소로 인한 중단이면 Vision 내부 에러가 아니라 취소로 알린다.
+            try cancelHandle.throwIfCancelled()
+            throw error
+        }
+        // cancel된 request는 throw 없이 빈 결과로 끝날 수 있어, 취소를 결과로 오인하지 않게 확인.
+        try cancelHandle.throwIfCancelled()
+
+        let observations = request.results ?? []
+        let recognizedTexts = observations.compactMap { $0.topCandidates(1).first?.string }
+        return recognizedTexts
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.isEmpty == false }
+    }
+}
+
+
+// MARK: - TextRecognizeCancelHandle
+
+/// 실행 중인 OCR request를 Task 취소 시점에 끊기 위한 핸들.
+/// 등록·취소가 서로 다른 스레드에서 일어나므로 lock으로 보호한다.
+private final class TextRecognizeCancelHandle: @unchecked Sendable {
+
+    private let lock = NSLock()
+    private var request: VNRecognizeTextRequest?
+    private var isCancelled: Bool = false
+
+    func register(_ request: VNRecognizeTextRequest) throws {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+
+        guard self.isCancelled == false else { throw CancellationError() }
+        self.request = request
+    }
+
+    func cancel() {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+
+        self.isCancelled = true
+        self.request?.cancel()
+    }
+
+    func throwIfCancelled() throws {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+
+        guard self.isCancelled else { return }
+        throw CancellationError()
+    }
+}


### PR DESCRIPTION
Closes #780

## 문제

이미지 기반 AI 커맨드(#775)의 공통 기반이 없다 — 앱 진입점과 share extension 양쪽에서 이미지 속 텍스트를 추출해 `/v1/ai/command/interpret`(#774)로 보내려면, 온디바이스 OCR이 양쪽이 공유하는 모듈로 있어야 한다.

## 접근

SpeechService와 같은 분리 패턴: 계약은 Domain, SDK 결합 구현체는 Services.

- `ImageTextRecognizeService`(Domain) — 이미지 `Data` → 줄 단위 `[String]` 계약. 줄 구조를 보존해 넘겨야 서버 해석(sudopark/TodoCalendar-Functions#301)이 레이아웃 단서를 쓸 수 있다.
- `ImageTextRecognizeServiceImple`(FirstPartyServices) — Vision `VNRecognizeTextRequest`(accurate·자동 언어 감지·언어 교정). 원본 전체 디코딩 없이 `CGImageSourceCreateThumbnailAtIndex`로 최대 변 2048px 다운샘플 — share extension 메모리 상한 대비. completionHandler 없이 동기 `perform` 후 `request.results` 직독으로 continuation resume 경로를 하나로 유지(completionHandler 병용 시 perform throw와 이중 resume 크래시), 실행은 global queue로 내려 cooperative thread 점유 회피.

usecase는 두지 않았다 — 현재는 1:1 위임뿐이라(Domain bypass 금지 원칙) 소비자가 붙는 후속에서 필요성을 재판단한다. 순수 로직이 없어(전부 Vision SDK 결합) 테스트 타겟 없는 FirstPartyServices 선례(SpeechService 구현체와 동일)대로 유닛테스트는 없다.

## 남은 과제 (#775 분해 브리프의 후속 sub-work)

- 앱 내 이미지 입력 진입점 (PHPicker → 추출 → interpret 전송) — #774 머지 후
- Share extension 이미지 수용 (activation rule·image 로드·submit 합류) — #774 머지 후
- 서버 OCR 계약(sudopark/TodoCalendar-Functions#301) 확정 시 전송부 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdVDFCprWyqr84YHoTzWnC
