### PR TITLE
[#811] Transaction.updates 옵저빙을 로그인 세션에 묶고 종류 판별을 서버로 위임

### DIFF
--- a/Domain/Sources/Repositories/Billing/BillingRepository.swift
+++ b/Domain/Sources/Repositories/Billing/BillingRepository.swift
@@ -19,4 +19,8 @@ public protocol BillingRepository: AnyObject, Sendable {
 
     // 구매 반영 후 발효 플랜을 돌려준다 — 별도 usage 재조회가 필요 없다
     func postPurchase(signedTransaction: String) async throws -> BillingUserPlan
+
+    // 앱 밖에서 발견한 트랜잭션(갱신·환불·가족공유·승인통과·미완료 잔여)을 서버에 위임한다.
+    // 종류 판별과 처리 필요 여부는 전부 서버가 하고, 앱은 200 을 "확인됨" 으로만 읽는다
+    func postTransactionUpdate(signedTransaction: String) async throws -> BillingUserPlan
 }

--- a/Domain/Sources/Usecases/Billing/BillingUsecase.swift
+++ b/Domain/Sources/Usecases/Billing/BillingUsecase.swift
@@ -10,6 +10,7 @@ import Foundation
 import Combine
 import Prelude
 import Optics
+import Extensions
 
 
 public protocol BillingUsecase: AnyObject, Sendable {
@@ -33,7 +34,9 @@ public protocol BillingUsecase: AnyObject, Sendable {
     // 는 옵저빙 상태를 락 없는 플래그로 지킨다 — 셋 다 메인에서만 부른다
     func startObservingTransactions()
 
-    // 로그아웃·팩토리 교체 시. 이전 세션 리스너가 살아 있으면 같은 JWS 가 중복 post 된다
+    // 로그아웃·팩토리 교체 시. 이전 세션 리스너가 살아 있으면 같은 JWS 가 중복 post 된다.
+    // transactionUpdates 는 단일 소비 AsyncStream 이라, stop 후 같은 인스턴스에 startObservingTransactions
+    // 를 다시 불러도 재기동되지 않는다 — 새 세션은 항상 새 usecase 인스턴스로 만든다
     func stopObservingTransactions()
 
     // 서버 반영 전에 앱이 죽어 finish 되지 않은 트랜잭션을 재전송한다.
@@ -134,8 +137,8 @@ extension BillingUsecaseImple {
 
     // 앱이 뒤늦게 발견한 트랜잭션 — 종류를 판별하지 않고 서버에 위임한다.
     // 200 을 "서버가 확인했다" 로 읽고 그때만 finish 한다.
-    // 서버가 transactionId 기준 멱등이라, 옵저빙 스트림과 recoverUnfinishedTransactions 가
-    // 같은 트랜잭션을 각각 집어 두 번 보내도 안전하다
+    // 서버 원장 키가 관측(transactionId + 회수 여부) 기준 멱등이라, 옵저빙 스트림과
+    // recoverUnfinishedTransactions 가 같은 트랜잭션을 각각 집어 두 번 보내도 안전하다
     private func delegateAndFinish(
         _ transaction: BillingSignedTransaction
     ) async throws -> BillingUserPlan {
@@ -143,6 +146,9 @@ extension BillingUsecaseImple {
             signedTransaction: transaction.jws
         )
         await self.appStoreService.finishTransaction(id: transaction.id)
+        // 로그아웃은 shared store 를 비운 뒤 옵저빙을 끊는다. 그 사이 응답이 도착하면
+        // 이전 유저의 플랜이 비워진 store 에 다시 써져 다음 세션까지 남는다
+        guard !Task.isCancelled else { return userPlan }
         self.updateSharedUserPlan(userPlan)
         return userPlan
     }
@@ -155,7 +161,7 @@ extension BillingUsecaseImple {
         )
     }
 
-    // 서버가 transactionId ledger 로 멱등이라 전건 재제출이 안전하다.
+    // 서버 원장 키가 관측(transactionId + 회수 여부) 기준 멱등이라 전건 재제출이 안전하다.
     // 순차 await 이라 for 루프가 필요하다 — 마지막 반영 결과가 최신 상태.
     // recoverUnfinishedTransactions 와 달리 여기는 fail-fast 가 의도다 — restorePurchases 는
     // 유저가 직접 누른 액션이라 실패가 화면에 그대로 노출되고 재시도도 유저가 다시 누르면 되므로,
@@ -198,7 +204,14 @@ extension BillingUsecaseImple {
             // deinit 이 영영 오지 않아 deinit 의 cancel 이 죽은 코드가 된다
             for await transaction in updates {
                 guard let self else { return }
-                _ = try? await self.delegateAndFinish(transaction)
+                do {
+                    _ = try await self.delegateAndFinish(transaction)
+                } catch {
+                    logger.log(
+                        level: .error, "billing transaction delegate failed (stream): \(error)",
+                        with: ["transactionId": transaction.id]
+                    )
+                }
             }
         }
     }
@@ -220,7 +233,14 @@ extension BillingUsecaseImple {
             else { return }
             for transaction in transactions {
                 guard !Task.isCancelled, let self else { return }
-                _ = try? await self.delegateAndFinish(transaction)
+                do {
+                    _ = try await self.delegateAndFinish(transaction)
+                } catch {
+                    logger.log(
+                        level: .error, "billing transaction delegate failed (recovery): \(error)",
+                        with: ["transactionId": transaction.id]
+                    )
+                }
             }
         }
     }

--- a/Domain/Sources/Usecases/Billing/BillingUsecase.swift
+++ b/Domain/Sources/Usecases/Billing/BillingUsecase.swift
@@ -26,9 +26,17 @@ public protocol BillingUsecase: AnyObject, Sendable {
     @discardableResult
     func refreshUserPlan() async throws -> BillingUserPlan
 
-    // 앱 기동(로그인) 시 1회. 이후 생명주기 내내 유지된다.
+    // 로그인 세션에 묶여 기동한다. 여기서 처리하는 건 StoreKit.Transaction.updates 뿐이다 —
+    // 미완료 거래 복구는 트리거도 목적도 달라 아래 recoverUnfinishedTransactions 가 맡는다.
     // 중복 호출 방어가 락 없는 플래그라 메인에서만 부른다
     func startObservingTransactions()
+
+    // 로그아웃·팩토리 교체 시. 이전 세션 리스너가 살아 있으면 같은 JWS 가 중복 post 된다
+    func stopObservingTransactions()
+
+    // 서버 반영 전에 앱이 죽어 finish 되지 않은 트랜잭션을 재전송한다.
+    // 한 건이 영구 실패해도 나머지는 진행한다
+    func recoverUnfinishedTransactions() async
 
     var currentUserPlan: AnyPublisher<BillingUserPlan, Never> { get }
 }
@@ -120,6 +128,19 @@ extension BillingUsecaseImple {
         return userPlan
     }
 
+    // 앱이 뒤늦게 발견한 트랜잭션 — 종류를 판별하지 않고 서버에 위임한다.
+    // 200 을 "서버가 확인했다" 로 읽고 그때만 finish 한다
+    private func delegateAndFinish(
+        _ transaction: BillingSignedTransaction
+    ) async throws -> BillingUserPlan {
+        let userPlan = try await self.repository.postTransactionUpdate(
+            signedTransaction: transaction.jws
+        )
+        await self.appStoreService.finishTransaction(id: transaction.id)
+        self.updateSharedUserPlan(userPlan)
+        return userPlan
+    }
+
     private func updateSharedUserPlan(_ userPlan: BillingUserPlan) {
         self.sharedDataStore.put(
             BillingUserPlan.self,
@@ -167,23 +188,26 @@ extension BillingUsecaseImple {
         // 앱 밖 갱신·환불·가족공유·승인대기 통과가 들어오는 유일한 경로
         let updates = self.appStoreService.transactionUpdates
         self.observingTask = Task { [weak self] in
-            // 서버 반영 전에 앱이 죽은 트랜잭션을 먼저 복구한 뒤 스트림을 연다
-            await self?.recoverUnfinishedTransactions()
             // 루프 본문에서만 self 를 잡는다 — 끝나지 않는 스트림을 strong self 로 돌면
-            // deinit 이 영영 오지 않아 아래 cancel 이 죽은 코드가 된다
+            // deinit 이 영영 오지 않아 deinit 의 cancel 이 죽은 코드가 된다
             for await transaction in updates {
                 guard let self else { return }
-                _ = try? await self.applyAndFinish(transaction)
+                _ = try? await self.delegateAndFinish(transaction)
             }
         }
     }
 
+    public func stopObservingTransactions() {
+        self.observingTask?.cancel()
+        self.observingTask = nil
+    }
+
     // 한 건이 영구 실패해도 나머지는 반영돼야 한다 — fail-fast 면 앞의 실패가
-    // 매 기동마다 뒤 트랜잭션을 가려 영영 반영되지 않는다
-    private func recoverUnfinishedTransactions() async {
+    // 매 시도마다 뒤 트랜잭션을 가려 영영 반영되지 않는다
+    public func recoverUnfinishedTransactions() async {
         let transactions = await self.appStoreService.unfinishedTransactions()
         for transaction in transactions {
-            _ = try? await self.applyAndFinish(transaction)
+            _ = try? await self.delegateAndFinish(transaction)
         }
     }
 

--- a/Domain/Sources/Usecases/Billing/BillingUsecase.swift
+++ b/Domain/Sources/Usecases/Billing/BillingUsecase.swift
@@ -28,15 +28,17 @@ public protocol BillingUsecase: AnyObject, Sendable {
 
     // 로그인 세션에 묶여 기동한다. 여기서 처리하는 건 StoreKit.Transaction.updates 뿐이다 —
     // 미완료 거래 복구는 트리거도 목적도 달라 아래 recoverUnfinishedTransactions 가 맡는다.
-    // 중복 호출 방어가 락 없는 플래그라 메인에서만 부른다
+    //
+    // startObservingTransactions·stopObservingTransactions·recoverUnfinishedTransactions
+    // 는 옵저빙 상태를 락 없는 플래그로 지킨다 — 셋 다 메인에서만 부른다
     func startObservingTransactions()
 
     // 로그아웃·팩토리 교체 시. 이전 세션 리스너가 살아 있으면 같은 JWS 가 중복 post 된다
     func stopObservingTransactions()
 
     // 서버 반영 전에 앱이 죽어 finish 되지 않은 트랜잭션을 재전송한다.
-    // 한 건이 영구 실패해도 나머지는 진행한다
-    func recoverUnfinishedTransactions() async
+    // 한 건이 영구 실패해도 나머지는 진행한다. 재호출·stop 시 이전 시도는 취소된다
+    func recoverUnfinishedTransactions()
 
     var currentUserPlan: AnyPublisher<BillingUserPlan, Never> { get }
 }
@@ -59,9 +61,11 @@ public final class BillingUsecaseImple: BillingUsecase, @unchecked Sendable {
     }
 
     private var observingTask: Task<Void, Never>?
+    private var recoveryTask: Task<Void, Never>?
 
     deinit {
         self.observingTask?.cancel()
+        self.recoveryTask?.cancel()
     }
 }
 
@@ -129,7 +133,9 @@ extension BillingUsecaseImple {
     }
 
     // 앱이 뒤늦게 발견한 트랜잭션 — 종류를 판별하지 않고 서버에 위임한다.
-    // 200 을 "서버가 확인했다" 로 읽고 그때만 finish 한다
+    // 200 을 "서버가 확인했다" 로 읽고 그때만 finish 한다.
+    // 서버가 transactionId 기준 멱등이라, 옵저빙 스트림과 recoverUnfinishedTransactions 가
+    // 같은 트랜잭션을 각각 집어 두 번 보내도 안전하다
     private func delegateAndFinish(
         _ transaction: BillingSignedTransaction
     ) async throws -> BillingUserPlan {
@@ -200,14 +206,22 @@ extension BillingUsecaseImple {
     public func stopObservingTransactions() {
         self.observingTask?.cancel()
         self.observingTask = nil
+        self.recoveryTask?.cancel()
+        self.recoveryTask = nil
     }
 
     // 한 건이 영구 실패해도 나머지는 반영돼야 한다 — fail-fast 면 앞의 실패가
-    // 매 시도마다 뒤 트랜잭션을 가려 영영 반영되지 않는다
-    public func recoverUnfinishedTransactions() async {
-        let transactions = await self.appStoreService.unfinishedTransactions()
-        for transaction in transactions {
-            _ = try? await self.delegateAndFinish(transaction)
+    // 매 시도마다 뒤 트랜잭션을 가려 영영 반영되지 않는다.
+    // unfinished 는 OS 전역이라 두 시도가 겹치면 같은 트랜잭션을 중복 전송한다
+    public func recoverUnfinishedTransactions() {
+        self.recoveryTask?.cancel()
+        self.recoveryTask = Task { [weak self] in
+            guard let transactions = await self?.appStoreService.unfinishedTransactions()
+            else { return }
+            for transaction in transactions {
+                guard !Task.isCancelled, let self else { return }
+                _ = try? await self.delegateAndFinish(transaction)
+            }
         }
     }
 

--- a/Domain/Sources/Usecases/Billing/NotNeedBillingUsecase.swift
+++ b/Domain/Sources/Usecases/Billing/NotNeedBillingUsecase.swift
@@ -1,0 +1,53 @@
+//
+//  NotNeedBillingUsecase.swift
+//  Domain
+//
+//  Created by sudo.park on 8/8/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Combine
+import Extensions
+
+
+// 결제는 로그인 유저 전용 — 미로그인 세션과 paywall 플래그 off 세션엔 composition root 가
+// 이걸 주입한다. 소비자는 로그인 여부를 모른 채 그대로 호출하고 여기서 전부 무동작으로 끝난다.
+public final class NotNeedBillingUsecase: BillingUsecase, Sendable {
+
+    private let sharedDataStore: SharedDataStore
+
+    public init(sharedDataStore: SharedDataStore) {
+        self.sharedDataStore = sharedDataStore
+    }
+
+    public func loadPlanOfferings() async throws -> [BillingPlanOffering] { return [] }
+    public func loadTopupOfferings() async throws -> [BillingTopupOffering] { return [] }
+
+    // 진입점이 로그인 가드로 막혀 있어 도달하지 않는다. 도달하면 가드가 뚫린 것이라 드러낸다
+    public func purchase(productId: String) async throws -> BillingPurchaseResult {
+        throw RuntimeError(key: "Billing.needSignIn", "billing needs sign in")
+    }
+
+    public func restorePurchases() async throws -> BillingUserPlan? { return nil }
+
+    @discardableResult
+    public func refreshUserPlan() async throws -> BillingUserPlan {
+        throw RuntimeError(key: "Billing.needSignIn", "billing needs sign in")
+    }
+
+    public func startObservingTransactions() { }
+    public func stopObservingTransactions() { }
+    public func recoverUnfinishedTransactions() { }
+
+    // 플랜 정보는 결제 기능이 아니다 — AI usage 응답도 같은 키를 채우므로
+    // paywall 이 닫혀도 사용량 게이지는 플랜을 읽어야 한다
+    public var currentUserPlan: AnyPublisher<BillingUserPlan, Never> {
+        return self.sharedDataStore.observe(
+            BillingUserPlan.self,
+            key: ShareDataKeys.billingUserPlan.rawValue
+        )
+        .compactMap { $0 }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Domain/Tests/Doubles/StubBillingRepository.swift
+++ b/Domain/Tests/Doubles/StubBillingRepository.swift
@@ -65,4 +65,17 @@ final class StubBillingRepository: BillingRepository, @unchecked Sendable {
             |> \.planId .~ .standard
             |> \.topupRemaining .~ 12300
     }
+
+    // 기록만 한다 — 검증은 테스트 케이스 책임
+    private(set) var didPostedTransactionUpdates: [String] = []
+
+    func postTransactionUpdate(signedTransaction: String) async throws -> BillingUserPlan {
+        self.didPostedTransactionUpdates.append(signedTransaction)
+        guard !self.shouldFailPurchase,
+              !self.failingJWSTokens.contains(signedTransaction)
+        else { throw RuntimeError("transaction update apply failed") }
+        return BillingUserPlan()
+            |> \.planId .~ .standard
+            |> \.topupRemaining .~ 12300
+    }
 }

--- a/Domain/Tests/Usecases/Billing/BillingUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/Billing/BillingUsecaseImpleTests.swift
@@ -331,7 +331,7 @@ extension BillingUsecaseImpleTests {
 
         // when
         _ = try await self.firstOutput(expect, for: usecase.currentUserPlan) {
-            Task { await usecase.recoverUnfinishedTransactions() }
+            usecase.recoverUnfinishedTransactions()
         }
 
         // then
@@ -355,7 +355,7 @@ extension BillingUsecaseImpleTests {
 
         // when
         _ = try await self.firstOutput(expect, for: usecase.currentUserPlan) {
-            Task { await usecase.recoverUnfinishedTransactions() }
+            usecase.recoverUnfinishedTransactions()
         }
 
         // then

--- a/Domain/Tests/Usecases/Billing/BillingUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/Billing/BillingUsecaseImpleTests.swift
@@ -255,24 +255,92 @@ extension BillingUsecaseImpleTests {
 
 extension BillingUsecaseImpleTests {
 
-    // 서버 반영 전에 앱이 죽은 트랜잭션은 기동 시 복구된다
-    @Test func usecase_startObserving_recoversUnfinishedTransactions() async throws {
+    // 앱 밖에서 일어난 갱신·환불·가족공유가 들어오는 유일한 경로.
+    // 종류를 판별하지 않고 위임 엔드포인트로 올린다 — 구매 확정 경로가 아니다
+    @Test func usecase_startObserving_sendsStreamTransactionToDelegationEndpoint() async throws {
+        // given
+        let expect = expectConfirm("스트림으로 들어온 트랜잭션이 위임 경로로 반영된다")
+        let (usecase, repository, service) = self.makeUsecase()
+        usecase.startObservingTransactions()
+
+        // when
+        _ = try await self.firstOutput(expect, for: usecase.currentUserPlan) {
+            service.sendTransactionUpdate(
+                BillingSignedTransaction(id: "tx:renewal", productId: "plan.standard.monthly", jws: "jws:renewal")
+            )
+        }
+
+        // then
+        #expect(repository.didPostedTransactionUpdates == ["jws:renewal"])
+        #expect(repository.didPostedSignedTransactions == [])
+        #expect(service.didFinishedTransactionIds == ["tx:renewal"])
+    }
+
+    // 복구는 이 루틴에서 떨어져 나갔다 — startObserving 만으로는 미완료 건이 안 올라간다
+    @Test func usecase_startObserving_doesNotRecoverUnfinished() async throws {
+        // given
+        let pending = BillingSignedTransaction(
+            id: "tx:pending", productId: "plan.lifetime", jws: "jws:pending"
+        )
+        let (usecase, repository, service) = self.makeUsecase(unfinished: [pending])
+
+        // when
+        usecase.startObservingTransactions()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // then
+        #expect(repository.didPostedTransactionUpdates == [])
+        #expect(service.didFinishedTransactionIds == [])
+    }
+
+    // 취소 후 도착한 트랜잭션은 처리되지 않는다 — 로그아웃 구간에 이전 세션의
+    // 리스너가 살아 있으면 같은 JWS 가 중복 post 된다
+    @Test func usecase_afterStopObserving_ignoresIncomingTransaction() async throws {
+        // given
+        let (usecase, repository, service) = self.makeUsecase()
+        usecase.startObservingTransactions()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // when
+        usecase.stopObservingTransactions()
+        try await Task.sleep(nanoseconds: 50_000_000)
+        service.sendTransactionUpdate(
+            BillingSignedTransaction(id: "tx:late", productId: "plan.lifetime", jws: "jws:late")
+        )
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // then
+        #expect(repository.didPostedTransactionUpdates == [])
+        #expect(service.didFinishedTransactionIds == [])
+    }
+}
+
+
+// MARK: - 미완료 거래 복구
+
+extension BillingUsecaseImpleTests {
+
+    // 서버 반영 전에 앱이 죽은 트랜잭션은 독립 복구 경로로 올라간다
+    @Test func usecase_recoverUnfinished_sendsToDelegationEndpoint() async throws {
         // given
         let pending = BillingSignedTransaction(
             id: "tx:pending", productId: "plan.lifetime", jws: "jws:pending"
         )
         let expect = expectConfirm("미완료 트랜잭션이 복구된다")
-        let (usecase, repository, _) = self.makeUsecase(unfinished: [pending])
+        let (usecase, repository, service) = self.makeUsecase(unfinished: [pending])
+
         // when
         _ = try await self.firstOutput(expect, for: usecase.currentUserPlan) {
-            usecase.startObservingTransactions()
+            Task { await usecase.recoverUnfinishedTransactions() }
         }
+
         // then
-        #expect(repository.didPostedSignedTransactions == ["jws:pending"])
+        #expect(repository.didPostedTransactionUpdates == ["jws:pending"])
+        #expect(service.didFinishedTransactionIds == ["tx:pending"])
     }
 
-    // 앞 건이 영구 실패해도 뒤 건은 반영돼야 한다 — fail-fast 면 매 기동마다 뒤가 가려진다
-    @Test func usecase_startObserving_whenOneUnfinishedFails_stillAppliesTheRest() async throws {
+    // 앞 건이 영구 실패해도 뒤 건은 반영돼야 한다 — fail-fast 면 매 시도마다 뒤가 가려진다
+    @Test func usecase_recoverUnfinished_whenOneFails_stillAppliesTheRest() async throws {
         // given
         let failing = BillingSignedTransaction(
             id: "tx:bad", productId: "plan.lifetime", jws: "jws:bad"
@@ -284,31 +352,16 @@ extension BillingUsecaseImpleTests {
         let (usecase, repository, service) = self.makeUsecase(
             unfinished: [failing, pending], failingJWSTokens: ["jws:bad"]
         )
-        // when
-        _ = try await self.firstOutput(expect, for: usecase.currentUserPlan) {
-            usecase.startObservingTransactions()
-        }
-        // then
-        #expect(repository.didPostedSignedTransactions == ["jws:bad", "jws:pending"])
-        // 서버 반영에 실패한 건은 finish 되지 않아 다음 기동에 다시 잡힌다
-        #expect(service.didFinishedTransactionIds == ["tx:pending"])
-    }
 
-    // 앱 밖에서 일어난 갱신·환불·가족공유가 들어오는 유일한 경로
-    @Test func usecase_startObserving_appliesTransactionFromStream() async throws {
-        // given
-        let expect = expectConfirm("스트림으로 들어온 트랜잭션이 반영된다")
-        let (usecase, repository, service) = self.makeUsecase()
-        usecase.startObservingTransactions()
         // when
         _ = try await self.firstOutput(expect, for: usecase.currentUserPlan) {
-            service.sendTransactionUpdate(
-                BillingSignedTransaction(id: "tx:renewal", productId: "plan.standard.monthly", jws: "jws:renewal")
-            )
+            Task { await usecase.recoverUnfinishedTransactions() }
         }
+
         // then
-        #expect(repository.didPostedSignedTransactions == ["jws:renewal"])
-        #expect(service.didFinishedTransactionIds == ["tx:renewal"])
+        #expect(repository.didPostedTransactionUpdates == ["jws:bad", "jws:pending"])
+        // 서버 반영에 실패한 건은 finish 되지 않아 다음 시도에 다시 잡힌다
+        #expect(service.didFinishedTransactionIds == ["tx:pending"])
     }
 }
 

--- a/Presentations/AIAgentScene/Tests/Doubles/StubBillingUsecase.swift
+++ b/Presentations/AIAgentScene/Tests/Doubles/StubBillingUsecase.swift
@@ -35,6 +35,8 @@ final class StubBillingUsecase: BillingUsecase, @unchecked Sendable {
     }
 
     func startObservingTransactions() { }
+    func stopObservingTransactions() { }
+    func recoverUnfinishedTransactions() async { }
 
     var currentUserPlan: AnyPublisher<BillingUserPlan, Never> {
         self.currentUserPlanSubject.compactMap { $0 }.eraseToAnyPublisher()

--- a/Presentations/AIAgentScene/Tests/Doubles/StubBillingUsecase.swift
+++ b/Presentations/AIAgentScene/Tests/Doubles/StubBillingUsecase.swift
@@ -36,7 +36,7 @@ final class StubBillingUsecase: BillingUsecase, @unchecked Sendable {
 
     func startObservingTransactions() { }
     func stopObservingTransactions() { }
-    func recoverUnfinishedTransactions() async { }
+    func recoverUnfinishedTransactions() { }
 
     var currentUserPlan: AnyPublisher<BillingUserPlan, Never> {
         self.currentUserPlanSubject.compactMap { $0 }.eraseToAnyPublisher()

--- a/Presentations/BillingScenes/Tests/Doubles/StubBillingUsecase.swift
+++ b/Presentations/BillingScenes/Tests/Doubles/StubBillingUsecase.swift
@@ -78,6 +78,8 @@ final class StubBillingUsecase: BillingUsecase, @unchecked Sendable {
     }
 
     func startObservingTransactions() { }
+    func stopObservingTransactions() { }
+    func recoverUnfinishedTransactions() async { }
 
     var currentUserPlan: AnyPublisher<BillingUserPlan, Never> {
         self.userPlanSubject.compactMap { $0 }.eraseToAnyPublisher()

--- a/Presentations/BillingScenes/Tests/Doubles/StubBillingUsecase.swift
+++ b/Presentations/BillingScenes/Tests/Doubles/StubBillingUsecase.swift
@@ -79,7 +79,7 @@ final class StubBillingUsecase: BillingUsecase, @unchecked Sendable {
 
     func startObservingTransactions() { }
     func stopObservingTransactions() { }
-    func recoverUnfinishedTransactions() async { }
+    func recoverUnfinishedTransactions() { }
 
     var currentUserPlan: AnyPublisher<BillingUserPlan, Never> {
         self.userPlanSubject.compactMap { $0 }.eraseToAnyPublisher()

--- a/Repository/Sources/Remote/Endpoint.swift
+++ b/Repository/Sources/Remote/Endpoint.swift
@@ -294,6 +294,7 @@ enum BillingAPIEndpoints: Endpoint {
     case plans
     case topups
     case purchases
+    case transactions
     case userPlan
 
     var subPath: String {
@@ -301,6 +302,7 @@ enum BillingAPIEndpoints: Endpoint {
         case .plans: return "plans"
         case .topups: return "topups"
         case .purchases: return "purchases"
+        case .transactions: return "transactions"
         case .userPlan: return "user-plan"
         }
     }

--- a/Repository/Sources/Repository+Imple/Billing/BillingRepositoryImple.swift
+++ b/Repository/Sources/Repository+Imple/Billing/BillingRepositoryImple.swift
@@ -67,8 +67,12 @@ extension BillingRepositoryImple {
     public func postTransactionUpdate(signedTransaction: String) async throws -> BillingUserPlan {
         let body: [String: Any] = ["signed_transaction": signedTransaction]
         let json = try await self.requestJson(.post, BillingAPIEndpoints.transactions, parameters: body)
+        // 이 엔드포인트만 user_plan 으로 감싸 응답한다. 못 벗기면 빈 플랜으로 흘리지 않고 실패시킨다 —
+        // 매퍼가 throw 하지 않아 조용히 통과하면 보유 플랜이 지워지고 finish 까지 진행된다
+        guard let userPlan = json["user_plan"] as? [String: Any]
+        else { throw RuntimeError("invalid billing transaction response") }
         return BillingUserPlanMapper(
-            json: json, topupRemaining: json["topup_remaining"] as? Int
+            json: userPlan, topupRemaining: userPlan["topup_remaining"] as? Int
         ).userPlan
     }
 }

--- a/Repository/Sources/Repository+Imple/Billing/BillingRepositoryImple.swift
+++ b/Repository/Sources/Repository+Imple/Billing/BillingRepositoryImple.swift
@@ -63,6 +63,14 @@ extension BillingRepositoryImple {
             json: json, topupRemaining: json["topup_remaining"] as? Int
         ).userPlan
     }
+
+    public func postTransactionUpdate(signedTransaction: String) async throws -> BillingUserPlan {
+        let body: [String: Any] = ["signed_transaction": signedTransaction]
+        let json = try await self.requestJson(.post, BillingAPIEndpoints.transactions, parameters: body)
+        return BillingUserPlanMapper(
+            json: json, topupRemaining: json["topup_remaining"] as? Int
+        ).userPlan
+    }
 }
 
 

--- a/Repository/Tests/Auth/CalendarAPIAutenticatorTests.swift
+++ b/Repository/Tests/Auth/CalendarAPIAutenticatorTests.swift
@@ -127,6 +127,9 @@ extension CalendarAPIAutenticatorTests {
         parameterizeTest(
             BillingAPIEndpoints.purchases, method: .post, expecthasToken: true
         )
+        parameterizeTest(
+            BillingAPIEndpoints.transactions, method: .post, expecthasToken: true
+        )
     }
 }
 

--- a/Repository/Tests/Billing/BillingRepositoryImpleTests.swift
+++ b/Repository/Tests/Billing/BillingRepositoryImpleTests.swift
@@ -91,6 +91,24 @@ extension BillingRepositoryImpleTests {
 }
 
 
+// MARK: - 트랜잭션 위임
+
+extension BillingRepositoryImpleTests {
+
+    // 앱 밖에서 발견한 트랜잭션은 구매 확정과 다른 경로로 올린다 —
+    // 종류 판별은 서버가 하므로 앱은 JWS 만 싣는다
+    @Test func repository_postTransactionUpdate_returnsAppliedPlan() async throws {
+        // given
+        let repository = self.makeRepository()
+        // when
+        let plan = try await repository.postTransactionUpdate(signedTransaction: "jws_token")
+        // then
+        #expect(plan.planId == .lifetime)
+        #expect(plan.topupRemaining == 7700)
+    }
+}
+
+
 private struct DummyResponse {
 
     private var plansResponse: String {
@@ -124,6 +142,16 @@ private struct DummyResponse {
         """
     }
 
+    // 구매 확정 응답과 값을 일부러 다르게 둔다 — 잘못해서 purchases 로 나가면 TC 가 잡는다
+    private var transactionResponse: String {
+        return """
+        {
+            "id": "lifetime",
+            "topup_remaining": 7700
+        }
+        """
+    }
+
     // GET /v1/ai/usage 의 plan 필드·POST /v1/billing/purchases 응답과 동일 스키마
     private var userPlanResponse: String {
         return """
@@ -143,6 +171,8 @@ private struct DummyResponse {
                   resultJsonString: .success(self.topupsResponse)),
             .init(method: .post, endpoint: BillingAPIEndpoints.purchases,
                   resultJsonString: .success(self.purchaseResponse)),
+            .init(method: .post, endpoint: BillingAPIEndpoints.transactions,
+                  resultJsonString: .success(self.transactionResponse)),
             .init(method: .get, endpoint: BillingAPIEndpoints.userPlan,
                   resultJsonString: .success(self.userPlanResponse))
         ]

--- a/Repository/Tests/Billing/BillingRepositoryImpleTests.swift
+++ b/Repository/Tests/Billing/BillingRepositoryImpleTests.swift
@@ -18,6 +18,11 @@ final class BillingRepositoryImpleTests {
         let remote = StubRemoteAPI(responses: DummyResponse().responses)
         return BillingRepositoryImple(remote: remote)
     }
+
+    private func makeRepositoryWithUnwrappedTransactionResponse() -> BillingRepositoryImple {
+        let remote = StubRemoteAPI(responses: DummyResponse().unwrappedTransactionResponses)
+        return BillingRepositoryImple(remote: remote)
+    }
 }
 
 
@@ -106,6 +111,16 @@ extension BillingRepositoryImpleTests {
         #expect(plan.planId == .lifetime)
         #expect(plan.topupRemaining == 7700)
     }
+
+    // 서버가 계약을 어기고 user_plan 래핑 없이 평평한 응답을 주면 조용히 통과시키지 않는다
+    @Test func repository_postTransactionUpdate_whenResponseNotWrapped_throws() async throws {
+        // given
+        let repository = self.makeRepositoryWithUnwrappedTransactionResponse()
+        // when & then
+        await #expect(throws: (any Error).self) {
+            _ = try await repository.postTransactionUpdate(signedTransaction: "jws_token")
+        }
+    }
 }
 
 
@@ -142,8 +157,20 @@ private struct DummyResponse {
         """
     }
 
-    // 구매 확정 응답과 값을 일부러 다르게 둔다 — 잘못해서 purchases 로 나가면 TC 가 잡는다
+    // 구매 확정 응답과 값을 일부러 다르게 둔다 — 잘못해서 purchases 로 나가면 TC 가 잡는다.
+    // 이 엔드포인트만 user_plan 으로 감싼다
     private var transactionResponse: String {
+        return """
+        {
+            "user_plan": {
+                "id": "lifetime",
+                "topup_remaining": 7700
+            }
+        }
+        """
+    }
+
+    private var unwrappedTransactionResponse: String {
         return """
         {
             "id": "lifetime",
@@ -175,6 +202,13 @@ private struct DummyResponse {
                   resultJsonString: .success(self.transactionResponse)),
             .init(method: .get, endpoint: BillingAPIEndpoints.userPlan,
                   resultJsonString: .success(self.userPlanResponse))
+        ]
+    }
+
+    var unwrappedTransactionResponses: [StubRemoteAPI.Response] {
+        return [
+            .init(method: .post, endpoint: BillingAPIEndpoints.transactions,
+                  resultJsonString: .success(self.unwrappedTransactionResponse))
         ]
     }
 }

--- a/TodoCalendarApp/Sources/Factories/ApplicationBase.swift
+++ b/TodoCalendarApp/Sources/Factories/ApplicationBase.swift
@@ -16,31 +16,13 @@ import FirebaseAuth
 import Alamofire
 import SQLiteService
 import ExternalServices
-import StoreKitService
 
 
 final class ApplicationBase {
 
-    init() {
-        // remoteAPI·sharedDataStore 준비가 끝난 뒤 리스너를 앱 수명으로 1회 기동한다.
-        // billingUsecase 가 다른 lazy 프로퍼티(remoteAPI 등)를 참조하므로 이 시점엔 lazy var여야
-        // self 를 phase-1 초기화 제약 없이 쓸 수 있다 (let 로는 컴파일 불가)
-        self.billingUsecase.startObservingTransactions()
-    }
-
     let sharedDataStore: SharedDataStore = .init()
     let eventNotifyService: SharedEventNotifyService = .init()
 
-    // 트랜잭션 리스너는 앱 수명 단일 인스턴스여야 한다 — 로그인 세션에 묶으면 로그아웃 구간에
-    // 리스너가 사라지고, 팩토리 교체 순간 둘이 공존해 같은 JWS 를 중복 POST 한다 (#739)
-    lazy var billingUsecase: any BillingUsecase = {
-        return BillingUsecaseImple(
-            repository: BillingRepositoryImple(remote: self.remoteAPI),
-            appStoreService: AppStoreBillingServiceImple(),
-            sharedDataStore: self.sharedDataStore
-        )
-    }()
-    
     let userDefaultEnvironmentStorage = UserDefaultEnvironmentStorageImple(
         suiteName: AppEnvironment.groupID
     )

--- a/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
+++ b/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
@@ -27,6 +27,7 @@ struct NonLoginUsecaseFactoryImple: UsecaseFactory {
     let eventUploadService: any EventUploadService = NotNeedEventUploadService()
     let appUpdateCheckUsecase: any AppUpdateCheckUsecase
     let aiAgentOrchestrationUsecase: any AIAgentOrchestrationUsecase
+    let billingUsecase: any BillingUsecase
     private let applicationBase: ApplicationBase
 
     init(
@@ -44,6 +45,7 @@ struct NonLoginUsecaseFactoryImple: UsecaseFactory {
         self.appUpdateCheckUsecase = appUpdateCheckUsecase
         self.eventSyncUsecase = NotNeedEventSyncUsecase()
         self.applicationBase = applicationBase
+        self.billingUsecase = NotNeedBillingUsecase(sharedDataStore: applicationBase.sharedDataStore)
 
         // AI 기능은 로그인 유저 전용 — 실제 스택을 만들지 않는다 (#772).
         // 진입점 UI는 그대로 노출되고 탭 시 로그인 유도로 갈린다.
@@ -52,12 +54,6 @@ struct NonLoginUsecaseFactoryImple: UsecaseFactory {
 
     var eventNotifyService: SharedEventNotifyService {
         return self.applicationBase.eventNotifyService
-    }
-
-    // 미로그인 유저는 진입점이 숨겨지지만(Task 6) 프로토콜 충족을 위해 필요.
-    // 로그인 전 카탈로그 조회도 같은 앱 수명 인스턴스로 돈다 (#739)
-    var billingUsecase: any BillingUsecase {
-        return self.applicationBase.billingUsecase
     }
 }
 
@@ -373,6 +369,7 @@ struct LoginUsecaseFactoryImple: UsecaseFactory {
     let eventUploadService: any EventUploadService
     let appUpdateCheckUsecase: any AppUpdateCheckUsecase
     let aiAgentOrchestrationUsecase: any AIAgentOrchestrationUsecase
+    let billingUsecase: any BillingUsecase
     private let applicationBase: ApplicationBase
 
     init(
@@ -472,15 +469,20 @@ struct LoginUsecaseFactoryImple: UsecaseFactory {
             speechRecognizeUsecase: speech,
             eventSyncUsecase: self.eventSyncUsecase
         )
+
+        // 결제는 로그인 유저 전용이고, paywall 이 닫힌 동안엔 리스너도 돌 이유가 없다.
+        // 환경 분기는 composition root 소관이라 Domain 이 플래그를 모른다
+        self.billingUsecase = FeatureFlag.isEnable(.billingPaywall)
+            ? BillingUsecaseImple(
+                repository: BillingRepositoryImple(remote: applicationBase.remoteAPI),
+                appStoreService: AppStoreBillingServiceImple(),
+                sharedDataStore: applicationBase.sharedDataStore
+            )
+            : NotNeedBillingUsecase(sharedDataStore: applicationBase.sharedDataStore)
     }
 
     var eventNotifyService: SharedEventNotifyService {
         return self.applicationBase.eventNotifyService
-    }
-
-    // 트랜잭션 리스너는 앱 수명 단일 인스턴스 — ApplicationBase 소유를 그대로 노출 (#739)
-    var billingUsecase: any BillingUsecase {
-        return self.applicationBase.billingUsecase
     }
 }
 

--- a/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
@@ -352,6 +352,9 @@ extension ApplicationRootRouter {
     private func changeUsecaseFactroy(
         by auth: Auth?
     ) {
+        // 새 팩토리를 세우기 전에 끊는다 — 둘이 잠깐이라도 공존하면 같은 JWS 가 중복 post 된다
+        self.usecaseFactory?.billingUsecase.stopObservingTransactions()
+
         if let auth = auth {
             self.usecaseFactory = LoginUsecaseFactoryImple(
                 userId: auth.uid,
@@ -375,6 +378,12 @@ extension ApplicationRootRouter {
         }
         self.backgroundEventSyncUsecase.change(factory: self.usecaseFactory)
         self.aiJobRefreshUsecase.change(factory: self.usecaseFactory)
+
+        let billingUsecase = self.usecaseFactory.billingUsecase
+        billingUsecase.startObservingTransactions()
+        // 스트림이 콜드 스타트에 unfinished 를 안 흘려주는 경우가 있어 별도로 한 번 훑는다.
+        // 포그라운드 복귀 재시도는 #812
+        billingUsecase.recoverUnfinishedTransactions()
     }
     
     @MainActor

--- a/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
@@ -349,10 +349,14 @@ extension ApplicationRootRouter {
         }
     }
     
+    @MainActor
     private func changeUsecaseFactroy(
         by auth: Auth?
     ) {
-        // 새 팩토리를 세우기 전에 끊는다 — 둘이 잠깐이라도 공존하면 같은 JWS 가 중복 post 된다
+        // 새 팩토리를 세우기 전에 끊는다 — 둘이 잠깐이라도 공존하면 같은 JWS 가 중복 post 된다.
+        // 여기서 끊기는 건 usecase 의 소비자 Task 뿐이다 — service 의 생산자 listenerTask 는
+        // deinit 에서만 멈춘다. 소비자가 취소되면 단일 소비 AsyncStream 이 영구 종료돼
+        // 구 service 의 잔여 yield 는 받는 쪽 없이 버려진다
         self.usecaseFactory?.billingUsecase.stopObservingTransactions()
 
         if let auth = auth {


### PR DESCRIPTION
`StoreKit.Transaction.updates` 옵저빙이 **언제 뜨는지**와 **들어온 걸 어디로 보내는지** 둘 다 틀려 있었다. #811

## 문제

**1. 앱 기동 즉시 무인증 요청이 나갔다.** `ApplicationBase.init()`이 옵저빙을 걸어서, Firebase Auth 세션 복원이 끝나기 전에 서버로 POST가 나갔다. credential이 없어 401로 죽는데 `try?`가 삼켜 로그도 안 남고 재시도 경로도 없었다. 실행마다 성공/실패가 갈리는 레이스가 로컬 테스트에서 재현됐다. `FeatureFlag.billingPaywall` 보호도 못 받아, 진입점은 닫혀 있는데 리스너만 항상 돌았다.

**2. 환불을 구매로 올렸다.** 스트림으로 들어오는 건 구독 자동 갱신·환불·가족 공유·Ask to Buy 승인으로 성격이 제각각인데, 종류 구분 없이 전부 `POST /v1/billing/purchases`를 때렸다.

**3. 미완료 거래 복구가 같은 루틴에 얹혀 있었다.** 옵저빙 기동 시 1회만 돌아서, 그 한 번이 실패하면 다음 콜드 스타트까지 복구 경로가 없었다.

## 접근

**종류 판별을 서버로 넘긴다.** 신규 엔드포인트 `POST /v1/billing/transactions`에 JWS만 올리고, 처리 필요 여부는 서버가 payload를 디코드해 판단한다. `revocationDate`·`type`·`reason`이 전부 서명 안에 있으니 앱이 파싱할 이유가 없고, 앱에 분기표를 박으면 서버 정책이 클라 버전에 고정돼 정책이 바뀔 때마다 앱 배포를 기다려야 한다.

경로는 **유저 동선**으로 가른다 — 기존 `purchases`는 유저가 방금 산 것(`purchase`·`restore`), 신규 `transactions`는 앱이 뒤늦게 발견해 종류를 모르는 것(`updates`·`unfinished`). 결과가 같아도 의도가 다르면 합치지 않는다. `finish()`는 양쪽 다 서버 반영 성공 뒤에만 부른다.

**옵저빙을 로그인 세션에 묶는다.** `billingUsecase`를 `ApplicationBase`(앱 수명)에서 `LoginUsecaseFactoryImple`(로그인 세션)로 옮기고, 미로그인·플래그 off는 `NotNeedBillingUsecase`로 대체한다. paywall 진입점 2곳이 전부 로그인 전용이라 미로그인이 잃는 동선은 없다.

기존 코드는 "리스너는 앱 수명 단일 인스턴스여야 한다 — 세션에 묶으면 팩토리 교체 순간 둘이 공존해 같은 JWS를 중복 POST 한다"(#739)는 반대 전제로 짜여 있었다. 그 전제를 뒤집으려면 **교체 구간에 리스너가 둘 공존하지 않는 것**이 조건이라, `ApplicationRootRouter.changeUsecaseFactroy`가 새 팩토리를 세우기 **전에** 이전 인스턴스를 명시적으로 stop 한다. `deinit`에 맡기면 Scene이 usecase를 붙들고 있을 때 취소 시점이 보장되지 않는다. 세션 전이 4경로(콜드 스타트·로그인·로그아웃·토큰 갱신 실패로 인한 강제 로그아웃)가 전부 이 함수 한 곳으로 수렴한다.

**미완료 복구를 독립 경로로 승격한다.** 옵저빙 루틴에서 떼어내되 로그인 시점 1회 호출은 유지했다. `Transaction.unfinished`가 OS 전역이라 두 시도가 겹치면 같은 트랜잭션을 중복 전송하므로, 복구 Task도 usecase가 소유해 재호출·stop 시 이전 시도를 취소한다.

## 서버 계약 (확정)

`POST /v1/billing/transactions`는 [Functions#310](https://github.com/sudopark/TodoCalendar-Functions/pull/310)으로 머지됐다. 확정 계약:

```
{ "signed_transaction": "<JWS>" }
→ 200 { "user_plan": { "id", "scheduled_change", "topup_remaining" } }
```

**이 엔드포인트만 응답을 `user_plan`으로 감싼다** — `/purchases`·`/user-plan`은 평평하다. 400은 서명을 못 믿을 때뿐이고, 반영이든 무시든 전부 200이다. 앱은 200을 받아야만 `finish()`하므로 "서버 반영 성공 뒤에만 finish" 불변식이 이 경로에도 그대로 선다.

반영 안 된 결제도 **사유와 함께 `billingEvents` 원장에 남는다** — 앱이 200을 구분 못 해 영수증을 finish 하더라도 결제 사실이 유실되지 않게 서버가 받아준다.

> **ASSN 웹훅이 프로덕션에 미등록이라, 당분간 이 엔드포인트는 백업이 아니라 갱신·환불 반영의 주 경로다.** 실기기 검증 우선순위가 그만큼 높다.

## 남은 과제

- **포그라운드 복귀 재시도 배선** (#812) — 이 PR은 `recoverUnfinishedTransactions()`를 **호출 가능하게 만드는 것까지**만 한다. `willEnterForegroundNotification`에 물리는 건 그쪽 소관
- **`appAccountToken` 미부착** — 같은 기기에서 계정이 바뀌면 A의 트랜잭션이 B의 토큰으로 올라갈 수 있다. 원래 있던 구멍인데 401 레이스가 우연히 막고 있었고, 그 레이스를 고치는 이 PR이 경로를 실제로 연다. 서버 검증은 [Functions#309에 요청](https://github.com/sudopark/TodoCalendar-Functions/issues/309#issuecomment-5229202679), 앱 쪽 부착은 #814

## 실기기 확인이 필요한 것

유닛 테스트로 못 잡는 축들이다.

- 로그인 → 로그아웃 → 재로그인 후 리스너가 1개만 남는지
- 구독 자동 갱신이 `/transactions`로 나가고 응답의 `user_plan`이 게이지·paywall에 반영되는지 (ASSN 미등록이라 이 경로가 유일하다)
- 서버가 미배포인 구간에서 트랜잭션이 `finish` 안 되고 남는지, 유저에게 에러가 안 보이는지
- `aiAgent` on + `billingPaywall` off 조합에서 AI 사용량 게이지의 플랜 칩이 뜨는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqpeqbgFA57QfYdcCGTiUP
