### PR TITLE
[#783] AI 음성 입력 — 앱 비활성 시 중지 + 진입 인지 개선

### DIFF
--- a/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperScene+Builder.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperScene+Builder.swift
@@ -19,6 +19,7 @@ protocol CalendarPaperSceneInteractor: Sendable, AnyObject, MonthSceneListener, 
     func updateMonthIfNeed(_ newMonth: CalendarMonth)
     func selectToday()
     func selectDay(_ day: CalendarDay)
+    func scrollToVoiceInput()
 }
 //
 protocol CalendarPaperSceneListener: AnyObject {

--- a/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperView.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperView.swift
@@ -7,7 +7,30 @@
 //
 
 import SwiftUI
+import Combine
 import CommonPresentation
+
+@Observable final class CalendarPaperViewState {
+
+    @ObservationIgnored private var didBind = false
+    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+
+    // 값 자체엔 의미가 없다 — 증가가 곧 스크롤 트리거다.
+    fileprivate var scrollToVoiceInputTrigger: Int = 0
+
+    func bind(_ viewModel: any CalendarPaperViewModel) {
+
+        guard self.didBind == false else { return }
+        self.didBind = true
+
+        viewModel.requestScrollToVoiceInput
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.scrollToVoiceInputTrigger += 1
+            }
+            .store(in: &self.cancellables)
+    }
+}
 
 final class CalenarPaperViewEventHandelr: Observable {
     
@@ -37,25 +60,33 @@ struct CalenarPaperContainerView: View {
         self.eventHandler = eventHandler
     }
     
+    @State private var state: CalendarPaperViewState = .init()
+    var stateBinding: (CalendarPaperViewState) -> Void = { _ in }
+
     var body: some View {
         return PapgerView(
             monthView: monthView,
             eventListView: eventListView
         )
-        .onAppear(perform: eventHandler.onAppear)
+        .onAppear {
+            self.stateBinding(self.state)
+            self.eventHandler.onAppear()
+        }
+        .environment(state)
         .environment(viewAppearance)
         .environment(eventHandler)
     }
-    
+
     struct PapgerView: View {
-        
+
         private let monthView: MonthContainerView
         private let eventListView: DayEventListContainerView
         @Environment(ViewAppearance.self) private var appearance
         @Environment(CalenarPaperViewEventHandelr.self) private var eventHandler
-        
+        @Environment(CalendarPaperViewState.self) private var state
+
         @State private var keyboardHeightObserver = KeyboardHeightObserver()
-        
+
         init(
             monthView: MonthContainerView,
             eventListView: DayEventListContainerView
@@ -63,16 +94,23 @@ struct CalenarPaperContainerView: View {
             self.monthView = monthView
             self.eventListView = eventListView
         }
-        
+
         var body: some View {
-            ScrollView {
-                VStack {
-                    self.monthView
-                    self.eventListView
+            ScrollViewReader { proxy in
+                ScrollView {
+                    VStack {
+                        self.monthView
+                        self.eventListView
+                    }
+                    .offset(y: -keyboardHeightObserver.showingKeyboardHeight)
                 }
-                .offset(y: -keyboardHeightObserver.showingKeyboardHeight)
+                .background(appearance.colorSet.bg0.asColor)
+                .onChange(of: self.state.scrollToVoiceInputTrigger) { _, _ in
+                    withAnimation(.easeInOut(duration: 0.3)) {
+                        proxy.scrollTo(DayEventListScrollAnchor.quickAddField, anchor: .bottom)
+                    }
+                }
             }
-            .background(appearance.colorSet.bg0.asColor)
         }
     }
 }

--- a/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperViewController.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperViewController.swift
@@ -63,6 +63,7 @@ final class CalendarPaperViewController: UIHostingController<CalenarPaperContain
             viewAppearance: viewAppearance,
             eventHandler: eventHandler
         )
+        .eventHandler(\.stateBinding, { $0.bind(viewModel) })
         super.init(rootView: containerView)
     }
     

--- a/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperViewModel.swift
@@ -19,8 +19,9 @@ protocol CalendarPaperViewModel: AnyObject, Sendable, CalendarPaperSceneInteract
 
     // interactor
     func prepare()
-    
+
     // presenter
+    var requestScrollToVoiceInput: AnyPublisher<Void, Never> { get }
 }
 
 
