### PR TITLE
[#794] tuist 매니페스트 의존 경로를 relativeToRoot 기준으로 전환

### DIFF
--- a/.claude/skills/add-framework/SKILL.md
+++ b/.claude/skills/add-framework/SKILL.md
@@ -14,7 +14,7 @@ description: Use when creating a new framework (module) in this project — 신�
   - 테스트 없는 지원 모듈: `Project.framework(...)`
 - `<위치>/<Name>/<Name>.h` — **모듈 루트에 헤더 파일 필수** (팩토리가 `Headers.headers(public:)`로 요구).
 - `Sources/`, `Tests/` 디렉토리 생성. 테스트 배치는 testability §8.
-- 의존성은 `.project(target:path: .relativeToCurrentFile("../../<Layer>/<Module>"))` 상대경로. Presentation Scene 표준 세트: `Common3rdParty`·`CommonPresentation`·`Domain`·`Extensions`·`Scenes` (선례: `Presentations/AIAgentScene/Project.swift`).
+- 의존성은 `.project(target:path: .relativeToRoot("<Layer>/<Module>"))` — 레포 루트 기준. **`.relativeToCurrentFile`은 쓰지 않는다** (#794): 직렬화된 매니페스트에 `#file` 절대경로가 `callerPath`로 실리는데, tuist의 전역 manifest 캐시 키에는 매니페스트 위치가 없어서 같은 레포의 다른 체크아웃(워크트리·self-hosted CI 러너)과 충돌하면 의존 경로가 남의 트리로 샌다. Presentation Scene 표준 세트: `Common3rdParty`·`CommonPresentation`·`Domain`·`Extensions`·`Scenes` (선례: `Presentations/AIAgentScene/Project.swift`).
 - Service 프레임워크(Domain 프로토콜의 플랫폼·서드파티 SDK 결합 구현체): 위치 `Services/<Name>`, 네이밍 `XxxService`(여러 SDK를 묶는 성격이면 `XxxServices`), 의존 표준 세트 `Common3rdParty`·`Domain`·`Extensions` (선례: `Services/AuthService/Project.swift`). 분할 축은 의존 SDK 성격 — auth / MapKit(PlaceService) / AVFoundation(SpeechService) / 기타 1st party(FirstPartyServices) / 외부 서드파티(ExternalServices). 프로토콜은 Domain 잔류, 조립은 앱 타겟(ApplicationRootBuilder·Factories). 단일 소비자 SPM은 Common3rdParty가 아니라 해당 서비스가 `.external`로 직접 의존 (선례: ExternalServices ↔ SwiftLinkPreview).
 
 ## 2. 등록

--- a/.claude/skills/orchestrate/SKILL.md
+++ b/.claude/skills/orchestrate/SKILL.md
@@ -23,7 +23,7 @@ sub-work 목록·각 목표·의존 관계를 표로 정리해 유저 확인을 
 
 ### 2. 실행 모드 판정 — 의존성 그래프
 
-- **독립 sub-work → 병렬 가능.** 단 셋 다 충족할 때만: 파일 겹침 없음 / 각자 워크트리 확보(워크트리 tuist 함정 — 전용 워크스페이스 사용, 메인 워크트리 generated 재생성 주의) / **동시 진행 sub-work 2개 상한** (상한의 단위는 sub-work — 각 sub-work 내부 dispatch는 순차라, 동시에 활성인 워크트리·xcodebuild가 2개를 넘지 않게 하는 기준이다).
+- **독립 sub-work → 병렬 가능.** 단 셋 다 충족할 때만: 파일 겹침 없음 / 각자 워크트리 확보 / **동시 진행 sub-work 2개 상한** (상한의 단위는 sub-work — 각 sub-work 내부 dispatch는 순차라, 동시에 활성인 워크트리·xcodebuild가 2개를 넘지 않게 하는 기준이다).
 - **의존 sub-work → stacked 체인.** 앞 sub-work의 PR 머지를 기다리지 않는다 — 앞 브랜치를 베이스로 다음 sub-work을 진행하고, PR도 앞 브랜치를 base로 올린다.
 
 ### 3. Ledger — 컴팩션 생존 장부

--- a/Domain/Project.swift
+++ b/Domain/Project.swift
@@ -5,8 +5,8 @@ let project = Project.frameworkWithTest(name: "Domain",
                                         destinations: [.iPhone],
                                         iOSTargetVersion: "17.0",
                                         dependencies: [
-                                            .project(target: "Common3rdParty", path: .relativeToCurrentFile("../Supports/Common3rdParty")),
-                                            .project(target: "Extensions", path: .relativeToCurrentFile("../Supports/Extensions"))
+                                            .project(target: "Common3rdParty", path: .relativeToRoot("Supports/Common3rdParty")),
+                                            .project(target: "Extensions", path: .relativeToRoot("Supports/Extensions"))
                                         ])
 
 

--- a/Presentations/AIAgentScene/Project.swift
+++ b/Presentations/AIAgentScene/Project.swift
@@ -7,13 +7,13 @@ let project = Project.frameworkWithTest(name: "AIAgentScene",
                                         snapshotTests: true,
                                         dependencies: [
                                             .project(target: "Common3rdParty",
-                                                     path: .relativeToCurrentFile("../../Supports/Common3rdParty")),
+                                                     path: .relativeToRoot("Supports/Common3rdParty")),
                                             .project(target: "CommonPresentation",
-                                                     path: .relativeToCurrentFile("../../Presentations/CommonPresentation")),
+                                                     path: .relativeToRoot("Presentations/CommonPresentation")),
                                             .project(target: "Domain",
-                                                     path: .relativeToCurrentFile("../../Domain")),
+                                                     path: .relativeToRoot("Domain")),
                                             .project(target: "Extensions",
-                                                     path: .relativeToCurrentFile("../../Supports/Extensions")),
+                                                     path: .relativeToRoot("Supports/Extensions")),
                                             .project(target: "Scenes",
-                                                     path: .relativeToCurrentFile("../../Presentations/Scenes"))
+                                                     path: .relativeToRoot("Presentations/Scenes"))
                                         ])

