### PR TITLE
[#795] AI job 중지가 서버까지 가도록 — 취소 대상 판정 이관 + 복귀 갱신 지연 제거

### DIFF
--- a/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
@@ -279,12 +279,11 @@ extension AIAgentOrchestrationUsecaseImple {
         self.subject.state.send(.idle)
     }
 
+    // 취소 대상 판정은 commandUsecase가 한다 — 여기서 jobId 보유로 판정하면 첫 job 조회
+    // 전(폴링 주기만큼)의 중지가 통째로 유실된다 (#795).
     public func reset() {
-        let jobId = self.currentProcessingJobId
         self.stopTrackingJob()
-        if let jobId {
-            self.commandUsecase.cancelOngoingCommand(jobId)
-        }
+        self.commandUsecase.cancelOngoingCommand()
         self.subject.state.send(.idle)
     }
 

--- a/Domain/Sources/Usecases/AI/AICommandUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AICommandUsecase.swift
@@ -21,7 +21,7 @@ public protocol AICommandUsecase: AnyObject, Sendable {
 
     func rejectConfirmCommand(_ action: AIConfirmCommandAction)
 
-    func cancelOngoingCommand(_ jobId: String)
+    func cancelOngoingCommand()
 
     func clearProcessingCommandRecord() async
 
@@ -66,6 +66,7 @@ public final class AICommandUsecaseImple: AICommandUsecase, @unchecked Sendable 
         let jobFinishEvent = PassthroughSubject<String, Never>()
     }
     private let subject = Subject()
+    private let ongoingCommand = OngoingCommandTracker()
     private var cancelBag = Set<AnyCancellable>()
 
     private func internalBind() {
@@ -81,55 +82,86 @@ public final class AICommandUsecaseImple: AICommandUsecase, @unchecked Sendable 
 // MARK: - process command
 
 extension AICommandUsecaseImple {
-    
+
     public func processCommand(_ commandText: String) -> AnyPublisher<AIJob, any Error> {
-        
+
         let timeZone = self.currentIANATimeZone(); let repository = self.repository
 
-        let makeJob: some Publisher<String, any Error> = Publishers.create(do: {
-            let jobId = try await repository.processCommand(commandText, timeZone: timeZone)
-            try? await repository.updateProcessingAICommand(
-                .init(jobId: jobId, isConfirmJob: false)
-            )
-            return jobId
-        })
-        
-        let waitJobUntilFinish = makeJob
-            .flatMap { [weak self] jobId in
-                return self?.checkJob(jobId) ?? Empty().eraseToAnyPublisher()
-            }
+        let creation = self.makeJob(isConfirmJob: false) {
+            try await repository.processCommand(commandText, timeZone: timeZone)
+        }
 
-        return waitJobUntilFinish
-            .handleClearProcessingCommand(repository)
-            .eraseToAnyPublisher()
+        return self.waitJobUntilFinish(creation)
     }
 
     public func processConfirmCommand(_ action: AIConfirmCommandAction) -> AnyPublisher<AIJob, any Error> {
 
         let timeZone = self.currentIANATimeZone(); let repository = self.repository
 
-        let makeConfirmJob: some Publisher<String, any Error> = Publishers.create(do: {
-            let jobId = try await repository.processConfirmCommand(action, timeZone: timeZone)
-            try? await repository.updateProcessingAICommand(
-                .init(jobId: jobId, isConfirmJob: true)
-            )
-            return jobId
-        })
+        let creation = self.makeJob(isConfirmJob: true) {
+            try await repository.processConfirmCommand(action, timeZone: timeZone)
+        }
 
-        let waitUntilFinish = makeConfirmJob
-            .flatMap { [weak self] jobId in
-                return self?.checkJob(jobId) ?? Empty().eraseToAnyPublisher()
+        return self.waitJobUntilFinish(creation)
+    }
+
+    // job 생성은 구독 수명에서 떼어낸다 — 시트가 닫히거나 중지로 구독이 끊겨도 jobId를
+    // 받아내야 서버에 취소를 보낼 수 있다. 구독이 끊긴 채 생성만 성공하면 서버 job은
+    // 계속 돌고 취소 요청은 갈 곳을 잃는다 (#795).
+    // unstructured Task라 구독 취소는 결과 대기만 끊고 생성 자체는 완주한다.
+    private func makeJob(
+        isConfirmJob: Bool,
+        _ create: @escaping @Sendable () async throws -> String
+    ) -> AnyPublisher<JobCreationResult, any Error> {
+
+        let repository = self.repository; let ongoing = self.ongoingCommand
+        return Deferred {
+            ongoing.beginCreating()
+            let creation = Task { () throws -> JobCreationResult in
+                do {
+                    let jobId = try await create()
+                    try? await repository.updateProcessingAICommand(
+                        .init(jobId: jobId, isConfirmJob: isConfirmJob)
+                    )
+                    switch ongoing.attachJob(jobId) {
+                    case .tracked:
+                        return .created(jobId: jobId)
+                    case .cancelNow:
+                        await repository.cancelJobAndClearRecord(jobId)
+                        return .canceledWhileCreating
+                    }
+                } catch {
+                    ongoing.clear()
+                    throw error
+                }
             }
+            let waitCreation: some Publisher<JobCreationResult, any Error> = Publishers
+                .create(do: { try await creation.value })
+            return waitCreation
+        }
+        .eraseToAnyPublisher()
+    }
 
-        return waitUntilFinish
-            .handleClearProcessingCommand(repository)
+    private func waitJobUntilFinish(
+        _ jobCreation: AnyPublisher<JobCreationResult, any Error>
+    ) -> AnyPublisher<AIJob, any Error> {
+
+        return jobCreation
+            .flatMap { [weak self] creation -> AnyPublisher<AIJob, any Error> in
+                // 생성 도중 중지된 job은 취소가 이미 나갔다 — 폴링을 시작하지 않는다.
+                guard let self, case .created(let jobId) = creation
+                else { return Empty().eraseToAnyPublisher() }
+                return self.checkJob(jobId)
+            }
+            .handleClearProcessingCommand(self.repository, self.ongoingCommand)
             .eraseToAnyPublisher()
     }
-    
+
     public func rejectConfirmCommand(_ action: AIConfirmCommandAction) {
         // 서버 거부 API(Functions#243) 미구현 — 준비 전까지 fire-and-forget.
         // 거부는 confirm 대기의 종착점이라 로컬 기록도 함께 정리한다 (cancelOngoingCommand와 대칭).
         // 안 지우면 거부한 confirm이 다음 복원에 되살아나고, 앱 밖 진입점도 영구 차단된다.
+        self.ongoingCommand.clear()
         let repository = self.repository
         Task {
             try? await repository.rejectConfirmCommand(action)
@@ -137,20 +169,23 @@ extension AICommandUsecaseImple {
         }
     }
 
-    public func cancelOngoingCommand(_ jobId: String) {
-        // fire-and-forget — 호출 시점에 orchestration이 이미 구독을 끊고 idle로 보냈다.
-        // 서버의 CANCELED 통보를 클라가 소비하는 경로는 없다 (clear 전에 앱이 죽어
-        // 잔여 레코드가 restore되는 경우만 예외 — AIJob.Status.canceled가 이를 방어한다).
+    // 취소 대상 판정은 호출자가 아니라 여기서 한다 — 호출자는 jobId를 모르거나(첫 조회 전)
+    // 이미 끝난 job을 들고 있을 수 있다. 진행 중인 게 없으면 아무것도 하지 않는다 (#795).
+    // fire-and-forget — 호출 시점에 orchestration이 이미 구독을 끊고 idle로 보냈다.
+    // 서버의 CANCELED 통보를 클라가 소비하는 경로는 없다 (clear 전에 앱이 죽어
+    // 잔여 레코드가 restore되는 경우만 예외 — AIJob.Status.canceled가 이를 방어한다).
+    public func cancelOngoingCommand() {
+        guard let jobId = self.ongoingCommand.requestCancel() else { return }
         let repository = self.repository
         Task {
-            try? await repository.cancelCommand(jobId)
-            try? await repository.clearProcessingAICommand()
+            await repository.cancelJobAndClearRecord(jobId)
         }
     }
 
     // 로그아웃 정리 전용 — 서버 job은 그대로 두고 로컬 복원 근거만 지운다.
     // 남겨두면 재로그인 시 restoreCommandifNeed가 죽은 job을 이어받아 다시 폴링한다.
     public func clearProcessingCommandRecord() async {
+        self.ongoingCommand.clear()
         try? await self.repository.clearProcessingAICommand()
     }
 
@@ -216,19 +251,34 @@ extension AICommandUsecaseImple {
 
         return processingCmd
             .flatMap { [weak self] cmd -> AnyPublisher<AIJob?, any Error> in
-                guard let self, let cmd
+                guard let self, let cmd else { return Self.noRestoredJob }
+                // 복원한 job도 진행 중으로 등록해야 이후 중지가 서버까지 간다
+                guard case .tracked = self.ongoingCommand.attachJob(cmd.jobId)
                 else {
-                    return Just<AIJob?>(nil)
-                        .setFailureType(to: (any Error).self)
-                        .eraseToAnyPublisher()
+                    return self.cancelRestoredJob(cmd.jobId)
                 }
 
                 return self.checkJob(cmd.jobId, immediateCheck: true)
-                    .handleClearProcessingCommand(self.repository)
+                    .handleClearProcessingCommand(self.repository, self.ongoingCommand)
                     .map { Optional($0) }
                     .eraseToAnyPublisher()
             }
             .eraseToAnyPublisher()
+    }
+
+    private static var noRestoredJob: AnyPublisher<AIJob?, any Error> {
+        return Just<AIJob?>(nil)
+            .setFailureType(to: (any Error).self)
+            .eraseToAnyPublisher()
+    }
+
+    // 복원 도중 중지가 들어온 경우 — 폴링을 시작하지 않고 취소만 집행한다
+    private func cancelRestoredJob(_ jobId: String) -> AnyPublisher<AIJob?, any Error> {
+        let repository = self.repository
+        Task {
+            await repository.cancelJobAndClearRecord(jobId)
+        }
+        return Self.noRestoredJob
     }
     
     private func loadProcessingCommand() -> some Publisher<ProcessingAICommand?, any Error> {
@@ -253,8 +303,81 @@ extension AICommandUsecaseImple {
     }
 }
 
+// MARK: - OngoingCommandTracker
+
+private enum JobCreationResult {
+    case created(jobId: String)
+    case canceledWhileCreating
+}
+
+
+
+// 진행 중 command의 취소 대상 여부를 한 곳에서 소유한다. 중지 요청이 job 생성 응답보다
+// 먼저 도착할 수 있어(POST in-flight), 그 경우 취소를 예약했다가 생성 직후 집행한다 (#795).
+private final class OngoingCommandTracker: @unchecked Sendable {
+
+    enum AttachResult {
+        case tracked
+        case cancelNow
+    }
+
+    private enum State {
+        case none
+        case creating(cancelRequested: Bool)
+        case ongoing(jobId: String)
+    }
+
+    private let lock = NSLock()
+    private var state: State = .none
+
+    func beginCreating() {
+        self.lock.lock(); defer { self.lock.unlock() }
+        self.state = .creating(cancelRequested: false)
+    }
+
+    func attachJob(_ jobId: String) -> AttachResult {
+        self.lock.lock(); defer { self.lock.unlock() }
+        if case .creating(let cancelRequested) = self.state, cancelRequested {
+            self.state = .none
+            return .cancelNow
+        }
+        self.state = .ongoing(jobId: jobId)
+        return .tracked
+    }
+
+    // 지금 취소해야 할 jobId. nil이면 취소할 대상이 없거나(none) 생성 완료 후로 예약됐다.
+    func requestCancel() -> String? {
+        self.lock.lock(); defer { self.lock.unlock() }
+        switch self.state {
+        case .ongoing(let jobId):
+            self.state = .none
+            return jobId
+        case .creating:
+            self.state = .creating(cancelRequested: true)
+            return nil
+        case .none:
+            return nil
+        }
+    }
+
+    func clear() {
+        self.lock.lock(); defer { self.lock.unlock() }
+        self.state = .none
+    }
+}
+
+
+private extension AICommandRepository {
+
+    func cancelJobAndClearRecord(_ jobId: String) async {
+        try? await self.cancelCommand(jobId)
+        try? await self.clearProcessingAICommand()
+    }
+}
+
+
 private extension Publisher where Output == AIJob, Failure == any Error {
-    
+
     func notFinishJobTimeout(_ intervalMs: Int) -> some Publisher<Output, Failure> {
         
         return self
@@ -270,18 +393,21 @@ private extension Publisher where Output == AIJob, Failure == any Error {
     }
     
     func handleClearProcessingCommand(
-        _ repository: AICommandRepository
+        _ repository: AICommandRepository,
+        _ ongoingCommand: OngoingCommandTracker
     ) -> some Publisher<AIJob, Failure> {
-        
+
         // confirm은 종료가 아니라 유저 응답 대기다. 여기서 지우면 콜드스타트 복원 근거가
         // 사라져 대기 중이던 confirm이 유실된다 — 정리는 응답(confirm/decline/중지)이 한다.
         let handleOutput: (AIJob) -> Void = { job in
             guard job.isFinish, job.status != .confirm else { return }
+            ongoingCommand.clear()
             Task { try await repository.clearProcessingAICommand() }
         }
-        
+
         let handleError: (Subscribers.Completion<any Error>) -> Void = { completion in
             guard case .failure = completion else { return }
+            ongoingCommand.clear()
             Task { try await repository.clearProcessingAICommand() }
         }
         

--- a/Domain/Tests/Doubles/StubAICommandRepository.swift
+++ b/Domain/Tests/Doubles/StubAICommandRepository.swift
@@ -17,10 +17,14 @@ import Extensions
 class BaseStubAICommandRepository: AICommandRepository, @unchecked Sendable {
 
     var shouldFailProcessCommand: Bool = false
+    var processCommandDelay: TimeInterval = 0
     func processCommand(_ commandText: String, timeZone: String) async throws -> String {
         guard !self.shouldFailProcessCommand
         else {
             throw RuntimeError("not imple")
+        }
+        if self.processCommandDelay > 0 {
+            try await Task.sleep(for: .seconds(self.processCommandDelay))
         }
         return "some_job"
     }

--- a/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
@@ -563,7 +563,21 @@ extension AIAgentOrchestrationUsecaseImpleTests {
         }
         // then
         #expect(states.last.map(self.stateName) == "idle")
-        #expect(self.stubCommand.didCancelJobId == "job-1")
+        #expect(self.stubCommand.didRequestCancelOngoing == true)
+    }
+
+    // job이 아직 방출되지 않아 orchestration이 jobId를 모르는 시점에도 중지는 나가야 한다 —
+    // 중지 여부를 jobId 보유로 판정하던 게 #795의 원인이었다
+    @Test func usecase_reset_requestsCancelEvenBeforeJobEmitted() async throws {
+        // given — command job이 방출되지 않는 상태(첫 조회 전)
+        let usecase = self.makeUsecase()
+        try? usecase.submit("회의")
+
+        // when
+        usecase.reset()
+
+        // then
+        #expect(self.stubCommand.didRequestCancelOngoing == true)
     }
 
     @Test func usecase_decline_rejectsButDoesNotCancelOngoing() async throws {
@@ -579,7 +593,7 @@ extension AIAgentOrchestrationUsecaseImpleTests {
         // then — reject은 가되 cancel(중지) API는 안 나간다
         #expect(states.last.map(self.stateName) == "idle")
         #expect(self.stubCommand.didRejectParentJobId == "parent-job")
-        #expect(self.stubCommand.didCancelJobId == nil)  // decline은 cancelOngoing 호출 안 함
+        #expect(self.stubCommand.didRequestCancelOngoing == false)  // decline은 cancelOngoing 호출 안 함
     }
 }
 
@@ -730,7 +744,7 @@ private final class StubAICommandUsecase: AICommandUsecase, @unchecked Sendable 
     var didRejectParentJobId: String?
     var didProcessCommand: String?
     var didRestore: Bool = false
-    var didCancelJobId: String?
+    var didRequestCancelOngoing: Bool = false
     var didProcessConfirmToken: String?
 
     func processCommand(_ commandText: String) -> AnyPublisher<AIJob, any Error> {
@@ -745,8 +759,8 @@ private final class StubAICommandUsecase: AICommandUsecase, @unchecked Sendable 
     func rejectConfirmCommand(_ action: AIConfirmCommandAction) {
         self.didRejectParentJobId = action.parentJobId
     }
-    func cancelOngoingCommand(_ jobId: String) {
-        self.didCancelJobId = jobId
+    func cancelOngoingCommand() {
+        self.didRequestCancelOngoing = true
     }
     func restoreCommandifNeed() -> AnyPublisher<AIJob?, any Error> {
         self.didRestore = true
@@ -1360,7 +1374,7 @@ extension AIAgentOrchestrationUsecaseImpleTests {
 
         // then
         #expect(self.stubCommand.didClearProcessingCommandRecord == true)
-        #expect(self.stubCommand.didCancelJobId == nil)
+        #expect(self.stubCommand.didRequestCancelOngoing == false)
     }
 
     @Test("로그아웃하면 진행 중이던 상태를 idle로 되돌린다")

--- a/Domain/Tests/Usecases/AICommandUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AICommandUsecaseImpleTests.swift
@@ -29,10 +29,12 @@ final class AICommandUsecaseImpleTests: PublisherWaitable {
         customStubLoadJobs: [AIJob]? = nil,
         customStubLoadJobAsResult: [Result<AIJob, any Error>]? = nil,
         shouldFailLoadJobWithError: ServerErrorModel? = nil,
-        customPollingPolicy: AICommandUsecaseImple.PollingPolicy? = nil
+        customPollingPolicy: AICommandUsecaseImple.PollingPolicy? = nil,
+        processCommandDelay: TimeInterval = 0
     ) -> AICommandUsecaseImple {
 
         stubRepository.shouldFailProcessCommand = shouldFailMakeJob
+        stubRepository.processCommandDelay = processCommandDelay
         stubRepository.shouldFailProcessConfirmCommand = shouldFailMakeConfirmJob
         let jobs = customStubLoadJobs ?? [
             .dummyPendingJob, .dummyRunningJob, .dummyRunningJob, .dummyDoneJob
@@ -449,15 +451,142 @@ extension AICommandUsecaseImpleTests {
 
 extension AICommandUsecaseImpleTests {
 
+    // 폴링 주기를 길게 둬서 "job은 만들어졌지만 아직 한 번도 조회되지 않은" 구간을 만든다
+    private var pollingPolicyNotReachingFirstCheck: AICommandUsecaseImple.PollingPolicy {
+        return .init(checkInterval: 10, totalTimeout: 60)
+    }
+
     @Test func usecase_cancelOngoingCommand_delegatesJobCancellationAndClear() async throws {
         // given
-        let usecase = self.makeUsecase()
+        let usecase = self.makeUsecase(
+            customPollingPolicy: self.pollingPolicyNotReachingFirstCheck
+        )
+        let processing = usecase.processCommand("cmd")
+            .sink(receiveCompletion: { _ in }, receiveValue: { _ in })
+        try await Task.sleep(for: .milliseconds(50))
+
         // when
-        usecase.cancelOngoingCommand("some_job")
-        try await Task.sleep(nanoseconds: 50_000_000)
-        // then — 전달받은 jobId로 repository cancel + clear 위임
+        usecase.cancelOngoingCommand()
+        try await Task.sleep(for: .milliseconds(50))
+
+        // then — 진행 중 job의 jobId로 repository cancel + clear 위임
         #expect(self.stubRepository.didCancelJobId == "some_job")
         #expect(self.stubRepository.didClearProcessing == true)
+        processing.cancel()
+    }
+
+    // job 조회 응답이 오기 전에 중지를 눌러도 서버 취소가 나가야 한다 —
+    // 첫 폴링까지 10초가 비어 있어 그 사이 중지가 통째로 유실되던 구멍 (#795)
+    @Test func usecase_whenCancelBeforeFirstJobCheck_requestsCancel() async throws {
+        // given
+        let usecase = self.makeUsecase(
+            customPollingPolicy: self.pollingPolicyNotReachingFirstCheck
+        )
+        var emitted: [AIJob] = []
+        let processing = usecase.processCommand("cmd")
+            .sink(receiveCompletion: { _ in }, receiveValue: { emitted.append($0) })
+        try await Task.sleep(for: .milliseconds(50))
+
+        // when — 시트가 닫혀 구독이 끊긴 뒤 중지
+        processing.cancel()
+        usecase.cancelOngoingCommand()
+        try await Task.sleep(for: .milliseconds(50))
+
+        // then
+        #expect(emitted.isEmpty == true)
+        #expect(self.stubRepository.didCancelJobId == "some_job")
+    }
+
+    // job 생성 응답조차 오기 전에 중지를 누른 경우 — 생성이 끝나는 즉시 취소가 집행돼야 한다
+    @Test func usecase_whenCancelBeforeJobCreated_requestsCancelRightAfterCreated() async throws {
+        // given
+        let usecase = self.makeUsecase(
+            customPollingPolicy: self.pollingPolicyNotReachingFirstCheck,
+            processCommandDelay: 0.2
+        )
+        let processing = usecase.processCommand("cmd")
+            .sink(receiveCompletion: { _ in }, receiveValue: { _ in })
+
+        // when — 생성 응답 전에 중지 + 시트 닫힘(구독 해제)
+        try await Task.sleep(for: .milliseconds(20))
+        usecase.cancelOngoingCommand()
+        processing.cancel()
+        try await Task.sleep(for: .milliseconds(400))
+
+        // then
+        #expect(self.stubRepository.didCancelJobId == "some_job")
+        #expect(self.stubRepository.didClearProcessing == true)
+    }
+
+    @Test func usecase_whenNoOngoingCommand_cancelRequestIsIgnored() async throws {
+        // given
+        let usecase = self.makeUsecase()
+
+        // when
+        usecase.cancelOngoingCommand()
+        try await Task.sleep(for: .milliseconds(50))
+
+        // then
+        #expect(self.stubRepository.didCancelJobId == nil)
+        #expect(self.stubRepository.didClearProcessing == false)
+    }
+
+    // 결과 확인(acknowledge)도 중지와 같은 경로를 타지만, 끝난 job에 취소가 나가면 안 된다
+    @Test func usecase_whenCommandAlreadyFinished_cancelRequestIsIgnored() async throws {
+        // given
+        let expect = expectConfirm("완료까지 진행")
+        expect.count = 4
+        expect.timeout = .seconds(1)
+        let usecase = self.makeUsecase()
+        let jobs = try await self.outputs(expect, for: usecase.processCommand("cmd"))
+        #expect(jobs.last?.isFinish == true)
+
+        // when
+        usecase.cancelOngoingCommand()
+        try await Task.sleep(for: .milliseconds(50))
+
+        // then
+        #expect(self.stubRepository.didCancelJobId == nil)
+    }
+
+    // 생성부터 실패하면 서버에 job이 없다 — 실패 화면을 확인(acknowledge)해도 취소가 나가면 안 된다
+    @Test func usecase_whenCommandCreationFailed_cancelRequestIsIgnored() async throws {
+        // given
+        let expect = expectConfirm("커맨드 생성 실패")
+        expect.timeout = .seconds(1)
+        let usecase = self.makeUsecase(shouldFailMakeJob: true)
+        let fail = try await self.failure(expect, for: usecase.processCommand("cmd"))
+        #expect(fail != nil)
+
+        // when
+        usecase.cancelOngoingCommand()
+        try await Task.sleep(for: .milliseconds(50))
+
+        // then
+        #expect(self.stubRepository.didCancelJobId == nil)
+    }
+
+    // 복원으로 이어받은 job도 중지 대상이다 — 콜드스타트 후 중지가 안 먹으면 안 된다
+    @Test func usecase_cancelRestoredCommand() async throws {
+        // given
+        let expect = expectConfirm("복원된 진행 중 job")
+        expect.timeout = .seconds(1)
+        let usecase = self.makeUsecase(
+            customStubLoadJobs: [.dummyRunningJob],
+            customPollingPolicy: self.pollingPolicyNotReachingFirstCheck
+        )
+        self.stubRepository.stubProcessingCommand = .init(
+            jobId: "restored_job", isConfirmJob: false
+        )
+        let restored = try await self.outputs(expect, for: usecase.restoreCommandifNeed())
+        #expect(restored.first??.isFinish == false)
+
+        // when
+        usecase.cancelOngoingCommand()
+        try await Task.sleep(for: .milliseconds(50))
+
+        // then
+        #expect(self.stubRepository.didCancelJobId == "restored_job")
     }
 }
 

--- a/TodoCalendarApp/Sources/Root/ApplicationRootViewModel.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootViewModel.swift
@@ -64,10 +64,6 @@ final class ApplicationRootViewModelImple: @unchecked Sendable {
     private var cancellables: Set<AnyCancellable> = []
 }
 
-private enum Constant {
-    static let processingJobRefreshInterval: TimeInterval = 30
-}
-
 
 // MARK: - handle root routing
 
@@ -191,13 +187,11 @@ extension ApplicationRootViewModelImple {
             })
             .store(in: &self.cancellables)
 
-        // didBecomeActive는 제어센터·알림센터 여닫기나 권한 다이얼로그 dismiss로도 매번 온다.
+        // 제어센터·알림센터 여닫기로도 매번 오지만 상한을 두지 않는다 — throttle은 창에 갇힌
+        // 이벤트를 버리지 않고 창 끝까지 미뤄서, 백그라운드 복귀의 job 갱신이 최대 창 길이만큼
+        // 늦어졌다 (#795). 진행 중 job이 없으면 refreshProcessingJobIfNeeded가 로컬 조회로
+        // 끝나 잦은 호출의 비용도 낮다.
         NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
-            .throttle(
-                for: .seconds(Constant.processingJobRefreshInterval),
-                scheduler: DispatchQueue.main,
-                latest: false
-            )
             .sink(receiveValue: { [weak self] _ in
                 self?.handleDidBecomeActive()
             })

--- a/TodoCalendarApp/TodoCalendarAppTests/ApplicationRootViewModelImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/ApplicationRootViewModelImpleTests.swift
@@ -94,10 +94,11 @@ extension ApplicationRootViewModelImpleTests {
         withExtendedLifetime(viewModel) { }
     }
 
-    // didBecomeActive는 제어센터·알림센터 여닫기, 권한 다이얼로그 dismiss 등에서도 매번 온다.
-    // 그때마다 재조회하면 job 진행 중 구간에 불필요한 서버 조회가 반복된다.
-    @Test("짧은 간격의 연속 활성 전환은 한 번만 이어받는다")
-    func viewModel_whenDidBecomeActiveRepeatedly_refreshOnlyOnce() async {
+    // 잦은 전환을 throttle로 묶었더니 창에 갇힌 백그라운드 복귀가 창 끝까지 밀려, 복귀 직후
+    // 진행 중 job이 안 보이는 구간이 생겼다 (#795). 상한을 걷어내고 전환마다 이어받는다 —
+    // 진행 중 job이 없으면 이어받기는 로컬 조회로 끝나 잦은 호출의 비용이 낮다.
+    @Test("연속된 활성 전환도 매번 이어받는다")
+    func viewModel_whenDidBecomeActiveRepeatedly_refreshEveryTime() async {
         // given
         let viewModel = self.makeViewModel()
 
@@ -110,7 +111,7 @@ extension ApplicationRootViewModelImpleTests {
         try? await Task.sleep(for: .milliseconds(100))
 
         // then
-        #expect(self.spyAIJobRefreshUsecase.didRefreshProcessingJobTimes == 1)
+        #expect(self.spyAIJobRefreshUsecase.didRefreshProcessingJobTimes == 3)
         withExtendedLifetime(viewModel) { }
     }
 

--- a/docs/troubleshooting/2026-08-09-ai-job-stop-not-reaching-server.md
+++ b/docs/troubleshooting/2026-08-09-ai-job-stop-not-reaching-server.md
@@ -1,0 +1,28 @@
+---
+issue: "#795"
+subdomain: AIAgent
+symptoms: [중지 눌러도 취소 안됨, 중지 후 완료 푸시 도착, 포그라운드 복귀 시 진행중 안보임, 중지한 질의 결과 시트가 뒤늦게 노출]
+resolution: fixed
+---
+
+# 중지를 눌러도 서버에 cancel이 안 나가고, 중지한 job의 결과가 뒤늦게 뜬다
+
+- **증상**: 음성 커맨드 전송 직후 바텀시트에서 "중지"를 눌렀는데 (1) 잠시 뒤 처리 완료 푸시가 오고, (2) 포그라운드 복귀 시엔 진행 중 표시가 없다가, (3) 한참 뒤 중지했던 커맨드의 결과 시트가 튀어나온다.
+
+- **근본 원인**: 두 개가 겹쳤다.
+  - **취소 미발신** — `AIAgentOrchestrationUsecaseImple.reset()`이 `currentProcessingJobId`가 있을 때만 `cancelOngoingCommand`를 불렀다. 그 필드는 job 조회 응답이 처음 돌아올 때 채워지는데, `AICommandUsecaseImple.checkJob`은 `immediateCheck: false`라 첫 조회가 폴링 주기(10초) 뒤다. 그래서 시트가 뜬 직후 ~10초간 중지가 통째로 무시됐다. 서버 job은 계속 돌아 완료 푸시가 왔고(증상 1), 로컬 `ProcessingAICommand` 레코드도 `cancelOngoingCommand` 안에서만 지워지므로 남아 복원 대상이 됐다(증상 3).
+  - **복귀 갱신 지연** — `ApplicationRootViewModelImple`이 `didBecomeActive`에 30초 `throttle`을 걸고 있었다. Combine의 `throttle`은 창에 갇힌 값을 **버리지 않고 창 끝에 흘린다**(실측: 5초 창에서 t=2s 입력이 t=5s에 방출). 그래서 백그라운드 복귀가 창 안에 들어가면 `refreshProcessingJobIfNeeded`가 최대 30초 늦게 돌았다 — 복귀 직후엔 아무것도 안 보이고(증상 2), 창 끝에 뒤늦게 복원이 돌아 결과 시트가 떴다(증상 3).
+
+- **해결**:
+  - 취소 대상 판정을 `AICommandUsecaseImple`로 응집. `OngoingCommandTracker`가 `none / creating / ongoing(jobId)`를 들고, `cancelOngoingCommand()`가 인자 없이 "지금 진행 중인 것"을 취소한다. 생성 in-flight면 취소를 예약했다가 jobId 확보 직후 집행한다.
+  - job 생성을 unstructured `Task`로 구독 수명에서 분리 — 시트가 닫히거나 중지로 구독이 끊겨도 jobId를 받아 취소를 보낸다.
+  - `didBecomeActive`의 throttle 제거. 진행 중 job이 없으면 이어받기가 로컬 조회로 끝나 잦은 호출의 비용이 낮다.
+  - 부수 효과로 "정상 완료 후 확인(acknowledge)에도 끝난 job에 cancel API가 나가던" 문제가 같은 추적 상태로 해소됐다.
+
+- **기각 방향**: `throttle`의 `latest: true` 전환 — Combine에서 `latest`는 trailing 방출 여부가 아니라 갇힌 값 중 무엇을 낼지만 고르고, 이 시나리오는 갇힌 값이 하나라 동작이 동일하다 (실측 확인).
+- **기각 방향**: leading-only 상한(창 안 이벤트 폐기) — 정상 복귀가 통째로 버려져 증상이 "늦게 뜸"에서 "안 뜸"으로 바뀔 뿐이다.
+- **기각 방향**: orchestration에 jobId를 즉시 노출(생성 직후 stub job 선방출) — 첫 조회 전 구멍만 막고 생성 in-flight 구간은 그대로 남아 보완 패치가 또 필요하다.
+
+## 참고 — 기존 플레이키
+
+`AICommandUsecaseImpleTests`의 "실패/타임아웃 직후 `loadProcessingAICommand() == nil`"류 케이스는 `clearProcessingAICommand`가 fire-and-forget `Task`인데 테스트가 대기 없이 읽어 랜덤 실패한다. develop에서도 동일하게 재현되는 기존 문제라 이번 변경의 회귀가 아니다.

--- a/docs/troubleshooting/INDEX.md
+++ b/docs/troubleshooting/INDEX.md
@@ -6,6 +6,8 @@
 
 <!-- 레코드는 아래에 최신순으로 추가 -->
 
+- [2026-08-09 중지를 눌러도 서버에 cancel이 안 나가고, 중지한 job의 결과가 뒤늦게 뜬다](2026-08-09-ai-job-stop-not-reaching-server.md) — AIAgent / fixed / 중지 안됨, 중지 후 완료 푸시, 복귀 시 진행중 안보임, 결과 시트 뒤늦게 노출, Combine throttle 지연
+
 - [2026-08-08 run-all-tests.sh가 컴파일 실패를 PASSED로 보고한다](2026-08-08-run-all-tests-reports-compile-failure-as-passed.md) — Infra / fixed / PASSED 오보, 컴파일 에러인데 통과, TEST FAILED 미감지, Executed 0 tests
 
 - [2026-08-07 비반복 이벤트를 롱탭했는데 컨텍스트 메뉴에 "이번만 삭제"가 뜬다](2026-08-07-day-event-list-context-menu-shows-wrong-remove-action.md) — Event / fixed / 이번만 삭제 오노출, 메뉴 깜빡임, 탭 무반응, 셀 목록 재방출


### PR DESCRIPTION
close #795

## 문제

음성 커맨드 전송 직후 바텀시트에서 "중지"를 눌렀는데 (1) 잠시 뒤 처리 완료 푸시가 오고, (2) 포그라운드 복귀 시엔 진행 중 표시가 없다가, (3) 한참 뒤 중지했던 커맨드의 결과 시트가 튀어나왔다. 원인은 두 개다.

**취소가 아예 발신되지 않았다.** `AIAgentOrchestrationUsecaseImple.reset()`이 `currentProcessingJobId`가 있을 때만 취소를 요청했는데, 그 필드는 job 조회 응답이 처음 돌아올 때 채워진다. `checkJob`은 `immediateCheck: false`라 첫 조회가 폴링 주기(10초) 뒤라서, 시트가 뜬 직후 ~10초 동안 누른 중지는 통째로 무시됐다. 서버 job은 계속 돌아 완료 푸시가 왔고, 로컬 처리중 기록도 취소 경로 안에서만 지워지므로 남아 나중에 복원 대상이 됐다.

**복귀 시 갱신이 최대 30초 늦었다.** `didBecomeActive`에 30초 throttle이 걸려 있었는데, Combine의 `throttle`은 창에 갇힌 값을 버리지 않고 창 끝에 흘린다(실측: 5초 창에서 t=2s 입력이 t=5s 방출). 그래서 백그라운드 복귀가 창 안에 들어가면 복귀 직후엔 아무것도 안 보이고, 창 끝에 뒤늦게 복원이 돌아 결과 시트가 떴다. 증상 (2)와 (3)이 같은 사건의 앞뒤였다.

## 접근

**취소 대상 판정을 `AICommandUsecaseImple`로 응집했다.** jobId를 아는 주체가 거기라서, 호출자가 jobId를 모르든(첫 조회 전) 이미 끝난 job을 들고 있든 판정이 한 곳에서 끝난다. `OngoingCommandTracker`가 `none / creating / ongoing(jobId)`를 소유하고, 생성 in-flight 중 들어온 중지는 예약했다가 jobId 확보 직후 집행한다.

**job 생성을 구독 수명에서 떼어냈다.** unstructured `Task`로 돌려서 시트가 닫히거나 중지로 구독이 끊겨도 생성이 완주하고 jobId를 받아 취소를 보낸다. 구독이 끊긴 채 생성만 성공하면 서버 job은 계속 돌고 취소 요청은 갈 곳을 잃는 구멍이었다.

**throttle은 제거했다.** 진행 중 job이 없으면 이어받기가 로컬 조회로 끝나(`refreshProcessingJobIfNeeded`의 상태 가드) 잦은 호출의 비용이 낮다. `latest: true` 전환은 갇힌 값이 하나라 동작이 같고, leading-only 상한은 정상 복귀를 통째로 버려 증상이 "늦게 뜸"에서 "안 뜸"으로 바뀔 뿐이라 둘 다 기각했다.

부수 효과로 **정상 완료 후 확인(acknowledge)에도 끝난 job에 cancel API가 나가던 문제**가 같은 추적 상태로 해소됐다.

규명 과정과 기각 방향은 `docs/troubleshooting/2026-08-09-ai-job-stop-not-reaching-server.md`에 남겼다.

## 검증

Domain·TodoCalendarApp 스킴 통과. 신규 TC 6건 — 첫 조회 전 중지 / 생성 응답 전 중지 / 진행 중 없음 / 이미 종료 / 생성 실패 / 복원된 job 중지.

`AICommandUsecaseImpleTests`의 "실패·타임아웃 직후 처리중 기록이 비었는지" 확인하는 케이스들은 fire-and-forget `clearProcessingAICommand`를 대기 없이 읽어 랜덤 실패한다. develop에서도 동일하게 재현되는 기존 플레이키라 이번 회귀가 아니다 — 아카이브에 메모해뒀다.

## 남은 과제

서버 cancel API가 실제로 나가는지는 stub 레벨까지만 검증했다. 실기기에서 "말하고 → 바로 중지 → 백그라운드" 동선으로 완료 푸시가 오지 않는지 QA 확인이 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166a3ZsHehJAwymxS9eUoaR