### PR TITLE
[#809] 음성 입력 중지 기준을 앱 비활성에서 백그라운드 전환으로 교체

### DIFF
--- a/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
@@ -19,6 +19,7 @@ public protocol AIAgentOrchestrationUsecase: AnyObject, Sendable {
     var usage: AnyPublisher<AIAgentUsage, Never> { get }
     var recognizingText: AnyPublisher<String, Never> { get }
     var voiceLevel: AnyPublisher<Float, Never> { get }
+    var speechPermissionDenied: AnyPublisher<Void, Never> { get }
 
     func prepare()
     func enterVoiceInput()
@@ -66,6 +67,7 @@ public final class AIAgentOrchestrationUsecaseImple: AIAgentOrchestrationUsecase
         let state = CurrentValueSubject<AIAgentState?, Never>(nil)
         let recognizingText = PassthroughSubject<String, Never>()
         let voiceLevel = PassthroughSubject<Float, Never>()
+        let speechPermissionDenied = PassthroughSubject<Void, Never>()
     }
     private let subject = Subject()
     private var commandCancellable: AnyCancellable?
@@ -203,8 +205,20 @@ extension AIAgentOrchestrationUsecaseImple {
     private func handleRecognizeEnd(_ result: Result<SpeechRecognizeResult, any Error>) {
         self.resetVoiceBinding()
         self.subject.state.send(.idle)
-        guard case .success(.recognized(let text)) = result else { return }
-        try? self.submit(text)
+        switch result {
+        case .success(.recognized(let text)):
+            try? self.submit(text)
+        case .failure(let error):
+            self.notifyIfPermissionDenied(error)
+        default:
+            break
+        }
+    }
+
+    private func notifyIfPermissionDenied(_ error: any Error) {
+        guard let authError = error as? SpeechRecognizeAuthError, authError.isDenied
+        else { return }
+        self.subject.speechPermissionDenied.send(())
     }
 
     private func resetVoiceBinding() {
@@ -414,6 +428,10 @@ extension AIAgentOrchestrationUsecaseImple {
     public var voiceLevel: AnyPublisher<Float, Never> {
         return self.subject.voiceLevel.eraseToAnyPublisher()
     }
+
+    public var speechPermissionDenied: AnyPublisher<Void, Never> {
+        return self.subject.speechPermissionDenied.eraseToAnyPublisher()
+    }
 }
 
 
@@ -438,6 +456,10 @@ public final class NotNeedAIAgentOrchestrationUsecase: AIAgentOrchestrationUseca
     }
 
     public var voiceLevel: AnyPublisher<Float, Never> {
+        return Empty(completeImmediately: false).eraseToAnyPublisher()
+    }
+
+    public var speechPermissionDenied: AnyPublisher<Void, Never> {
         return Empty(completeImmediately: false).eraseToAnyPublisher()
     }
 

--- a/Domain/Sources/Usecases/Speech/SpeechRecognizePermissionChecker.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizePermissionChecker.swift
@@ -22,6 +22,14 @@ public struct SpeechRecognizeAuthError: Error {
         self.micNotAvail = micNotAvail
         self.speechNotAvail = speechNotAvail
     }
+
+    // restricted는 유저가 설정에서 풀 수 없다 — 조치 가능한 거부만 구분한다
+    public var isDenied: Bool {
+        switch (self.micNotAvail, self.speechNotAvail) {
+        case (.denied, _), (_, .denied): return true
+        default: return false
+        }
+    }
 }
 
 

--- a/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
@@ -932,6 +932,53 @@ extension AIAgentOrchestrationUsecaseImpleTests {
         }
     }
 