--- a/Presentations/BillingScenes/Project.swift
+++ b/Presentations/BillingScenes/Project.swift
@@ -7,13 +7,13 @@ let project = Project.frameworkWithTest(name: "BillingScenes",
                                         snapshotTests: true,
                                         dependencies: [
                                             .project(target: "Common3rdParty",
-                                                     path: .relativeToCurrentFile("../../Supports/Common3rdParty")),
+                                                     path: .relativeToRoot("Supports/Common3rdParty")),
                                             .project(target: "CommonPresentation",
-                                                     path: .relativeToCurrentFile("../../Presentations/CommonPresentation")),
+                                                     path: .relativeToRoot("Presentations/CommonPresentation")),
                                             .project(target: "Domain",
-                                                     path: .relativeToCurrentFile("../../Domain")),
+                                                     path: .relativeToRoot("Domain")),
                                             .project(target: "Extensions",
-                                                     path: .relativeToCurrentFile("../../Supports/Extensions")),
+                                                     path: .relativeToRoot("Supports/Extensions")),
                                             .project(target: "Scenes",
-                                                     path: .relativeToCurrentFile("../../Presentations/Scenes"))
+                                                     path: .relativeToRoot("Presentations/Scenes"))
                                         ])

--- a/Presentations/CalendarScenes/Project.swift
+++ b/Presentations/CalendarScenes/Project.swift
@@ -7,14 +7,14 @@ let project = Project.frameworkWithTest(name: "CalendarScenes",
                                         snapshotTests: true,
                                         dependencies: [
                                             .project(target: "Common3rdParty",
-                                                     path: .relativeToCurrentFile("../../Supports/Common3rdParty")),
+                                                     path: .relativeToRoot("Supports/Common3rdParty")),
                                             .project(target: "CommonPresentation",
-                                                     path: .relativeToCurrentFile("../../Presentations/CommonPresentation")),
+                                                     path: .relativeToRoot("Presentations/CommonPresentation")),
                                             .project(target: "Domain",
-                                                     path: .relativeToCurrentFile("../../Domain")),
+                                                     path: .relativeToRoot("Domain")),
                                             .project(target: "Extensions",
-                                                     path: .relativeToCurrentFile("../../Supports/Extensions")),
+                                                     path: .relativeToRoot("Supports/Extensions")),
                                             .project(target: "Scenes",
-                                                     path: .relativeToCurrentFile("../../Presentations/Scenes"))
+                                                     path: .relativeToRoot("Presentations/Scenes"))
                                         ])
 

