### PR TITLE
[#795] AI job 중지가 서버까지 가도록 — 커맨드 처리 진행 상태 모델링 + 복귀 갱신 지연 제거

### DIFF
--- a/Domain/Sources/Models/AI/AICommand+Job.swift
+++ b/Domain/Sources/Models/AI/AICommand+Job.swift
@@ -64,6 +64,22 @@ public struct AIJob: Sendable {
     }
 }
 
+// MARK: - AICommandProcessing
+
+// 커맨드 처리 진행 상태. 생성 응답으로 jobId를 먼저 받고, 그 뒤 조회로 job이 따라온다.
+public enum AICommandProcessing: Sendable {
+    case started(jobId: String)
+    case job(AIJob)
+
+    public var jobId: String {
+        switch self {
+        case .started(let jobId): return jobId
+        case .job(let job): return job.jobId
+        }
+    }
+}
+
+
 // MARK: - AIJobResult
 
 public enum AIJobResult: Sendable {

--- a/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
@@ -72,17 +72,19 @@ public final class AIAgentOrchestrationUsecaseImple: AIAgentOrchestrationUsecase
     private var voiceInputBindings = Set<AnyCancellable>()
     private var currentProcessingJobId: String?
 
-    private func startProcessing(_ jobPublisher: AnyPublisher<AIJob, any Error>) {
+    private func startProcessing(_ processing: AnyPublisher<AICommandProcessing, any Error>) {
         self.commandCancellable?.cancel()
-        self.commandCancellable = jobPublisher
+        self.commandCancellable = processing
             .sink(
                 receiveCompletion: { [weak self] completion in
                     if case .failure = completion {
+                        self?.currentProcessingJobId = nil
                         self?.subject.state.send(.failed(command: self?.currentCommand ?? "", reason: nil, errorCode: nil))
                     }
                 },
-                receiveValue: { [weak self] job in
-                    self?.currentProcessingJobId = job.jobId
+                receiveValue: { [weak self] processing in
+                    self?.currentProcessingJobId = processing.jobId
+                    guard case .job(let job) = processing else { return }
                     self?.handleJobResult(job)
                 }
             )
@@ -90,6 +92,10 @@ public final class AIAgentOrchestrationUsecaseImple: AIAgentOrchestrationUsecase
 
     private func handleJobResult(_ job: AIJob) {
         guard job.isFinish else { return }
+        // confirm은 유저 응답 대기라 아직 중지 대상이다 — 그 외 종료는 추적에서 뺀다
+        if job.status != .confirm {
+            self.currentProcessingJobId = nil
+        }
         self.triggerEventSyncIfNeeded(job.result)
         if job.status == .rejected || job.status == .canceled {
             self.subject.state.send(.idle)
@@ -314,13 +320,14 @@ extension AIAgentOrchestrationUsecaseImple {
                         self?.subject.state.send(.idle)
                     }
                 },
-                receiveValue: { [weak self] job in
+                receiveValue: { [weak self] processing in
                     guard let self else { return }
-                    guard let job else {
+                    guard let processing else {
                         self.subject.state.send(.idle)
                         return
                     }
-                    self.currentProcessingJobId = job.jobId
+                    self.currentProcessingJobId = processing.jobId
+                    guard case .job(let job) = processing else { return }
                     // 앱 밖에서 만들어진 job은 복원 시점에 아직 진행 중이다.
                     // handleJobResult는 종료 job만 다루므로 여기서 processing으로 올려야
                     // 진행 상태가 보이고 canSubmit 가드도 이 job을 인지한다.

--- a/Domain/Sources/Usecases/AI/AICommandUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AICommandUsecase.swift
@@ -15,9 +15,9 @@ import Extensions
 
 public protocol AICommandUsecase: AnyObject, Sendable {
     
-    func processCommand(_ commandText: String) -> AnyPublisher<AIJob, any Error>
-    
-    func processConfirmCommand(_ action: AIConfirmCommandAction) -> AnyPublisher<AIJob, any Error>
+    func processCommand(_ commandText: String) -> AnyPublisher<AICommandProcessing, any Error>
+
+    func processConfirmCommand(_ action: AIConfirmCommandAction) -> AnyPublisher<AICommandProcessing, any Error>
 
     func rejectConfirmCommand(_ action: AIConfirmCommandAction)
 
@@ -25,7 +25,7 @@ public protocol AICommandUsecase: AnyObject, Sendable {
 
     func clearProcessingCommandRecord() async
 
-    func restoreCommandifNeed() -> AnyPublisher<AIJob?, any Error>
+    func restoreCommandifNeed() -> AnyPublisher<AICommandProcessing?, any Error>
 
     func refreshJobStatus(_ jobId: String)
 }
@@ -82,8 +82,8 @@ public final class AICommandUsecaseImple: AICommandUsecase, @unchecked Sendable 
 
 extension AICommandUsecaseImple {
     
-    public func processCommand(_ commandText: String) -> AnyPublisher<AIJob, any Error> {
-        
+    public func processCommand(_ commandText: String) -> AnyPublisher<AICommandProcessing, any Error> {
+
         let timeZone = self.currentIANATimeZone(); let repository = self.repository
 
         let makeJob: some Publisher<String, any Error> = Publishers.create(do: {
@@ -93,18 +93,11 @@ extension AICommandUsecaseImple {
             )
             return jobId
         })
-        
-        let waitJobUntilFinish = makeJob
-            .flatMap { [weak self] jobId in
-                return self?.checkJob(jobId) ?? Empty().eraseToAnyPublisher()
-            }
 
-        return waitJobUntilFinish
-            .handleClearProcessingCommand(repository)
-            .eraseToAnyPublisher()
+        return self.waitJobUntilFinish(makeJob)
     }
 
-    public func processConfirmCommand(_ action: AIConfirmCommandAction) -> AnyPublisher<AIJob, any Error> {
+    public func processConfirmCommand(_ action: AIConfirmCommandAction) -> AnyPublisher<AICommandProcessing, any Error> {
 
         let timeZone = self.currentIANATimeZone(); let repository = self.repository
 
@@ -116,13 +109,26 @@ extension AICommandUsecaseImple {
             return jobId
         })
 
-        let waitUntilFinish = makeConfirmJob
-            .flatMap { [weak self] jobId in
-                return self?.checkJob(jobId) ?? Empty().eraseToAnyPublisher()
-            }
+        return self.waitJobUntilFinish(makeConfirmJob)
+    }
 
-        return waitUntilFinish
-            .handleClearProcessingCommand(repository)
+    // 생성 응답의 jobId를 초기 이벤트로 먼저 내보낸다 — 조회로 job이 오기 전에도
+    // 소비자가 진행 중 job을 지목할 수 있어야 한다.
+    private func waitJobUntilFinish(
+        _ makeJobId: some Publisher<String, any Error>,
+        immediateCheck: Bool = false
+    ) -> AnyPublisher<AICommandProcessing, any Error> {
+
+        let repository = self.repository
+        return makeJobId
+            .flatMap { [weak self] jobId -> AnyPublisher<AICommandProcessing, any Error> in
+                guard let self else { return Empty().eraseToAnyPublisher() }
+                return self.checkJob(jobId, immediateCheck: immediateCheck)
+                    .handleClearProcessingCommand(repository)
+                    .map { AICommandProcessing.job($0) }
+                    .prepend(.started(jobId: jobId))
+                    .eraseToAnyPublisher()
+            }
             .eraseToAnyPublisher()
     }
     
@@ -210,21 +216,21 @@ extension AICommandUsecaseImple {
 
 extension AICommandUsecaseImple {
     
-    public func restoreCommandifNeed() -> AnyPublisher<AIJob?, any Error> {
+    public func restoreCommandifNeed() -> AnyPublisher<AICommandProcessing?, any Error> {
 
         let processingCmd = self.loadProcessingCommand()
 
         return processingCmd
-            .flatMap { [weak self] cmd -> AnyPublisher<AIJob?, any Error> in
+            .flatMap { [weak self] cmd -> AnyPublisher<AICommandProcessing?, any Error> in
                 guard let self, let cmd
                 else {
-                    return Just<AIJob?>(nil)
+                    return Just<AICommandProcessing?>(nil)
                         .setFailureType(to: (any Error).self)
                         .eraseToAnyPublisher()
                 }
 
-                return self.checkJob(cmd.jobId, immediateCheck: true)
-                    .handleClearProcessingCommand(self.repository)
+                let restoredJobId = Just(cmd.jobId).setFailureType(to: (any Error).self)
+                return self.waitJobUntilFinish(restoredJobId, immediateCheck: true)
                     .map { Optional($0) }
                     .eraseToAnyPublisher()
             }

--- a/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
@@ -553,7 +553,9 @@ extension AIAgentOrchestrationUsecaseImpleTests {
         expect.count = 2
         var done = AIJobResult.DoneResult()
         done.text = "완료"
-        let usecase = self.makeUsecaseWithCommandJob(self.dummyJob(.done(done)))
+        let usecase = self.makeUsecaseWithCommandJob(
+            self.dummyJob(.done(done), status: .running)
+        )
         usecase.reset()
         try? usecase.submit("회의")
         try await Task.sleep(for: .milliseconds(30))
@@ -564,6 +566,38 @@ extension AIAgentOrchestrationUsecaseImpleTests {
         // then
         #expect(states.last.map(self.stateName) == "idle")
         #expect(self.stubCommand.didCancelJobId == "job-1")
+    }
+
+    // job 조회가 한 번도 안 끝난 시점 — 생성 응답의 started 이벤트로 받아둔 jobId로 중지한다
+    @Test func usecase_reset_cancelsWithJobIdFromStartedEvent() async throws {
+        // given — started만 방출되고 job은 아직 없다
+        let usecase = self.makeUsecase()
+        usecase.reset()
+        try? usecase.submit("회의")
+        try await Task.sleep(for: .milliseconds(30))
+
+        // when
+        usecase.reset()
+
+        // then
+        #expect(self.stubCommand.didCancelJobId == "job-1")
+    }
+
+    // 결과 확인(acknowledge)도 reset을 타는데, 이미 끝난 job에 취소가 나가면 안 된다
+    @Test func usecase_whenJobFinished_resetDoesNotCancel() async throws {
+        // given
+        var done = AIJobResult.DoneResult()
+        done.text = "완료"
+        let usecase = self.makeUsecaseWithCommandJob(self.dummyJob(.done(done)))
+        usecase.reset()
+        try? usecase.submit("회의")
+        try await Task.sleep(for: .milliseconds(30))
+
+        // when
+        usecase.reset()
+
+        // then
+        #expect(self.stubCommand.didCancelJobId == nil)
     }
 
     @Test func usecase_decline_rejectsButDoesNotCancelOngoing() async throws {
@@ -733,14 +767,14 @@ private final class StubAICommandUsecase: AICommandUsecase, @unchecked Sendable 
     var didCancelJobId: String?
     var didProcessConfirmToken: String?
 
-    func processCommand(_ commandText: String) -> AnyPublisher<AIJob, any Error> {
+    func processCommand(_ commandText: String) -> AnyPublisher<AICommandProcessing, any Error> {
         self.didProcessCommand = commandText
-        return self.jobPublisher(self.stubCommandJob)
+        return self.processingPublisher(self.stubCommandJob)
     }
 
-    func processConfirmCommand(_ action: AIConfirmCommandAction) -> AnyPublisher<AIJob, any Error> {
+    func processConfirmCommand(_ action: AIConfirmCommandAction) -> AnyPublisher<AICommandProcessing, any Error> {
         self.didProcessConfirmToken = action.confirmToken
-        return self.jobPublisher(self.stubConfirmJob)
+        return self.processingPublisher(self.stubConfirmJob)
     }
     func rejectConfirmCommand(_ action: AIConfirmCommandAction) {
         self.didRejectParentJobId = action.parentJobId
@@ -748,12 +782,16 @@ private final class StubAICommandUsecase: AICommandUsecase, @unchecked Sendable 
     func cancelOngoingCommand(_ jobId: String) {
         self.didCancelJobId = jobId
     }
-    func restoreCommandifNeed() -> AnyPublisher<AIJob?, any Error> {
+    func restoreCommandifNeed() -> AnyPublisher<AICommandProcessing?, any Error> {
         self.didRestore = true
         if self.shouldFail {
             return Fail(error: RuntimeError("stub fail")).eraseToAnyPublisher()
         }
-        return Just(self.stubRestoreJob)
+        guard let job = self.stubRestoreJob else {
+            return Just(nil).setFailureType(to: (any Error).self).eraseToAnyPublisher()
+        }
+        return [.started(jobId: job.jobId), .job(job)].publisher
+            .map { Optional($0) }
             .setFailureType(to: (any Error).self)
             .eraseToAnyPublisher()
     }
@@ -767,12 +805,19 @@ private final class StubAICommandUsecase: AICommandUsecase, @unchecked Sendable 
         self.didClearProcessingCommandRecord = true
     }
 
-    private func jobPublisher(_ job: AIJob?) -> AnyPublisher<AIJob, any Error> {
+    // 실물과 같은 순서로 방출한다 — 생성 응답(jobId)이 먼저, 조회된 job이 뒤
+    var stubStartedJobId: String = "job-1"
+    private func processingPublisher(_ job: AIJob?) -> AnyPublisher<AICommandProcessing, any Error> {
         if self.shouldFail {
             return Fail(error: RuntimeError("stub fail")).eraseToAnyPublisher()
         }
-        guard let job else { return Empty().eraseToAnyPublisher() }
-        return Just(job).setFailureType(to: (any Error).self).eraseToAnyPublisher()
+        let started = AICommandProcessing.started(jobId: self.stubStartedJobId)
+        guard let job else {
+            return Just(started).setFailureType(to: (any Error).self).eraseToAnyPublisher()
+        }
+        return [started, .job(job)].publisher
+            .setFailureType(to: (any Error).self)
+            .eraseToAnyPublisher()
     }
 }
 

--- a/Domain/Tests/Usecases/AICommandUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AICommandUsecaseImpleTests.swift
@@ -94,10 +94,73 @@ extension AICommandUsecaseImpleTests {
 }
 
 
+// MARK: - 생성 응답 jobId 초기 방출
+
+extension AICommandUsecaseImpleTests {
+
+    // 폴링 주기를 길게 둬서 "생성은 됐지만 아직 한 번도 조회되지 않은" 구간을 만든다
+    private var pollingPolicyNotReachingFirstCheck: AICommandUsecaseImple.PollingPolicy {
+        return .init(checkInterval: 10, totalTimeout: 60)
+    }
+
+    @Test func usecase_processCommand_emitsStartedWithJobIdBeforeFirstCheck() async throws {
+        // given
+        let expect = expectConfirm("생성 응답 jobId가 첫 조회 전에 방출된다")
+        expect.timeout = .seconds(1)
+        let usecase = self.makeUsecase(
+            customPollingPolicy: self.pollingPolicyNotReachingFirstCheck
+        )
+
+        // when
+        let first = try await self.firstOutput(expect, for: usecase.processCommand("cmd"))
+
+        // then
+        guard case .started(let jobId) = try #require(first)
+        else { Issue.record("started 아님"); return }
+        #expect(jobId == "some_job")
+    }
+
+    @Test func usecase_processConfirmCommand_emitsStartedWithJobIdBeforeFirstCheck() async throws {
+        // given
+        let expect = expectConfirm("컨펌 생성 응답 jobId가 첫 조회 전에 방출된다")
+        expect.timeout = .seconds(1)
+        let usecase = self.makeUsecase(
+            customPollingPolicy: self.pollingPolicyNotReachingFirstCheck
+        )
+
+        // when
+        let first = try await self.firstOutput(expect, for: usecase.processConfirmCommand(.init()))
+
+        // then
+        guard case .started(let jobId) = try #require(first)
+        else { Issue.record("started 아님"); return }
+        #expect(jobId == "some_job")
+    }
+
+    @Test func usecase_processCommand_emitsStartedThenJobs() async throws {
+        // given
+        let expect = expectConfirm("started → job 순서")
+        expect.count = 3
+        expect.timeout = .seconds(1)
+        let usecase = self.makeUsecase(
+            customStubLoadJobs: [.dummyRunningJob, .dummyDoneJob]
+        )
+
+        // when
+        let outputs = try await self.outputs(expect, for: usecase.processCommand("cmd"))
+
+        // then
+        guard case .started = outputs.first else { Issue.record("첫 방출이 started 아님"); return }
+        #expect(outputs.map { $0.jobId } == ["some_job", "some_job", "some_job"])
+        #expect(outputs.dropFirst().allSatisfy { if case .job = $0 { true } else { false } })
+    }
+}
+
+
 // MARK: - process commmand
 
 extension AICommandUsecaseImpleTests {
-    
+
     @Test(arguments: [AIJob.dummyDoneJob, .dummyFailJob, .dummyConfirmJob])
     func usecase_processCommand(_ finalJob: AIJob) async throws {
         // given
@@ -111,7 +174,7 @@ extension AICommandUsecaseImpleTests {
         ])
         
         // when
-        let processing = usecase.processCommand("cmd")
+        let processing = usecase.processCommand("cmd").jobsOnly()
         let jobs = try await self.outputs(expect, for: processing)
         
         // then
@@ -128,7 +191,7 @@ extension AICommandUsecaseImpleTests {
         let usecase = self.makeUsecase()
         
         // when
-        let processing = usecase.processCommand("cmd")
+        let processing = usecase.processCommand("cmd").jobsOnly()
         let jobs = try await self.outputs(expect, for: processing)
         
         // then
@@ -151,7 +214,7 @@ extension AICommandUsecaseImpleTests {
         ])
 
         // when
-        let jobs = try await self.outputs(expect, for: usecase.processCommand("cmd"))
+        let jobs = try await self.outputs(expect, for: usecase.processCommand("cmd").jobsOnly())
 
         // then
         #expect(jobs.last?.status == .confirm)
@@ -173,7 +236,7 @@ extension AICommandUsecaseImpleTests {
         self.stubRepository.loadJobMocking = .success(.dummyRunningJob)
         
         // when
-        let processing = usecase.processCommand("cmd")
+        let processing = usecase.processCommand("cmd").jobsOnly()
         let jobs = try await self.outputs(expect, for: processing) {
             
             try await Task.sleep(for: .milliseconds(10))
@@ -204,7 +267,7 @@ extension AICommandUsecaseImpleTests {
         )
         
         // when
-        let processing = usecase.processCommand("cmd")
+        let processing = usecase.processCommand("cmd").jobsOnly()
         let jobs = try await self.outputs(expect, for: processing)
         
         // then
@@ -228,7 +291,7 @@ extension AICommandUsecaseImpleTests {
         )
         
         // when
-        let processing = usecase.processCommand("cmd")
+        let processing = usecase.processCommand("cmd").jobsOnly()
         let fail = try await self.failure(expect, for: processing)
         
         // then
@@ -249,7 +312,7 @@ extension AICommandUsecaseImpleTests {
         )
         
         // when
-        let processing = usecase.processCommand("cmd")
+        let processing = usecase.processCommand("cmd").jobsOnly()
         let fail = try await self.failure(expect, for: processing)
         
         // then
@@ -268,7 +331,7 @@ extension AICommandUsecaseImpleTests {
         let usecase = self.makeUsecase(shouldFailMakeJob: true)
         
         // when
-        let processing = usecase.processCommand("cmd")
+        let processing = usecase.processCommand("cmd").jobsOnly()
         let fail = try await self.failure(expect, for: processing)
         
         // then
@@ -297,7 +360,7 @@ extension AICommandUsecaseImpleTests {
         ])
 
         // when
-        let processing = usecase.processConfirmCommand(.init())
+        let processing = usecase.processConfirmCommand(.init()).jobsOnly()
         let jobs = try await self.outputs(expect, for: processing)
 
         // then
@@ -314,7 +377,7 @@ extension AICommandUsecaseImpleTests {
         let usecase = self.makeUsecase()
 
         // when
-        let processing = usecase.processConfirmCommand(.init())
+        let processing = usecase.processConfirmCommand(.init()).jobsOnly()
         let jobs = try await self.outputs(expect, for: processing)
 
         // then
@@ -339,7 +402,7 @@ extension AICommandUsecaseImpleTests {
         self.stubRepository.loadJobMocking = .success(.dummyRunningJob)
 
         // when
-        let processing = usecase.processConfirmCommand(.init())
+        let processing = usecase.processConfirmCommand(.init()).jobsOnly()
         let jobs = try await self.outputs(expect, for: processing) {
 
             try await Task.sleep(for: .milliseconds(10))
@@ -370,7 +433,7 @@ extension AICommandUsecaseImpleTests {
         )
 
         // when
-        let processing = usecase.processConfirmCommand(.init())
+        let processing = usecase.processConfirmCommand(.init()).jobsOnly()
         let jobs = try await self.outputs(expect, for: processing)
 
         // then
@@ -394,7 +457,7 @@ extension AICommandUsecaseImpleTests {
         )
 
         // when
-        let processing = usecase.processConfirmCommand(.init())
+        let processing = usecase.processConfirmCommand(.init()).jobsOnly()
         let fail = try await self.failure(expect, for: processing)
 
         // then
@@ -415,7 +478,7 @@ extension AICommandUsecaseImpleTests {
         )
 
         // when
-        let processing = usecase.processConfirmCommand(.init())
+        let processing = usecase.processConfirmCommand(.init()).jobsOnly()
         let fail = try await self.failure(expect, for: processing)
 
         // then
@@ -434,7 +497,7 @@ extension AICommandUsecaseImpleTests {
         let usecase = self.makeUsecase(shouldFailMakeConfirmJob: true)
 
         // when
-        let processing = usecase.processConfirmCommand(.init())
+        let processing = usecase.processConfirmCommand(.init()).jobsOnly()
         let fail = try await self.failure(expect, for: processing)
 
         // then
@@ -490,9 +553,9 @@ extension AICommandUsecaseImpleTests {
         )
         
         let firstJob = if isConfirm {
-            usecase.processCommand("cmd").first()
+            usecase.processCommand("cmd").jobsOnly().first()
         } else {
-            usecase.processConfirmCommand(.init()).first()
+            usecase.processConfirmCommand(.init()).jobsOnly().first()
         }
         
         let _ = try await firstJob.values.first(where: { _ in true })
@@ -508,7 +571,7 @@ extension AICommandUsecaseImpleTests {
         let usecase = try await self.makeUsecaseWithProcessingCmd(isConfirm: false)
         
         // when
-        let restore = usecase.restoreCommandifNeed()
+        let restore = usecase.restoreCommandifNeed().restoredJobsOnly()
         let jobs = try await self.outputs(expect, for: restore)
         
         // then
@@ -528,7 +591,7 @@ extension AICommandUsecaseImpleTests {
         let usecase = try await self.makeUsecaseWithProcessingCmd(isConfirm: true)
         
         // when
-        let restore = usecase.restoreCommandifNeed()
+        let restore = usecase.restoreCommandifNeed().restoredJobsOnly()
         let jobs = try await self.outputs(expect, for: restore)
         
         // then
@@ -550,7 +613,7 @@ extension AICommandUsecaseImpleTests {
             ServerErrorModel.dummy(.notFound)
         )
         // when
-        let restore = usecase.restoreCommandifNeed()
+        let restore = usecase.restoreCommandifNeed().restoredJobsOnly()
         let error = try await failure(expect, for: restore)
         
         // then
@@ -582,7 +645,9 @@ extension AICommandUsecaseImpleTests {
         let usecase = self.makeUsecaseWithRestoredJob(.dummyDoneJob)
 
         // when
-        let job = try await self.firstOutput(expect, for: usecase.restoreCommandifNeed())
+        let job = try await self.firstOutput(
+            expect, for: usecase.restoreCommandifNeed().restoredJobsOnly()
+        )
 
         // then
         #expect(job??.status == .done)
@@ -599,9 +664,9 @@ extension AICommandUsecaseImpleTests {
         )
         
         let firstJob = if isConfirm {
-            usecase.processCommand("cmd").first()
+            usecase.processCommand("cmd").jobsOnly().first()
         } else {
-            usecase.processConfirmCommand(.init()).first()
+            usecase.processConfirmCommand(.init()).jobsOnly().first()
         }
         
         let _ = try await firstJob.values.first(where: { _ in true })
@@ -659,5 +724,30 @@ private extension ServerErrorModel {
     static func dummy(_ code: ServerErrorModel.ErrorCode) -> ServerErrorModel {
         return .init()
             |> \.code .~ code
+    }
+}
+
+
+// MARK: - test helpers
+
+private extension Publisher where Output == AICommandProcessing {
+
+    func jobsOnly() -> AnyPublisher<AIJob, Failure> {
+        return self
+            .compactMap { if case .job(let job) = $0 { return job } else { return nil } }
+            .eraseToAnyPublisher()
+    }
+}
+
+private extension Publisher where Output == AICommandProcessing? {
+
+    // 복원 없음(nil)은 그대로 흘리고, started는 걸러 job만 남긴다
+    func restoredJobsOnly() -> AnyPublisher<AIJob?, Failure> {
+        let pick: (AICommandProcessing?) -> AIJob?? = { processing in
+            guard let processing else { return .some(nil) }
+            guard case .job(let job) = processing else { return nil }
+            return .some(job)
+        }
+        return self.compactMap(pick).eraseToAnyPublisher()
     }
 }

--- a/TodoCalendarApp/Sources/Root/ApplicationRootViewModel.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootViewModel.swift
@@ -64,10 +64,6 @@ final class ApplicationRootViewModelImple: @unchecked Sendable {
     private var cancellables: Set<AnyCancellable> = []
 }
 
-private enum Constant {
-    static let processingJobRefreshInterval: TimeInterval = 30
-}
-
 
 // MARK: - handle root routing
 
@@ -191,13 +187,7 @@ extension ApplicationRootViewModelImple {
             })
             .store(in: &self.cancellables)
 
-        // didBecomeActive는 제어센터·알림센터 여닫기나 권한 다이얼로그 dismiss로도 매번 온다.
         NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)
-            .throttle(
-                for: .seconds(Constant.processingJobRefreshInterval),
-                scheduler: DispatchQueue.main,
-                latest: false
-            )
             .sink(receiveValue: { [weak self] _ in
                 self?.handleDidBecomeActive()
             })

--- a/TodoCalendarApp/TodoCalendarAppTests/ApplicationRootViewModelImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/ApplicationRootViewModelImpleTests.swift
@@ -94,10 +94,8 @@ extension ApplicationRootViewModelImpleTests {
         withExtendedLifetime(viewModel) { }
     }
 
-    // didBecomeActive는 제어센터·알림센터 여닫기, 권한 다이얼로그 dismiss 등에서도 매번 온다.
-    // 그때마다 재조회하면 job 진행 중 구간에 불필요한 서버 조회가 반복된다.
-    @Test("짧은 간격의 연속 활성 전환은 한 번만 이어받는다")
-    func viewModel_whenDidBecomeActiveRepeatedly_refreshOnlyOnce() async {
+    @Test("연속된 활성 전환도 매번 이어받는다")
+    func viewModel_whenDidBecomeActiveRepeatedly_refreshEveryTime() async {
         // given
         let viewModel = self.makeViewModel()
 
@@ -110,7 +108,7 @@ extension ApplicationRootViewModelImpleTests {
         try? await Task.sleep(for: .milliseconds(100))
 
         // then
-        #expect(self.spyAIJobRefreshUsecase.didRefreshProcessingJobTimes == 1)
+        #expect(self.spyAIJobRefreshUsecase.didRefreshProcessingJobTimes == 3)
         withExtendedLifetime(viewModel) { }
     }
 

--- a/docs/troubleshooting/2026-08-09-ai-job-stop-not-reaching-server.md
+++ b/docs/troubleshooting/2026-08-09-ai-job-stop-not-reaching-server.md
@@ -1,0 +1,32 @@
+---
+issue: "#795"
+subdomain: AIAgent
+symptoms: [중지 눌러도 취소 안됨, 중지 후 완료 푸시 도착, 포그라운드 복귀 시 진행중 안보임, 중지한 질의 결과 시트가 뒤늦게 노출]
+resolution: fixed
+---
+
+# 중지를 눌러도 서버에 cancel이 안 나가고, 중지한 job의 결과가 뒤늦게 뜬다
+
+- **증상**: 음성 커맨드 전송 직후 바텀시트에서 "중지"를 눌렀는데 (1) 잠시 뒤 처리 완료 푸시가 오고, (2) 포그라운드 복귀 시엔 진행 중 표시가 없다가, (3) 한참 뒤 중지했던 커맨드의 결과 시트가 튀어나온다.
+
+- **근본 원인**: 두 개가 겹쳤다.
+  - **취소 미발신** — `AIAgentOrchestrationUsecaseImple.reset()`이 `currentProcessingJobId`가 있을 때만 `cancelOngoingCommand`를 불렀다. 그 필드는 job 조회 응답이 처음 돌아올 때 채워지는데, `AICommandUsecaseImple.checkJob`은 `immediateCheck: false`라 첫 조회가 폴링 주기(10초) 뒤다. 그래서 시트가 뜬 직후 ~10초간 중지가 통째로 무시됐다. 서버 job은 계속 돌아 완료 푸시가 왔고(증상 1), 로컬 `ProcessingAICommand` 레코드도 `cancelOngoingCommand` 안에서만 지워지므로 남아 복원 대상이 됐다(증상 3).
+  - **복귀 갱신 지연** — `ApplicationRootViewModelImple`이 `didBecomeActive`에 30초 `throttle`을 걸고 있었다. Combine의 `throttle`은 창에 갇힌 값을 **버리지 않고 창 끝에 흘린다**(실측: 5초 창에서 t=2s 입력이 t=5s에 방출). 그래서 백그라운드 복귀가 창 안에 들어가면 `refreshProcessingJobIfNeeded`가 최대 30초 늦게 돌았다 — 복귀 직후엔 아무것도 안 보이고(증상 2), 창 끝에 뒤늦게 복원이 돌아 결과 시트가 떴다(증상 3).
+
+- **해결**:
+  - 커맨드 처리 진행 상태를 `AICommandProcessing`(`.started(jobId:)` / `.job(AIJob)`)으로 모델링하고, `processCommand`·`processConfirmCommand`·`restoreCommandifNeed`의 방출 타입을 여기로 통일했다. 생성 API 응답의 jobId가 `.started`로 먼저 나가므로 첫 조회를 기다릴 이유가 없다.
+  - `AIAgentOrchestrationUsecaseImple`이 그 초기 이벤트로 `currentProcessingJobId`를 채운다 — 진행 중 job의 소유는 원래대로 orchestration 한 곳이고, 별도 추적 상태를 만들지 않았다.
+  - `handleJobResult`가 종료(confirm 제외)·실패 completion에서 `currentProcessingJobId`를 비운다. 정상 완료 후 확인(acknowledge)에도 끝난 job에 cancel API가 나가던 문제가 여기서 함께 해소됐다.
+  - `didBecomeActive`의 throttle 제거. 진행 중 job이 없으면 이어받기가 로컬 조회로 끝나 잦은 호출의 비용이 낮다.
+
+- **남은 구멍**: 생성 API 응답이 오기 전(POST in-flight, 1~3초)에 누른 중지는 여전히 나가지 않는다. 구독이 끊기며 생성 Task가 취소돼 jobId를 못 받기 때문. 막으려면 생성을 구독 수명에서 분리해야 하는데 창이 짧아 이번엔 두지 않았다.
+
+- **기각 방향**: `throttle`의 `latest: true` 전환 — Combine에서 `latest`는 trailing 방출 여부가 아니라 갇힌 값 중 무엇을 낼지만 고르고, 이 시나리오는 갇힌 값이 하나라 동작이 동일하다 (실측 확인).
+- **기각 방향**: leading-only 상한(창 안 이벤트 폐기) — 정상 복귀가 통째로 버려져 증상이 "늦게 뜸"에서 "안 뜸"으로 바뀔 뿐이다.
+- **기각 방향**: 생성된 jobId를 가짜 `AIJob`(status pending)으로 스트림에 선방출 — 타입이 그대로라 소비자가 "조회된 job"과 구분할 수 없고, 방출 시퀀스를 검증하던 기존 테스트 10여 개가 함께 밀렸다. 별도 case로 모델링해야 구분이 타입에 드러난다.
+- **기각 방향**: `AICommandUsecaseImple`이 jobId를 자체 보관 + `cancelOngoingCommand()` 무인자화 — 진행 중 job 소유가 orchestration과 usecase 두 곳으로 갈라진다.
+- **기각 방향**: 취소 예약 상태기계(`none/creating/ongoing`) + 생성 Task 분리 — 응답에 이미 있는 jobId를 두고 별도 추적 상태를 신설하는 과설계.
+
+## 참고 — 기존 플레이키
+
+`AICommandUsecaseImpleTests`의 "실패/타임아웃 직후 `loadProcessingAICommand() == nil`"류 케이스는 `clearProcessingAICommand`가 fire-and-forget `Task`인데 테스트가 대기 없이 읽어 랜덤 실패한다. develop에서도 동일하게 재현되는 기존 문제라 이번 변경의 회귀가 아니다.

--- a/docs/troubleshooting/INDEX.md
+++ b/docs/troubleshooting/INDEX.md
@@ -6,6 +6,8 @@
 
 <!-- 레코드는 아래에 최신순으로 추가 -->
 
+- [2026-08-09 중지를 눌러도 서버에 cancel이 안 나가고, 중지한 job의 결과가 뒤늦게 뜬다](2026-08-09-ai-job-stop-not-reaching-server.md) — AIAgent / fixed / 중지 안됨, 중지 후 완료 푸시, 복귀 시 진행중 안보임, 결과 시트 뒤늦게 노출, Combine throttle 지연
+
 - [2026-08-08 run-all-tests.sh가 컴파일 실패를 PASSED로 보고한다](2026-08-08-run-all-tests-reports-compile-failure-as-passed.md) — Infra / fixed / PASSED 오보, 컴파일 에러인데 통과, TEST FAILED 미감지, Executed 0 tests
 
 - [2026-08-07 비반복 이벤트를 롱탭했는데 컨텍스트 메뉴에 "이번만 삭제"가 뜬다](2026-08-07-day-event-list-context-menu-shows-wrong-remove-action.md) — Event / fixed / 이번만 삭제 오노출, 메뉴 깜빡임, 탭 무반응, 셀 목록 재방출


### PR DESCRIPTION
close #795

## 문제

음성 커맨드 전송 직후 바텀시트에서 "중지"를 눌렀는데 (1) 잠시 뒤 처리 완료 푸시가 오고, (2) 포그라운드 복귀 시엔 진행 중 표시가 없다가, (3) 한참 뒤 중지했던 커맨드의 결과 시트가 튀어나왔다. 원인은 두 개다.

**취소가 아예 발신되지 않았다.** `AIAgentOrchestrationUsecaseImple.reset()`이 `currentProcessingJobId`가 있을 때만 취소를 요청했는데, 그 필드는 job 조회 응답이 처음 돌아올 때 채워진다. `checkJob`은 `immediateCheck: false`라 첫 조회가 폴링 주기(10초) 뒤라서, 시트가 뜬 직후 ~10초 동안 누른 중지는 통째로 무시됐다. 서버 job은 계속 돌아 완료 푸시가 왔고, 로컬 처리중 기록도 취소 경로 안에서만 지워지므로 남아 나중에 복원 대상이 됐다.

**복귀 시 갱신이 최대 30초 늦었다.** `didBecomeActive`에 30초 throttle이 걸려 있었는데, Combine의 `throttle`은 창에 갇힌 값을 버리지 않고 창 끝에 흘린다(실측: 5초 창에서 t=2s 입력이 t=5s 방출). 그래서 백그라운드 복귀가 창 안에 들어가면 복귀 직후엔 아무것도 안 보이고, 창 끝에 뒤늦게 복원이 돌아 결과 시트가 떴다. 증상 (2)와 (3)이 같은 사건의 앞뒤였다.

## 접근

**jobId는 커맨드 생성 API 응답에 이미 온다.** 조회를 기다릴 이유가 없어서, 커맨드 처리 진행 상태를 `AICommandProcessing`(`.started(jobId:)` / `.job(AIJob)`)으로 모델링하고 `processCommand`·`processConfirmCommand`·`restoreCommandifNeed`의 방출 타입을 여기로 통일했다. 세 진입점이 `waitJobUntilFinish(_:immediateCheck:)` 하나를 타면서 prepend·기록 정리 중복도 사라졌다.

**진행 중 job의 소유는 orchestration 한 곳으로 유지했다.** `AIAgentOrchestrationUsecaseImple`이 `.started` 이벤트로 기존 `currentProcessingJobId`를 채우고, 종료(confirm 제외)·실패 completion에 비운다. 별도 추적 상태를 신설하지 않았고, **정상 완료 후 확인(acknowledge)에도 끝난 job에 cancel API가 나가던 문제**가 이 해제로 함께 해소됐다.

**throttle은 제거했다.** 진행 중 job이 없으면 이어받기가 로컬 조회로 끝나(`refreshProcessingJobIfNeeded`의 상태 가드) 잦은 호출의 비용이 낮다. `latest: true` 전환은 갇힌 값이 하나라 동작이 같고, leading-only 상한은 정상 복귀를 통째로 버려 증상이 "늦게 뜸"에서 "안 뜸"으로 바뀔 뿐이라 둘 다 기각했다.

규명 과정과 기각 방향 5건은 `docs/troubleshooting/2026-08-09-ai-job-stop-not-reaching-server.md`에 남겼다.

## 검증

Domain·TodoCalendarApp 스킴 통과. 신규 TC — `.started` 선방출(커맨드·컨펌·순서) 3건, reset 경로(조회 전 중지 / 진행 중 / 종료 후) 3건.

`AICommandUsecaseImpleTests`의 "실패·타임아웃 직후 처리중 기록이 비었는지" 확인하는 케이스들은 fire-and-forget `clearProcessingAICommand`를 대기 없이 읽어 랜덤 실패한다. develop에서도 동일하게 재현되는 기존 플레이키라 이번 회귀가 아니다 — 아카이브에 메모해뒀다.

## 남은 과제

생성 API 응답이 오기 전(POST in-flight, 1~3초)에 누른 중지는 여전히 나가지 않는다. 구독이 끊기며 생성 Task가 취소돼 jobId를 못 받기 때문이다. 막으려면 생성을 구독 수명에서 분리해야 하는데 창이 짧아 이번엔 두지 않았다.

서버 cancel API가 실제로 나가는지는 stub 레벨까지만 검증했다. 실기기에서 "말하고 → 바로 중지 → 백그라운드" 동선으로 완료 푸시가 오지 않는지 QA 확인이 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166a3ZsHehJAwymxS9eUoaR