@@ -46,6 +47,11 @@ final class CalendarPaperViewModelImple: CalendarPaperViewModel, @unchecked Send
     }
     
     private var currentSelectedDayAndEvents: (CurrentSelectDayModel, [any CalendarEvent])?
+
+    private struct Subject {
+        let requestScrollToVoiceInput = PassthroughSubject<Void, Never>()
+    }
+    private let subject = Subject()
 }
 
 
@@ -84,11 +90,19 @@ extension CalendarPaperViewModelImple {
     func dayEventListDidRequestShowAICommand() {
         self.listener?.calendarPaperDidRequestShowAICommand()
     }
+
+    func scrollToVoiceInput() {
+        self.subject.requestScrollToVoiceInput.send(())
+    }
 }
 
 
 // MARK: - CalendarPaperViewModelImple Presenter
 
 extension CalendarPaperViewModelImple {
-    
+
+    var requestScrollToVoiceInput: AnyPublisher<Void, Never> {
+        return self.subject.requestScrollToVoiceInput
+            .eraseToAnyPublisher()
+    }
 }

--- a/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
@@ -302,6 +302,7 @@ extension CalendarViewModelImple {
             self.aiAgentOrchestrationUsecase.prepare()
             self.bindShowAICommandResultIfNeed()
             self.bindVoiceInputLifecycle()
+            self.bindScrollToVoiceInputOnFocusedMonth()
         }
     }
     
@@ -450,6 +451,21 @@ extension CalendarViewModelImple {
             .filter { $0 }
             .sink { [weak self] _ in
                 self?.router?.routeToAICommand()
+            }
+            .store(in: &self.cancellables)
+    }
+
+    // 음성 입력 '진입 순간'에만 스크롤한다 — 같은 상태의 반복 방출로는 재스크롤하지 않는다.
+    // paper는 화면당 3개(이전·현재·다음)라 전부에 보내면 안 보이는 달까지 목록 하단으로 내려간다.
+    private func bindScrollToVoiceInputOnFocusedMonth() {
+        self.aiAgentOrchestrationUsecase.state
+            .map { Self.isVoiceListeningPhase($0) }
+            .removeDuplicates()
+            .filter { $0 }
+            .sink { [weak self] _ in
+                guard let focusedIndex = self?.subject.monthsInCurrentRange.value?.focusedIndex
+                else { return }
+                self?.calendarPaperInteractors?[safe: focusedIndex]?.scrollToVoiceInput()
             }
             .store(in: &self.cancellables)
     }

--- a/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
@@ -248,6 +248,25 @@ final class CalendarViewModelImple: CalendarViewModel, @unchecked Sendable {
         })
         .store(in: &self.cancellables)
     }
+
+    // 앱이 가려지면(제어센터·앱 스위처·시스템 다이얼로그 포함) 오디오 세션이 끊겨 계속 들을 수 없다.
+    // 듣던 중이면 입력 자체를 접는다 — 키보드 입력은 오디오와 무관하므로 건드리지 않는다.
+    private func bindVoiceInputLifecycle() {
+
+        NotificationCenter.default
+            .publisher(for: UIApplication.willResignActiveNotification)
+            .withLatestFrom(self.aiAgentOrchestrationUsecase.state) { $1 }
+            .filter { Self.isVoiceListeningPhase($0) }
+            .sink(receiveValue: { [weak self] _ in
+                self?.aiAgentOrchestrationUsecase.stopInput()
+            })
+            .store(in: &self.cancellables)
+    }
+
+    private static func isVoiceListeningPhase(_ state: AIAgentState) -> Bool {
+        guard case .listening(.voice) = state else { return false }
+        return true
+    }
 }
 
 
@@ -282,6 +301,7 @@ extension CalendarViewModelImple {
         if FeatureFlag.isEnable(.aiAgent) {
             self.aiAgentOrchestrationUsecase.prepare()
             self.bindShowAICommandResultIfNeed()
+            self.bindVoiceInputLifecycle()
         }
     }
     

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListView.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListView.swift
@@ -29,6 +29,10 @@ private enum AICommandBadge: Equatable {
     case failed
 }
 
+enum DayEventListScrollAnchor {
+    static let quickAddField: String = "day-event-list-quick-add-field"
+}
+
 
 // MARK: - DayEventListViewController
 