--- a/Presentations/CommonPresentation/Project.swift
+++ b/Presentations/CommonPresentation/Project.swift
@@ -7,9 +7,9 @@ let project = Project.framework(
     iOSTargetVersion: "17.0",
     snapshotTests: true,
     dependencies: [
-        .project(target: "Common3rdParty", path: .relativeToCurrentFile("../../Supports/Common3rdParty")),
-        .project(target: "Domain", path: .relativeToCurrentFile("../../Domain")),
-        .project(target: "Extensions", path: .relativeToCurrentFile("../../Supports/Extensions")),
+        .project(target: "Common3rdParty", path: .relativeToRoot("Supports/Common3rdParty")),
+        .project(target: "Domain", path: .relativeToRoot("Domain")),
+        .project(target: "Extensions", path: .relativeToRoot("Supports/Extensions")),
         .external(name: "Kingfisher"),
         .external(name: "Toaster")
     ]

--- a/Presentations/EventDetailScene/Project.swift
+++ b/Presentations/EventDetailScene/Project.swift
@@ -7,15 +7,15 @@ let project = Project.frameworkWithTest(name: "EventDetailScene",
                                         snapshotTests: true,
                                         dependencies: [
                                             .project(target: "Common3rdParty",
-                                                     path: .relativeToCurrentFile("../../Supports/Common3rdParty")),
+                                                     path: .relativeToRoot("Supports/Common3rdParty")),
                                             .project(target: "CommonPresentation",
-                                                     path: .relativeToCurrentFile("../../Presentations/CommonPresentation")),
+                                                     path: .relativeToRoot("Presentations/CommonPresentation")),
                                             .project(target: "Domain",
-                                                     path: .relativeToCurrentFile("../../Domain")),
+                                                     path: .relativeToRoot("Domain")),
                                             .project(target: "Extensions",
-                                                     path: .relativeToCurrentFile("../../Supports/Extensions")),
+                                                     path: .relativeToRoot("Supports/Extensions")),
                                             .project(target: "Scenes",
-                                                     path: .relativeToCurrentFile("../../Presentations/Scenes"))
+                                                     path: .relativeToRoot("Presentations/Scenes"))
                                         ])
 
 

--- a/Presentations/EventListScenes/Project.swift
+++ b/Presentations/EventListScenes/Project.swift
@@ -7,11 +7,11 @@ let project = Project.frameworkWithTest(
     iOSTargetVersion: "17.0",
     snapshotTests: true,
     dependencies: [
-        .project(target: "Common3rdParty", path: .relativeToCurrentFile("../../Supports/Common3rdParty")),
-        .project(target: "CommonPresentation", path: .relativeToCurrentFile("../../Presentations/CommonPresentation")),
-        .project(target: "Domain", path: .relativeToCurrentFile("../../Domain")),
-        .project(target: "Extensions", path: .relativeToCurrentFile("../../Supports/Extensions")),
-        .project(target: "Scenes", path: .relativeToCurrentFile("../../Presentations/Scenes"))
+        .project(target: "Common3rdParty", path: .relativeToRoot("Supports/Common3rdParty")),
+        .project(target: "CommonPresentation", path: .relativeToRoot("Presentations/CommonPresentation")),
+        .project(target: "Domain", path: .relativeToRoot("Domain")),
+        .project(target: "Extensions", path: .relativeToRoot("Supports/Extensions")),
+        .project(target: "Scenes", path: .relativeToRoot("Presentations/Scenes"))
     ]
 )
 

--- a/Presentations/MemberScenes/Project.swift
+++ b/Presentations/MemberScenes/Project.swift
@@ -8,15 +8,15 @@ let project = Project.frameworkWithTest(
     snapshotTests: true,
     dependencies: [
         .project(target: "Common3rdParty",
-                 path: .relativeToCurrentFile("../../Supports/Common3rdParty")),
+                 path: .relativeToRoot("Supports/Common3rdParty")),
         .project(target: "CommonPresentation",
-                 path: .relativeToCurrentFile("../../Presentations/CommonPresentation")),
+                 path: .relativeToRoot("Presentations/CommonPresentation")),
         .project(target: "Domain",
-                 path: .relativeToCurrentFile("../../Domain")),
+                 path: .relativeToRoot("Domain")),
         .project(target: "Extensions",
-                 path: .relativeToCurrentFile("../../Supports/Extensions")),
+                 path: .relativeToRoot("Supports/Extensions")),
         .project(target: "Scenes",
-                                         path: .relativeToCurrentFile("../../Presentations/Scenes"))
+                                         path: .relativeToRoot("Presentations/Scenes"))
     ]
 )
 

