### PR TITLE
[#707] paywall 카탈로그 실패 팝업 제거 + 로컬 StoreKit 가격표 확정

### DIFF
--- a/Presentations/BillingScenes/Sources/Paywall/PaywallViewModel.swift
+++ b/Presentations/BillingScenes/Sources/Paywall/PaywallViewModel.swift
@@ -174,13 +174,11 @@ extension PaywallViewModelImple {
     private func loadCatalog() async {
         do {
             // 여기서 catch 하는 건 서버 카탈로그 요청(loadPlans) 실패다 — StoreKit 상품 조회
-            // 실패는 loadPlanOfferings 내부(try?)가 이미 삼켜 product만 nil로 온다. 성격이
-            // 다른 실패라 같은 근거로 묻지 않는다 (#739)
+            // 실패는 loadPlanOfferings 내부(try?)가 이미 삼켜 product만 nil로 온다
             let offerings = try await self.billingUsecase.loadPlanOfferings()
             self.subject.catalogState.send(.loaded(offerings))
         } catch {
             self.subject.catalogState.send(.failed)
-            self.router?.showError(error)
         }
     }
 

--- a/Presentations/BillingScenes/Tests/Paywall/PaywallViewModelImpleTests.swift
+++ b/Presentations/BillingScenes/Tests/Paywall/PaywallViewModelImpleTests.swift
@@ -189,8 +189,8 @@ extension PaywallViewModelImpleTests {
     }
 
     // I1/I2 회귀 — 서버 카탈로그 요청 실패는 .loaded([]) 로 조용히 삼키지 않고 .failed 로
-    // 드러나며, purchase()/restore() 와 동일하게 showError 로 알린다
-    @Test func viewModel_whenCatalogLoadFails_setsFailedStateAndShowsError() async throws {
+    // 드러난다. 단 화면이 그 상태를 이미 그리므로 showError 로 중복 통지하지 않는다
+    @Test func viewModel_whenCatalogLoadFails_setsFailedStateWithoutErrorPopup() async throws {
         // given
         let (viewModel, _, router) = self.makeViewModel(catalogLoadError: TestError())
 
@@ -203,7 +203,7 @@ extension PaywallViewModelImpleTests {
 
         // then
         #expect(states.last == .failed)
-        #expect(router.didShowError is TestError)
+        #expect(router.didShowError == nil)
     }
 }
 
@@ -566,7 +566,7 @@ extension PaywallViewModelImpleTests {
     }
 
     // 유저 플랜 조회는 성공했는데 카탈로그만 실패하는 조합 — 화면은 그려지되(.ready) 카탈로그
-    // 축은 기존 .failed 처리를 그대로 물려받는다(이번 스코프에서 바뀌지 않는 계약)
+    // 축만 .failed 로 드러난다. 어느 축이 실패하든 팝업은 띄우지 않는다
     @Test func viewModel_whenUserPlanSucceedsButCatalogFails_screenStateIsReadyWithFailedCatalog() async throws {
         // given
         let (viewModel, _, router) = self.makeViewModel(catalogLoadError: TestError())
@@ -583,6 +583,6 @@ extension PaywallViewModelImpleTests {
 
         // then
         #expect(final == .ready(.failed))
-        #expect(router.didShowError is TestError)
+        #expect(router.didShowError == nil)
     }
 }

--- a/TodoCalendarApp/Resources/Billing.storekit
+++ b/TodoCalendarApp/Resources/Billing.storekit
@@ -5,7 +5,7 @@
   ],
   "products" : [
     {
-      "displayPrice" : "39000",
+      "displayPrice" : "29.99",
       "familyShareable" : false,
       "internalID" : "F7209EB6-48D6-42B3-B770-CFDE31F263DB",
       "localizations" : [
@@ -20,7 +20,7 @@
       "type" : "NonConsumable"
     },
     {
-      "displayPrice" : "1200",
+      "displayPrice" : "0.99",
       "familyShareable" : false,
       "internalID" : "F22C4EF8-F1F7-483C-A910-6BE2F898DE32",
       "localizations" : [
@@ -35,7 +35,7 @@
       "type" : "Consumable"
     },
     {
-      "displayPrice" : "2900",
+      "displayPrice" : "4.99",
       "familyShareable" : false,
       "internalID" : "4FF2B0AC-1B06-4A95-AEFD-038A399BD6CB",
       "localizations" : [
@@ -50,7 +50,7 @@
       "type" : "Consumable"
     },
     {
-      "displayPrice" : "5900",
+      "displayPrice" : "9.99",
       "familyShareable" : false,
       "internalID" : "845E09E0-87E7-4AE5-9077-E4F8C379F91A",
       "localizations" : [
@@ -70,7 +70,7 @@
     "_billingIssuesEnabled" : false,
     "_disableDialogs" : false,
     "_failTransactionsEnabled" : false,
-    "_locale" : "ko_KR",
+    "_locale" : "en_US",
     "_negativeReviewsEnabled" : false,
     "_storeKitErrors" : [
       {
@@ -119,7 +119,7 @@
         "name" : "Offer Code Redeem Sheet"
       }
     ],
-    "_storefront" : "KOR"
+    "_storefront" : "USA"
   },
   "subscriptionGroups" : [
     {
@@ -136,7 +136,7 @@
           "codeOffers" : [
 
           ],
-          "displayPrice" : "4900",
+          "displayPrice" : "0.99",
           "familyShareable" : false,
           "groupNumber" : 1,
           "internalID" : "C2B87CBB-20C6-4673-ACEB-39A1861026AC",


### PR DESCRIPTION
로컬 StoreKit(`.storekit`) + Firebase Functions 에뮬레이터로 결제 동선을 처음 끝까지 돌려봤다. 그 과정에서 드러난 두 가지를 고친다.

## paywall 에러 팝업 중복

카탈로그 조회가 실패하면 화면이 이미 실패 상태를 그리는데, 그 위로 에러 팝업이 한 번 더 떴다. 같은 사실을 두 경로로 통지하는 셈이라 `loadCatalog`의 `showError`를 뺐다.

`purchase()`·`restore()`의 `showError`는 그대로 둔다 — 유저가 직접 누른 액션이고 결과가 화면 어딘가에 드러나지 않아서, 팝업이 유일한 통지 경로다.

## 로컬 StoreKit 가격표

`Billing.storekit`의 `displayPrice`가 원화 추정치(39000·1200·…)로 박혀 있어 실제 결제 시트와 자릿수부터 달랐다. App Store Connect 등록 가격(달러)으로 맞추고, 기준 스토어프론트도 `USA`/`en_US`로 바꿨다 — 달러가 기준 가격이라 로컬에서도 같은 스토어프론트로 봐야 환산 표시에 속지 않는다.

---

실측에서 함께 드러난 결함들은 별도 이슈로 분리했다 — #811 · #812 · #813 · #814 (정리는 #707 본문).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqpeqbgFA57QfYdcCGTiUP