+    @Test func usecase_permissionDenied_notifiesSpeechPermissionDenied() async throws {
+        // given
+        let usecase = self.makeUsecaseInIdle()
+        usecase.enterVoiceInput()
+        let expect = expectConfirm("권한 거부 안내")
+        // when
+        let notified = try await self.outputs(expect, for: usecase.speechPermissionDenied) {
+            self.stubSpeech.recognizeResultSubject.send(
+                .failure(SpeechRecognizeAuthError(micNotAvail: .denied))
+            )
+        }
+        // then
+        #expect(notified.count == 1)
+    }
+
+    @Test func usecase_permissionRestricted_doesNotNotifySpeechPermissionDenied() async throws {
+        // given
+        let usecase = self.makeUsecaseInIdle()
+        usecase.enterVoiceInput()
+        let expect = expectConfirm("제한 상태는 안내 없음")
+        expect.count = 0
+        expect.timeout = .milliseconds(100)
+        // when
+        let notified = try await self.outputs(expect, for: usecase.speechPermissionDenied) {
+            self.stubSpeech.recognizeResultSubject.send(
+                .failure(SpeechRecognizeAuthError(speechNotAvail: .restricted))
+            )
+        }
+        // then
+        #expect(notified.isEmpty)
+    }
+
+    @Test func usecase_recognizeFailedWithoutPermissionIssue_doesNotNotifySpeechPermissionDenied() async throws {
+        // given
+        let usecase = self.makeUsecaseInIdle()
+        usecase.enterVoiceInput()
+        let expect = expectConfirm("일반 실패는 안내 없음")
+        expect.count = 0
+        expect.timeout = .milliseconds(100)
+        // when
+        let notified = try await self.outputs(expect, for: usecase.speechPermissionDenied) {
+            self.stubSpeech.recognizeResultSubject.send(.failure(RuntimeError("speech fail")))
+        }
+        // then
+        #expect(notified.isEmpty)
+    }
+
     // 일반 인식 실패 → state.idle
     @Test func usecase_recognizeFailed_stateBecomesIdle() async throws {
         // given

--- a/Presentations/AIAgentScene/Tests/Doubles/StubAIAgentOrchestrationUsecase.swift
+++ b/Presentations/AIAgentScene/Tests/Doubles/StubAIAgentOrchestrationUsecase.swift
@@ -18,6 +18,7 @@ final class StubAIAgentOrchestrationUsecase: AIAgentOrchestrationUsecase, @unche
     let usageSubject = CurrentValueSubject<AIAgentUsage, Never>(.init(input: 0, output: 0, limit: 0))
     let recognizingTextSubject = PassthroughSubject<String, Never>()
     let voiceLevelSubject = PassthroughSubject<Float, Never>()
+    let speechPermissionDeniedSubject = PassthroughSubject<Void, Never>()
     private(set) var didPrepare = false
     private(set) var didEnterVoiceInput = false
     private(set) var didFinishVoiceInput = false
@@ -74,5 +75,8 @@ final class StubAIAgentOrchestrationUsecase: AIAgentOrchestrationUsecase, @unche
     }
     var voiceLevel: AnyPublisher<Float, Never> {
         self.voiceLevelSubject.eraseToAnyPublisher()
+    }
+    var speechPermissionDenied: AnyPublisher<Void, Never> {
+        self.speechPermissionDeniedSubject.eraseToAnyPublisher()
     }
 }