--- a/Presentations/Scenes/Project.swift
+++ b/Presentations/Scenes/Project.swift
@@ -6,9 +6,9 @@ let project = Project.frameworkWithTest(
     destinations: [.iPhone],
     iOSTargetVersion: "17.0",
     dependencies: [
-        .project(target: "Common3rdParty", path: .relativeToCurrentFile("../../Supports/Common3rdParty")),
-        .project(target: "CommonPresentation", path: .relativeToCurrentFile("../../Presentations/CommonPresentation")),
-        .project(target: "Domain", path: .relativeToCurrentFile("../../Domain")),
-        .project(target: "Extensions", path: .relativeToCurrentFile("../../Supports/Extensions"))
+        .project(target: "Common3rdParty", path: .relativeToRoot("Supports/Common3rdParty")),
+        .project(target: "CommonPresentation", path: .relativeToRoot("Presentations/CommonPresentation")),
+        .project(target: "Domain", path: .relativeToRoot("Domain")),
+        .project(target: "Extensions", path: .relativeToRoot("Supports/Extensions"))
     ]
 )

--- a/Presentations/SettingScene/Project.swift
+++ b/Presentations/SettingScene/Project.swift
@@ -7,14 +7,14 @@ let project = Project.frameworkWithTest(name: "SettingScene",
                                         snapshotTests: true,
                                         dependencies: [
                                             .project(target: "Common3rdParty", 
-                                                     path: .relativeToCurrentFile("../../Supports/Common3rdParty")),
+                                                     path: .relativeToRoot("Supports/Common3rdParty")),
                                             .project(target: "CommonPresentation",
-                                                     path: .relativeToCurrentFile("../../Presentations/CommonPresentation")),
+                                                     path: .relativeToRoot("Presentations/CommonPresentation")),
                                             .project(target: "Domain",
-                                                     path: .relativeToCurrentFile("../../Domain")),
+                                                     path: .relativeToRoot("Domain")),
                                             .project(target: "Extensions",
-                                                     path: .relativeToCurrentFile("../../Supports/Extensions")),
+                                                     path: .relativeToRoot("Supports/Extensions")),
                                             .project(target: "Scenes",
-                                                     path: .relativeToCurrentFile("../../Presentations/Scenes"))
+                                                     path: .relativeToRoot("Presentations/Scenes"))
                                         ])
 

--- a/Repository/Project.swift
+++ b/Repository/Project.swift
@@ -6,11 +6,11 @@ let project = Project.frameworkWithTest(name: "Repository",
                                         iOSTargetVersion: "17.0",
                                         dependencies: [
                                             .project(target: "Common3rdParty", 
-                                                     path: .relativeToCurrentFile("../Supports/Common3rdParty")),
+                                                     path: .relativeToRoot("Supports/Common3rdParty")),
                                             .project(target: "Domain",
-                                                     path: .relativeToCurrentFile("../Domain")),
+                                                     path: .relativeToRoot("Domain")),
                                             .project(target: "Extensions",
-                                                     path: .relativeToCurrentFile("../Supports/Extensions"))
+                                                     path: .relativeToRoot("Supports/Extensions"))
                                         ])
 
 

--- a/Services/AuthService/Project.swift
+++ b/Services/AuthService/Project.swift
@@ -8,15 +8,15 @@ let project = Project.frameworkWithTest(
     dependencies: [
         .project(
             target: "Common3rdParty",
-            path: .relativeToCurrentFile("../../Supports/Common3rdParty")
+            path: .relativeToRoot("Supports/Common3rdParty")
         ),
         .project(
             target: "Domain",
-            path: .relativeToCurrentFile("../../Domain")
+            path: .relativeToRoot("Domain")
         ),
         .project(
             target: "Extensions",
-            path: .relativeToCurrentFile("../../Supports/Extensions")
+            path: .relativeToRoot("Supports/Extensions")
         )
     ]
 )