@@ -253,6 +257,7 @@ struct DayEventListView: View {
                     QuickAddNewTodoView(isFocusInput: $isFocusInput)
                         .eventHandler(\.addNewTodoQuickly, eventHandler.addNewTodoQuickly)
                         .eventHandler(\.makeNewTodoWithGivenNameAndDetails, eventHandler.makeNewTodoWithGivenNameAndDetails)
+                        .id(DayEventListScrollAnchor.quickAddField)
                     addNewButton()
                 }
                 .animation(.easeInOut(duration: 0.3), value: self.state.isVoiceListening)
@@ -440,13 +445,31 @@ private struct QuickAddNewTodoView: View {
         quickAddField()
             .padding(.vertical, spacing: .xsmall).padding(.horizontal, spacing: .small)
             .frame(height: 50)
-            .backgroundAsRoundedRectForEventList(self.appearance)
+            .background(self.fieldBackground())
             .overlay {
                 if self.state.isVoiceListening {
                     NeonListeningBorder(cornerRadius: 5)
                         .transition(.opacity)
                 }
             }
+    }
+
+    // listening 중엔 이벤트 셀과 같은 bg1을 벗고 네온 그라데이션을 입어 목록에서 분리된다.
+    @ViewBuilder
+    private func fieldBackground() -> some View {
+        if self.state.isVoiceListening {
+            RoundedRectangle(cornerRadius: Metric.Radius.chip)
+                .fill(
+                    LinearGradient(
+                        colors: self.appearance.colorSet.aiListeningBackground.map { $0.asColor },
+                        startPoint: .init(x: 0, y: 0.15),
+                        endPoint: .init(x: 1, y: 0.85)
+                    )
+                )
+        } else {
+            RoundedRectangle(cornerRadius: Metric.Radius.chip)
+                .fill(self.appearance.colorSet.bg1.asColor)
+        }
     }
 
     private func quickAddField() -> some View {

--- a/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
@@ -1022,6 +1022,76 @@ extension CalendarViewModelImpleTests {
     }
 }
 
