### PR TITLE
[#736] 반복 할일 업로드 시 회차 유실로 count 종료가 안 되던 문제 수정

### DIFF
--- a/Repository/Sources/Repository+Imple/Event/Todo/Remote/Todo+Mapping.swift
+++ b/Repository/Sources/Repository+Imple/Event/Todo/Remote/Todo+Mapping.swift
@@ -294,6 +294,7 @@ struct RevertToggleTodoDoneParameter {
             .map { $0.asJson() }
         originPayload[Key.repeating.rawValue] = self.origin.repeating.map { EventRepeatingMapper(repeating: $0) }
             .map { $0.asJson() }
+        originPayload[Key.repeatingTurn.rawValue] = self.origin.repeatingTurn
         originPayload[Key.notificationOptions.rawValue] = self.origin.notificationOptions
             .map { EventNotificationTimeOptionMapper(option: $0) }
             .map { try? $0.asJson() }

--- a/Repository/Sources/Repository+Imple/Event/Upload/EventUploadServiceImple.swift
+++ b/Repository/Sources/Repository+Imple/Event/Upload/EventUploadServiceImple.swift
@@ -162,6 +162,7 @@ extension EventUploadServiceImple {
             |> \.eventTagId .~ todo.eventTagId
             |> \.time .~ todo.time
             |> \.repeating .~ todo.repeating
+            |> \.repeatingTurn .~ todo.repeatingTurn
             |> \.notificationOptions .~ todo.notificationOptions
         _ = try await self.todoRemote.updateTodoEvent(todoId, params)
     }

--- a/Repository/Sources/Repository+Imple/Setting/Migration/Migration+Mapping.swift
+++ b/Repository/Sources/Repository+Imple/Setting/Migration/Migration+Mapping.swift
@@ -49,6 +49,7 @@ struct BatchTodoEventPayload {
                 |> \.notificationOptions .~ pure(todo.notificationOptions)
             var payload = params.asJson()
             payload[TodoCodingKeys.createTime.rawValue] = todo.creatTimeStamp
+            payload[TodoCodingKeys.repeatingTurn.rawValue] = todo.repeatingTurn
             acc[todo.uuid] = payload
         }
     }

--- a/Repository/Tests/Event/Todo/TodoRemoteRepositoryImpleTests.swift
+++ b/Repository/Tests/Event/Todo/TodoRemoteRepositoryImpleTests.swift
@@ -722,6 +722,32 @@ extension TodoRemoteRepositoryImpleTests {
         )
     }
     
+    // toggle revert -> origin의 반복 회차도 함께 전송
+    func testRepository_whenRevertToggleRepeatingTodo_sendRepeatingTurn() async throws {
+        // given
+        let todoId = "origin"
+        let origin = TodoEvent(uuid: todoId, name: "origin")
+            |> \.time .~ .at(100)
+            |> \.repeating .~ pure(
+                EventRepeating(
+                    repeatingStartTime: 100,
+                    repeatOption: EventRepeatingOptions.EveryDay()
+                )
+                |> \.repeatingEndOption .~ .count(10)
+            )
+            |> \.repeatingTurn .~ 4
+        let repository = try await self.makeRepositoryWithUpdateToggleState(
+            todoId, .completing(origin: origin)
+        )
+
+        // when
+        let _ = try await repository.toggleTodo(todoId)
+
+        // then
+        let originPayload = self.stubRemote.didRequestedParams?["origin"] as? [String: Any]
+        XCTAssertEqual(originPayload?["repeating_turn"] as? Int, 4)
+    }
+
     // toggle -> reverting시에는 아무것도 안함
     func testRepository_whenToggleTodoIsRevertingAndToggleRequested_doNothing() async throws {
         // given

--- a/Repository/Tests/Event/Upload/EventUploadServiceImpleTests.swift
+++ b/Repository/Tests/Event/Upload/EventUploadServiceImpleTests.swift
@@ -9,6 +9,8 @@
 import Testing
 import SQLiteService
 import Combine
+import Prelude
+import Optics
 import Domain
 import Extensions
 import UnitTestHelpKit
@@ -45,8 +47,19 @@ final class EventUploadServiceImpleTests: LocalTestable {
         ])
         
         let todoLocal = TodoLocalStorageImple(sqliteService: self.sqliteService)
