### PR TITLE
[#755] 셀 목록 재방출로 컨텍스트 메뉴가 다른 이벤트 메뉴로 갈리는 문제 수정

### DIFF
--- a/Presentations/CalendarScenes/Sources/Common/CalendarEvents/CalendarEvent.swift
+++ b/Presentations/CalendarScenes/Sources/Common/CalendarEvents/CalendarEvent.swift
@@ -262,7 +262,7 @@ public struct GoogleCalendarEvent: CalendarEvent {
     }
 
     public var compareKey: String {
-        return "\(String(describing: Self.self))-\(eventId)-\(name)-\(eventTime?.hashValue ?? -1)-\(eventTimeOnCalendar?.hashValue ?? -1)-\(eventTagId.hashValue)-\(self.isForemost)-\(self.colorId ?? "nil")-\(self.htmlLink ?? "nil")-\(self.locationText ?? "nil")"
+        return "\(String(describing: Self.self))-\(eventId)-\(accountId)-\(name)-\(eventTime?.hashValue ?? -1)-\(eventTimeOnCalendar?.hashValue ?? -1)-\(eventTagId.hashValue)-\(self.isForemost)-\(self.colorId ?? "nil")-\(self.htmlLink ?? "nil")-\(self.locationText ?? "nil")"
     }
 }
 

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventCellViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventCellViewModel.swift
@@ -165,6 +165,31 @@ public protocol EventCellViewModel: Sendable {
     var isRepeating: Bool { get }
     var moreActions: EventListMoreActionModel? { get }
     var isAlldayEvent: Bool { get }
+
+    /// 셀이 그리는 값 + 셀 액션이 소비하는 값 전부를 담는다. 이 키가 같으면 셀 목록 재방출이 생략된다.
+    /// 프로토콜 밖 프로퍼티는 각 타입이 `makeCustomCompareKey`의 추가 성분으로 직접 얹어야 한다 — 빠뜨리면 그 값의 변경이 화면·동작에 안 붙는다.
+    var customCompareKey: String { get }
+}
+
+extension EventCellViewModel {
+
+    fileprivate func makeCustomCompareKey(_ additionalComponents: [String?]) -> String {
+        let baseComponents: [String?] = [
+            "\(Self.self)",
+            self.eventIdentifier,
+            self.name,
+            "\(self.colorSource)",
+            self.periodText?.customCompareKey,
+            self.periodDescription,
+            "\(self.isForemost)",
+            "\(self.isRepeating)",
+            "\(self.isAlldayEvent)",
+            String(describing: self.moreActions)
+        ]
+        return (baseComponents + additionalComponents)
+            .map { $0 ?? "nil" }
+            .joined(separator: "-")
+    }
 }
 
 
@@ -233,6 +258,13 @@ public struct TodoEventCellViewModel: EventCellViewModel {
             removeActions: removeActions
         )
     }
+
+    public var customCompareKey: String {
+        return self.makeCustomCompareKey([
+            self.eventTimeRawValue.map { "\($0)" },
+            "\(self.isCurrentTodo)"
+        ])
+    }
 }
 
 struct PendingTodoEventCellViewModel: EventCellViewModel {
@@ -254,8 +286,9 @@ struct PendingTodoEventCellViewModel: EventCellViewModel {
         self.colorSource = defaultTagId.map { EventTagId.custom($0) } ?? EventTagId.default
     }
 
-    // TOOD: make custom compare key
     var moreActions: EventListMoreActionModel? { nil }
+
+    var customCompareKey: String { self.makeCustomCompareKey([]) }
 }
 
 // MARK: - Schedule
@@ -317,6 +350,13 @@ public struct ScheduleEventCellViewModel: EventCellViewModel {
             removeActions: removeActions
         )
     }
+
+    public var customCompareKey: String {
+        return self.makeCustomCompareKey([
+            self.turn.map { "\($0)" },
+            self.eventTimeRawValue.map { "\($0)" }
+        ])
+    }
 }
 
 
@@ -342,6 +382,8 @@ public struct HolidayEventCellViewModel: EventCellViewModel {
     }
 
     public var moreActions: EventListMoreActionModel? { nil }