+// MARK: - 음성 입력 진입 시 포커스된 달만 스크롤
+
+extension CalendarViewModelImpleTests {
+
+    func testViewModel_whenVoiceInputStarts_scrollsOnlyFocusedMonthPaper() async throws {
+        // given
+        FeatureFlag.enable(.aiAgent)
+        let viewModel = self.makeViewModel()
+        viewModel.prepare()
+        try await Task.sleep(for: .milliseconds(50))
+
+        // when
+        self.stubOrchestration.stateSubject.send(.listening(.voice))
+        try await Task.sleep(for: .milliseconds(50))
+
+        // then — 초기 포커스는 가운데(index 1) 달
+        let counts = self.spyRouter.spyInteractors.map { $0.didScrollToVoiceInputCount }
+        XCTAssertEqual(counts, [0, 1, 0])
+    }
+
+    func testViewModel_whenFocusMovedToOtherMonth_scrollsThatMonthPaper() async throws {
+        // given
+        FeatureFlag.enable(.aiAgent)
+        let viewModel = self.makeViewModel()
+        viewModel.prepare()
+        try await Task.sleep(for: .milliseconds(50))
+
+        // when
+        viewModel.focusChanged(from: 1, to: 2)
+        self.stubOrchestration.stateSubject.send(.listening(.voice))
+        try await Task.sleep(for: .milliseconds(50))
+
+        // then
+        let counts = self.spyRouter.spyInteractors.map { $0.didScrollToVoiceInputCount }
+        XCTAssertEqual(counts, [0, 0, 1])
+    }
+
+    func testViewModel_whenStayInVoiceListening_scrollsOnlyOncePerEntry() async throws {
+        // given
+        FeatureFlag.enable(.aiAgent)
+        let viewModel = self.makeViewModel()
+        viewModel.prepare()
+        try await Task.sleep(for: .milliseconds(50))
+
+        // when — 같은 상태가 반복 방출돼도 진입 edge는 1회
+        self.stubOrchestration.stateSubject.send(.listening(.voice))
+        self.stubOrchestration.stateSubject.send(.listening(.voice))
+        try await Task.sleep(for: .milliseconds(50))
+
+        // then
+        let counts = self.spyRouter.spyInteractors.map { $0.didScrollToVoiceInputCount }
+        XCTAssertEqual(counts, [0, 1, 0])
+    }
+
+    func testViewModel_whenAIAgentFlagOff_doesNotScrollOnVoiceInput() async throws {
+        // given
+        let viewModel = self.makeViewModel()
+        viewModel.prepare()
+        try await Task.sleep(for: .milliseconds(50))
+
+        // when
+        self.stubOrchestration.stateSubject.send(.listening(.voice))
+        try await Task.sleep(for: .milliseconds(50))
+
+        // then
+        let counts = self.spyRouter.spyInteractors.map { $0.didScrollToVoiceInputCount }
+        XCTAssertEqual(counts, [0, 0, 0])
+    }
+}
+
 private extension CalendarViewModelImpleTests {
     
     class SpyRouter: BaseSpyRouter, CalendarViewRouting, @unchecked Sendable {
@@ -1071,6 +1141,11 @@ private extension CalendarViewModelImpleTests {
             self.didSelectDayCallback?()
         }
         
+        var didScrollToVoiceInputCount: Int = 0
+        func scrollToVoiceInput() {
+            self.didScrollToVoiceInputCount += 1
+        }
+
         func monthScene(didChange currentSelectedDay: CurrentSelectDayModel, and eventsThatDay: [any CalendarEvent]) { }
         func dayEventListDidRequestShowAICommand() { }
     }

--- a/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import UIKit
 import Combine
 import Prelude
 import Optics
@@ -1221,6 +1222,64 @@ private extension CalendarViewModelImpleTests {
             return isSyncing.removeDuplicates()
                 .eraseToAnyPublisher()
         }
+    }
+}
+
+// MARK: - 앱 비활성과 음성 입력
+
+extension CalendarViewModelImpleTests {
+
+    private func resignActiveAfterPrepared(
+        aiAgentEnabled: Bool = true,
+        state: AIAgentState?
+    ) async throws {
+        if aiAgentEnabled { FeatureFlag.enable(.aiAgent) }
+        let viewModel = self.makeViewModel()
+        viewModel.prepare()
+        try await Task.sleep(for: .milliseconds(50))
+        state.map { self.stubOrchestration.stateSubject.send($0) }
+
+        NotificationCenter.default.post(
+            name: UIApplication.willResignActiveNotification, object: nil
+        )
+        try await Task.sleep(for: .milliseconds(50))
+        // VM이 해제되면 구독도 끊겨 단언이 무의미해진다
+        withExtendedLifetime(viewModel) { }
+    }
+
+    func testViewModel_whenAppResignsActiveWhileVoiceListening_stopsInput() async throws {
+        // given, when
+        try await self.resignActiveAfterPrepared(state: .listening(.voice))
+
+        // then
+        XCTAssertEqual(self.stubOrchestration.didStopInput, true)
+    }
+
+    // 키보드 입력은 오디오와 무관하므로 앱이 비활성이 돼도 유지된다
+    func testViewModel_whenAppResignsActiveWhileKeyboardListening_keepsInput() async throws {
+        // given, when
+        try await self.resignActiveAfterPrepared(state: .listening(.keyboard))
+
+        // then
+        XCTAssertNil(self.stubOrchestration.didStopInput)
+    }
+
+    func testViewModel_whenAppResignsActiveWhileIdle_keepsInput() async throws {
+        // given, when
+        try await self.resignActiveAfterPrepared(state: .idle)
+
+        // then
+        XCTAssertNil(self.stubOrchestration.didStopInput)
+    }
+
+    func testViewModel_whenAIAgentFlagOff_doesNotStopInput() async throws {
+        // given, when
+        try await self.resignActiveAfterPrepared(
+            aiAgentEnabled: false, state: .listening(.voice)
+        )
+
+        // then
+        XCTAssertNil(self.stubOrchestration.didStopInput)
     }
 }
 