+        let repeatingTodo = TodoEvent(uuid: "repeating-todo", name: "name")
+            |> \.time .~ .at(100)
+            |> \.repeating .~ pure(
+                EventRepeating(
+                    repeatingStartTime: 100,
+                    repeatOption: EventRepeatingOptions.EveryDay()
+                )
+                |> \.repeatingEndOption .~ .count(10)
+            )
+            |> \.repeatingTurn .~ 4
         try await todoLocal.updateTodoEvents([
-            .init(uuid: "todo", name: "name")
+            .init(uuid: "todo", name: "name"),
+            repeatingTodo
         ])
         let done = DoneTodoEvent(uuid: "done", name: "name", originEventId: "origin", doneTime: Date())
         try await todoLocal.saveDoneTodoEvent(done)
@@ -361,7 +374,25 @@ extension EventUploadServiceImpleTests {
             #expect(self.spyRemote.didEditTodoIds == ["todo"])
         }
     }
-    
+
+    // uploading task - update repeating todo: 반복 회차도 함께 업로드
+    @Test func service_updateRepeatingTodo_uploadRepeatingTurn() async throws {
+        try await self.runTestWithOpenClose("upload_tc13_todo_turn") {
+            // given
+            let service = try await self.makeService(with: [
+                .init(timestamp: 100, dataType: .todo, uuid: "repeating-todo", isRemovingTask: false)
+            ])
+
+            // when
+            try await service.resume()
+            try await service.waitUntilUploadingEnd()
+
+            // then
+            #expect(self.spyRemote.didEditTodoIds == ["repeating-todo"])
+            #expect(self.spyRemote.didEditTodoParams?.repeatingTurn == 4)
+        }
+    }
+
     // uploading task - delete schedule
     @Test func service_deleteSchedule() async throws {
         try await self.runTestWithOpenClose("upload_tc14_sc") {
@@ -487,6 +518,7 @@ private final class PrivateStubRemote: @unchecked Sendable {
     var didEditTagIds: [String] = []
     var didRemoveTodoIds: [String] = []
     var didEditTodoIds: [String] = []
+    var didEditTodoParams: TodoEditParams?
     var didRemoveScheduleIds: [String] = []
     var didEditScheduleIds: [String] = []
     var didEditEventDetailIds: [String] = []
@@ -531,6 +563,7 @@ extension PrivateStubRemote: TodoRemote {
     func updateTodoEvent(_ eventId: String, _ params: TodoEditParams) async throws -> TodoEvent {
         self.deleteOrUpdateIds.append(eventId)
         self.didEditTodoIds.append(eventId)
+        self.didEditTodoParams = params
         return .init(uuid: eventId, name: params.name ?? "")
     }
     

--- a/Repository/Tests/Setting/TemporaryUserDataMigrationRepositoryImpleTests.swift
+++ b/Repository/Tests/Setting/TemporaryUserDataMigrationRepositoryImpleTests.swift
@@ -66,7 +66,8 @@ class TemporaryUserDataMigrationRepositoryImpleTests: BaseLocalTests {
             |> \.repeating .~ pure(self.dummyRepeating)
             |> \.notificationOptions .~ self.dummyNotificationOptions
             |> \.creatTimeStamp .~ 100
-        
+            |> \.repeatingTurn .~ 4
+
         let todo2 = TodoEvent(uuid: "todo2", name: "todo2")
             |> \.eventTagId .~ .custom("t2")
             |> \.creatTimeStamp .~ 200
@@ -155,6 +156,19 @@ extension TemporaryUserDataMigrationRepositoryImpleTests {
         XCTAssertEqual(createTimestamps, [
             "todo1": 100, "todo2": 200
         ])
+    }
+
+    // 반복 할일 이관시 회차도 함께 전송
+    func testRepository_whenMigrateRepeatingTodo_uploadRepeatingTurn() async throws {
+        // given
+        let repository = try await self.makeRepository()
+
+        // when
+        try await repository.migrateTodoEvents()
+
+        // then
+        let todo1Payload = self.stubRemote.didRequestedParams?["todo1"] as? [String: Any]
+        XCTAssertEqual(todo1Payload?["repeating_turn"] as? Int, 4)
     }
     
     func testRepository_migrationScheduleEvents() async throws {

--- a/docs/troubleshooting/2026-08-09-repeating-todo-count-end-not-working.md
+++ b/docs/troubleshooting/2026-08-09-repeating-todo-count-end-not-working.md
@@ -1,0 +1,16 @@
+---
+issue: "#736"
+subdomain: Event
+symptoms: [반복 todo count 종료 안됨, 종료조건 n회 초과 반복, repeatingTurn 유실, 업로드 후 turn 리셋]
+resolution: fixed
+---
+
+# 종료조건이 n회인 반복 할일이 n회를 훌쩍 넘겨서까지 반복된다
+
+- **증상**: 로그인 상태에서 `.count(10)` 반복 할일이 10회를 넘겨 30회 가까이 반복되다 종료됨. 완료·스킵·이번만 삭제·이번만 수정 중 무엇으로 회차를 넘겨도 동일.
+
+- **근본 원인**: `EventUploadServiceImple.uploadTodoEvent`가 로컬 할일을 서버로 올릴 때 `repeatingTurn`을 페이로드에서 빠뜨렸다. 이 업로드는 `TodoEditParams(.put)` = HTTP PUT(전체 교체)이라 서버의 `repeating_turn`이 비워진다. 이후 sync가 서버 우선(Last-Write-Wins)으로 로컬을 덮으면서(`EventSyncRepositoryImple.updateCreatedOrUpdated` → `updateTodoEvents`는 `shouldReplace: true`) 로컬 turn까지 nil이 되고, `origin.repeatingTurn ?? 1`이 turn 1로 되돌린다. 로컬 turn 전진(`TodoLocalRepositoryImple.replaceTodoNextEventTimeIfIsRepeating`)은 정상이었고, sync가 끼지 않은 구간에서만 회차가 누적돼 종료 시점이 들쭉날쭉했다.
+
+- **해결**: `uploadTodoEvent` 페이로드에 `repeatingTurn`을 실었다. 바로 옆 `uploadScheduleEvent`가 일정의 반복 장부(`showTurn`·`repeatingTimeToExcludes`)를 이미 그대로 올리고 있어 규약 복원에 가깝다. 회귀 테스트는 `EventUploadServiceImpleTests.service_updateRepeatingTodo_uploadRepeatingTurn`.
+
+- **기각 방향**: sync 반영 시 서버 turn이 nil이면 로컬 turn 유지 — 서버 값은 계속 비어 있어 기기 교체·재설치에서 재발하는 증상 패치.

--- a/docs/troubleshooting/2026-08-09-repeating-todo-count-end-not-working.md
+++ b/docs/troubleshooting/2026-08-09-repeating-todo-count-end-not-working.md
@@ -13,4 +13,6 @@ resolution: fixed
 
 - **해결**: `uploadTodoEvent` 페이로드에 `repeatingTurn`을 실었다. 바로 옆 `uploadScheduleEvent`가 일정의 반복 장부(`showTurn`·`repeatingTimeToExcludes`)를 이미 그대로 올리고 있어 규약 복원에 가깝다. 회귀 테스트는 `EventUploadServiceImpleTests.service_updateRepeatingTodo_uploadRepeatingTurn`.
 
+  같은 누락이 서버로 나가는 페이로드 두 곳에 더 있어 함께 실었다 — `BatchTodoEventPayload.asJson`(비로그인 로컬 데이터의 로그인 시 이관)과 `RevertToggleTodoDoneParameter.asJson`(위젯 토글 되돌리기의 origin). 단 후자는 origin이 `PendingDoneTodoEventTable`에서 복원되는데 그 테이블에 `repeating_turn` 컬럼이 없어, 해당 컬럼이 생기기 전까지 실리는 값은 항상 nil이다 (#835 항목 2).
+
 - **기각 방향**: sync 반영 시 서버 turn이 nil이면 로컬 turn 유지 — 서버 값은 계속 비어 있어 기기 교체·재설치에서 재발하는 증상 패치.

--- a/docs/troubleshooting/INDEX.md
+++ b/docs/troubleshooting/INDEX.md
@@ -6,6 +6,8 @@
 
 <!-- 레코드는 아래에 최신순으로 추가 -->
 
+- [2026-08-09 종료조건이 n회인 반복 할일이 n회를 훌쩍 넘겨서까지 반복된다](2026-08-09-repeating-todo-count-end-not-working.md) — Event / fixed / 반복 todo count 종료 안됨, 종료조건 n회 초과 반복, repeatingTurn 유실, 업로드 후 turn 리셋
+
 - [2026-08-09 중지를 눌러도 서버에 cancel이 안 나가고, 중지한 job의 결과가 뒤늦게 뜬다](2026-08-09-ai-job-stop-not-reaching-server.md) — AIAgent / fixed / 중지 안됨, 중지 후 완료 푸시, 복귀 시 진행중 안보임, 결과 시트 뒤늦게 노출, Combine throttle 지연
 
 - [2026-08-08 run-all-tests.sh가 컴파일 실패를 PASSED로 보고한다](2026-08-08-run-all-tests-reports-compile-failure-as-passed.md) — Infra / fixed / PASSED 오보, 컴파일 에러인데 통과, TEST FAILED 미감지, Executed 0 tests


### PR DESCRIPTION
## 문제

종료조건이 `.count(n)`인 반복 할일이 n회를 훌쩍 넘겨서까지 반복되다 뒤늦게 종료됐다 (#736 — 10회 설정이 30회 가까이).

할일은 일정과 달리 시리즈를 전개하지 않고 **현재 회차 하나만** 들고 전진한다. 회차는 `TodoEvent.repeatingTurn`(DB `repeating_turn` 컬럼)에 저장되고, 저장된 값이 없으면 `origin.repeatingTurn ?? 1`로 1회차 취급된다 — 시작 시각에서 몇 번째인지 역산하는 경로가 없어서, 이 값이 유실되면 복구되지 않는다.

`EventUploadServiceImple.uploadTodoEvent`가 로컬 할일을 서버로 올릴 때 이 회차만 페이로드에서 빠뜨리고 있었다. 이 업로드는 `TodoEditParams(.put)` = 전체 교체라 서버의 `repeating_turn`이 비워지고, 서버 우선(Last-Write-Wins) sync가 로컬을 통째로 덮으면서(`updateTodoEvents`는 `shouldReplace: true`) 로컬 회차까지 1로 되돌아갔다. 회차 전진 자체는 정상이었고, sync가 끼지 않은 구간에서만 누적돼 종료 시점이 들쭉날쭉했다.

이슈에 적힌 "이번만 삭제"가 트리거는 아니다 — 완료·건너뛰기·이번만 수정 등 회차를 전진시키는 모든 액션이 같은 업로드 경로를 탄다.

## 접근

업로드 페이로드에 `repeatingTurn`을 실었다. 로컬 상태를 온전히 올리면 sync가 덮어써도 같은 값이라, 유실 자체가 생기지 않는다. 바로 옆 `uploadScheduleEvent`가 일정의 반복 장부(`showTurn`·`repeatingTimeToExcludes`)를 이미 그대로 올리고 있어 규약 복원에 가깝다.

sync 반영 시 서버 회차가 nil이면 로컬 값을 유지하는 방향은 기각했다 — 서버 값은 계속 비어 있어 기기 교체·재설치에서 재발하는 증상 패치다.

회귀 테스트는 반복·회차를 가진 할일 픽스처를 올려 업로드 파라미터에 회차가 실리는지 검증한다. 수정 전 RED(`repeatingTurn → nil`) 확인 후 GREEN.

규명 기록: `docs/troubleshooting/2026-08-09-repeating-todo-count-end-not-working.md`

## 확인 필요

서버 PUT 핸들러가 `repeating_turn`을 저장하는지. 이미 PATCH 경로(`skipRepeatingTodo`·`replaceCurrentTodoToNext`)가 같은 필드에 의존하고 있어 PUT도 읽을 것으로 보지만, 서버 레포에서 확인이 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsSsa2VygKArMgxVgAzvdd