--- a/Services/ExternalServices/Project.swift
+++ b/Services/ExternalServices/Project.swift
@@ -8,7 +8,7 @@ let project = Project.framework(
     dependencies: [
         .project(
             target: "Domain",
-            path: .relativeToCurrentFile("../../Domain")
+            path: .relativeToRoot("Domain")
         ),
         .external(name: "SwiftLinkPreview")
     ]

--- a/Services/FirstPartyServices/Project.swift
+++ b/Services/FirstPartyServices/Project.swift
@@ -8,15 +8,15 @@ let project = Project.framework(
     dependencies: [
         .project(
             target: "Common3rdParty",
-            path: .relativeToCurrentFile("../../Supports/Common3rdParty")
+            path: .relativeToRoot("Supports/Common3rdParty")
         ),
         .project(
             target: "Domain",
-            path: .relativeToCurrentFile("../../Domain")
+            path: .relativeToRoot("Domain")
         ),
         .project(
             target: "Extensions",
-            path: .relativeToCurrentFile("../../Supports/Extensions")
+            path: .relativeToRoot("Supports/Extensions")
         )
     ]
 )

--- a/Services/PlaceService/Project.swift
+++ b/Services/PlaceService/Project.swift
@@ -8,15 +8,15 @@ let project = Project.framework(
     dependencies: [
         .project(
             target: "Common3rdParty",
-            path: .relativeToCurrentFile("../../Supports/Common3rdParty")
+            path: .relativeToRoot("Supports/Common3rdParty")
         ),
         .project(
             target: "Domain",
-            path: .relativeToCurrentFile("../../Domain")
+            path: .relativeToRoot("Domain")
         ),
         .project(
             target: "Extensions",
-            path: .relativeToCurrentFile("../../Supports/Extensions")
+            path: .relativeToRoot("Supports/Extensions")
         )
     ]
 )

--- a/Services/SpeechService/Project.swift
+++ b/Services/SpeechService/Project.swift
@@ -8,15 +8,15 @@ let project = Project.framework(
     dependencies: [
         .project(
             target: "Common3rdParty",
-            path: .relativeToCurrentFile("../../Supports/Common3rdParty")
+            path: .relativeToRoot("Supports/Common3rdParty")
         ),
         .project(
             target: "Domain",
-            path: .relativeToCurrentFile("../../Domain")
+            path: .relativeToRoot("Domain")
         ),
         .project(
             target: "Extensions",
-            path: .relativeToCurrentFile("../../Supports/Extensions")
+            path: .relativeToRoot("Supports/Extensions")
         )
     ]
 )

--- a/Services/StoreKitService/Project.swift
+++ b/Services/StoreKitService/Project.swift
@@ -8,15 +8,15 @@ let project = Project.framework(
     dependencies: [
         .project(
             target: "Common3rdParty",
-            path: .relativeToCurrentFile("../../Supports/Common3rdParty")
+            path: .relativeToRoot("Supports/Common3rdParty")
         ),
         .project(
             target: "Domain",
-            path: .relativeToCurrentFile("../../Domain")
+            path: .relativeToRoot("Domain")
         ),
         .project(
             target: "Extensions",
-            path: .relativeToCurrentFile("../../Supports/Extensions")
+            path: .relativeToRoot("Supports/Extensions")
         )
     ]
 )

--- a/Supports/Extensions/Project.swift
+++ b/Supports/Extensions/Project.swift
@@ -9,7 +9,7 @@ let project = Project.frameworkWithTest(
     dependencies: [
         .project(
             target: "Common3rdParty",
-            path: .relativeToCurrentFile("../../Supports/Common3rdParty")
+            path: .relativeToRoot("Supports/Common3rdParty")
         )
     ]
 )

--- a/Supports/TestDoubles/Project.swift
+++ b/Supports/TestDoubles/Project.swift
@@ -6,15 +6,15 @@ let project = Project.framework(name: "TestDoubles",
                                 iOSTargetVersion: "17.0",
                                 dependencies: [
                                     .project(target: "Common3rdParty",
-                                             path: .relativeToCurrentFile("../../Supports/Common3rdParty")),
+                                             path: .relativeToRoot("Supports/Common3rdParty")),
                                     .project(target: "Domain",
-                                             path: .relativeToCurrentFile("../../Domain")),
+                                             path: .relativeToRoot("Domain")),
                                     .project(target: "Extensions",
-                                             path: .relativeToCurrentFile("../../Supports/Extensions")),
+                                             path: .relativeToRoot("Supports/Extensions")),
                                     .project(target: "Scenes",
-                                             path: .relativeToCurrentFile("../../Presentations/Scenes")),
+                                             path: .relativeToRoot("Presentations/Scenes")),
                                     .project(target: "UnitTestHelpKit",
-                                             path: .relativeToCurrentFile("../../Supports/UnitTestHelpKit")),
+                                             path: .relativeToRoot("Supports/UnitTestHelpKit")),
                                     .xctest
                                 ])
 

--- a/Supports/UnitTestHelpKit/Project.swift
+++ b/Supports/UnitTestHelpKit/Project.swift
@@ -6,7 +6,7 @@ let project = Project.frameworkWithTest(name: "UnitTestHelpKit",
                                         iOSTargetVersion: "15.0",
                                         dependencies: [
                                             .project(target: "Common3rdParty",
-                                                     path: .relativeToCurrentFile("../../Supports/Common3rdParty")),
+                                                     path: .relativeToRoot("Supports/Common3rdParty")),
                                             .xctest
                                         ])
 

