### PR TITLE
[#772] 로그아웃 직후 AI 커맨드 실패 팝업 해소 — 미로그인 세션 AI 차단 + 로컬 기록 정리

### DIFF
--- a/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
@@ -36,6 +36,8 @@ public protocol AIAgentOrchestrationUsecase: AnyObject, Sendable {
 
     func handleJobStatusChanged(_ jobId: String)
     func refreshProcessingJobIfNeeded()
+
+    func handleSignedOut() async
 }
 
 
@@ -274,20 +276,32 @@ extension AIAgentOrchestrationUsecaseImple {
         default:
             break
         }
-        self.commandCancellable?.cancel()
-        self.commandCancellable = nil
-        self.currentProcessingJobId = nil
+        self.stopTrackingJob()
         self.subject.state.send(.idle)
     }
 
     public func reset() {
         let jobId = self.currentProcessingJobId
-        self.commandCancellable?.cancel()
-        self.commandCancellable = nil
-        self.currentProcessingJobId = nil
+        self.stopTrackingJob()
         if let jobId {
             self.commandUsecase.cancelOngoingCommand(jobId)
         }
+        self.subject.state.send(.idle)
+    }
+
+    private func stopTrackingJob() {
+        self.commandCancellable?.cancel()
+        self.commandCancellable = nil
+        self.currentProcessingJobId = nil
+    }
+
+    // 로그아웃 — 폴링·음성 인식을 끊고 로컬 복원 근거를 지운다. 서버 cancel은 부르지 않는다.
+    // async인 이유는 호출자(앱 루트)가 DB를 닫기 전에 삭제 완료를 기다려야 하기 때문.
+    public func handleSignedOut() async {
+        self.stopTrackingJob()
+        self.resetVoiceBinding()
+        self.speechRecognizeUsecase.stopListening()
+        await self.commandUsecase.clearProcessingCommandRecord()
         self.subject.state.send(.idle)
     }
 

--- a/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
@@ -409,3 +409,49 @@ extension AIAgentOrchestrationUsecaseImple {
         return self.subject.voiceLevel.eraseToAnyPublisher()
     }
 }
+
+
+// MARK: - NotNeedAIAgentOrchestrationUsecase
+
+// AI 기능은 로그인 유저 전용 — 미로그인 세션엔 composition root가 이걸 주입한다.
+// 소비자는 로그인 여부를 모른 채 그대로 호출하고 여기서 전부 무동작으로 끝난다.
+public final class NotNeedAIAgentOrchestrationUsecase: AIAgentOrchestrationUsecase, Sendable {
+
+    public init() { }
+
+    public var state: AnyPublisher<AIAgentState, Never> {
+        return Just(.idle).eraseToAnyPublisher()
+    }
+
+    public var usage: AnyPublisher<AIAgentUsage, Never> {
+        return Empty(completeImmediately: false).eraseToAnyPublisher()
+    }
+
+    public var recognizingText: AnyPublisher<String, Never> {
+        return Empty(completeImmediately: false).eraseToAnyPublisher()
+    }
+
+    public var voiceLevel: AnyPublisher<Float, Never> {
+        return Empty(completeImmediately: false).eraseToAnyPublisher()
+    }
+
+    public func prepare() { }
+    public func enterVoiceInput() { }
+    public func finishVoiceInput() { }
+    public func enterKeyboardInput() { }
+    public func stopInput() { }
+
+    // 진입점이 로그인 가드로 막혀 있어 도달하지 않는다. 도달하면 가드가 뚫린 것이라 드러낸다.
+    public func submit(_ text: String) throws {
+        throw RuntimeError(key: "AIAgent.needSignIn", "ai agent needs sign in")
+    }
+
+    public func confirm() { }
+    public func decline() { }
+    public func reset() { }
+    public func restoreIfNeeded() { }
+    public func loadUsage() { }
+    public func handleJobStatusChanged(_ jobId: String) { }
+    public func refreshProcessingJobIfNeeded() { }
+    public func handleSignedOut() async { }
+}