+
+    public var customCompareKey: String { self.makeCustomCompareKey([]) }
 }
 
 
@@ -378,6 +420,10 @@ public struct AppleCalendarEventCellViewModel: EventCellViewModel {
     }
 
     public var moreActions: EventListMoreActionModel? { nil }
+
+    public var customCompareKey: String {
+        return self.makeCustomCompareKey([self.calendarId])
+    }
 }
 
 
@@ -421,6 +467,10 @@ public struct GoogleCalendarEventCellViewModel: EventCellViewModel {
         return .init(
             basicActions: [.editGoogleEvent(link: link)], removeActions: []
         )
+    }
+
+    public var customCompareKey: String {
+        return self.makeCustomCompareKey([self.calendarId, self.accountId])
     }
 }
 

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListViewModel.swift
@@ -336,6 +336,7 @@ extension DayEventListViewModelImple {
         .map(asCellViewModel)
 
         return foremostModel
+            .removeDuplicates(by: { $0?.customCompareKey == $1?.customCompareKey })
             .eraseToAnyPublisher()
     }
 
@@ -358,6 +359,7 @@ extension DayEventListViewModelImple {
             self.uiSettingUsecase.currentCalendarUISeting.map { $0.is24hourForm }.removeDuplicates()
         )
         .compactMap(asCellViewModels)
+        .removeDuplicates(by: { $0.map { $0.customCompareKey } == $1.map { $0.customCompareKey } })
         .eraseToAnyPublisher()
     }
 
@@ -389,6 +391,7 @@ extension DayEventListViewModelImple {
         .map(combineEvents)
 
         return cells
+            .removeDuplicates(by: { $0.map { $0.customCompareKey } == $1.map { $0.customCompareKey } })
             .eraseToAnyPublisher()
     }
 

--- a/Presentations/CalendarScenes/Tests/Common/CalendarEventTests.swift
+++ b/Presentations/CalendarScenes/Tests/Common/CalendarEventTests.swift
@@ -1,0 +1,86 @@
+//
+//  CalendarEventTests.swift
+//  CalendarScenesTests
+//
+//  Created by sudo.park on 8/8/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Domain
+
+@testable import CalendarScenes
+
+
+class CalendarEventTests {
+
+    private let timeZone = TimeZone(abbreviation: "UTC")!
+
+    private func makeGoogleEvent(
+        calendarId: String = "calendar",
+        accountId: String = "account"
+    ) -> GoogleCalendarEvent {
+        let raw = GoogleCalendar.Event(
+            "google", calendarId,
+            accountId: accountId, name: "name", colorId: "color",
+            time: .at(100)
+        )
+        return GoogleCalendarEvent(raw, in: self.timeZone)
+    }
+
+    private func makeAppleEvent(calendarId: String = "calendar") -> AppleCalendarEvent {
+        let raw = AppleCalendar.Event(
+            eventId: "apple",
+            originalEventId: "apple",
+            calendarId: calendarId,
+            name: "name",
+            eventTime: .at(100)
+        )
+        return AppleCalendarEvent(raw, in: self.timeZone)
+    }
+}
+
+extension CalendarEventTests {
+
+    @Test("외부 캘린더 이벤트는 모든 값이 같으면 compare key도 같다")
+    func externalEvent_compareKeyIsSame_whenAllValuesAreSame() {
+        // given
+        let (google, sameGoogle) = (self.makeGoogleEvent(), self.makeGoogleEvent())
+        let (apple, sameApple) = (self.makeAppleEvent(), self.makeAppleEvent())
+
+        // when + then
+        #expect(google.compareKey == sameGoogle.compareKey)
+        #expect(apple.compareKey == sameApple.compareKey)
+    }
+
+    @Test("google 이벤트는 계정이 달라지면 compare key도 달라진다")
+    func googleEvent_compareKeyIsDifferent_whenAccountIdChanged() {
+        // given
+        let event = self.makeGoogleEvent(accountId: "account")
+        let accountChangedEvent = self.makeGoogleEvent(accountId: "another-account")
+
+        // when + then
+        #expect(event.compareKey != accountChangedEvent.compareKey)
+    }
+
+    @Test("google 이벤트는 소속 캘린더가 달라지면 compare key도 달라진다")
+    func googleEvent_compareKeyIsDifferent_whenCalendarIdChanged() {
+        // given
+        let event = self.makeGoogleEvent(calendarId: "calendar")
+        let calendarChangedEvent = self.makeGoogleEvent(calendarId: "another-calendar")
+
+        // when + then
+        #expect(event.compareKey != calendarChangedEvent.compareKey)
+    }
+
+    @Test("apple 이벤트는 소속 캘린더가 달라지면 compare key도 달라진다")
+    func appleEvent_compareKeyIsDifferent_whenCalendarIdChanged() {
+        // given
+        let event = self.makeAppleEvent(calendarId: "calendar")
+        let calendarChangedEvent = self.makeAppleEvent(calendarId: "another-calendar")
+
+        // when + then
+        #expect(event.compareKey != calendarChangedEvent.compareKey)
+    }
+}