--- a/TodoCalendarApp/Project.swift
+++ b/TodoCalendarApp/Project.swift
@@ -17,79 +17,79 @@ let project = Project.app(
         ),
         .project(
             target: "CalendarScenes",
-            path: .relativeToCurrentFile("../Presentations/CalendarScenes")
+            path: .relativeToRoot("Presentations/CalendarScenes")
         ),
         .project(
             target: "Common3rdParty",
-            path: .relativeToCurrentFile("../Supports/Common3rdParty")
+            path: .relativeToRoot("Supports/Common3rdParty")
         ),
         .project(
             target: "CommonPresentation",
-            path: .relativeToCurrentFile("../Presentations/CommonPresentation")
+            path: .relativeToRoot("Presentations/CommonPresentation")
         ),
         .project(
             target: "Domain",
-            path: .relativeToCurrentFile("../Domain")
+            path: .relativeToRoot("Domain")
         ),
         .project(
             target: "EventDetailScene",
-            path: .relativeToCurrentFile("../Presentations/EventDetailScene")
+            path: .relativeToRoot("Presentations/EventDetailScene")
         ),
         .project(
             target: "Extensions",
-            path: .relativeToCurrentFile("../Supports/Extensions")
+            path: .relativeToRoot("Supports/Extensions")
         ),
         .project(
             target: "Repository",
-            path: .relativeToCurrentFile("../Repository")
+            path: .relativeToRoot("Repository")
         ),
         .project(
             target: "Scenes",
-            path: .relativeToCurrentFile("../Presentations/Scenes")
+            path: .relativeToRoot("Presentations/Scenes")
         ),
         .project(
             target: "SettingScene",
-            path: .relativeToCurrentFile("../Presentations/SettingScene")
+            path: .relativeToRoot("Presentations/SettingScene")
         ),
         .project(
             target: "MemberScenes",
-            path: .relativeToCurrentFile("../Presentations/MemberScenes")
+            path: .relativeToRoot("Presentations/MemberScenes")
         ),
         .project(
             target: "EventListScenes",
-            path: .relativeToCurrentFile("../Presentations/EventListScenes")
+            path: .relativeToRoot("Presentations/EventListScenes")
         ),
         .project(
             target: "AIAgentScene",
-            path: .relativeToCurrentFile("../Presentations/AIAgentScene")
+            path: .relativeToRoot("Presentations/AIAgentScene")
         ),
         .project(
             target: "BillingScenes",
-            path: .relativeToCurrentFile("../Presentations/BillingScenes")
+            path: .relativeToRoot("Presentations/BillingScenes")
         ),
         .project(
             target: "FirstPartyServices",
-            path: .relativeToCurrentFile("../Services/FirstPartyServices")
+            path: .relativeToRoot("Services/FirstPartyServices")
         ),
         .project(
             target: "SpeechService",
-            path: .relativeToCurrentFile("../Services/SpeechService")
+            path: .relativeToRoot("Services/SpeechService")
         ),
         .project(
             target: "PlaceService",
-            path: .relativeToCurrentFile("../Services/PlaceService")
+            path: .relativeToRoot("Services/PlaceService")
         ),
         .project(
             target: "AuthService",
-            path: .relativeToCurrentFile("../Services/AuthService")
+            path: .relativeToRoot("Services/AuthService")
         ),
         .project(
             target: "ExternalServices",
-            path: .relativeToCurrentFile("../Services/ExternalServices")
+            path: .relativeToRoot("Services/ExternalServices")
         ),
         .project(
             target: "StoreKitService",
-            path: .relativeToCurrentFile("../Services/StoreKitService")
+            path: .relativeToRoot("Services/StoreKitService")
         )
       ],
     extensionTargets:
@@ -109,27 +109,27 @@ let project = Project.app(
             dependencies: [
                 .project(
                     target: "Extensions",
-                    path: .relativeToCurrentFile("../Supports/Extensions")
+                    path: .relativeToRoot("Supports/Extensions")
                 ),
                 .project(
                     target: "Common3rdParty",
-                    path: .relativeToCurrentFile("../Supports/Common3rdParty")
+                    path: .relativeToRoot("Supports/Common3rdParty")
                 ),
                 .project(
                     target: "Domain",
-                    path: .relativeToCurrentFile("../Domain")
+                    path: .relativeToRoot("Domain")
                 ),
                 .project(
                     target: "Repository",
-                    path: .relativeToCurrentFile("../Repository")
+                    path: .relativeToRoot("Repository")
                 ),
                 .project(
                     target: "CommonPresentation",
-                    path: .relativeToCurrentFile("../Presentations/CommonPresentation")
+                    path: .relativeToRoot("Presentations/CommonPresentation")
                 ),
                 .project(
                     target: "CalendarScenes",
-                    path: .relativeToCurrentFile("../Presentations/CalendarScenes")
+                    path: .relativeToRoot("Presentations/CalendarScenes")
                 )
             ],
             signingConfigures: [
@@ -165,19 +165,19 @@ let project = Project.app(
         dependencies: [
             .project(
                 target: "Extensions",
-                path: .relativeToCurrentFile("../Supports/Extensions")
+                path: .relativeToRoot("Supports/Extensions")
             ),
             .project(
                 target: "Common3rdParty",
-                path: .relativeToCurrentFile("../Supports/Common3rdParty")
+                path: .relativeToRoot("Supports/Common3rdParty")
             ),
             .project(
                 target: "Domain",
-                path: .relativeToCurrentFile("../Domain")
+                path: .relativeToRoot("Domain")
             ),
             .project(
                 target: "Repository",
-                path: .relativeToCurrentFile("../Repository")
+                path: .relativeToRoot("Repository")
             ),
         ],
         signingConfigures: [
@@ -215,23 +215,23 @@ let project = Project.app(
         dependencies: [
             .project(
                 target: "Extensions",
-                path: .relativeToCurrentFile("../Supports/Extensions")
+                path: .relativeToRoot("Supports/Extensions")
             ),
             .project(
                 target: "Common3rdParty",
-                path: .relativeToCurrentFile("../Supports/Common3rdParty")
+                path: .relativeToRoot("Supports/Common3rdParty")
             ),
             .project(
                 target: "Domain",
-                path: .relativeToCurrentFile("../Domain")
+                path: .relativeToRoot("Domain")
             ),
             .project(
                 target: "Repository",
-                path: .relativeToCurrentFile("../Repository")
+                path: .relativeToRoot("Repository")
             ),
             .project(
                 target: "CommonPresentation",
-                path: .relativeToCurrentFile("../Presentations/CommonPresentation")
+                path: .relativeToRoot("Presentations/CommonPresentation")
             )
         ],
         signingConfigures: [

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -124,8 +124,8 @@ extension Project {
                              resources: [],
                              dependencies: [
                                 .target(name: name),
-                                .project(target: "SnapshotTestHelpKit", path: .relativeToCurrentFile("../../Supports/SnapshotTestHelpKit")),
-                                .project(target: "TestDoubles", path: .relativeToCurrentFile("../../Supports/TestDoubles")),
+                                .project(target: "SnapshotTestHelpKit", path: .relativeToRoot("Supports/SnapshotTestHelpKit")),
+                                .project(target: "TestDoubles", path: .relativeToRoot("Supports/TestDoubles")),
                              ])
     }
 
@@ -164,9 +164,9 @@ extension Project {
                            resources: [],
                            dependencies: [
                             .target(name: name),
-                            .project(target: "UnitTestHelpKit", path: .relativeToCurrentFile("../../Supports/UnitTestHelpKit")),
-                            .project(target: "TestDoubles", path: .relativeToCurrentFile("../../Supports/TestDoubles")),
-                            .project(target: "Common3rdParty", path: .relativeToCurrentFile("../../Supports/Common3rdParty")),
+                            .project(target: "UnitTestHelpKit", path: .relativeToRoot("Supports/UnitTestHelpKit")),
+                            .project(target: "TestDoubles", path: .relativeToRoot("Supports/TestDoubles")),
+                            .project(target: "Common3rdParty", path: .relativeToRoot("Supports/Common3rdParty")),
                            ])
         return [sources, tests]
     }
@@ -293,9 +293,9 @@ extension Project {
             dependencies: [
                 .target(name: "\(name)"),
                 .project(target: "UnitTestHelpKit", path:
-                        .relativeToCurrentFile("../../Supports/UnitTestHelpKit")),
-                .project(target: "TestDoubles", path: .relativeToCurrentFile("../../Supports/TestDoubles")),
-                .project(target: "Common3rdParty", path: .relativeToCurrentFile("../../Supports/Common3rdParty")),
+                        .relativeToRoot("Supports/UnitTestHelpKit")),
+                .project(target: "TestDoubles", path: .relativeToRoot("Supports/TestDoubles")),
+                .project(target: "Common3rdParty", path: .relativeToRoot("Supports/Common3rdParty")),
             ])
         return [mainTarget, testTarget]
     }
@@ -361,15 +361,15 @@ extension Project {
                 .target(name: appName),
                 .project(
                     target: "UnitTestHelpKit",
-                    path: .relativeToCurrentFile("../../Supports/UnitTestHelpKit")
+                    path: .relativeToRoot("Supports/UnitTestHelpKit")
                 ),
                 .project(
                     target: "TestDoubles",
-                    path: .relativeToCurrentFile("../../Supports/TestDoubles")
+                    path: .relativeToRoot("Supports/TestDoubles")
                 ),
                 .project(
                     target: "Common3rdParty",
-                    path: .relativeToCurrentFile("../../Supports/Common3rdParty")
+                    path: .relativeToRoot("Supports/Common3rdParty")
                 )
             ]
         )
@@ -393,15 +393,15 @@ extension Project {
                         .target(name: appName),
                         .project(
                             target: "SnapshotTestHelpKit",
-                            path: .relativeToCurrentFile("../../Supports/SnapshotTestHelpKit")
+                            path: .relativeToRoot("Supports/SnapshotTestHelpKit")
                         ),
                         .project(
                             target: "TestDoubles",
-                            path: .relativeToCurrentFile("../../Supports/TestDoubles")
+                            path: .relativeToRoot("Supports/TestDoubles")
                         ),
                         .project(
                             target: "Common3rdParty",
-                            path: .relativeToCurrentFile("../../Supports/Common3rdParty")
+                            path: .relativeToRoot("Supports/Common3rdParty")
                         )
                     ]
                 )