--- a/Presentations/CommonPresentation/Sources/Appearance/ColorSet.swift
+++ b/Presentations/CommonPresentation/Sources/Appearance/ColorSet.swift
@@ -64,6 +64,9 @@ public protocol ColorSet: Sendable {
     var accentWarn: UIColor { get }
     var accentAI: UIColor { get }
 
+    // AI 음성 입력 중 입력 바 배경 (그라데이션 stops — NeonListeningBorder와 같은 팔레트)
+    var aiListeningBackground: [UIColor] { get }
+
     // AI chat bubble (유저 메시지 말풍선)
     var aiUserBubbleBackground: UIColor { get }
     var aiUserBubbleText: UIColor { get }
@@ -113,6 +116,12 @@ public struct DefaultLightColorSet: ColorSet {
     public let accentInfo: UIColor = UIColor(rgb: 0xff7417)
     public let accentWarn: UIColor = UIColor(rgb: 0xea4444)
     public let accentAI: UIColor = UIColor(rgb: 0x6272a4)
+
+    public let aiListeningBackground: [UIColor] = [
+        UIColor(rgb: 0xbd93f9).withAlphaComponent(0.20),
+        UIColor(rgb: 0xff79c6).withAlphaComponent(0.13),
+        UIColor(rgb: 0x8be9fd).withAlphaComponent(0.20)
+    ]
 
     // AI chat bubble (유저 메시지 말풍선)
     public let aiUserBubbleBackground: UIColor = UIColor(rgb: 0x44475a)
@@ -165,6 +174,12 @@ public struct DefaultDarkColorSet: ColorSet {
     public let accentInfo: UIColor = UIColor(rgb: 0xff7417)
     public let accentWarn: UIColor = UIColor(rgb: 0xea4444)
     public let accentAI: UIColor = UIColor(rgb: 0x6272a4)
+
+    public let aiListeningBackground: [UIColor] = [
+        UIColor(rgb: 0xbd93f9).withAlphaComponent(0.28),
+        UIColor(rgb: 0xff79c6).withAlphaComponent(0.18),
+        UIColor(rgb: 0x8be9fd).withAlphaComponent(0.26)
+    ]
 
     // AI chat bubble (유저 메시지 말풍선)
     public let aiUserBubbleBackground: UIColor = UIColor(rgb: 0xccd0dc)


### PR DESCRIPTION
close #783

## 문제

**1. 앱이 가려지면 음성 입력이 조용히 죽는다.** 제어센터·앱 스위처·시스템 다이얼로그로 앱이 비활성이 되면 오디오 세션이 끊기는데, UI는 `.listening(.voice)` 그대로라 사용자는 계속 듣고 있는 줄 안다. 돌아와도 마이크는 죽어 있다.

**2. 음성 입력이 시작된 걸 알아채기 어렵다.** 특히 딥링크로 진입해 바로 발화 대기 상태가 되면, 입력 바가 화면 밖이거나 이벤트 셀과 같은 배경색(`bg1`)이라 묻힌다.

## 접근

### 비활성 시 음성 입력 중지

일시중지 후 복귀 시 재개하는 방향을 먼저 만들어 실기기에서 써봤으나, 끊긴 발화를 이어붙이는 동선이 실제로는 어색해 **입력 자체를 접는 쪽**으로 정리했다. 상태를 실제(마이크 꺼짐)와 일치시키는 게 우선이다.

- `CalendarViewModelImple.bindVoiceInputLifecycle` — `willResignActive`를 orchestration state와 묶어, 음성으로 듣던 중일 때만 기존 `stopInput()`을 호출한다. 키보드 입력은 오디오와 무관하므로 건드리지 않는다. Domain은 UIKit을 모르므로 라이프사이클 감지는 Presentation 몫이고, `CalendarViewModelImple`이 단일 인스턴스라 여기에 둔다.

Domain에는 아무것도 추가하지 않았다 — 필요한 건 기존 `stopInput()`과 이미 VM이 구독 중인 `state`뿐이라, 소비자 하나를 위해 usecase 프로토콜을 넓히지 않는다.

인식 중이던 텍스트는 버린다(`stopInput()`의 기존 동작). 끝나지 않은 문장을 제출하면 AI가 의도하지 않은 이벤트를 만든다.

### 진입 인지

- **자동 스크롤** — `.listening(.voice)` 진입 순간 입력 바를 화면 안으로. 오케스트레이션은 앱 전역 단일인데 `CalendarPaper`는 이전·현재·다음 3개가 동시에 살아있어, 각 paper가 직접 구독하면 안 보이는 달까지 목록 하단으로 내려간다. 대상 선정은 focus를 아는 `CalendarViewModelImple`이 하고 해당 paper에만 지시한다.
- **입력 바 배경** — listening 중에만 네온 4색 저알파 그라데이션. `ColorSet.aiListeningBackground`로 라이트·다크 각각 정의.

## 범위 밖

`AVAudioSession`의 interruption(전화 수신)·routeChange(이어폰 분리)는 다루지 않았다. 앱이 활성인 채로 오디오만 끊기는 별개 경로라, 같은 "중지" 처리를 붙일 자리가 하나 더 있다.