--- a/Presentations/CalendarScenes/Tests/Common/EventCellViewModelTests.swift
+++ b/Presentations/CalendarScenes/Tests/Common/EventCellViewModelTests.swift
@@ -1,0 +1,90 @@
+//
+//  EventCellViewModelTests.swift
+//  CalendarScenesTests
+//
+//  Created by sudo.park on 8/8/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Prelude
+import Optics
+import Domain
+
+@testable import CalendarScenes
+
+
+class EventCellViewModelTests {
+
+    private let timeZone = TimeZone(abbreviation: "UTC")!
+    private let todayRange: Range<TimeInterval> = 0..<24*3600
+
+    private func makeTodoCell(rawTime: EventTime?) -> TodoEventCellViewModel {
+        return TodoEventCellViewModel("todo", name: "name")
+            |> \.eventTimeRawValue .~ rawTime
+    }
+
+    private func makeScheduleCell(rawTime: EventTime?) -> ScheduleEventCellViewModel {
+        return ScheduleEventCellViewModel("schedule", turn: 1, name: "name")
+            |> \.eventTimeRawValue .~ rawTime
+    }
+
+    private func makeGoogleCell(accountId: String) -> GoogleCalendarEventCellViewModel? {
+        let raw = GoogleCalendar.Event(
+            "google", "calendar",
+            accountId: accountId, name: "name", colorId: "color",
+            time: .at(100)
+        )
+        let event = GoogleCalendarEvent(raw, in: self.timeZone)
+        return GoogleCalendarEventCellViewModel(
+            event, in: self.todayRange, self.timeZone, true
+        )
+    }
+}
+
+extension EventCellViewModelTests {
+
+    @Test("셀이 그리는 값과 동작에 쓰는 값이 모두 같으면 compare key도 같다")
+    func cell_compareKeyIsSame_whenAllValuesAreSame() {
+        // given
+        let (todo, sameTodo) = (self.makeTodoCell(rawTime: .at(100)), self.makeTodoCell(rawTime: .at(100)))
+        let (schedule, sameSchedule) = (self.makeScheduleCell(rawTime: .at(100)), self.makeScheduleCell(rawTime: .at(100)))
+        let (google, sameGoogle) = (self.makeGoogleCell(accountId: "account"), self.makeGoogleCell(accountId: "account"))
+
+        // when + then
+        #expect(todo.customCompareKey == sameTodo.customCompareKey)
+        #expect(schedule.customCompareKey == sameSchedule.customCompareKey)
+        #expect(google?.customCompareKey == sameGoogle?.customCompareKey)
+    }
+
+    @Test("todo 셀은 표시 텍스트에 안 드러나는 raw event time이 달라져도 compare key가 달라진다")
+    func todoCell_compareKeyIsDifferent_whenRawEventTimeChanged() {
+        // given
+        let cell = self.makeTodoCell(rawTime: .at(100))
+        let timeChangedCell = self.makeTodoCell(rawTime: .at(200))
+
+        // when + then
+        #expect(cell.customCompareKey != timeChangedCell.customCompareKey)
+    }
+
+    @Test("schedule 셀은 표시 텍스트에 안 드러나는 raw event time이 달라져도 compare key가 달라진다")
+    func scheduleCell_compareKeyIsDifferent_whenRawEventTimeChanged() {
+        // given
+        let cell = self.makeScheduleCell(rawTime: .at(100))
+        let timeChangedCell = self.makeScheduleCell(rawTime: .at(200))
+
+        // when + then
+        #expect(cell.customCompareKey != timeChangedCell.customCompareKey)
+    }
+
+    @Test("google 셀은 표시에 안 쓰이는 account id가 달라져도 compare key가 달라진다")
+    func googleCell_compareKeyIsDifferent_whenAccountIdChanged() {
+        // given
+        let cell = self.makeGoogleCell(accountId: "account")
+        let accountChangedCell = self.makeGoogleCell(accountId: "another-account")
+
+        // when + then
+        #expect(cell?.customCompareKey != accountChangedCell?.customCompareKey)
+    }
+}