### PR DESCRIPTION
closes #794

메인에서 `tuist generate`를 돌릴 때마다 생성된 `TodoCalendar.xcworkspace`에 다른 워크트리의 프로젝트가 딸려 들어와 `Domain.framework` 등의 생산자가 둘이 되던 문제를 해소한다.

## 문제

tuist가 워크트리를 스캔해서가 아니었다. 전역 manifest 캐시(`~/.cache/tuist/Manifests`)의 키는 `manifestHash + pluginsHash + helpersHash + environmentHash + disableSandboxHash` — **매니페스트 위치가 안 들어간다.** 반면 `.relativeToCurrentFile`은 직렬화될 때 `#file` 절대경로를 `callerPath`로 박는다:

```json
{"pathString":"../../Domain",
 "callerPath":"/Users/sudo.park/Desktop/actions/_work/TodoCalendar/TodoCalendar/Presentations/MemberScenes/Project.swift",
 "type":"relativeToCurrentFile"}
```

그래서 같은 레포의 체크아웃이 여럿이면(메인·워크트리·self-hosted CI 러너) 내용이 같은 `Project.swift`끼리 캐시가 충돌하고, **먼저 캐시를 채운 체크아웃의 경로가 이긴다.** 딸려오는 게 `Domain`·`Scenes`·`CommonPresentation`·`Supports/*`뿐인 이유도 이것 — 최상위 프로젝트는 `Workspace.swift` glob이 실제 경로로 잡고 의존성 경로만 캐시에서 나온다.

## 접근

모든 매니페스트의 의존 경로를 `.relativeToRoot`로 바꾼다. 이쪽은 `callerPath`를 안 박아서(`{"pathString":"Domain","type":"relativeToRoot"}`) 캐시 엔트리가 위치 독립이 되고, 충돌해도 해가 없다. tuist의 캐시 키 설계는 우리가 못 바꾸니 매니페스트 쪽에서 위치 의존을 없애는 게 해소 지점이다.

같은 이유로 하네스에서도 `.relativeToCurrentFile` 지침을 걷어냈다 — add-framework가 그대로 남으면 신규 모듈이 오염을 재도입한다. 그리고 워크트리 generate가 자기 트리만 건드리게 되면서 전용 `Orthodox.xcworkspace`/`Southpaw.xcworkspace` 우회가 불필요해져 orchestrate의 관련 단서도 삭제했다.

## 검증

- 메인: 워크스페이스의 워크트리 참조 0, "duplicated product names" 경고 0, 앱 빌드 성공, `Domain.SwiftFileList` 첫 줄이 메인 트리 경로
- 워크트리에서 generate → 자기 트리만 담은 워크스페이스가 나오고 메인의 generated 파일 mtime 불변
- southpaw·orthodox가 캐시를 채운 뒤 메인 재생성해도 참조 0 유지
- 앱 빌드가 안 덮는 테스트 타겟 의존(UnitTestHelpKit·TestDoubles·SnapshotTestHelpKit) 확인 — `Domain`·`CommonPresentationSnapshots` build-for-testing 통과
