### PR TITLE
[#799] 음성 인식이 결과 없이 끝나는 경로에서 입력 상태를 접는다

### DIFF
--- a/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
@@ -158,6 +158,7 @@ extension AIAgentOrchestrationUsecaseImple {
 
     public func enterKeyboardInput() {
         guard self.canEnterKeyboardInput else { return }
+        self.resetVoiceBinding()
         self.speechRecognizeUsecase.stopListening()
         self.subject.state.send(.listening(.keyboard))
     }

--- a/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
@@ -173,14 +173,7 @@ extension AIAgentOrchestrationUsecaseImple {
 
         self.speechRecognizeUsecase.recognizeResult
             .sink { [weak self] result in
-                switch result {
-                case .success(let text):
-                    self?.resetVoiceBinding()
-                    self?.subject.state.send(.idle)
-                    try? self?.submit(text)
-                case .failure(let error):
-                    self?.handleRecognizeFailed(error)
-                }
+                self?.handleRecognizeEnd(result)
             }
             .store(in: &self.voiceInputBindings)
 
@@ -198,8 +191,13 @@ extension AIAgentOrchestrationUsecaseImple {
             .store(in: &self.voiceInputBindings)
     }
 
-    private func handleRecognizeFailed(_ error: any Error) {
+    // 인식 종료는 텍스트 확보·무인식·실패를 가리지 않고 stopInput과 동등하게 접는다.
+    // 바인딩을 남기면 다음 입력 세션에 이전 구독이 겹친다.
+    private func handleRecognizeEnd(_ result: Result<SpeechRecognizeResult, any Error>) {
+        self.resetVoiceBinding()
         self.subject.state.send(.idle)
+        guard case .success(.recognized(let text)) = result else { return }
+        try? self.submit(text)
     }
 
     private func resetVoiceBinding() {

--- a/Domain/Sources/Usecases/Speech/SpeechRecognizeService.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizeService.swift
@@ -34,4 +34,8 @@ public protocol SpeechRecognizeService: Sendable {
 
     // raw 오디오 입력 세기 (0...1 정규화 레벨)
     var voiceLevel: AnyPublisher<Float, Never> { get }
+
+    // 시스템이 오디오 입력을 회수한 순간 (인터럽션 · 입력 라우트 소실).
+    // 앱은 여전히 활성이라 앱 생명주기 이벤트로는 감지되지 않는다.
+    var audioInputDisrupted: AnyPublisher<Void, Never> { get }
 }

--- a/Domain/Sources/Usecases/Speech/SpeechRecognizeService.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizeService.swift
@@ -35,7 +35,7 @@ public protocol SpeechRecognizeService: Sendable {
     // raw 오디오 입력 세기 (0...1 정규화 레벨)
     var voiceLevel: AnyPublisher<Float, Never> { get }
 
-    // 시스템이 오디오 입력을 회수한 순간 (인터럽션 · 입력 라우트 소실).
+    // 시스템이 오디오 입력을 회수해 인식을 이어갈 수 없는 순간.
     // 앱은 여전히 활성이라 앱 생명주기 이벤트로는 감지되지 않는다.
     var audioInputDisrupted: AnyPublisher<Void, Never> { get }
 }

--- a/Domain/Sources/Usecases/Speech/SpeechRecognizeUsecase.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizeUsecase.swift
@@ -106,17 +106,25 @@ extension SpeechRecognizeUsecaseImple {
         self.subject.recognizingText.send("")
         self.serviceBinding = []
 
-        Publishers.CombineLatest(
+        let recognizedOrTimeout = Publishers.CombineLatest(
             self.service.recognized.mapAsOptional().prepend(nil),
             self.silenceTimeout.mapAsAnyError().mapAsOptional().prepend(nil)
         )
         .compactMap(selectResult)
-        .first()
-        .sink(
-            receiveCompletion: self.handleCompletion(),
-            receiveValue: self.handleRecognized()
-        )
-        .store(in: &self.serviceBinding)
+        .eraseToAnyPublisher()
+
+        let disrupted = self.service.audioInputDisrupted
+            .map { SpeechRecognizeResult.endedWithoutRecognizing }
+            .mapNever()
+            .eraseToAnyPublisher()
+
+        Publishers.Merge(recognizedOrTimeout, disrupted)
+            .first()
+            .sink(
+                receiveCompletion: self.handleCompletion(),
+                receiveValue: self.handleRecognized()
+            )
+            .store(in: &self.serviceBinding)
 
         self.service.recognized
             .map { $0.text }

--- a/Domain/Sources/Usecases/Speech/SpeechRecognizeUsecase.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizeUsecase.swift
@@ -62,21 +62,33 @@ public final class SpeechRecognizeUsecaseImple: SpeechRecognizeUsecase, @uncheck
     }
     private let subject = Subject()
     private var serviceBinding = Set<AnyCancellable>()
+    private var startTask: Task<Void, Never>?
 }
 
 extension SpeechRecognizeUsecaseImple {
-    
+
     public func startListening() {
-       
+
         guard !self.subject.isRecognizing.value else { return }
-        
-        Task {
+
+        // 권한 대기 중인 이전 start가 있으면 그것부터 접는다 — 살려두면 bind·start가 두 번 돈다
+        self.startTask?.cancel()
+        self.startTask = Task { [weak self] in
+            guard let self else { return }
             do {
                 try await self.permissionChecker.requestAccess()
+                // 대기 중에 stopListening이 왔으면 마이크를 켜지 않는다
+                guard !Task.isCancelled else { return }
                 self.bindService()
                 try self.service.start()
+                // start가 도는 동안 들어온 중지도 반영한다 — 안 그러면 마이크만 켜진 채 남는다
+                guard !Task.isCancelled else {
+                    self.service.stop()
+                    self.serviceBinding = []
+                    return
+                }
                 self.subject.isRecognizing.send(true)
-                
+
             } catch {
                 self.serviceBinding = []
                 self.subject.isRecognizing.send(false)
@@ -84,8 +96,10 @@ extension SpeechRecognizeUsecaseImple {
             }
         }
     }
-    
+
     public func stopListening() {
+        self.startTask?.cancel()
+        self.startTask = nil
         self.service.stop()
         self.serviceBinding = []
         self.subject.isRecognizing.send(false)
@@ -189,7 +203,11 @@ extension SpeechRecognizeUsecaseImple {
     }
 
     public func finishListening() {
-        guard self.subject.isRecognizing.value else { return }
+        guard self.subject.isRecognizing.value else {
+            // 아직 안 켜진 세션은 접기만 한다 — 살려두면 뒤늦은 인식이 커맨드로 전송된다
+            self.stopListening()
+            return
+        }
         let text = self.subject.recognizingText.value
         self.stopListening()
         self.subject.result.send(.success(.recognized(text)))

--- a/Domain/Sources/Usecases/Speech/SpeechRecognizeUsecase.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizeUsecase.swift
@@ -10,6 +10,16 @@ import Foundation
 import Combine
 
 
+// MARK: - SpeechRecognizeResult
+
+// 텍스트 없이 끝나는 종료(침묵 타임아웃·오디오 입력 끊김)도 소비자가 인지해야 하므로
+// completion이 아니라 명시적 값으로 방출한다.
+public enum SpeechRecognizeResult: Sendable, Equatable {
+    case recognized(String)
+    case endedWithoutRecognizing
+}
+
+
 // MARK: - SpeechRecognizeUsecase
 
 public protocol SpeechRecognizeUsecase: Sendable {
@@ -18,7 +28,7 @@ public protocol SpeechRecognizeUsecase: Sendable {
     func stopListening()
     func finishListening()
 
-    var recognizeResult: AnyPublisher<Result<String, any Error>, Never> { get }
+    var recognizeResult: AnyPublisher<Result<SpeechRecognizeResult, any Error>, Never> { get }
     var recognizingText: AnyPublisher<String, Never> { get }
     var isRecognizingWithLevel: AnyPublisher<Float?, Never> { get }
 }
@@ -47,7 +57,7 @@ public final class SpeechRecognizeUsecaseImple: SpeechRecognizeUsecase, @uncheck
 
     private struct Subject {
         let isRecognizing = CurrentValueSubject<Bool, Never>(false)
-        let result = PassthroughSubject<Result<String, any Error>, Never>()
+        let result = PassthroughSubject<Result<SpeechRecognizeResult, any Error>, Never>()
         let recognizingText = CurrentValueSubject<String, Never>("")
     }
     private let subject = Subject()
@@ -83,16 +93,16 @@ extension SpeechRecognizeUsecaseImple {
     
     private func bindService() {
         
-        let selectText: (SpeechRecognizeFragment?, Void?) -> RecognizeResult? = { fragment, timeout in
-            
+        let selectResult: (SpeechRecognizeFragment?, Void?) -> SpeechRecognizeResult? = { fragment, timeout in
+
             switch (fragment, timeout) {
             case (.some(let frg), _) where frg.isFinal: return .recognized(frg.text)
             case (.some(let frg), .some): return .recognized(frg.text)
-            case (.none, .some): return .timeout
+            case (.none, .some): return .endedWithoutRecognizing
             default: return nil
             }
         }
-        
+
         self.subject.recognizingText.send("")
         self.serviceBinding = []
 
@@ -100,7 +110,7 @@ extension SpeechRecognizeUsecaseImple {
             self.service.recognized.mapAsOptional().prepend(nil),
             self.silenceTimeout.mapAsAnyError().mapAsOptional().prepend(nil)
         )
-        .compactMap(selectText)
+        .compactMap(selectResult)
         .first()
         .sink(
             receiveCompletion: self.handleCompletion(),
@@ -119,11 +129,6 @@ extension SpeechRecognizeUsecaseImple {
             .store(in: &self.serviceBinding)
     }
     
-    private enum RecognizeResult {
-        case recognized(String)
-        case timeout
-    }
-    
     private func handleCompletion() -> (Subscribers.Completion<any Error>) -> Void  {
         return  { [weak self] completion in
             guard let self, case .failure(let error) = completion
@@ -134,11 +139,10 @@ extension SpeechRecognizeUsecaseImple {
         }
     }
     
-    private func handleRecognized() -> (RecognizeResult) -> Void {
+    private func handleRecognized() -> (SpeechRecognizeResult) -> Void {
         return { [weak self] result in
             self?.stopListening()
-            guard case .recognized(let text) = result else { return }
-            self?.subject.result.send(.success(text))
+            self?.subject.result.send(.success(result))
         }
     }
     
@@ -165,7 +169,7 @@ extension SpeechRecognizeUsecaseImple {
 
 extension SpeechRecognizeUsecaseImple {
     
-    public var recognizeResult: AnyPublisher<Result<String, any Error>, Never> {
+    public var recognizeResult: AnyPublisher<Result<SpeechRecognizeResult, any Error>, Never> {
         return self.subject.result
             .eraseToAnyPublisher()
     }
@@ -180,7 +184,7 @@ extension SpeechRecognizeUsecaseImple {
         guard self.subject.isRecognizing.value else { return }
         let text = self.subject.recognizingText.value
         self.stopListening()
-        self.subject.result.send(.success(text))
+        self.subject.result.send(.success(.recognized(text)))
     }
 
     public var isRecognizingWithLevel: AnyPublisher<Float?, Never> {

--- a/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
@@ -790,7 +790,7 @@ private final class StubAIAgentUsageUsecase: AIAgentUsageUsecase, @unchecked Sen
 
 private final class StubSpeechRecognizeUsecase: SpeechRecognizeUsecase, @unchecked Sendable {
 
-    let recognizeResultSubject = PassthroughSubject<Result<String, any Error>, Never>()
+    let recognizeResultSubject = PassthroughSubject<Result<SpeechRecognizeResult, any Error>, Never>()
     let recognizingTextSubject = CurrentValueSubject<String, Never>("")
     let levelSubject = CurrentValueSubject<Float?, Never>(nil)
 
@@ -803,7 +803,7 @@ private final class StubSpeechRecognizeUsecase: SpeechRecognizeUsecase, @uncheck
     func stopListening() { self.didStopListening = true }
     func finishListening() { self.didFinishListening = true }
 
-    var recognizeResult: AnyPublisher<Result<String, any Error>, Never> {
+    var recognizeResult: AnyPublisher<Result<SpeechRecognizeResult, any Error>, Never> {
         self.recognizeResultSubject.eraseToAnyPublisher()
     }
     var recognizingText: AnyPublisher<String, Never> {
@@ -858,7 +858,7 @@ extension AIAgentOrchestrationUsecaseImpleTests {
         expect.count = 2
         // when
         let states = try await self.outputs(expect, for: usecase.state.dropFirst()) {
-            self.stubSpeech.recognizeResultSubject.send(.success("내일 회의"))
+            self.stubSpeech.recognizeResultSubject.send(.success(.recognized("내일 회의")))
         }
         // then — listening → idle → processing
         #expect(self.stubCommand.didProcessCommand == "내일 회의")
@@ -901,6 +901,57 @@ extension AIAgentOrchestrationUsecaseImpleTests {
         if case .idle = state {} else {
             Issue.record("expected idle, got \(String(describing: state))")
         }
+    }
+
+    // 침묵 타임아웃·오디오 끊김 등 무인식 종료 → idle 복귀 (커맨드 전송 없음)
+    @Test func usecase_recognizeEndedWithoutText_stateBecomesIdle() async throws {
+        // given
+        let usecase = self.makeUsecaseInIdle()
+        usecase.enterVoiceInput()
+        let expect = expectConfirm("idle on ended without recognizing")
+        // when
+        let state = try await self.firstOutput(expect, for: usecase.state.dropFirst()) {
+            self.stubSpeech.recognizeResultSubject.send(.success(.endedWithoutRecognizing))
+        }
+        // then
+        if case .idle = state {} else {
+            Issue.record("expected idle, got \(String(describing: state))")
+        }
+        #expect(self.stubCommand.didProcessCommand == nil)
+    }
+
+    // 무인식 종료 후 이전 음성 구독이 남지 않는다
+    @Test func usecase_afterRecognizeEndedWithoutText_stopsForwardingRecognizingText() async throws {
+        // given
+        let usecase = self.makeUsecaseInIdle()
+        usecase.enterVoiceInput()
+        self.stubSpeech.recognizeResultSubject.send(.success(.endedWithoutRecognizing))
+        let expect = expectConfirm("바인딩 해제 후 인식 텍스트 미전달")
+        expect.count = 0
+        expect.timeout = .milliseconds(100)
+        // when
+        let texts = try await self.outputs(expect, for: usecase.recognizingText) {
+            self.stubSpeech.recognizingTextSubject.send("남은 구독이 흘리면 안 되는 텍스트")
+        }
+        // then
+        #expect(texts.isEmpty)
+    }
+
+    // 인식 실패 후에도 이전 음성 구독이 남지 않는다
+    @Test func usecase_afterRecognizeFailed_stopsForwardingRecognizingText() async throws {
+        // given
+        let usecase = self.makeUsecaseInIdle()
+        usecase.enterVoiceInput()
+        self.stubSpeech.recognizeResultSubject.send(.failure(RuntimeError("speech fail")))
+        let expect = expectConfirm("실패 후 인식 텍스트 미전달")
+        expect.count = 0
+        expect.timeout = .milliseconds(100)
+        // when
+        let texts = try await self.outputs(expect, for: usecase.recognizingText) {
+            self.stubSpeech.recognizingTextSubject.send("남은 구독이 흘리면 안 되는 텍스트")
+        }
+        // then
+        #expect(texts.isEmpty)
     }
 
     // stopInput → idle, speech stop

--- a/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
@@ -1103,6 +1103,40 @@ extension AIAgentOrchestrationUsecaseImpleTests {
             Issue.record("expected listening(.voice), got \(String(describing: state))")
         }
     }
+
+    // 키보드 전환 후 이전 음성 구독이 남지 않는다
+    @Test func usecase_afterEnterKeyboardInput_stopsForwardingRecognizingText() async throws {
+        // given
+        let usecase = self.makeUsecaseInIdle()
+        usecase.enterVoiceInput()
+        usecase.enterKeyboardInput()
+        let expect = expectConfirm("키보드 전환 후 인식 텍스트 미전달")
+        expect.count = 0
+        expect.timeout = .milliseconds(100)
+        // when
+        let texts = try await self.outputs(expect, for: usecase.recognizingText) {
+            self.stubSpeech.recognizingTextSubject.send("음성 잔여 텍스트")
+        }
+        // then
+        #expect(texts.isEmpty)
+    }
+
+    // 뒤늦게 도착한 음성 종료가 키보드 입력 상태를 덮지 않는다
+    @Test func usecase_lateRecognizeEndAfterEnterKeyboardInput_keepsKeyboardListening() async throws {
+        // given
+        let usecase = self.makeUsecaseInIdle()
+        usecase.enterVoiceInput()
+        usecase.enterKeyboardInput()
+        let expect = expectConfirm("키보드 입력 상태 유지")
+        expect.count = 0
+        expect.timeout = .milliseconds(100)
+        // when
+        let states = try await self.outputs(expect, for: usecase.state.dropFirst()) {
+            self.stubSpeech.recognizeResultSubject.send(.success(.endedWithoutRecognizing))
+        }
+        // then
+        #expect(states.isEmpty)
+    }
 }
 
 

--- a/Domain/Tests/Usecases/Speech/SpeechRecognizeUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/Speech/SpeechRecognizeUsecaseImpleTests.swift
@@ -204,6 +204,48 @@ extension SpeechRecognizeUsecaseImpleTests {
         }
         #expect(recognizeResult == .endedWithoutRecognizing)
     }
+
+    @Test func usecase_whenAudioInputDisrupted_emitsEndedWithoutRecognizing() async throws {
+        // given
+        let (usecase, service) = self.makeUsecase()
+
+        // when
+        let captured = try await self.captureResult(for: usecase) {
+            usecase.startListening()
+            try await Task.sleep(for: .milliseconds(50))
+            service.emitAudioDisruption()
+        }
+
+        // then
+        let result = try #require(captured)
+        guard case .success(let recognizeResult) = result else {
+            Issue.record("성공 결과가 아님")
+            return
+        }
+        #expect(recognizeResult == .endedWithoutRecognizing)
+    }
+
+    @Test func usecase_whenAudioInputDisruptedWhileSpeaking_discardsPartialText() async throws {
+        // given
+        let (usecase, service) = self.makeUsecase()
+
+        // when
+        let captured = try await self.captureResult(for: usecase) {
+            usecase.startListening()
+            try await Task.sleep(for: .milliseconds(50))
+            service.emit(.init(text: "오늘 회의", isFinal: false))
+            try await Task.sleep(for: .milliseconds(20))
+            service.emitAudioDisruption()
+        }
+
+        // then
+        let result = try #require(captured)
+        guard case .success(let recognizeResult) = result else {
+            Issue.record("성공 결과가 아님")
+            return
+        }
+        #expect(recognizeResult == .endedWithoutRecognizing)
+    }
 }
 
 
@@ -330,6 +372,26 @@ extension SpeechRecognizeUsecaseImpleTests {
         // then
         #expect(levels.last == .some(nil))
     }
+
+    @Test func usecase_whenAudioInputDisrupted_stopsListening() async throws {
+        // given
+        let expect = expectConfirm("오디오 입력이 끊기면 듣기 종료")
+        expect.count = 4
+        let (usecase, service) = self.makeUsecase()
+
+        // when
+        let levels = try await self.outputs(expect, for: usecase.isRecognizingWithLevel) {
+            usecase.startListening()
+            try await Task.sleep(for: .milliseconds(60))
+            service.sendLevel(0.5)
+            try await Task.sleep(for: .milliseconds(20))
+            service.emitAudioDisruption()
+            try await Task.sleep(for: .milliseconds(40))
+        }
+
+        // then
+        #expect(levels == [nil, 0.0, 0.5, nil])
+    }
 }
 
 
@@ -369,6 +431,7 @@ private final class StubSpeechRecognizeService: SpeechRecognizeService, @uncheck
 
     private let recognizedSubject = PassthroughSubject<SpeechRecognizeFragment, any Error>()
     private let voiceLevelSubject = CurrentValueSubject<Float, Never>(0)
+    private let audioInputDisruptedSubject = PassthroughSubject<Void, Never>()
 
     var startError: (any Error)?
 
@@ -377,6 +440,9 @@ private final class StubSpeechRecognizeService: SpeechRecognizeService, @uncheck
     }
     var voiceLevel: AnyPublisher<Float, Never> {
         return self.voiceLevelSubject.eraseToAnyPublisher()
+    }
+    var audioInputDisrupted: AnyPublisher<Void, Never> {
+        return self.audioInputDisruptedSubject.eraseToAnyPublisher()
     }
     func start() throws {
         if let startError { throw startError }
@@ -391,6 +457,9 @@ private final class StubSpeechRecognizeService: SpeechRecognizeService, @uncheck
     }
     func sendLevel(_ level: Float) {
         self.voiceLevelSubject.send(level)
+    }
+    func emitAudioDisruption() {
+        self.audioInputDisruptedSubject.send(())
     }
 }
 

--- a/Domain/Tests/Usecases/Speech/SpeechRecognizeUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/Speech/SpeechRecognizeUsecaseImpleTests.swift
@@ -49,6 +49,13 @@ class SpeechRecognizeUsecaseImpleTests: PublisherWaitable {
         try await Task.sleep(for: timeout)
         return box.value
     }
+
+    private func waitUntilListening(_ service: StubSpeechRecognizeService) async throws {
+        let deadline = ContinuousClock.now + .milliseconds(500)
+        while service.didStartCount == 0, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+    }
 }
 
 
@@ -212,7 +219,7 @@ extension SpeechRecognizeUsecaseImpleTests {
         // when
         let captured = try await self.captureResult(for: usecase) {
             usecase.startListening()
-            try await Task.sleep(for: .milliseconds(50))
+            try await self.waitUntilListening(service)
             service.emitAudioDisruption()
         }
 
@@ -232,7 +239,7 @@ extension SpeechRecognizeUsecaseImpleTests {
         // when
         let captured = try await self.captureResult(for: usecase) {
             usecase.startListening()
-            try await Task.sleep(for: .milliseconds(50))
+            try await self.waitUntilListening(service)
             service.emit(.init(text: "오늘 회의", isFinal: false))
             try await Task.sleep(for: .milliseconds(20))
             service.emitAudioDisruption()
@@ -382,7 +389,7 @@ extension SpeechRecognizeUsecaseImpleTests {
         // when
         let levels = try await self.outputs(expect, for: usecase.isRecognizingWithLevel) {
             usecase.startListening()
-            try await Task.sleep(for: .milliseconds(60))
+            try await self.waitUntilListening(service)
             service.sendLevel(0.5)
             try await Task.sleep(for: .milliseconds(20))
             service.emitAudioDisruption()
@@ -391,6 +398,20 @@ extension SpeechRecognizeUsecaseImpleTests {
 
         // then
         #expect(levels == [nil, 0.0, 0.5, nil])
+    }
+
+    @Test func usecase_whenAudioInputDisrupted_releasesMicrophone() async throws {
+        // given
+        let (usecase, service) = self.makeUsecase()
+
+        // when
+        usecase.startListening()
+        try await self.waitUntilListening(service)
+        service.emitAudioDisruption()
+        try await Task.sleep(for: .milliseconds(40))
+
+        // then
+        #expect(service.didStop == true)
     }
 }
 
@@ -418,6 +439,32 @@ extension SpeechRecognizeUsecaseImpleTests {
         // then
         #expect(levels == [nil, 0.0, 0.5])
     }
+
+    @Test func usecase_whenStoppedBeforeAccessGranted_doesNotStartRecognizing() async throws {
+        // given
+        let (usecase, service) = self.makeUsecase()
+
+        // when
+        usecase.startListening()
+        usecase.stopListening()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // then
+        #expect(service.didStartCount == 0)
+    }
+
+    @Test func usecase_whenStartCalledTwiceBeforeReady_startsOnlyOnce() async throws {
+        // given
+        let (usecase, service) = self.makeUsecase()
+
+        // when
+        usecase.startListening()
+        usecase.startListening()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // then
+        #expect(service.didStartCount == 1)
+    }
 }
 
 
@@ -434,6 +481,8 @@ private final class StubSpeechRecognizeService: SpeechRecognizeService, @uncheck
     private let audioInputDisruptedSubject = PassthroughSubject<Void, Never>()
 
     var startError: (any Error)?
+    private(set) var didStartCount: Int = 0
+    private(set) var didStop: Bool = false
 
     var recognized: AnyPublisher<SpeechRecognizeFragment, any Error> {
         return self.recognizedSubject.eraseToAnyPublisher()
@@ -445,9 +494,12 @@ private final class StubSpeechRecognizeService: SpeechRecognizeService, @uncheck
         return self.audioInputDisruptedSubject.eraseToAnyPublisher()
     }
     func start() throws {
+        self.didStartCount += 1
         if let startError { throw startError }
     }
-    func stop() { }
+    func stop() {
+        self.didStop = true
+    }
 
     func emit(_ fragment: SpeechRecognizeFragment) {
         self.recognizedSubject.send(fragment)

--- a/Domain/Tests/Usecases/Speech/SpeechRecognizeUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/Speech/SpeechRecognizeUsecaseImpleTests.swift
@@ -40,7 +40,7 @@ class SpeechRecognizeUsecaseImpleTests: PublisherWaitable {
         for usecase: SpeechRecognizeUsecaseImple,
         timeout: Duration = .milliseconds(150),
         _ action: () async throws -> Void
-    ) async throws -> Result<String, any Error>? {
+    ) async throws -> Result<SpeechRecognizeResult, any Error>? {
         let box = ResultBox()
         usecase.recognizeResult
             .sink { box.value = $0 }
@@ -69,7 +69,7 @@ extension SpeechRecognizeUsecaseImpleTests {
 
         // then
         let result = try #require(captured)
-        guard case .success(let text) = result else {
+        guard case .success(.recognized(let text)) = result else {
             Issue.record("성공 결과가 아님")
             return
         }
@@ -92,7 +92,7 @@ extension SpeechRecognizeUsecaseImpleTests {
 
         // then
         let result = try #require(captured)
-        guard case .success(let text) = result else {
+        guard case .success(.recognized(let text)) = result else {
             Issue.record("성공 결과가 아님")
             return
         }
@@ -113,7 +113,7 @@ extension SpeechRecognizeUsecaseImpleTests {
 
         // then
         let result = try #require(captured)
-        guard case .success(let text) = result else {
+        guard case .success(.recognized(let text)) = result else {
             Issue.record("성공 결과가 아님")
             return
         }
@@ -186,6 +186,24 @@ extension SpeechRecognizeUsecaseImpleTests {
             return
         }
     }
+
+    @Test func usecase_whenSilentWithoutSpeech_emitsEndedWithoutRecognizing() async throws {
+        // given
+        let (usecase, _) = self.makeUsecase(autoStopAfterSilence: 0.1)
+
+        // when
+        let captured = try await self.captureResult(for: usecase, timeout: .milliseconds(300)) {
+            usecase.startListening()
+        }
+
+        // then
+        let result = try #require(captured)
+        guard case .success(let recognizeResult) = result else {
+            Issue.record("성공 결과가 아님")
+            return
+        }
+        #expect(recognizeResult == .endedWithoutRecognizing)
+    }
 }
 
 
@@ -227,7 +245,7 @@ extension SpeechRecognizeUsecaseImpleTests {
 
         // then
         let result = try #require(captured)
-        guard case .success(let text) = result else {
+        guard case .success(.recognized(let text)) = result else {
             Issue.record("성공 결과가 아님")
             return
         }
@@ -247,7 +265,7 @@ extension SpeechRecognizeUsecaseImpleTests {
 
         // then
         let result = try #require(captured)
-        guard case .success(let text) = result else {
+        guard case .success(.recognized(let text)) = result else {
             Issue.record("성공 결과가 아님")
             return
         }
@@ -344,7 +362,7 @@ extension SpeechRecognizeUsecaseImpleTests {
 // MARK: - test doubles
 
 private final class ResultBox: @unchecked Sendable {
-    var value: Result<String, any Error>?
+    var value: Result<SpeechRecognizeResult, any Error>?
 }
 
 private final class StubSpeechRecognizeService: SpeechRecognizeService, @unchecked Sendable {

--- a/Presentations/AIAgentScene/Tests/Doubles/StubSpeechRecognizeUsecase.swift
+++ b/Presentations/AIAgentScene/Tests/Doubles/StubSpeechRecognizeUsecase.swift
@@ -13,7 +13,7 @@ import Domain
 
 final class StubSpeechRecognizeUsecase: SpeechRecognizeUsecase, @unchecked Sendable {
 
-    let recognizeResultSubject = PassthroughSubject<Result<String, any Error>, Never>()
+    let recognizeResultSubject = PassthroughSubject<Result<SpeechRecognizeResult, any Error>, Never>()
     let recognizingTextSubject = CurrentValueSubject<String, Never>("")
     let levelSubject = CurrentValueSubject<Float?, Never>(nil)
 
@@ -25,7 +25,7 @@ final class StubSpeechRecognizeUsecase: SpeechRecognizeUsecase, @unchecked Senda
     func stopListening() { self.didStopListening = true }
     func finishListening() { self.didFinishListening = true }
 
-    var recognizeResult: AnyPublisher<Result<String, any Error>, Never> {
+    var recognizeResult: AnyPublisher<Result<SpeechRecognizeResult, any Error>, Never> {
         self.recognizeResultSubject.eraseToAnyPublisher()
     }
     var recognizingText: AnyPublisher<String, Never> {

--- a/Services/SpeechService/Sources/SpeechRecognizeServiceImple.swift
+++ b/Services/SpeechService/Sources/SpeechRecognizeServiceImple.swift
@@ -17,7 +17,7 @@ import Domain
 public final class SpeechRecognizeServiceImple: SpeechRecognizeService, @unchecked Sendable {
 
     private let recognizer: SFSpeechRecognizer?
-    private let audioEngine = AVAudioEngine()
+    private var audioEngine = AVAudioEngine()
     private var request: SFSpeechAudioBufferRecognitionRequest?
     private var task: SFSpeechRecognitionTask?
 
@@ -66,21 +66,26 @@ extension SpeechRecognizeServiceImple {
         try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
     }
 
-    // 이어폰 분리는 interruption이 아니라 routeChange(.oldDeviceUnavailable)로 온다 — 둘 다 봐야 한다.
+    // 이어폰 분리는 interruption이 아니라 routeChange(.oldDeviceUnavailable)로 오고,
+    // 미디어 서비스 리셋은 둘 중 어느 쪽으로도 오지 않는다 — 셋 다 봐야 한다.
     private func observeAudioDisruption() {
         self.audioSessionObserving = []
 
         let interruptionBegan = NotificationCenter.default
             .publisher(for: AVAudioSession.interruptionNotification)
-            .filter { Self.isInterruptionBegan($0) }
+            .filter(self.isInterruptionBegan())
             .map { _ in () }
 
-        let inputDeviceLost = NotificationCenter.default
+        let oldDeviceUnavailable = NotificationCenter.default
             .publisher(for: AVAudioSession.routeChangeNotification)
-            .filter { Self.isInputDeviceLost($0) }
+            .filter(self.isOldDeviceUnavailable())
             .map { _ in () }
 
-        Publishers.Merge(interruptionBegan, inputDeviceLost)
+        let mediaServicesReset = NotificationCenter.default
+            .publisher(for: AVAudioSession.mediaServicesWereResetNotification)
+            .map { _ in () }
+
+        Publishers.Merge3(interruptionBegan, oldDeviceUnavailable, mediaServicesReset)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.subject.audioInputDisrupted.send(())
@@ -88,16 +93,20 @@ extension SpeechRecognizeServiceImple {
             .store(in: &self.audioSessionObserving)
     }
 
-    private static func isInterruptionBegan(_ notification: Notification) -> Bool {
-        guard let raw = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt
-        else { return false }
-        return AVAudioSession.InterruptionType(rawValue: raw) == .began
+    private func isInterruptionBegan() -> (Notification) -> Bool {
+        return { notification in
+            guard let raw = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt
+            else { return false }
+            return AVAudioSession.InterruptionType(rawValue: raw) == .began
+        }
     }
 
-    private static func isInputDeviceLost(_ notification: Notification) -> Bool {
-        guard let raw = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt
-        else { return false }
-        return AVAudioSession.RouteChangeReason(rawValue: raw) == .oldDeviceUnavailable
+    private func isOldDeviceUnavailable() -> (Notification) -> Bool {
+        return { notification in
+            guard let raw = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt
+            else { return false }
+            return AVAudioSession.RouteChangeReason(rawValue: raw) == .oldDeviceUnavailable
+        }
     }
 
     private func makeRequest() -> SFSpeechAudioBufferRecognitionRequest {
@@ -156,6 +165,8 @@ extension SpeechRecognizeServiceImple {
         self.task?.cancel()
         self.audioEngine.stop()
         self.audioEngine.inputNode.removeTap(onBus: 0)
+        // 미디어 서비스 리셋은 오디오 객체 그래프를 통째로 무효화한다 — 세션마다 새 엔진으로 시작한다
+        self.audioEngine = AVAudioEngine()
         self.request = nil
         self.task = nil
         self.subject.voiceLevel.send(0)

--- a/Services/SpeechService/Sources/SpeechRecognizeServiceImple.swift
+++ b/Services/SpeechService/Sources/SpeechRecognizeServiceImple.swift
@@ -26,8 +26,10 @@ public final class SpeechRecognizeServiceImple: SpeechRecognizeService, @uncheck
             Result<SpeechRecognizeFragment, any Error>, Never
         >()
         let voiceLevel = CurrentValueSubject<Float, Never>(0)
+        let audioInputDisrupted = PassthroughSubject<Void, Never>()
     }
     private let subject = Subject()
+    private var audioSessionObserving = Set<AnyCancellable>()
 
     // 이 dBFS 이하를 0(무음)으로, 0dBFS를 1로 매핑하는 노이즈 플로어
     private let noiseFloor: Float = -50.0
@@ -46,6 +48,7 @@ extension SpeechRecognizeServiceImple {
                 throw RuntimeError(key: "recognizerUnavailable", "speech recognizer unavailable")
             }
             try self.configureAudioSession()
+            self.observeAudioDisruption()
             let request = self.makeRequest()
             self.installInputTap()
             self.task = self.makeRecognitionTask(recognizer: recognizer, request: request)
@@ -61,6 +64,40 @@ extension SpeechRecognizeServiceImple {
         let audioSession = AVAudioSession.sharedInstance()
         try audioSession.setCategory(.record, mode: .measurement)
         try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+    }
+
+    // 이어폰 분리는 interruption이 아니라 routeChange(.oldDeviceUnavailable)로 온다 — 둘 다 봐야 한다.
+    private func observeAudioDisruption() {
+        self.audioSessionObserving = []
+
+        let interruptionBegan = NotificationCenter.default
+            .publisher(for: AVAudioSession.interruptionNotification)
+            .filter { Self.isInterruptionBegan($0) }
+            .map { _ in () }
+
+        let inputDeviceLost = NotificationCenter.default
+            .publisher(for: AVAudioSession.routeChangeNotification)
+            .filter { Self.isInputDeviceLost($0) }
+            .map { _ in () }
+
+        Publishers.Merge(interruptionBegan, inputDeviceLost)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.subject.audioInputDisrupted.send(())
+            }
+            .store(in: &self.audioSessionObserving)
+    }
+
+    private static func isInterruptionBegan(_ notification: Notification) -> Bool {
+        guard let raw = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt
+        else { return false }
+        return AVAudioSession.InterruptionType(rawValue: raw) == .began
+    }
+
+    private static func isInputDeviceLost(_ notification: Notification) -> Bool {
+        guard let raw = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt
+        else { return false }
+        return AVAudioSession.RouteChangeReason(rawValue: raw) == .oldDeviceUnavailable
     }
 
     private func makeRequest() -> SFSpeechAudioBufferRecognitionRequest {
@@ -115,6 +152,7 @@ extension SpeechRecognizeServiceImple {
     // 무조건 호출해도 안전(idempotent): stop/cancel/removeTap 모두 미동작·미설치 상태에서 호출해도 무해.
     // start 실패 cleanup, 중복 stop, 에러 분기 self-teardown 모두 이 한 경로로 처리.
     private func teardownAudio() {
+        self.audioSessionObserving = []
         self.task?.cancel()
         self.audioEngine.stop()
         self.audioEngine.inputNode.removeTap(onBus: 0)
@@ -156,5 +194,8 @@ extension SpeechRecognizeServiceImple {
     }
     public var voiceLevel: AnyPublisher<Float, Never> {
         return self.subject.voiceLevel.eraseToAnyPublisher()
+    }
+    public var audioInputDisrupted: AnyPublisher<Void, Never> {
+        return self.subject.audioInputDisrupted.eraseToAnyPublisher()
     }
 }

--- a/Supports/TestDoubles/Sources/Usecases/StubSpeechRecognizeUsecase.swift
+++ b/Supports/TestDoubles/Sources/Usecases/StubSpeechRecognizeUsecase.swift
@@ -13,7 +13,7 @@ import Domain
 
 public final class StubSpeechRecognizeUsecase: SpeechRecognizeUsecase, @unchecked Sendable {
 
-    public let recognizeResultSubject = PassthroughSubject<Result<String, any Error>, Never>()
+    public let recognizeResultSubject = PassthroughSubject<Result<SpeechRecognizeResult, any Error>, Never>()
     public let recognizingTextSubject = CurrentValueSubject<String, Never>("")
     public let levelSubject = CurrentValueSubject<Float?, Never>(nil)
 
@@ -27,7 +27,7 @@ public final class StubSpeechRecognizeUsecase: SpeechRecognizeUsecase, @unchecke
     public func stopListening() { self.didStopListening = true }
     public func finishListening() { self.didFinishListening = true }
 
-    public var recognizeResult: AnyPublisher<Result<String, any Error>, Never> {
+    public var recognizeResult: AnyPublisher<Result<SpeechRecognizeResult, any Error>, Never> {
         self.recognizeResultSubject.eraseToAnyPublisher()
     }
     public var recognizingText: AnyPublisher<String, Never> {


### PR DESCRIPTION
close #799

## 문제

음성 인식이 **결과 없이 끝나는 경로**에서 마이크는 꺼졌는데 UI는 `.listening(.voice)`에 갇힌다. 빠져나갈 방법이 없다.

오케스트레이션은 `speechRecognizeUsecase.recognizeResult`를 받아야만 `.idle`로 돌아간다. 그런데 결과를 안 보내고 끝나는 경로가 있었다.

- **침묵 타임아웃** — 내부 `.timeout` 케이스가 `stopListening()`만 하고 결과를 방출하지 않았다. 전송 버튼도 `isRecognizing` 가드에 막혀 no-op이라 손쓸 방법이 없었다.
- **시스템 오디오 회수** — 전화 수신·알람·이어폰 분리 때 오디오가 끊기지만 앱은 여전히 active라 `willResignActive`가 오지 않아 #783의 중지 처리가 안 걸린다.

## 접근

### 종료를 명시적 값으로 방출

`recognizeResult`의 success 페이로드를 `String` → `SpeechRecognizeResult`(`.recognized(String)` / `.endedWithoutRecognizing`)로 승격했다. "텍스트 없이 끝남"을 completion이 아니라 값으로 흘려보내, 무인식 종료가 소비자에게 도달한다.

- `AIAgentOrchestrationUsecaseImple.handleRecognizeEnd` — 성공·무인식·실패를 한 경로로 접는다(`resetVoiceBinding()` + `.idle`, 텍스트가 있을 때만 submit). 기존 `handleRecognizeFailed`는 `.idle`만 보내고 바인딩을 안 풀어 다음 입력 세션에 이전 구독이 겹쳤는데, 이 통합으로 함께 해소된다.
- `AIAgentOrchestrationUsecaseImple.enterKeyboardInput` — 음성 바인딩 해제를 나머지 세 종료 경로와 같은 모양으로.

### 오디오 회수를 같은 통지에 연결

`SpeechRecognizeService`(Domain 프로토콜)에 `audioInputDisrupted` 통로를 뚫고, `AVAudioSession`을 아는 유일한 자리인 `SpeechRecognizeServiceImple`이 관측한다. Domain은 AVFoundation을 모르는 상태를 유지한다.

- `SpeechRecognizeServiceImple.observeAudioDisruption` — `interruptionNotification(.began)` · `routeChangeNotification(.oldDeviceUnavailable)` · `mediaServicesWereResetNotification` 셋을 관측한다. 이슈 본문은 이어폰 분리를 interruption으로 묶었으나 실제로는 routeChange로 오고, 미디어 서비스 리셋은 둘 중 어느 쪽으로도 오지 않는다.
- `SpeechRecognizeUsecaseImple.bindService` — 끊김을 `.endedWithoutRecognizing`으로 병합한다. 인식 중이던 부분 텍스트는 버린다 (#783 선례 — 끝나지 않은 문장을 제출하면 AI가 의도하지 않은 이벤트를 만든다). 끊김 후 자동 재개도 하지 않는다.

### 시작 in-flight 취소

리뷰 중 드러난 인접 결함. `startListening()`이 권한 요청을 `Task`로 띄우는데 `isRecognizing`은 start 성공 후에야 true가 되므로, Task가 떠 있는 동안 들어온 호출이 가드를 그대로 통과했다.

- `SpeechRecognizeUsecaseImple.startListening` — in-flight start를 보유하고 재진입·`stopListening()` 때 취소한다. 권한 대기에서 깨어나면 취소 여부를 확인하고 진행한다. 중복 `bindService()`·`start()`가 사라지고, **취소했는데 마이크만 켜지는** 상태도 막힌다.

## 검증

Domain·AIAgentScene·CalendarScenes·TodoCalendarApp 통과. `Services/SpeechService`에는 테스트 타겟이 없어 알림 관측은 컴파일까지만 자동 검증된다 — 침묵 3초 / 전화 수신 / 이어폰 분리 3항목은 실기기 확인이 남아 있다. `aiAgent` 플래그가 off라 현재 사용자에게 노출되지는 않는다.

## 범위 밖

`AVAudioEngineConfigurationChangeNotification`은 관측하지 않았다. 정상 상황에서도 발생해, 오탐으로 멀쩡한 세션을 끊을 위험이 관측 이득보다 크다.