--- a/Presentations/CalendarScenes/CLAUDE.md
+++ b/Presentations/CalendarScenes/CLAUDE.md
@@ -137,6 +137,7 @@ graph LR
 |---|---|---|
 | `EventListCellView` (`Common/EventListCell/`) | 모든 이벤트(할일/일정/휴일/구글)를 렌더링하는 이벤트 셀 공용 뷰 — 완료 처리·상세 이동·more 액션 콜백 포함. 동반 UI 모델 `EventCellViewModel` 프로토콜도 공유 | DayEventListView, ForemostEventView, UncompletedTodoView |
 | `Common/AIAgentSignInConfirm` | AI 기능 미로그인 시 로그인 유도 confirm 다이얼로그 팩토리 (`ConfirmDialogInfo.aiAgentNeedSignIn`, DayEventList·Calendar VM 공유, #768) | DayEventListViewModelImple, CalendarViewModelImple |
+| `Common/AIAgentSpeechPermissionConfirm` | 마이크·음성인식 권한 거부 시 설정 이동 confirm 다이얼로그 팩토리 (`ConfirmDialogInfo.aiAgentSpeechPermissionDenied`, #809) | CalendarViewModelImple |
 
 주의: `ForemostEventView`·`UncompletedTodoView`는 `CalendarPaper/` 폴더에 있으나 실제 소비는 `DayEventList/` — 배치·사용처 불일치 알려짐 (#659 리스트업 16번 메모).
 

--- a/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
@@ -277,6 +277,19 @@ final class CalendarViewModelImple: CalendarViewModel, @unchecked Sendable {
                 self?.aiAgentOrchestrationUsecase.stopInput()
             })
             .store(in: &self.cancellables)
+
+        self.aiAgentOrchestrationUsecase.speechPermissionDenied
+            .sink(receiveValue: { [weak self] _ in
+                self?.showSpeechPermissionSettingGuide()
+            })
+            .store(in: &self.cancellables)
+    }
+
+    private func showSpeechPermissionSettingGuide() {
+        let info = ConfirmDialogInfo.aiAgentSpeechPermissionDenied { [weak self] in
+            self?.router?.openSystemSetting()
+        }
+        self.router?.showConfirm(dialog: info)
     }
 
     private static func isVoiceListeningPhase(_ state: AIAgentState) -> Bool {

--- a/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
@@ -267,12 +267,10 @@ final class CalendarViewModelImple: CalendarViewModel, @unchecked Sendable {
         .store(in: &self.cancellables)
     }
 
-    // 앱이 가려지면(제어센터·앱 스위처·시스템 다이얼로그 포함) 오디오 세션이 끊겨 계속 들을 수 없다.
-    // 듣던 중이면 입력 자체를 접는다 — 키보드 입력은 오디오와 무관하므로 건드리지 않는다.
     private func bindVoiceInputLifecycle() {
 
         NotificationCenter.default
-            .publisher(for: UIApplication.willResignActiveNotification)
+            .publisher(for: UIApplication.didEnterBackgroundNotification)
             .withLatestFrom(self.aiAgentOrchestrationUsecase.state) { $1 }
             .filter { Self.isVoiceListeningPhase($0) }
             .sink(receiveValue: { [weak self] _ in

--- a/Presentations/CalendarScenes/Sources/CalendarViewRouter.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewRouter.swift
@@ -5,7 +5,7 @@
 //  Created by sudo.park on 2023/06/30.
 //
 
-import Foundation
+import UIKit
 import Domain
 import Scenes
 
@@ -20,6 +20,8 @@ protocol CalendarViewRouting: Routing, Sendable {
     func routeToAICommand()
 
     func routeToSignIn()
+
+    func openSystemSetting()
 }
 
 final class CalendarViewRouterImple: BaseRouterImple, CalendarViewRouting, @unchecked Sendable {
@@ -78,6 +80,15 @@ final class CalendarViewRouterImple: BaseRouterImple, CalendarViewRouting, @unch
         Task { @MainActor in
             let next = self.memberSceneBuilder.makeSignInScene()
             self.showBottomSlide(next)
+        }
+    }
+
+    func openSystemSetting() {
+        Task { @MainActor in
+            guard let url = URL(string: UIApplication.openSettingsURLString),
+                  UIApplication.shared.canOpenURL(url)
+            else { return }
+            UIApplication.shared.open(url)
         }
     }
 }

--- a/Presentations/CalendarScenes/Sources/Common/AIAgentSpeechPermissionConfirm.swift
+++ b/Presentations/CalendarScenes/Sources/Common/AIAgentSpeechPermissionConfirm.swift
@@ -1,0 +1,27 @@
+//
+//  AIAgentSpeechPermissionConfirm.swift
+//  CalendarScenes
+//
+//  Created by sudo.park on 8/9/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Prelude
+import Optics
+import Scenes
+import Extensions
+
+
+extension ConfirmDialogInfo {
+
+    static func aiAgentSpeechPermissionDenied(
+        confirmed: @escaping () -> Void
+    ) -> ConfirmDialogInfo {
+        return ConfirmDialogInfo()
+            |> \.title .~ "aiAgent::speechPermissionDenied::title".localized()
+            |> \.message .~ "aiAgent::speechPermissionDenied::message".localized()
+            |> \.confirmText .~ "aiAgent::speechPermissionDenied::confirm".localized()
+            |> \.confirmed .~ confirmed
+    }
+}

--- a/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
@@ -1240,6 +1240,11 @@ private extension CalendarViewModelImpleTests {
         func routeToSignIn() {
             self.didRouteToSignIn = true
         }
+
+        var didOpenSystemSetting: Bool?
+        func openSystemSetting() {
+            self.didOpenSystemSetting = true
+        }
     }
     
     class SpyPaperInteractor: CalendarPaperSceneInteractor, @unchecked Sendable {
@@ -1499,6 +1504,28 @@ extension CalendarViewModelImpleTests {
 
         // then
         XCTAssertNil(self.stubOrchestration.didStopInput)
+    }
+
+    private func makePreparedViewModel() async throws -> CalendarViewModelImple {
+        FeatureFlag.enable(.aiAgent)
+        let viewModel = self.makeViewModel()
+        viewModel.prepare()
+        try await Task.sleep(for: .milliseconds(50))
+        return viewModel
+    }
+
+    func testViewModel_whenSpeechPermissionDenied_showsSettingGuide() async throws {
+        // given
+        let viewModel = try await self.makePreparedViewModel()
+
+        // when
+        self.stubOrchestration.speechPermissionDeniedSubject.send(())
+        try await Task.sleep(for: .milliseconds(50))
+
+        // then
+        XCTAssertNotNil(self.spyRouter.didShowConfirmWith)
+        XCTAssertEqual(self.spyRouter.didOpenSystemSetting, true)
+        withExtendedLifetime(viewModel) { }
     }
 }
 

--- a/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
@@ -1426,11 +1426,12 @@ private extension CalendarViewModelImpleTests {
     }
 }
 
-// MARK: - 앱 비활성과 음성 입력
+// MARK: - 앱 백그라운드 전환과 음성 입력
 
 extension CalendarViewModelImpleTests {
 
-    private func resignActiveAfterPrepared(
+    private func postAppLifecycleAfterPrepared(
+        _ notificationName: Notification.Name,
         aiAgentEnabled: Bool = true,
         state: AIAgentState?
     ) async throws {
@@ -1440,34 +1441,41 @@ extension CalendarViewModelImpleTests {
         try await Task.sleep(for: .milliseconds(50))
         state.map { self.stubOrchestration.stateSubject.send($0) }
 
-        NotificationCenter.default.post(
-            name: UIApplication.willResignActiveNotification, object: nil
-        )
+        NotificationCenter.default.post(name: notificationName, object: nil)
         try await Task.sleep(for: .milliseconds(50))
         // VM이 해제되면 구독도 끊겨 단언이 무의미해진다
         withExtendedLifetime(viewModel) { }
     }
 
-    func testViewModel_whenAppResignsActiveWhileVoiceListening_stopsInput() async throws {
+    private func enterBackgroundAfterPrepared(
+        aiAgentEnabled: Bool = true,
+        state: AIAgentState?
+    ) async throws {
+        try await self.postAppLifecycleAfterPrepared(
+            UIApplication.didEnterBackgroundNotification,
+            aiAgentEnabled: aiAgentEnabled, state: state
+        )
+    }
+
+    func testViewModel_whenAppEntersBackgroundWhileVoiceListening_stopsInput() async throws {
         // given, when
-        try await self.resignActiveAfterPrepared(state: .listening(.voice))
+        try await self.enterBackgroundAfterPrepared(state: .listening(.voice))
 
         // then
         XCTAssertEqual(self.stubOrchestration.didStopInput, true)
     }
 
-    // 키보드 입력은 오디오와 무관하므로 앱이 비활성이 돼도 유지된다
-    func testViewModel_whenAppResignsActiveWhileKeyboardListening_keepsInput() async throws {
+    func testViewModel_whenAppEntersBackgroundWhileKeyboardListening_keepsInput() async throws {
         // given, when
-        try await self.resignActiveAfterPrepared(state: .listening(.keyboard))
+        try await self.enterBackgroundAfterPrepared(state: .listening(.keyboard))
 
         // then
         XCTAssertNil(self.stubOrchestration.didStopInput)
     }
 
-    func testViewModel_whenAppResignsActiveWhileIdle_keepsInput() async throws {
+    func testViewModel_whenAppEntersBackgroundWhileIdle_keepsInput() async throws {
         // given, when
-        try await self.resignActiveAfterPrepared(state: .idle)
+        try await self.enterBackgroundAfterPrepared(state: .idle)
 
         // then
         XCTAssertNil(self.stubOrchestration.didStopInput)
@@ -1475,8 +1483,18 @@ extension CalendarViewModelImpleTests {
 
     func testViewModel_whenAIAgentFlagOff_doesNotStopInput() async throws {
         // given, when
-        try await self.resignActiveAfterPrepared(
+        try await self.enterBackgroundAfterPrepared(
             aiAgentEnabled: false, state: .listening(.voice)
+        )
+
+        // then
+        XCTAssertNil(self.stubOrchestration.didStopInput)
+    }
+
+    func testViewModel_whenAppResignsActiveWhileVoiceListening_keepsInput() async throws {
+        // given, when
+        try await self.postAppLifecycleAfterPrepared(
+            UIApplication.willResignActiveNotification, state: .listening(.voice)
         )
 
         // then

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -551,6 +551,9 @@
 "aiAgent::retry" = "Retry";
 "aiAgent::needSignIn::title" = "Sign in required";
 "aiAgent::needSignIn::message" = "Sign in to use AI quick input.";
+"aiAgent::speechPermissionDenied::title" = "Permission required";
+"aiAgent::speechPermissionDenied::message" = "Allow microphone and speech recognition access in Settings to use voice input.";
+"aiAgent::speechPermissionDenied::confirm" = "Open Settings";
 "aiAgent::title" = "AI Quick Input";
 "aiAgent::keyboard::stop" = "Stop";
 "aiAgent::keyboard::send" = "Send";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -551,6 +551,9 @@
 "aiAgent::retry" = "다시";
 "aiAgent::needSignIn::title" = "로그인이 필요해요";
 "aiAgent::needSignIn::message" = "AI 빠른 입력은 로그인 후 이용할 수 있어요.";
+"aiAgent::speechPermissionDenied::title" = "권한이 필요해요";
+"aiAgent::speechPermissionDenied::message" = "음성 입력을 쓰려면 설정에서 마이크와 음성 인식 권한을 허용해 주세요.";
+"aiAgent::speechPermissionDenied::confirm" = "설정 열기";
 "aiAgent::title" = "AI 빠른 입력";
 "aiAgent::keyboard::stop" = "중지";
 "aiAgent::keyboard::send" = "전송";

--- a/Supports/TestDoubles/Sources/Usecases/StubAIAgentOrchestrationUsecase.swift
+++ b/Supports/TestDoubles/Sources/Usecases/StubAIAgentOrchestrationUsecase.swift
@@ -14,6 +14,7 @@ public final class StubAIAgentOrchestrationUsecase: AIAgentOrchestrationUsecase,
     public let usageSubject = CurrentValueSubject<AIAgentUsage, Never>(.init(input: 0, output: 0, limit: 0))
     public let recognizingTextSubject = PassthroughSubject<String, Never>()
     public let voiceLevelSubject = PassthroughSubject<Float, Never>()
+    public let speechPermissionDeniedSubject = PassthroughSubject<Void, Never>()
     public private(set) var didPrepare: Bool?
     public private(set) var didEnterVoiceInput: Bool?
     public private(set) var didFinishVoiceInput: Bool?
@@ -61,5 +62,8 @@ public final class StubAIAgentOrchestrationUsecase: AIAgentOrchestrationUsecase,
     }
     public var voiceLevel: AnyPublisher<Float, Never> {
         self.voiceLevelSubject.eraseToAnyPublisher()
+    }
+    public var speechPermissionDenied: AnyPublisher<Void, Never> {
+        self.speechPermissionDeniedSubject.eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
마이크·음성인식 권한이 `notDetermined`인 상태에서 AI 음성 입력 버튼을 누르면, 권한을 허용해도 인식이 시작되지 않고 버튼을 한 번 더 눌러야 했다.

## 문제

시스템 권한 알럿이 뜨는 순간 `willResignActive`가 발생한다. `bindVoiceInputLifecycle`은 이 알림을 받아 `.listening(.voice)`면 입력을 접었고(#783), 그 중지가 권한 대기 중이던 in-flight 시작 Task를 취소했다(#799). 유저가 허용해 Task가 깨어나도 이미 취소된 뒤라 마이크가 켜지지 않았다.

거부했을 때도 문제가 있었다. 실패가 `recognizeResult`로 흘러 오케스트레이션이 `.idle`로 접기만 해서, 유저는 왜 음성 입력이 안 되는지 알 수 없었다.

## 접근

**중지 기준을 비활성이 아니라 백그라운드 전환으로 잡았다.** #783의 전제는 "앱이 가려지면 오디오 세션이 끊긴다"였는데, 권한 알럿과 제어센터는 앱을 비활성으로만 만들 뿐 세션을 끊지 않는다. 실제로 세션이 끊기는 건 백그라운드로 내려갈 때다. 시리처럼 오디오를 선점하는 경로는 이 리스너의 몫이 아니다 — `SpeechRecognizeServiceImple.observeAudioDisruption()`이 `AVAudioSession.interruptionNotification`을 관측해 이미 접고 있다(이어폰 분리·미디어 서비스 리셋도 함께).

상태 선언 시점을 늦추거나(`enterVoiceInput`이 권한 획득을 await) 권한 대기 플래그를 두는 대안도 검토했으나, 잘못된 트리거를 그대로 두고 우회하는 형태라 택하지 않았다.

**거부는 설정 이동 안내로 이어지게 했다.** 인식 종료 실패가 권한 거부일 때만 오케스트레이션이 전용 신호를 방출하고, 루트 VM이 그걸 받아 confirm을 띄운다. 설정에서 되돌릴 수 없는 `restricted`는 안내 대상에서 뺐다. 구독을 `DayEventListViewModelImple`이 아니라 루트 VM에 둔 건, 전자가 CalendarPaper마다 하나씩 살아 있어 다이얼로그가 여러 번 뜨기 때문이다.

## 검증

권한 리셋 후 실기기·시뮬레이터 수동 확인이 필요하다 — 알럿이 만드는 `willResignActive`는 유닛 테스트로 재현되지 않는다.

- 마이크·음성인식 둘 다 `notDetermined` → 버튼 1회 → 알럿 둘 다 허용 → 인식이 바로 시작
- 하나라도 거부 → `.idle`로 접히며 설정 이동 안내가 뜨고, 확인 시 설정 앱으로 이동
- 인식 중 앱 스위처·홈으로 이탈 → 중지 (#783 동작 유지)
- 인식 중 시리 호출 → 인터럽션으로 종료

en/ko 외 29개 언어 번역은 #810 대기 목록에 등록했다.

Closes #809