--- a/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
@@ -690,6 +690,21 @@ extension DayEventListViewModelImpleTests {
             "2023-09-30-holiday"
         ]
     }
+
+    private var dummyEventsWithScheduleTurnedRepeating: [any CalendarEvent] {
+        let turnedRepeating = ScheduleCalendarEvent(
+            eventIdWithoutTurn: "ev",
+            eventId: "not-repeating-schedule",
+            name: "not-repeating-schedule",
+            eventTime: .at(self.todayRange.lowerBound),
+            eventTimeOnCalendar: nil,
+            eventTagId: .custom("some"),
+            isRepeating: true
+        ) |> \.turn .~ 1
+        return self.dummyEvents.map { event in
+            event.eventId == "not-repeating-schedule" ? turnedRepeating : event
+        }
+    }
     
     func testViewModel_whenAppleCalendarEventExists_showInList() {
         // given
@@ -776,6 +791,32 @@ extension DayEventListViewModelImpleTests {
             .map { $0.filter { $0.name.starts(with: "current-todo") }}
             .map { !$0.isEmpty }
         XCTAssertEqual(hasCurrentTodo, [true, false])
+    }
+
+    func testViewModel_whenSameEventListNotifiedAgain_notRefreshCellViewModels() {
+        // given
+        let expect = expectation(description: "같은 이벤트 목록이 다시 통지되면 셀 목록을 재방출하지 않고, 실제로 바뀌었을때만 재방출한다")
+        expect.expectedFulfillmentCount = 2
+        let viewModel = self.makeViewModelWithInitialListLoaded()
+
+        // when
+        let cvmLists = self.waitOutputs(expect, for: viewModel.cellViewModels, timeout: 0.1) {
+            viewModel.selectedDayChanaged(self.dummyCurrentDay, and: self.dummyEvents)
+            viewModel.selectedDayChanaged(
+                self.dummyCurrentDay, and: self.dummyEventsWithScheduleTurnedRepeating
+            )
+        }
+
+        // then
+        XCTAssertEqual(cvmLists.count, 2)
+        let removeActionsPerEmit = cvmLists.map { cvms in
+            cvms.first(where: { $0.eventIdentifier == "not-repeating-schedule" })?.moreActions?.removeActions
+        }
+        XCTAssertEqual(removeActionsPerEmit.first, [.remove(onlyThisTime: false)])
+        XCTAssertEqual(
+            removeActionsPerEmit.last,
+            [.remove(onlyThisTime: true), .remove(onlyThisTime: false)]
+        )
     }
 }
 