--- a/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
@@ -296,8 +296,9 @@ extension AIAgentOrchestrationUsecaseImple {
         self.commandCancellable = self.commandUsecase.restoreCommandifNeed()
             .sink(
                 receiveCompletion: { [weak self] completion in
+                    // 복원은 유저가 낸 커맨드가 아니다 — 실패를 결과 화면으로 띄우지 않는다
                     if case .failure = completion {
-                        self?.subject.state.send(.failed(command: self?.currentCommand ?? "", reason: nil, errorCode: nil))
+                        self?.subject.state.send(.idle)
                     }
                 },
                 receiveValue: { [weak self] job in

--- a/Domain/Sources/Usecases/AI/AICommandUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AICommandUsecase.swift
@@ -23,6 +23,8 @@ public protocol AICommandUsecase: AnyObject, Sendable {
 
     func cancelOngoingCommand(_ jobId: String)
 
+    func clearProcessingCommandRecord() async
+
     func restoreCommandifNeed() -> AnyPublisher<AIJob?, any Error>
 
     func refreshJobStatus(_ jobId: String)
@@ -144,6 +146,12 @@ extension AICommandUsecaseImple {
             try? await repository.cancelCommand(jobId)
             try? await repository.clearProcessingAICommand()
         }
+    }
+
+    // 로그아웃 정리 전용 — 서버 job은 그대로 두고 로컬 복원 근거만 지운다.
+    // 남겨두면 재로그인 시 restoreCommandifNeed가 죽은 job을 이어받아 다시 폴링한다.
+    public func clearProcessingCommandRecord() async {
+        try? await self.repository.clearProcessingAICommand()
     }
 
     public func refreshJobStatus(_ jobId: String) {

--- a/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
@@ -762,6 +762,11 @@ private final class StubAICommandUsecase: AICommandUsecase, @unchecked Sendable 
         self.didRefreshJobStatusWith = jobId
     }
 
+    var didClearProcessingCommandRecord: Bool = false
+    func clearProcessingCommandRecord() async {
+        self.didClearProcessingCommandRecord = true
+    }
+
     private func jobPublisher(_ job: AIJob?) -> AnyPublisher<AIJob, any Error> {
         if self.shouldFail {
             return Fail(error: RuntimeError("stub fail")).eraseToAnyPublisher()
@@ -1242,5 +1247,62 @@ extension AIAgentOrchestrationUsecaseImpleTests {
 
         // then
         #expect(self.stubCommand.didRefreshJobStatusWith == "some_job")
+    }
+}
+
+
+// MARK: - 로그아웃
+
+extension AIAgentOrchestrationUsecaseImpleTests {
+
+    private func makeUsecaseWithRunningJob() -> AIAgentOrchestrationUsecaseImple {
+        let running = AIJob(jobId: "some_job")
+            |> \.status .~ AIJob.Status.running
+            |> \.command .~ "9월 10일 약속"
+        let usecase = self.makeUsecaseWithRestoredJob(running)
+        usecase.restoreIfNeeded()
+        return usecase
+    }
+
+    // 서버 job은 살려두고 로컬 복원 근거만 지운다 — 재로그인 시 죽은 job이 되살아나는 걸 막는다
+    @Test("로그아웃하면 서버 취소 없이 로컬 커맨드 기록만 지운다")
+    func usecase_whenSignedOut_clearsLocalRecordWithoutServerCancel() async throws {
+        // given
+        let usecase = self.makeUsecaseWithRunningJob()
+
+        // when
+        await usecase.handleSignedOut()
+
+        // then
+        #expect(self.stubCommand.didClearProcessingCommandRecord == true)
+        #expect(self.stubCommand.didCancelJobId == nil)
+    }
+
+    @Test("로그아웃하면 진행 중이던 상태를 idle로 되돌린다")
+    func usecase_whenSignedOut_backToIdle() async throws {
+        // given
+        let expect = expectConfirm("로그아웃 → idle")
+        let usecase = self.makeUsecaseWithRunningJob()
+
+        // when
+        let states = try await self.outputs(expect, for: usecase.state.dropFirst()) {
+            Task { await usecase.handleSignedOut() }
+        }
+
+        // then
+        #expect(states.map(self.stateName).last == "idle")
+    }
+
+    @Test("로그아웃하면 음성 인식도 중지한다")
+    func usecase_whenSignedOut_stopsListening() async throws {
+        // given
+        let usecase = self.makeUsecase()
+        usecase.enterVoiceInput()
+
+        // when
+        await usecase.handleSignedOut()
+
+        // then
+        #expect(self.stubSpeech.didStopListening == true)
     }
 }

--- a/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
@@ -528,6 +528,18 @@ extension AIAgentOrchestrationUsecaseImpleTests {
         // then — status 우선 판정으로 confirm 아닌 idle
         #expect(state.map(self.stateName) == "idle")
     }
+
+    @Test func usecase_restoreIfNeeded_whenFailed_staysIdleNotFailed() async throws {
+        // given — 복원 조회 자체가 실패 (로그아웃 직후 401 등)
+        let expect = expectConfirm("복원 실패는 결과 화면 없이 idle")
+        let usecase = self.makeUsecase(shouldFail: true)
+        // when
+        let state = try await self.firstOutput(expect, for: usecase.state) {
+            usecase.restoreIfNeeded()
+        }
+        // then
+        #expect(state.map(self.stateName) == "idle")
+    }
 }
 
 

--- a/Presentations/AIAgentScene/Tests/Doubles/StubAIAgentOrchestrationUsecase.swift
+++ b/Presentations/AIAgentScene/Tests/Doubles/StubAIAgentOrchestrationUsecase.swift
@@ -58,6 +58,11 @@ final class StubAIAgentOrchestrationUsecase: AIAgentOrchestrationUsecase, @unche
         self.didRefreshProcessingJob = true
     }
 
+    private(set) var didHandleSignedOut = false
+    func handleSignedOut() async {
+        self.didHandleSignedOut = true
+    }
+
     var state: AnyPublisher<AIAgentState, Never> {
         self.stateSubject.compactMap { $0 }.eraseToAnyPublisher()
     }

--- a/Supports/TestDoubles/Sources/Usecases/StubAIAgentOrchestrationUsecase.swift
+++ b/Supports/TestDoubles/Sources/Usecases/StubAIAgentOrchestrationUsecase.swift
@@ -45,6 +45,11 @@ public final class StubAIAgentOrchestrationUsecase: AIAgentOrchestrationUsecase,
         self.didRefreshProcessingJob = true
     }
 
+    public private(set) var didHandleSignedOut: Bool?
+    public func handleSignedOut() async {
+        self.didHandleSignedOut = true
+    }
+
     public var state: AnyPublisher<AIAgentState, Never> {
         self.stateSubject.compactMap { $0 }.eraseToAnyPublisher()
     }

--- a/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
+++ b/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
@@ -45,36 +45,9 @@ struct NonLoginUsecaseFactoryImple: UsecaseFactory {
         self.eventSyncUsecase = NotNeedEventSyncUsecase()
         self.applicationBase = applicationBase
 
-        let aiLocalStorage = AICommandLocalStorageImple(sqliteService: applicationBase.commonSqliteService)
-        let aiRepository = AICommandRepositoryImple(
-            remote: applicationBase.remoteAPI,
-            localStorage: aiLocalStorage
-        )
-        let calendarSettingRepository = CalendarSettingRepositoryImple(
-            environmentStorage: applicationBase.userDefaultEnvironmentStorage
-        )
-        let calendarSettingUsecase = CalendarSettingUsecaseImple(
-            settingRepository: calendarSettingRepository,
-            shareDataStore: applicationBase.sharedDataStore
-        )
-        let aiCommandUsecase = AICommandUsecaseImple(
-            repository: aiRepository,
-            calendarSettingUsecase: calendarSettingUsecase
-        )
-        let aiUsageUsecase = AIAgentUsageUsecaseImple(
-            repository: aiRepository,
-            sharedDataStore: applicationBase.sharedDataStore
-        )
-        let speech = SpeechRecognizeUsecaseImple(
-            service: SpeechRecognizeServiceImple(),
-            permissionChecker: SpeechRecognizePermissionCheckerImple()
-        )
-        self.aiAgentOrchestrationUsecase = AIAgentOrchestrationUsecaseImple(
-            commandUsecase: aiCommandUsecase,
-            usageUsecase: aiUsageUsecase,
-            speechRecognizeUsecase: speech,
-            eventSyncUsecase: self.eventSyncUsecase
-        )
+        // AI 기능은 로그인 유저 전용 — 실제 스택을 만들지 않는다 (#772).
+        // 진입점 UI는 그대로 노출되고 탭 시 로그인 유도로 갈린다.
+        self.aiAgentOrchestrationUsecase = NotNeedAIAgentOrchestrationUsecase()
     }
 
     var eventNotifyService: SharedEventNotifyService {

--- a/TodoCalendarApp/Sources/Root/AIJobRefreshUsecase.swift
+++ b/TodoCalendarApp/Sources/Root/AIJobRefreshUsecase.swift
@@ -17,6 +17,7 @@ protocol AIJobRefreshUsecase: Sendable {
 
     func handleJobStatusChanged(_ jobId: String)
     func refreshProcessingJobIfNeeded()
+    func handleSignedOut() async
 }
 
 
@@ -42,5 +43,11 @@ extension AIJobRefreshUsecaseImple {
     func refreshProcessingJobIfNeeded() {
         self.usecaseFactory?.aiAgentOrchestrationUsecase
             .refreshProcessingJobIfNeeded()
+    }
+
+    // 팩토리 교체 전에 불려야 로그인 세션의 오케스트레이션이 정리 대상이 된다
+    func handleSignedOut() async {
+        await self.usecaseFactory?.aiAgentOrchestrationUsecase
+            .handleSignedOut()
     }
 }

--- a/TodoCalendarApp/Sources/Root/ApplicationRootViewModel.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootViewModel.swift
@@ -132,6 +132,8 @@ extension ApplicationRootViewModelImple: AutenticatorTokenRefreshListener {
     private func handleUserSignedOut() {
         Task { [weak self] in
             self?.subject.isSignIn.send(false)
+            // DB가 닫히기 전에 로컬 AI 커맨드 기록을 지워야 재로그인 때 되살아나지 않는다
+            await self?.aiJobRefreshUsecase.handleSignedOut()
             await self?.prepareUsecase.prepareSignedOut()
             
             try? await Task.sleep(for: .milliseconds(100))

--- a/TodoCalendarApp/TodoCalendarAppTests/ApplicationRootViewModelImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/ApplicationRootViewModelImpleTests.swift
@@ -19,14 +19,16 @@ import UnitTestHelpKit
 
 final class ApplicationRootViewModelImpleTests {
 
-    private let spyAIJobRefreshUsecase = SpyAIJobRefreshUsecase()
+    private let callOrder = CallOrderRecorder()
     private let spyAppUpdateCheckUsecase = SpyAppUpdateCheckUsecase()
+    private let fakeAccountUsecase = FakeAccountUsecase()
+    private lazy var spyAIJobRefreshUsecase = SpyAIJobRefreshUsecase(recorder: self.callOrder)
 
     private func makeViewModel() -> ApplicationRootViewModelImple {
         return ApplicationRootViewModelImple(
             authUsecase: StubAuthUsecase(),
-            accountUsecase: StubAccountUsecase(),
-            prepareUsecase: StubApplicationPrepareUsecase(),
+            accountUsecase: self.fakeAccountUsecase,
+            prepareUsecase: StubApplicationPrepareUsecase(recorder: self.callOrder),
             deepLinkHandler: ApplicationDeepLinkHandlerImple(),
             externalCalendarServiceUsecase: StubExternalCalendarIntegrationUsecase([]),
             userNotificationUsecase: StubUserNotificationUsecase(),
@@ -131,9 +133,59 @@ extension ApplicationRootViewModelImpleTests {
 }
 
 
+// MARK: - 로그아웃
+
+extension ApplicationRootViewModelImpleTests {
+
+    // 로컬 AI 커맨드 기록은 로그인 유저의 DB에 있다 — prepareSignedOut이 DB를 닫고
+    // 익명 DB로 갈아끼우기 전에 지워야 재로그인 때 죽은 job이 되살아나지 않는다.
+    @Test("로그아웃하면 DB 정리보다 AI 커맨드 정리를 먼저 끝낸다")
+    func viewModel_whenSignedOut_clearAICommandBeforeDatabaseSwap() async {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        self.fakeAccountUsecase.sendSignOut()
+        try? await Task.sleep(for: .milliseconds(300))
+
+        // then
+        #expect(self.callOrder.calls == ["aiHandleSignedOut", "prepareSignedOut"])
+        withExtendedLifetime(viewModel) { }
+    }
+}
+
+
 // MARK: - doubles
 
+private final class CallOrderRecorder: @unchecked Sendable {
+
+    private(set) var calls: [String] = []
+
+    func record(_ name: String) {
+        self.calls.append(name)
+    }
+}
+
+private final class FakeAccountUsecase: StubAccountUsecase, @unchecked Sendable {
+
+    private let statusSubject = PassthroughSubject<AccountChangedEvent, Never>()
+
+    override var accountStatusChanged: AnyPublisher<AccountChangedEvent, Never> {
+        return self.statusSubject.eraseToAnyPublisher()
+    }
+
+    func sendSignOut() {
+        self.statusSubject.send(.signOut)
+    }
+}
+
 private final class SpyAIJobRefreshUsecase: AIJobRefreshUsecase, @unchecked Sendable {
+
+    private let recorder: CallOrderRecorder
+
+    init(recorder: CallOrderRecorder) {
+        self.recorder = recorder
+    }
 
     var didHandleJobStatusChangedWith: String?
     func handleJobStatusChanged(_ jobId: String) {
@@ -149,9 +201,19 @@ private final class SpyAIJobRefreshUsecase: AIJobRefreshUsecase, @unchecked Send
     func change(factory: any UsecaseFactory) {
         self.didChangeFactory = true
     }
+
+    func handleSignedOut() async {
+        self.recorder.record("aiHandleSignedOut")
+    }
 }
 
 private final class StubApplicationPrepareUsecase: ApplicationPrepareUsecase {
+
+    private let recorder: CallOrderRecorder
+
+    init(recorder: CallOrderRecorder) {
+        self.recorder = recorder
+    }
 
     func prepareLaunch() async throws -> ApplicationPrepareResult {
         return ApplicationPrepareResult(
@@ -167,7 +229,9 @@ private final class StubApplicationPrepareUsecase: ApplicationPrepareUsecase {
 
     func prepareSignedIn(_ auth: Auth) async { }
 
-    func prepareSignedOut() async { }
+    func prepareSignedOut() async {
+        self.recorder.record("prepareSignedOut")
+    }
 
     func prepareExternalCalendarIntegrated(_ serviceId: String) { }
 


### PR DESCRIPTION
Close #772

## 결론 먼저

- **팝업 원인은 좀비 폴링이 아니라 로그아웃 직후 미로그인 캘린더가 건 `prepare()`다.**
- **좀비 폴링은 없었다.** 이슈에 적힌 의심은 확인 결과 성립하지 않는다.
- 다만 로그아웃 훅이 없어 **로컬 `ProcessingAICommand` 레코드는 실제로 남는다.** 폴링이 아니라 이 레코드가 재로그인 때 되살아나는 게 진짜 결함이라 함께 잡았다.

## 팝업 원인

이슈 스크린샷으로 확정했다.

- 시트가 **미로그인 캘린더 위에** 떠 있다. 로그인 세션 오케스트레이션이 낸 `.failed`를 받는 건 교체 전 CalendarViewModel인데, `ApplicationRootRouter.refreshRoot()`가 `window.rootViewController`를 통째로 갈아끼우면서 present돼 있던 시트도 사라진다. 화면에 남아 있다는 건 현재(미로그인) 루트의 라우터가 띄웠다는 뜻이다.
- 미로그인 CalendarViewModel이 `.failed`에 들어갈 경로는 `prepare()` → `restoreIfNeeded()` 실패 하나뿐이다. `submit`·`confirm`은 유저 조작이 필요하다.
- 시트에 command 에코도 사유도 없다 — `.failed(command: "", reason: nil, errorCode: nil)`, `restoreIfNeeded()`의 실패 매핑 그대로다. 유저 제출 커맨드(`startProcessing`)였으면 command가 채워진다.

실패 지점은 서버가 아니라 **로컬 DB 읽기**다. `AICommandUsecaseImple.loadJobWithFilterError`는 `.forbidden`/`.notFound`만 `Fail`로 올리고 나머지(401 `unauthorized` 포함)는 `Empty()`로 삼키므로 서버 응답은 `.failed`를 만들 수 없다. 반면 그 앞단 `loadProcessingAICommand()`(`sqliteService.async.run`)의 실패는 필터 없이 전파된다. 로그아웃 시 `ApplicationPrepareUsecase.prepareSignedOut()`이 DB를 닫고 익명 DB로 재오픈하는 창이 바로 직전에 있다.

성립 조건은 두 겹이었다.

1. **`restoreIfNeeded()`의 실패가 사용자향 상태로 올라갔다.** 이건 유저 커맨드가 아니라 저장소의 `ProcessingAICommand`를 이어받는 백그라운드 복원 경로인데 실패가 `.failed`로 매핑돼 있었고, `CalendarViewModel.bindShowAICommandResultIfNeed()`가 `.failed` 진입을 감지해 결과 시트를 자동 present한다.
2. **미로그인 세션이 실제 AI 스택을 들고 있었다.** `NonLoginUsecaseFactoryImple`이 `AICommandLocalStorageImple` → `AICommandRepositoryImple` → `AICommandUsecaseImple` → `AIAgentOrchestrationUsecaseImple`을 전부 조립했다. 로그인 가드는 UI 진입점(`DayEventListViewModel.enterVoiceInput()`)에만 있고 `prepare`/`restore`/`loadUsage`/푸시/포그라운드 refresh 같은 배경 경로엔 없었다.

## 좀비 폴링 검토 결과 — 없다

폴링은 `AICommandUsecaseImple.checkJob`의 `Timer.publish(every: 10s)`인데 `prefixWithInclude(firstMatch: { $0.isFinish })`로 종료된다. `AIJob.isFinish`는 `done`·`confirm`·`failed`·`rejected`·`canceled`를 **전부** 포함하므로(`AICommand+Job.swift:54-60`), 폴링이 도는 구간은 job이 `pending`/`running`인 동안뿐이다. 그마저도 `notFinishJobTimeout`이 10분 뒤 강제 종료시킨다. 로그아웃 시점에 진행 중인 job이 없었으므로 폴링은 애초에 돌고 있지 않았다.

**대신 남는 건 로컬 레코드다.** `handleClearProcessingCommand`는 `confirm` 상태 job의 레코드를 일부러 안 지운다 — 유저 응답 대기의 복원 근거이기 때문이다. 그래서 응답하지 않은 confirm이 있으면 폴링은 멈춰도 레코드는 로그인 유저 DB에 남고, 재로그인 시 `restoreIfNeeded()`가 죽은 job을 이어받는다. 로그아웃 훅이 없어 이 레코드를 지울 자리가 아예 없었다.

## 접근

레이어별 4커밋.

**Domain — 복원 실패는 조용히 흡수.** `restoreIfNeeded()`의 실패를 `.failed` 대신 `.idle`로 방출한다. 유저가 직접 제출한 커맨드의 실패(`startProcessing`)는 여전히 `.failed`로 보여준다 — 그건 보여줘야 하는 실패다.

**Domain — 로그아웃 처리 경로 신설.** `AIAgentOrchestrationUsecase.handleSignedOut()`이 로컬 레코드를 지우고 idle로 되돌린다. 폴링 구독·음성 인식 바인딩 해제도 함께 하지만 이건 부수적 안전장치고, 실질 목적은 레코드 정리다. 삭제는 `AICommandUsecase.clearProcessingCommandRecord()`로 분리했다 — 기존 `cancelOngoingCommand`(서버 취소 + 로컬 삭제)와 의도를 가르기 위해서다. **서버 `cancelCommand`는 부르지 않는다**: 토큰이 이미 무효고 서버 job은 그대로 두기로 했다. `async`인 이유는 호출자가 DB를 닫기 전에 삭제 완료를 기다려야 하기 때문 — fire-and-forget이면 `prepareSignedOut()`의 `database.close()`와 경합해 레코드가 남는다.

**Domain — `NotNeedAIAgentOrchestrationUsecase`.** `NotNeedEventSyncUsecase`와 같은 형태의 no-op. `submit`만 예외로 throw해서, 진입점 가드가 뚫렸을 때 조용히 삼키지 않게 했다.

**App — composition root 배선.** 미로그인 차단을 소비자 쪽이 아니라 팩토리에서 한다 (CLAUDE.md "환경/구성 분기는 composition root에서만"). `NonLoginUsecaseFactoryImple`이 no-op을 주입하면 배경 경로가 한꺼번에 죽고 ViewModel 코드는 한 줄도 안 바뀐다. 로그아웃 정리는 `AIJobRefreshUsecase.handleSignedOut()`이 현재 팩토리로 포워딩하고, `ApplicationRootViewModelImple.handleUserSignedOut()`이 팩토리 교체·DB close **이전에** await로 호출한다. 이 핸들러는 토큰 갱신 실패 경로에서도 불리는데 같은 정리가 필요해 분기하지 않았다.

정리하면 커밋 1과 커밋 4가 각각 독립적으로 팝업을 막고, 커밋 2가 재로그인 시 죽은 job 부활을 막는다.

### 의도적으로 안 바꾼 것

- **AI 진입점 UI는 현행 유지.** 미로그인 유저에게도 마이크/AI 버튼은 보이고, 탭하면 로그인 유도 다이얼로그가 뜬다. 숨기면 로그인 유인이 사라져서 유지하기로 했다.
- **`CalendarViewModel.bindShowAICommandResultIfNeed()`.** `.failed`에 시트를 여는 것 자체는 올바른 동작이다. 잘못된 건 `.failed`에 들어가던 쪽이었다.

### 검증

- 13개 스킴 전부 통과, 앱 타겟 빌드 성공
- 복원 실패 회귀테스트는 수정 전 `"failed" == "idle"`로 RED 확인 후 GREEN
- 로그아웃 호출 순서(`aiHandleSignedOut` → `prepareSignedOut`)를 `ApplicationRootViewModelImpleTests`에서 배열 비교로 고정

## 남은 과제

- `prepareSignedOut`의 close → sleep(100ms) → reopen 시퀀스는 그대로다. 이번 변경으로 그 창의 DB 실패가 유저에게 노출되지 않게 됐을 뿐, 창 자체를 없애는 건 별도 과제.
- 서버에 남는 job은 자연 만료에 맡긴다. 서버 세션 종료 시 job 정리가 필요하면 별도 이슈.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
