### PR TITLE
[#761] IntentExtensions 번들 버전이 앱 버전을 따라가게 수정

### DIFF
--- a/TodoCalendarApp/Project.swift
+++ b/TodoCalendarApp/Project.swift
@@ -159,8 +159,8 @@ let project = Project.app(
                 "NSExtensionPrincipalClass": .string("$(PRODUCT_MODULE_NAME).IntentHandler")
             ]),
             "CFBundleDisplayName": "To-do Calendar intent extension",
-            "CFBundleShortVersionString": "1.2.0",
-            "CFBundleVersion": "1"
+            "CFBundleShortVersionString": "\(Project.appVersion)",
+            "CFBundleVersion": "\(Project.buildNumber)"
         ],
         dependencies: [
             .project(


### PR DESCRIPTION
Close #761

## 문제

`TodoCalendarApp/Project.swift`의 IntentExtensions 타겟만 번들 버전을 `"1.2.0"`/`"1"`로 하드코딩하고 있었다. 앱 버전이 `2.9.6`까지 올라간 지금 확장과 부모 앱의 `CFBundleShortVersionString`이 어긋나, 앱 스킴 빌드마다 아래 경고가 뜨고 App Store 업로드 검증에서 걸릴 수 있는 상태였다.

```
warning: The CFBundleShortVersionString of an app extension ('1.2.0')
must match that of its containing parent app ('2.9.6').
```

같은 파일의 Widget(`:106-107`)·Share(`:212-213`)와 앱 본체(`Project+Templates.swift:258-259`)는 이미 `Project.appVersion`/`Project.buildNumber`를 참조하고 있어, 확장 3개 중 하나만 정본에서 떨어져 나와 있던 셈이다.

## 접근

IntentExtensions의 두 줄을 나머지와 같은 형태(`"\(Project.appVersion)"` / `"\(Project.buildNumber)"`)로 맞췄다. `buildNumber`는 현재 값이 우연히 `"1"`로 일치하지만 같은 이유로 언제든 어긋날 수 있어 함께 바꿨다.

검증:
- `tuist generate` 후 `TodoCalendarApp/Derived/InfoPlists/TodoCalendarAppIntentExtensions-Info.plist` → `2.9.6` / `1` (앱 plist와 동일)
- `xcodebuild -scheme TodoCalendarApp` **BUILD SUCCEEDED**, 로그에 해당 경고 0건 (`1.2.0` 문자열도 0건)

## 남은 과제

없음. 버전 상수(`2.9.6`) 자체를 올리는 릴리즈 작업과는 무관하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
