### PR TITLE
[#804] 다국어 작업 지침 전환 — 개발 시엔 en/ko만, 번역은 배포 전 일괄

### DIFF
--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -15,11 +15,24 @@ paths:
 - `Localizable.strings` — **AppIntents 라벨·다이얼로그**(`title`·`description`·`IntentDialog` 등). AppIntents 문구는 그 인텐트가 속한 타겟 자신의 번들에서 해석되므로, 공유 리소스인 `Supports/Extensions/Resources`에 넣으면 시스템이 못 찾는다 — 앱 타겟(`TodoCalendarApp`) 소속 인텐트는 반드시 여기. **#722에서 데인 함정**: AppIntents 메타데이터는 이 규칙을 몰라 다른 곳에 두면 조용히 원문(en)으로만 보이거나 라벨이 깨진다.
 - `AppShortcuts.strings` — Siri 발화 phrase(`AppShortcutsProvider`).
 
-## 1. 전 언어 동기화 짝 (CLAUDE.md §1)
+## 1. 개발 중엔 en/ko만 — 번역은 #810으로 미룬다 (CLAUDE.md §1)
 
-**en에 키를 추가·삭제·시그니처 변경하면 나머지 30개 언어 lproj를 같은 커밋 흐름에서 갱신한다.** en/ko만 갱신하고 끝내면 29개 언어가 즉시 stale이 된다.
+전 언어를 그 자리에서 번역하면 개별 작업이 번역에 발목잡힌다. 그래서 **개발 시점엔 `en`·`ko` lproj만 갱신하고, 나머지 29개 언어는 번역 대기 트래킹 이슈 #810에 미룬다.**
 
-검증: `python3 scripts/check-localization-parity.py` (인자 없으면 전 언어) — 키 세트·포맷 지정자 multiset·중복 키를 en과 대조. 커밋 전 0 위반 확인. 문법은 `plutil -lint <파일>`.
+작업 시 이 셋을 같이 한다:
+1. `en`·`ko` lproj에 키 추가·삭제·시그니처 변경 반영 (3개 리소스 위치 중 해당하는 곳).
+2. #810 본문 "대기 목록"에 **현재 작업의 이슈 또는 PR 링크**를 한 줄 추가.
+3. 커밋 전 `python3 scripts/check-localization-parity.py ko`로 en↔ko 파리티 0 위반 확인. 문법은 `plutil -lint <파일>`.
+
+**미번역 언어에선 그 문구가 원문 키 그대로 노출된다** — `NSLocalizedString`은 키가 해당 lproj에 없을 때 en으로 fallback하지 않고 키 문자열을 돌려준다(`String+Extensions.swift`). 배포 전 #810 소진이 전제다.
+
+### #810 처리 시점 (일괄 번역)
+
+유저 지시로 #810을 처리할 때만 29개 언어를 채운다:
+
+- 대기 키 목록의 정본은 `python3 scripts/check-localization-parity.py` (인자 없음 = 전 언어) 출력의 `missing keys`. #810 대기 목록의 링크는 번역 뉘앙스를 잡을 맥락 참조용.
+- 번역 원칙은 아래 §2·§3.
+- 전 언어 0 위반을 확인하고 #810 대기 목록을 비운 뒤 close.
 
 ## 2. 번역 원칙
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@
   - 신규 테스트 스킴 ↔ 스킴 목록 하드코딩 전부 (`pr_test.yml` 3곳·`scripts/run-all-tests.sh`·`impact-check.sh`+테스트·`run-tests` 스킬 — 상세는 add-framework 스킬. 단 `<Name>Snapshots` 스킴은 의도된 예외 — 로컬 전용, snapshot-check 스킬)
   - init 시그니처 ↔ 콜사이트
   - 인증 필요 신규 Endpoint enum ↔ `CalendarAPIAutenticator.shouldAdapt` case ↔ 회귀 테스트 (누락 시 무인증 요청 → 401, 리트라이도 안 됨)
-  - en `Localizable.strings` 키 추가/삭제 ↔ 나머지 30개 언어 lproj 동기화 (검증 `scripts/check-localization-parity.py`, 번역 원칙은 `.claude/rules/localization.md`)
+  - en `Localizable.strings` 키 추가/삭제 ↔ ko lproj 반영 ↔ 번역 대기 트래킹 이슈 #810에 작업 링크 기록 (나머지 29개 언어는 #810 처리 시점에 일괄 번역 — 상세는 `.claude/rules/localization.md`)
 - **스킬 종료·유저 교정은 레코드로 남긴다** (#690 flywheel 측정 신호):
   - 발동한 스킬의 절차가 끝나면: `python3 .claude/hooks/log-record.py skill_end --name <스킬> --compliance full|partial [--deviation "조항::사유"]` — 조항을 의도적으로 이행 안 했으면 partial + 이탈 조항·사유 필수.
   - 유저가 작업 결과·방식을 교정하면 그 자리에서: `python3 .claude/hooks/log-record.py correction --skills <귀속 스킬(쉼표 구분)> --summary "교정 요지" --gist "발화 요지"`. **귀속은 발동 중이던 스킬이 아니라 교정 대상의 소관으로 정한다** — 그 사안을 다루는 조항이 그 스킬에 **실제로 있을 때만** `--skills`에 넣고(규범 판단이 아니라 조항 존재라는 사실 확인), 응답 톤·글쓰기처럼 전역 규칙(CLAUDE.md) 소관인 교정은 `--skills` 생략. 발동 중이라는 이유로 붙이면 스킬 신호가 오염돼 엉뚱한 조항이 정비 대상으로 올라온다.

--- a/scripts/check-localization-parity.py
+++ b/scripts/check-localization-parity.py
@@ -5,9 +5,12 @@ usage:
   scripts/check-localization-parity.py <lang> [<lang> ...]   # 지정 언어만
   scripts/check-localization-parity.py                       # 전 언어 (en 제외 자동 탐색)
 
-en Localizable.strings에 키를 추가·삭제하면 나머지 전 언어 lproj를 함께 갱신해야 한다
-(CLAUDE.md §1 짝 규칙). 이 스크립트가 그 짝을 기계 검증한다. 세부 번역 원칙은
-.claude/rules/localization.md 참조.
+개발 중엔 en/ko만 갱신하고 나머지 29개 언어 번역은 트래킹 이슈 #810으로 미룬다
+(CLAUDE.md §1). 그래서 용도가 둘이다:
+  - 작업 커밋 전: `... ko` 로 en↔ko 파리티만 검증.
+  - #810 일괄 번역 시: 인자 없이 실행해 나온 missing keys 가 곧 번역 대기 키 목록이고,
+    전 언어 0 위반이 close 조건.
+세부 번역 원칙은 .claude/rules/localization.md 참조.
 """
 import re, sys, collections
 from pathlib import Path


### PR DESCRIPTION
closes #804

## 문제

신규 문구 하나를 추가할 때마다 31개 언어를 그 자리에서 번역해야 했다 (`CLAUDE.md` §1 짝 규칙, 커밋 전 전 언어 파리티 0 위반). 번역이 개별 작업의 병목이 됐다.

## 접근

번역 시점을 **작업 커밋에서 떼어내 배포 전 일괄 처리로** 옮긴다. 개발 중엔 `en`·`ko`만 반영하고, 나머지 29개 언어는 상시 트래킹 이슈 #810에 미룬다.

작업 시 3단계:
1. `en`·`ko` lproj 반영
2. #810 대기 목록에 작업 이슈/PR 링크 기록
3. `check-localization-parity.py ko`로 en↔ko 파리티만 확인

#810 처리 시엔 인자 없이 돌린 `missing keys`가 곧 번역 대기 키 목록이 되고, 전 언어 0 위반이 close 조건이다. parity 스크립트 로직은 그대로 두고 용도만 둘로 갈랐다.

## 트레이드오프

미번역 29개 언어엔 키를 아예 넣지 않기로 했다 (en 원문 placeholder 채우기 대신). `String+Extensions.swift`의 `NSLocalizedString(self, bundle: .module)`은 키 단위 en fallback이 없어서, **미번역 언어에선 그 문구가 원문 키 그대로 노출된다**. 배포 전 #810 소진이 프로세스의 전제고, 그 사실을 규칙에 명시했다.
