### PR TITLE
[#802] 콜드런치 AI 입력 진입 게이팅 — 상태 첫 방출·달력 부착 이후로

### DIFF
--- a/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
@@ -317,10 +317,10 @@ extension CalendarViewModelImple {
         self.bindUncompletedTodoRefresh()
 
         if FeatureFlag.isEnable(.aiAgent) {
-            self.aiAgentOrchestrationUsecase.prepare()
             self.bindShowAICommandResultIfNeed()
             self.bindVoiceInputLifecycle()
             self.bindScrollToVoiceInputOnFocusedMonth()
+            self.aiAgentOrchestrationUsecase.prepare()
         }
     }
     
@@ -501,7 +501,20 @@ extension CalendarViewModelImple {
 
 extension CalendarViewModelImple {
 
+    // 콜드런치 딥링크는 aiAgentState 미방출·달력 미부착 시점에 flush된다 — 그때 실행하면
+    // 상태를 idle로 오판독하고 스크롤도 유실된다. 웜 스타트면 구독 즉시 동기로 통과한다.
     func requestAIEntry() {
+        Publishers.CombineLatest(
+            self.subject.aiAgentState.compactMap { $0 }.first(),
+            self.subject.monthsInCurrentRange.compactMap { $0 }.first()
+        )
+        .sink(receiveValue: { [weak self] _, _ in
+            self?.performAIEntry()
+        })
+        .store(in: &self.cancellables)
+    }
+
+    private func performAIEntry() {
         self.router?.dismissPresented(animated: true) { [weak self] in
             guard let self = self else { return }
             let state = self.subject.aiAgentState.value ?? .idle

--- a/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
@@ -1099,10 +1099,22 @@ extension CalendarViewModelImpleTests {
 
 extension CalendarViewModelImpleTests {
 
-    func testViewModel_whenRequestAIEntryOnCommandPhase_routeToAICommand() {
+    // prepare() → prepareInitialMonths의 Task가 monthsInCurrentRange를 채울 때까지 대기.
+    // didInitialMonthsAttached는 send 직전에 불려 한 틱 양보가 필요하다.
+    private func prepareInitialMonths(_ viewModel: CalendarViewModelImple) async throws {
+        let expect = expectation(description: "초기 월 구성 완료 대기")
+        self.spyRouter.didInitialMonthsAttached = { expect.fulfill() }
+        viewModel.prepare()
+        await self.fulfillment(of: [expect], timeout: self.timeout)
+        self.spyRouter.didInitialMonthsAttached = nil
+        try await Task.sleep(for: .milliseconds(10))
+    }
+
+    func testViewModel_whenRequestAIEntryOnCommandPhase_routeToAICommand() async throws {
         // given
         let viewModel = self.makeViewModel()
         self.stubOrchestration.stateSubject.send(.processing(command: "회의"))
+        try await self.prepareInitialMonths(viewModel)
 
         // when
         viewModel.requestAIEntry()
@@ -1113,10 +1125,11 @@ extension CalendarViewModelImpleTests {
         XCTAssertNil(self.spyRouter.didShowConfirmWith)
     }
 
-    func testViewModel_whenRequestAIEntryOnIdleAndSignedIn_enterVoiceInput() {
+    func testViewModel_whenRequestAIEntryOnIdleAndSignedIn_enterVoiceInput() async throws {
         // given
         let viewModel = self.makeViewModel(isSignedIn: true)
         self.stubOrchestration.stateSubject.send(.idle)
+        try await self.prepareInitialMonths(viewModel)
 
         // when
         viewModel.requestAIEntry()
@@ -1127,10 +1140,11 @@ extension CalendarViewModelImpleTests {
         XCTAssertNil(self.spyRouter.didShowConfirmWith)
     }
 
-    func testViewModel_whenRequestAIEntryWithoutSignIn_askSignIn() {
+    func testViewModel_whenRequestAIEntryWithoutSignIn_askSignIn() async throws {
         // given
         let viewModel = self.makeViewModel(isSignedIn: false)
         self.stubOrchestration.stateSubject.send(.idle)
+        try await self.prepareInitialMonths(viewModel)
 
         // when
         viewModel.requestAIEntry()
@@ -1140,6 +1154,62 @@ extension CalendarViewModelImpleTests {
         XCTAssertNil(self.stubOrchestration.didEnterVoiceInput)
         // SpyRouter.showConfirm은 기본적으로 confirmed?()를 즉시 실행
         XCTAssertEqual(self.spyRouter.didRouteToSignIn, true)
+    }
+
+    func testViewModel_whenRequestAIEntryBeforeAIStateEmitted_notEnterVoiceInput() async throws {
+        // given
+        let viewModel = self.makeViewModel(isSignedIn: true)
+        try await self.prepareInitialMonths(viewModel)
+
+        // when
+        viewModel.requestAIEntry()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        XCTAssertNil(self.stubOrchestration.didEnterVoiceInput)
+        XCTAssertEqual(self.spyRouter.didRouteToAICommandCount, 0)
+    }
+
+    func testViewModel_whenAIStateEmittedAfterRequestAIEntry_enterVoiceInput() async throws {
+        // given
+        let viewModel = self.makeViewModel(isSignedIn: true)
+        try await self.prepareInitialMonths(viewModel)
+        viewModel.requestAIEntry()
+
+        // when
+        self.stubOrchestration.stateSubject.send(.idle)
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        XCTAssertEqual(self.stubOrchestration.didEnterVoiceInput, true)
+    }
+
+    func testViewModel_whenProcessingStateEmittedAfterRequestAIEntry_routeToAICommand() async throws {
+        // given
+        let viewModel = self.makeViewModel(isSignedIn: true)
+        try await self.prepareInitialMonths(viewModel)
+        viewModel.requestAIEntry()
+
+        // when
+        self.stubOrchestration.stateSubject.send(.processing(command: "회의"))
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        XCTAssertEqual(self.spyRouter.didRouteToAICommandCount, 1)
+        XCTAssertNil(self.stubOrchestration.didEnterVoiceInput)
+    }
+
+    func testViewModel_whenRequestAIEntryBeforeCalendarAttached_notEnterVoiceInput() async throws {
+        // given
+        let viewModel = self.makeViewModel(isSignedIn: true)
+        self.stubOrchestration.stateSubject.send(.idle)
+
+        // when
+        viewModel.requestAIEntry()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        XCTAssertNil(self.stubOrchestration.didEnterVoiceInput)
     }
 }
 


### PR DESCRIPTION
위젯·컨트롤 센터의 AI 입력 바로가기로 앱을 콜드스타트하면 음성 인식은 시작되는데 listening UI가 안 떴다. #768 PR 본문의 "남은 것" 마지막 항목이 그대로 터진 것.

## 문제

콜드런치 딥링크는 화면 조립 도중 flush된다. `SceneDelegate`의 `prepareInitialScene()`이 `Task`라 비동기로 빠지고 `handle(open:)`이 먼저 돌아 딥링크가 pending으로 쌓인 뒤, scene 조립 끝의 `attach(calendarInteractor:)`에서 `requestAIEntry()`로 흘러나온다.

이 시점엔 `aiAgentState`가 아직 미방출이다 — `viewDidLoad → prepare()`가 띄운 `restoreIfNeeded()`의 복원 조회가 진행 중이라서. 그래서 `.idle`로 오판독해 음성 진입을 시작하는데, 뒤늦게 도착한 복원 결과가 방금 켠 `.listening(.voice)`를 덮는다. 인식은 계속 도는데 UI만 idle로 남는 게 이 증상이다. 달력 paper도 아직 안 붙어 음성 입력 위치 스크롤까지 유실된다.

## 접근

진입 실행을 두 신호가 확보된 뒤로 미룬다 — `aiAgentState` 첫 방출(복원 완료)과 `monthsInCurrentRange` 첫 방출(paper 부착). 둘을 `CombineLatest`로 합성한 게이트가 열려야 진입 분기가 돈다. 웜 스타트(앱이 떠 있는 상태에서 위젯 탭)는 두 값이 이미 있어 구독 즉시 동기로 통과하므로 지연이 생기지 않는다.

- `CalendarViewModelImple.requestAIEntry` — 진입 실행을 게이트 뒤로 이동
- `CalendarViewModelImple.performAIEntry` — 진입 분기(커맨드 시트 · 음성 진입 · 로그인 유도)를 게이트와 분리
- `CalendarViewModelImple.prepare` — AI 소비 바인딩을 orchestration prepare보다 먼저 걸어, 게이트 통과 직후 방출되는 `.listening(.voice)`가 스크롤 바인딩을 놓치지 않게 함

## 검토 경위

신호가 늦을 때를 대비한 타임아웃 폴백(1.5초 후 현재 상태로 강행)을 함께 넣었다가 뺐다. 폴백으로 진입하면 그 시점 상태가 여전히 미방출이라 `.idle`로 오판독하는데, 살아 있는 복원 구독이 뒤늦게 `.idle`·`.processing`을 보내 진입 상태를 덮는다 — 고치려던 버그가 그대로 재현된다. 특히 진행 중 job이 있어 복원이 서버 조회까지 가는 유저, 즉 상태 판독이 가장 중요한 케이스에만 터진다.

대신 복원이 오래 걸리면 그만큼 진입이 늦어진다. 폴백을 지키려면 복원 결과가 입력 중 상태를 덮지 않도록 `AIAgentOrchestrationUsecase` 쪽에 가드가 필요한데, 이번 범위 밖으로 뒀다.