--- a/docs/troubleshooting/2026-08-07-day-event-list-context-menu-shows-wrong-remove-action.md
+++ b/docs/troubleshooting/2026-08-07-day-event-list-context-menu-shows-wrong-remove-action.md
@@ -1,0 +1,24 @@
+---
+issue: "#755"
+subdomain: Event
+symptoms: [비반복 이벤트에 이번만 삭제, 컨텍스트 메뉴 깜빡임, 메뉴 탭 무반응, sync 호출 과다]
+resolution: fixed
+---
+
+# 비반복 이벤트를 롱탭했는데 컨텍스트 메뉴에 "이번만 삭제"가 뜬다
+
+- **증상**: AI 커맨드로 일정을 만들고 백그라운드 갔다 복귀한 직후, 비반복 이벤트를 롱탭하면 반복 이벤트 전용인 "이번만 삭제"가 메뉴에 뜬다. 메뉴가 갱신되듯 깜빡이고 항목을 눌러도 반응이 없다.
+
+- **근본 원인**: `DayEventListViewModelImple`의 셀 목록 publisher가 내용이 같은 배열을 계속 재방출한다. `cellViewModels`·`foremostEventModel`·`uncompletedTodoEventModels` 어디에도 중복 제거가 없고, 상류인 `subject.currentDayAndEventLists`(Month → CalendarPaper → DayEventList 통지)와 `TodoEventUsecase.currentTodoEvents`(`ShareDataKeys.todos` dict 전체를 observe)가 무관한 갱신에도 매번 흘린다. 포그라운드 복귀는 전 범위 refresh + sync + syncEnd 후 재-refresh가 겹치는 구간이라 이 재방출이 몰린다.
+
+  셀 목록이 갈아엎히면 `EventListCellView.contextMenu`의 `cellViewModel.moreActions`도 매 렌더 다시 계산된다. 롱탭 시작과 메뉴 표시 사이에 그 자리를 반복 이벤트가 차지하면 반복 이벤트의 메뉴가 그려진다. `isRepeating`은 `schedule.repeating != nil` / `todo.time != nil && todo.repeating != nil`로만 정해져서 비반복이 반복으로 계산될 경로 자체가 없다 — 값이 틀린 게 아니라 다른 이벤트의 메뉴다. 깜빡임·탭 무반응(`removeEvent`의 confirm alert present가 씹힘)도 같은 재평가에서 나온다.
+
+- **해결**: `EventCellViewModel.customCompareKey`(셀이 그리는 값 전부 — 타입·id·이름·색 소스·기간 텍스트·isForemost·isRepeating·allday·moreActions)를 도입하고 위 세 publisher에 `removeDuplicates(by:)`를 건다. `CalendarEventListhUsecase`가 이미 쓰는 `compareKey` 기반 중복 제거와 같은 패턴. 값이 실제로 바뀌면 키가 달라져 그대로 방출된다.
+
+  키는 **프로토콜 요구사항**이어야 한다 — `EventCellViewModel`이 프로토콜이라 공통 프로퍼티만 보는 extension 단독 구현으로는 각 타입이 따로 들고 있는 값이 키에 못 들어간다. `makeCustomCompareKey(_:)`가 공통 성분을 조립하고 타입이 고유 값을 얹는다: Todo·Schedule은 `eventTimeRawValue`("이번만 삭제"가 지울 회차를 정하는 값 — 표시 텍스트가 같아도 달라질 수 있다), Google·Apple은 라우팅에 쓰는 `accountId`·`calendarId`. 이 구조는 #385에서 `ForEach(id:)` 오용을 고치며 같이 지워졌던 것(`a9e9583f`)이고, identity(안정적인 id)와 변경 감지(내용 키)는 별개 관심사라 `ForEach`는 `eventIdentifier`로 둔 채 키만 되살렸다.
+
+- **기각 방향**:
+  - Month → listener 통지 경로에 dedupe — 상류라 timezone·is24hourForm·pending todo 등 다른 축의 중복을 못 막는다
+  - ViewState 대입 시점 비교 — View 레이어에 비교 로직이 새고 상태 세 개에 각각 심어야 한다
+  - 포그라운드 복귀 sync/refresh 중복 정리 — 실재하지만(`CalendarViewModel.bindRefreshEvents`가 willEnterForeground 하나로 전 범위 refresh + sync를 동시에 걸고, sync 완료 후 `syncEnd`로 또 refresh) 이번 스코프에서 유저가 제외. 무한 재귀는 아님
+  - `EventSyncUsecaseImple.runSyncTask`의 취소 태스크가 CancellationError를 먹고 끝까지 굴러가 가짜 `isSyncing=false`를 쏘는 건 별건 — 미수정

--- a/docs/troubleshooting/2026-08-07-day-event-list-context-menu-shows-wrong-remove-action.md
+++ b/docs/troubleshooting/2026-08-07-day-event-list-context-menu-shows-wrong-remove-action.md
@@ -15,7 +15,7 @@ resolution: fixed
 
 - **해결**: `EventCellViewModel.customCompareKey`(셀이 그리는 값 전부 — 타입·id·이름·색 소스·기간 텍스트·isForemost·isRepeating·allday·moreActions)를 도입하고 위 세 publisher에 `removeDuplicates(by:)`를 건다. `CalendarEventListhUsecase`가 이미 쓰는 `compareKey` 기반 중복 제거와 같은 패턴. 값이 실제로 바뀌면 키가 달라져 그대로 방출된다.
 
-  키는 **프로토콜 요구사항**이어야 한다 — `EventCellViewModel`이 프로토콜이라 공통 프로퍼티만 보는 extension 단독 구현으로는 각 타입이 따로 들고 있는 값이 키에 못 들어간다. `makeCustomCompareKey(_:)`가 공통 성분을 조립하고 타입이 고유 값을 얹는다: Todo·Schedule은 `eventTimeRawValue`("이번만 삭제"가 지울 회차를 정하는 값 — 표시 텍스트가 같아도 달라질 수 있다), Google·Apple은 라우팅에 쓰는 `accountId`·`calendarId`. 이 구조는 #385에서 `ForEach(id:)` 오용을 고치며 같이 지워졌던 것(`a9e9583f`)이고, identity(안정적인 id)와 변경 감지(내용 키)는 별개 관심사라 `ForEach`는 `eventIdentifier`로 둔 채 키만 되살렸다.
+  키는 **프로토콜 요구사항**이어야 한다 — `EventCellViewModel`이 프로토콜이라 공통 프로퍼티만 보는 extension 단독 구현으로는 각 타입이 따로 들고 있는 값이 키에 못 들어간다. `makeCustomCompareKey(_:)`가 공통 성분을 조립하고 타입이 고유 값을 얹는다: Todo·Schedule은 `eventTimeRawValue`("이번만 삭제"가 지울 회차를 정하는 값 — 표시 텍스트가 같아도 달라질 수 있다), Google·Apple은 라우팅에 쓰는 `accountId`·`calendarId`. 상류 `GoogleCalendarEvent.compareKey`에도 `accountId`가 빠져 있어 함께 채웠다 — 상류에서 걸리면 셀 키가 정확해도 발화하지 못한다. 이 구조는 #385에서 `ForEach(id:)` 오용을 고치며 같이 지워졌던 것(`a9e9583f`)이고, identity(안정적인 id)와 변경 감지(내용 키)는 별개 관심사라 `ForEach`는 `eventIdentifier`로 둔 채 키만 되살렸다.
 
 - **기각 방향**:
   - Month → listener 통지 경로에 dedupe — 상류라 timezone·is24hourForm·pending todo 등 다른 축의 중복을 못 막는다

--- a/docs/troubleshooting/INDEX.md
+++ b/docs/troubleshooting/INDEX.md
@@ -6,5 +6,7 @@
 
 <!-- 레코드는 아래에 최신순으로 추가 -->
 
+- [2026-08-07 비반복 이벤트를 롱탭했는데 컨텍스트 메뉴에 "이번만 삭제"가 뜬다](2026-08-07-day-event-list-context-menu-shows-wrong-remove-action.md) — Event / fixed / 이번만 삭제 오노출, 메뉴 깜빡임, 탭 무반응, 셀 목록 재방출
+
 - [2026-08-07 키보드 입력 시트에서 커맨드를 전송하면 present 충돌로 크래시](2026-08-07-ai-command-sheet-present-while-keyboard-sheet-up.md) — AIAgent / fixed / already presenting, 바텀시트 크래시, 키보드 입력 전송
 - [2026-08-06 Share Extension으로 만든 AI job의 결과 푸시가 안 온다](2026-08-06-share-extension-ai-job-no-push.md) — AIAgent / non-issue / 푸시 안옴, device_id, DailyLimitExceeded, share extension


### PR DESCRIPTION
close #755

## 문제

비반복 이벤트를 롱탭했는데 반복 이벤트 전용인 "이번만 삭제"가 메뉴에 뜨고, 메뉴가 깜빡이며 항목을 눌러도 반응이 없다.

`isRepeating`은 `schedule.repeating != nil` / `todo.time != nil && todo.repeating != nil`로만 정해져서 비반복이 반복으로 계산될 경로가 없다. 값이 틀린 게 아니라 **다른 이벤트의 메뉴**였다.

원인은 `DayEventListViewModelImple`의 셀 목록 publisher가 내용이 같은 배열을 계속 재방출하는 것. 중복 제거가 어디에도 없고, 상류인 `subject.currentDayAndEventLists`와 `TodoEventUsecase.currentTodoEvents`가 무관한 갱신에도 매번 흘린다. 포그라운드 복귀는 전 범위 refresh + sync + syncEnd 후 재-refresh가 겹치는 구간이라 재방출이 몰린다. 목록이 갈아엎히면 `EventListCellView.contextMenu`의 `moreActions`도 매 렌더 다시 계산되고, 롱탭 시작과 메뉴 표시 사이에 그 자리를 반복 이벤트가 차지하면 그 이벤트의 메뉴가 그려진다. 깜빡임과 탭 무반응(confirm alert present가 씹힘)도 같은 재평가에서 나온다.

## 접근

셀이 그리는 값 전부를 담는 비교 키를 만들어, 내용이 안 바뀌었으면 방출 자체를 막는다. `CalendarEventListhUsecase`가 이미 `compareKey`로 쓰는 패턴과 같다.

`ForEach(id:)`는 `eventIdentifier`로 그대로 뒀다. identity(안정적인 id)와 변경 감지(내용 키)는 별개 관심사고, 내용 키를 id로 쓰면 내용이 바뀔 때마다 뷰가 파괴·재생성된다 — #385가 고친 게 그 오용이다. 이번엔 그때 같이 지워졌던 변경 감지 쪽만 되살렸다.

키는 **프로토콜 요구사항**으로 뒀다. `EventCellViewModel`이 프로토콜이라, 공통 프로퍼티만 보는 extension 단독 구현으로는 각 타입이 따로 들고 있는 값이 키에 못 들어간다. `makeCustomCompareKey(_:)`가 공통 성분을 조립하고 타입이 고유 값을 얹는 구조 — Todo·Schedule은 `eventTimeRawValue`, Google·Apple은 `accountId`·`calendarId`.

`eventTimeRawValue`가 특히 중요하다. `EventListCellEventHanleViewModel`이 "이번만 삭제"로 지울 회차를 이 값으로 정하는데, 표시 텍스트가 같아도 raw time은 달라질 수 있다. 키에서 빠지면 화면에 옛 시간이 남아 엉뚱한 회차를 지운다.

상류 `GoogleCalendarEvent.compareKey`에도 `accountId`가 빠져 있어 함께 채웠다. 상류에서 걸리면 셀 키가 정확해도 그 변화가 도달하지 못한다.

## 스코프에서 뺀 것

포그라운드 복귀 시 sync·refresh 중복은 실재한다 — `CalendarViewModel.bindRefreshEvents`가 `willEnterForeground` 하나로 전 범위 refresh와 sync를 동시에 걸고, sync 완료 후 `syncEnd`로 또 refresh한다. 이슈 제목의 "무한재귀"는 아니지만 정리할 여지가 있고, 이번엔 그리는 쪽만 고치기로 했다.

`EventSyncUsecaseImple.runSyncTask`의 취소된 태스크가 `CancellationError`를 먹고 끝까지 굴러가 가짜 `isSyncing = false`를 쏘는 것도 별건으로 두었다.

## 검증

`CalendarScenes` 162 / `TodoCalendarApp` 33 / `TodoCalendarAppWidget` 135, 실패 0.
