### PR TITLE
[#782] AI command 크레딧 소진 시 클라이언트 사전 차단

### DIFF
--- a/Domain/Sources/Models/AI/AIAgentUsage.swift
+++ b/Domain/Sources/Models/AI/AIAgentUsage.swift
@@ -47,6 +47,13 @@ public extension AIAgentUsage {
         guard self.dailyLimit > 0 else { return 0 }
         return min(Double(self.usedCredits) / Double(self.dailyLimit), 1.0)
     }
+
+    // 일일 한도와 top-up 은 합산하지 않는다 — topupRemaining 은 이미 차감된 잔량이라
+    // usedCredits 와 더하면 초과분이 이중 반영된다.
+    func isCreditExhausted(topupRemaining: Int?) -> Bool {
+        guard let topupRemaining else { return false }
+        return self.isLimitExceeded && topupRemaining <= 0
+    }
 }
 
 
@@ -62,5 +69,13 @@ public struct AIAgentUsageLoadResult: Sendable {
     public init(usage: AIAgentUsage, userPlan: BillingUserPlan?) {
         self.usage = usage
         self.userPlan = userPlan
+    }
+}
+
+
+public extension AIAgentUsageLoadResult {
+
+    var isCreditExhausted: Bool {
+        return self.usage.isCreditExhausted(topupRemaining: self.userPlan?.topupRemaining)
     }
 }

--- a/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
@@ -250,6 +250,10 @@ extension AIAgentOrchestrationUsecaseImple {
         guard self.canSubmit else {
             throw RuntimeError(key: "AIAgent.busy", "already processing a command")
         }
+        guard !self.usageUsecase.isCreditExhausted() else {
+            self.notifyCreditExhausted(command: trimmed)
+            return
+        }
         self.subject.state.send(.processing(command: trimmed))
         self.startProcessing(self.commandUsecase.processCommand(trimmed))
     }
@@ -270,6 +274,11 @@ extension AIAgentOrchestrationUsecaseImple {
         guard self.canSubmit
         else { throw AIImageCommandSubmitFailReason.busy }
 
+        guard !self.usageUsecase.isCreditExhausted() else {
+            self.notifyCreditExhausted(command: trimmed)
+            return
+        }
+
         self.subject.state.send(.processing(command: trimmed))
         self.startProcessing(
             self.commandUsecase.processInterpretCommand(
@@ -285,6 +294,14 @@ extension AIAgentOrchestrationUsecaseImple {
         case .none, .idle, .listening: return true
         default: return false
         }
+    }
+
+    // throw 대신 상태 방출인 이유는 음성 경로가 submit 에러를 삼키기 때문 (try?).
+    private func notifyCreditExhausted(command: String) {
+        self.subject.state.send(
+            .failed(command: command, reason: nil, errorCode: .dailyLimitExceeded)
+        )
+        self.usageUsecase.refresh()
     }
 
     private var canSubmit: Bool {

--- a/Domain/Sources/Usecases/AI/AIAgentUsageUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentUsageUsecase.swift
@@ -12,10 +12,11 @@ import AsyncFlatMap
 
 
 public protocol AIAgentUsageUsecase: AnyObject {
-    
+
     func refresh()
     func loadUsage() async throws -> AIAgentUsage
-    
+    func isCreditExhausted() -> Bool
+
     var currentUsage: AnyPublisher<AIAgentUsage, Never> { get }
 }
 
@@ -90,5 +91,15 @@ extension AIAgentUsageUsecaseImple {
         )
         .compactMap { $0 }
         .eraseToAnyPublisher()
+    }
+
+    public func isCreditExhausted() -> Bool {
+        guard let usage = self.sharedDataStore.value(
+            AIAgentUsage.self, key: ShareDataKeys.aiAgentUsage.rawValue
+        ) else { return false }
+        let userPlan = self.sharedDataStore.value(
+            BillingUserPlan.self, key: ShareDataKeys.billingUserPlan.rawValue
+        )
+        return usage.isCreditExhausted(topupRemaining: userPlan?.topupRemaining)
     }
 }

--- a/Domain/Tests/Models/AI/AIAgentUsageTests.swift
+++ b/Domain/Tests/Models/AI/AIAgentUsageTests.swift
@@ -7,13 +7,25 @@
 //
 
 import Testing
+import Foundation
 import Prelude
 import Optics
 
 @testable import Domain
 
 
-final class AIAgentUsageTests { }
+struct AIAgentUsageTests {
+
+    private func usage(used: Int, limit: Int) -> AIAgentUsage {
+        return AIAgentUsage(input: 0, output: 0, limit: limit)
+            |> \.creditsUsed .~ used
+    }
+
+    private func plan(topupRemaining: Int?) -> BillingUserPlan {
+        return BillingUserPlan()
+            |> \.topupRemaining .~ topupRemaining
+    }
+}
 
 
 // MARK: - credit 사용량 파생
@@ -73,5 +85,115 @@ extension AIAgentUsageTests {
         let usage = AIAgentUsage(input: 100, output: 200, limit: 0)
         // when + then
         #expect(usage.usedRatio == 0)
+    }
+}
+
+
+// MARK: - 일일 한도 기준 판정
+
+extension AIAgentUsageTests {
+
+    @Test("한도 미만이면 top-up 잔량과 무관하게 소진 아님", arguments: [0, 500])
+    func usage_whenUnderDailyLimit_isNotExhausted(_ topup: Int) {
+        // given
+        let usage = self.usage(used: 2999, limit: 3000)
+
+        // when
+        let isExhausted = usage.isCreditExhausted(topupRemaining: topup)
+
+        // then
+        #expect(isExhausted == false)
+    }
+
+    @Test("한도에 정확히 도달하고 top-up 잔량이 없으면 소진")
+    func usage_whenReachedDailyLimitWithoutTopup_isExhausted() {
+        // given
+        let usage = self.usage(used: 3000, limit: 3000)
+
+        // when
+        let isExhausted = usage.isCreditExhausted(topupRemaining: 0)
+
+        // then
+        #expect(isExhausted == true)
+    }
+
+    @Test("한도를 넘겨도 top-up 잔량이 남았으면 소진 아님")
+    func usage_whenOverDailyLimitButTopupRemains_isNotExhausted() {
+        // given
+        let usage = self.usage(used: 13000, limit: 10000)
+
+        // when
+        let isExhausted = usage.isCreditExhausted(topupRemaining: 2000)
+
+        // then
+        #expect(isExhausted == false)
+    }
+}
+
+
+// MARK: - 값 불명 구간은 막지 않는다 (fail-open)
+
+extension AIAgentUsageTests {
+
+    @Test("top-up 잔량이 불명이면 한도를 넘겨도 소진 아님")
+    func usage_whenTopupRemainingIsUnknown_isNotExhausted() {
+        // given
+        let usage = self.usage(used: 13000, limit: 10000)
+
+        // when
+        let isExhausted = usage.isCreditExhausted(topupRemaining: nil)
+
+        // then
+        #expect(isExhausted == false)
+    }
+
+    @Test("일일 한도가 0(미설정)이면 소진 아님")
+    func usage_whenDailyLimitIsNotConfigured_isNotExhausted() {
+        // given
+        let usage = self.usage(used: 100, limit: 0)
+
+        // when
+        let isExhausted = usage.isCreditExhausted(topupRemaining: 0)
+
+        // then
+        #expect(isExhausted == false)
+    }
+}
+
+
+// MARK: - 조회 응답에서 바로 파생
+
+extension AIAgentUsageTests {
+
+    @Test("응답의 usage·plan 조합으로 소진 판정")
+    func loadResult_derivesExhaustionFromUsageAndPlan() {
+        // given
+        let exhausted = AIAgentUsageLoadResult(
+            usage: self.usage(used: 3000, limit: 3000),
+            userPlan: self.plan(topupRemaining: 0)
+        )
+        let hasTopup = AIAgentUsageLoadResult(
+            usage: self.usage(used: 3000, limit: 3000),
+            userPlan: self.plan(topupRemaining: 100)
+        )
+
+        // when + then
+        #expect(exhausted.isCreditExhausted == true)
+        #expect(hasTopup.isCreditExhausted == false)
+    }
+
+    @Test("응답에 plan이 없으면 소진 아님")
+    func loadResult_whenPlanIsMissing_isNotExhausted() {
+        // given
+        let result = AIAgentUsageLoadResult(
+            usage: self.usage(used: 3000, limit: 3000),
+            userPlan: nil
+        )
+
+        // when
+        let isExhausted = result.isCreditExhausted
+
+        // then
+        #expect(isExhausted == false)
     }
 }

--- a/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
@@ -26,10 +26,14 @@ class AIAgentOrchestrationUsecaseImpleTests: PublisherWaitable {
     private var stubSpeech: StubSpeechRecognizeUsecase!
     private var stubSync: StubEventSyncUsecase!
 
-    private func makeUsecase(shouldFail: Bool = false) -> AIAgentOrchestrationUsecaseImple {
+    private func makeUsecase(
+        shouldFail: Bool = false,
+        isCreditExhausted: Bool = false
+    ) -> AIAgentOrchestrationUsecaseImple {
         self.stubCommand = .init()
         self.stubCommand.shouldFail = shouldFail
         self.stubUsage = .init()
+        self.stubUsage.stubIsCreditExhausted = isCreditExhausted
         self.stubSpeech = .init()
         self.stubSync = .init()
         return AIAgentOrchestrationUsecaseImple(
@@ -835,9 +839,11 @@ private final class StubAIAgentUsageUsecase: AIAgentUsageUsecase, @unchecked Sen
 
     let usageSubject = CurrentValueSubject<AIAgentUsage?, Never>(nil)
     var didRefresh: Bool = false
+    var stubIsCreditExhausted: Bool = false
 
     func refresh() { self.didRefresh = true }
     func loadUsage() async throws -> AIAgentUsage { throw RuntimeError("not imple") }
+    func isCreditExhausted() -> Bool { return self.stubIsCreditExhausted }
     var currentUsage: AnyPublisher<AIAgentUsage, Never> {
         return self.usageSubject.compactMap { $0 }.eraseToAnyPublisher()
     }
@@ -1633,5 +1639,77 @@ extension AIAgentOrchestrationUsecaseImpleTests {
         }
         // then
         #expect(caughtError == .busy)
+    }
+}
+
+
+// MARK: - 크레딧 소진 시 제출 차단
+
+extension AIAgentOrchestrationUsecaseImpleTests {
+
+    @Test("크레딧이 소진됐으면 요청 없이 소진 실패 상태를 방출한다")
+    func usecase_whenCreditExhausted_emitsFailedWithoutRequest() async throws {
+        // given
+        let expect = expectConfirm("소진 실패 상태 방출")
+        let usecase = self.makeUsecase(isCreditExhausted: true)
+
+        // when
+        let state = try await self.firstOutput(expect, for: usecase.state) {
+            try? usecase.submit("내일 회의 잡아줘")
+        }
+
+        // then
+        guard case .failed(let command, let reason, let errorCode) = state
+        else { Issue.record("failed 상태가 아니다"); return }
+        #expect(command == "내일 회의 잡아줘")
+        #expect(reason == nil)
+        #expect(errorCode == .dailyLimitExceeded)
+        #expect(self.stubCommand.didProcessCommand == nil)
+    }
+
+    @Test("크레딧이 소진됐으면 차단 후 usage 를 재조회한다")
+    func usecase_whenCreditExhausted_refreshesUsage() {
+        // given
+        let usecase = self.makeUsecase(isCreditExhausted: true)
+
+        // when
+        try? usecase.submit("내일 회의 잡아줘")
+
+        // then
+        #expect(self.stubUsage.didRefresh == true)
+    }
+
+    @Test("이미지 command 도 크레딧 소진이면 요청 없이 차단된다")
+    func usecase_whenCreditExhausted_blocksImageCommand() async throws {
+        // given
+        let expect = expectConfirm("소진 실패 상태 방출")
+        let usecase = self.makeUsecase(isCreditExhausted: true)
+
+        // when
+        let state = try await self.firstOutput(expect, for: usecase.state) {
+            try? usecase.submitImageCommand(text: "영수증 내용", additionalInstruction: nil)
+        }
+
+        // then
+        guard case .failed(_, _, let errorCode) = state
+        else { Issue.record("failed 상태가 아니다"); return }
+        #expect(errorCode == .dailyLimitExceeded)
+    }
+
+    @Test("크레딧이 남아 있으면 그대로 제출된다")
+    func usecase_whenCreditRemains_submitsCommand() async throws {
+        // given
+        let expect = expectConfirm("처리중 상태 방출")
+        let usecase = self.makeUsecase(isCreditExhausted: false)
+
+        // when
+        let state = try await self.firstOutput(expect, for: usecase.state) {
+            try? usecase.submit("내일 회의 잡아줘")
+        }
+
+        // then
+        guard case .processing(let command) = state
+        else { Issue.record("processing 상태가 아니다"); return }
+        #expect(command == "내일 회의 잡아줘")
     }
 }

--- a/Domain/Tests/Usecases/AIAgentUsageUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AIAgentUsageUsecaseImpleTests.swift
@@ -186,6 +186,90 @@ extension AIAgentUsageUsecaseImpleTests {
 }
 
 
+// MARK: - 캐시된 usage·plan 으로 소진 판정
+
+extension AIAgentUsageUsecaseImpleTests {
+
+    private func makeUsecaseWithCached(
+        usage: AIAgentUsage?,
+        userPlan: BillingUserPlan?
+    ) -> AIAgentUsageUsecaseImple {
+        let store = SharedDataStore()
+        if let usage {
+            store.put(AIAgentUsage.self, key: ShareDataKeys.aiAgentUsage.rawValue, usage)
+        }
+        if let userPlan {
+            store.put(BillingUserPlan.self, key: ShareDataKeys.billingUserPlan.rawValue, userPlan)
+        }
+        return AIAgentUsageUsecaseImple(
+            repository: PrivateStubRepository(),
+            sharedDataStore: store
+        )
+    }
+
+    private func exhaustedUsage() -> AIAgentUsage {
+        return AIAgentUsage(input: 0, output: 0, limit: 3000)
+            |> \.creditsUsed .~ 3000
+    }
+
+    @Test("캐시된 usage 가 소진이고 top-up 잔량이 없으면 소진")
+    func usecase_whenCachedUsageExhaustedWithoutTopup_isExhausted() {
+        // given
+        let usecase = self.makeUsecaseWithCached(
+            usage: self.exhaustedUsage(),
+            userPlan: BillingUserPlan() |> \.topupRemaining .~ 0
+        )
+
+        // when
+        let isExhausted = usecase.isCreditExhausted()
+
+        // then
+        #expect(isExhausted == true)
+    }
+
+    @Test("캐시된 usage 가 소진이어도 top-up 잔량이 있으면 소진 아님")
+    func usecase_whenCachedUsageExhaustedButTopupRemains_isNotExhausted() {
+        // given
+        let usecase = self.makeUsecaseWithCached(
+            usage: self.exhaustedUsage(),
+            userPlan: BillingUserPlan() |> \.topupRemaining .~ 500
+        )
+
+        // when
+        let isExhausted = usecase.isCreditExhausted()
+
+        // then
+        #expect(isExhausted == false)
+    }
+
+    @Test("캐시된 usage 가 없으면 소진 아님")
+    func usecase_whenUsageNotCached_isNotExhausted() {
+        // given
+        let usecase = self.makeUsecaseWithCached(usage: nil, userPlan: nil)
+
+        // when
+        let isExhausted = usecase.isCreditExhausted()
+
+        // then
+        #expect(isExhausted == false)
+    }
+
+    @Test("캐시된 plan 이 없으면 소진 아님")
+    func usecase_whenUserPlanNotCached_isNotExhausted() {
+        // given
+        let usecase = self.makeUsecaseWithCached(
+            usage: self.exhaustedUsage(), userPlan: nil
+        )
+
+        // when
+        let isExhausted = usecase.isCreditExhausted()
+
+        // then
+        #expect(isExhausted == false)
+    }
+}
+
+
 private final class PrivateStubRepository: BaseStubAICommandRepository, @unchecked Sendable {
 
     var stubResults: [Result<AIAgentUsage, any Error>] = []

--- a/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandStageView.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandStageView.swift
@@ -422,7 +422,7 @@ private extension AIAgentCommandStageView {
             self.assistantIconMessageBubble(
                 systemName: errorCode == .dailyLimitExceeded ? "hourglass.circle.fill" : "exclamationmark.triangle.fill",
                 tint: appearance.colorSet.accentWarn.asColor,
-                text: reason.flatMap { $0.isEmpty ? nil : $0 } ?? "aiAgent::failed::default".localized()
+                text: self.failedMessage(reason: reason, errorCode: errorCode)
             )
 
             let showsPlansCTA = errorCode == .dailyLimitExceeded && self.state.isPaywallAvailable
@@ -445,6 +445,13 @@ private extension AIAgentCommandStageView {
             .eventHandler(\.onTap, eventHandlers.acknowledge)
             .padding(.top, spacing: .xsmall)
         }
+    }
+
+    func failedMessage(reason: String?, errorCode: ServerErrorModel.ErrorCode?) -> String {
+        if let reason, !reason.isEmpty { return reason }
+        return errorCode == .dailyLimitExceeded
+            ? "aiAgent::failed::dailyLimitExceeded".localized()
+            : "aiAgent::failed::default".localized()
     }
 }
 

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -548,6 +548,7 @@
 "aiAgent::state::failed" = "Task failed";
 "aiAgent::done::default" = "Done";
 "aiAgent::failed::default" = "Couldn't complete that";
+"aiAgent::failed::dailyLimitExceeded" = "You've used up today's AI credits.";
 "aiAgent::retry" = "Retry";
 "aiAgent::needSignIn::title" = "Sign in required";
 "aiAgent::needSignIn::message" = "Sign in to use AI quick input.";
@@ -638,6 +639,7 @@
 "share.ai::sentButUntracked" = "Sent, but the app can't track the result. Check your calendar after a moment.";
 "share.ai::textTooLong" = "That text is too long to send. Shorten it and try again.";
 "share.ai::instructionTooLong" = "Your instruction is too long. Please shorten it.";
+"share.ai::limitExceeded" = "You've used up today's AI credits. They reset at midnight UTC.";
 "share.ai::image::title" = "Send image to AI";
 "share.ai::image::recognizing" = "Reading text from the image…";
 "share.ai::image::text::caption" = "Text read from the image — edit it if anything looks off.";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -548,6 +548,7 @@
 "aiAgent::state::failed" = "작업 실패";
 "aiAgent::done::default" = "완료했어요";
 "aiAgent::failed::default" = "처리하지 못했어요";
+"aiAgent::failed::dailyLimitExceeded" = "오늘 AI 크레딧을 다 썼어요.";
 "aiAgent::retry" = "다시";
 "aiAgent::needSignIn::title" = "로그인이 필요해요";
 "aiAgent::needSignIn::message" = "AI 빠른 입력은 로그인 후 이용할 수 있어요.";
@@ -638,6 +639,7 @@
 "share.ai::sentButUntracked" = "보냈지만 앱에서 결과를 추적할 수 없어요. 잠시 후 캘린더를 확인해 주세요.";
 "share.ai::textTooLong" = "보낼 내용이 너무 길어요. 줄여서 다시 시도해 주세요.";
 "share.ai::instructionTooLong" = "지시가 너무 길어요. 줄여 주세요.";
+"share.ai::limitExceeded" = "오늘 AI 크레딧을 다 썼어요. 세계 표준시 자정에 초기화돼요.";
 "share.ai::image::title" = "이미지를 AI로 보내기";
 "share.ai::image::recognizing" = "이미지에서 텍스트를 읽는 중…";
 "share.ai::image::text::caption" = "이미지에서 읽은 텍스트예요 — 어색한 부분이 있으면 수정해 주세요.";

--- a/TodoCalendarApp/AppExtensions/Share/Sources/ShareCommandSubmitService.swift
+++ b/TodoCalendarApp/AppExtensions/Share/Sources/ShareCommandSubmitService.swift
@@ -17,6 +17,7 @@ enum ShareSubmitPrecondition {
     case needSignIn
     /// 앞선 요청이 아직 처리 중이거나, 결과를 유저가 확인하지 않았다.
     case previousRequestPending
+    case creditExhausted
 }
 
 
@@ -56,12 +57,16 @@ extension ShareCommandSubmitService {
 
         do {
             let pending = try await self.repository.loadProcessingAICommand()
-            return pending == nil ? .ready : .previousRequestPending
+            guard pending == nil else { return .previousRequestPending }
         } catch {
             // 앞선 요청 유무를 확인 못 했으면 통과시키지 않는다 —
             // 통과 후 제출하면 앱이 추적 중인 job을 덮어써 결과가 유실된다.
             return .previousRequestPending
         }
+
+        // 조회 실패는 통과 — 결과 유실 위험이 없고 서버가 최종 판정한다.
+        let usage = try? await self.repository.loadUsage()
+        return usage?.isCreditExhausted == true ? .creditExhausted : .ready
     }
 
     func submit(

--- a/TodoCalendarApp/AppExtensions/Share/Sources/ShareCommandViewModel.swift
+++ b/TodoCalendarApp/AppExtensions/Share/Sources/ShareCommandViewModel.swift
@@ -58,7 +58,7 @@ final class ShareCommandViewModel: @unchecked Sendable {
         let source = CurrentValueSubject<ShareCommandSource?, Never>(nil)
         /// 공유 원문·전송 가능 여부를 아직 확인하는 중
         let isPreparing = CurrentValueSubject<Bool, Never>(true)
-        /// 미로그인·앞선 요청이라 제출 자체가 불가능하다 — 되돌아갈 곳이 없다
+        /// 제출 자체가 불가능하다 — 되돌아갈 곳이 없다
         let blockedMessage = CurrentValueSubject<String?, Never>(nil)
         let isSending = CurrentValueSubject<Bool, Never>(false)
         /// 제출이 끝나 더 할 일이 없다
@@ -114,6 +114,8 @@ extension ShareCommandViewModel {
             return "share.ai::needSignIn".localized()
         case .previousRequestPending:
             return "share.ai::pending".localized()
+        case .creditExhausted:
+            return "share.ai::limitExceeded".localized()
         }
     }
 

--- a/TodoCalendarApp/AppExtensions/Share/Tests/ShareCommandSubmitServiceTests.swift
+++ b/TodoCalendarApp/AppExtensions/Share/Tests/ShareCommandSubmitServiceTests.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 import Testing
+import Prelude
+import Optics
 import Domain
 import Repository
 import Extensions
@@ -307,6 +309,84 @@ extension ShareCommandSubmitServiceTests {
 }
 
 
+// MARK: - 크레딧 소진 전제
+
+extension ShareCommandSubmitServiceTests {
+
+    private func exhaustedUsage() -> AIAgentUsageLoadResult {
+        return AIAgentUsageLoadResult(
+            usage: AIAgentUsage(input: 0, output: 0, limit: 3000)
+                |> \.creditsUsed .~ 3000,
+            userPlan: BillingUserPlan() |> \.topupRemaining .~ 0
+        )
+    }
+
+    private func remainingUsage() -> AIAgentUsageLoadResult {
+        return AIAgentUsageLoadResult(
+            usage: AIAgentUsage(input: 0, output: 0, limit: 3000)
+                |> \.creditsUsed .~ 10,
+            userPlan: BillingUserPlan() |> \.topupRemaining .~ 0
+        )
+    }
+
+    @Test("크레딧이 소진됐으면 전제 판정이 소진으로 나온다")
+    func service_whenCreditExhausted_preconditionIsCreditExhausted() async {
+        // given
+        let repository = makeStubAICommandRepository(usageLoadResult: self.exhaustedUsage())
+        let (service, _) = self.makeService(repository: repository)
+
+        // when
+        let precondition = await service.checkPrecondition()
+
+        // then
+        #expect(precondition == .creditExhausted)
+    }
+
+    @Test("크레딧이 남았으면 전제 판정이 통과다")
+    func service_whenCreditRemains_preconditionIsReady() async {
+        // given
+        let repository = makeStubAICommandRepository(usageLoadResult: self.remainingUsage())
+        let (service, _) = self.makeService(repository: repository)
+
+        // when
+        let precondition = await service.checkPrecondition()
+
+        // then
+        #expect(precondition == .ready)
+    }
+
+    @Test("usage 조회에 실패하면 막지 않는다")
+    func service_whenUsageLoadFails_preconditionIsReady() async {
+        // given
+        let repository = makeStubAICommandRepository(shouldFailLoadUsage: true)
+        let (service, _) = self.makeService(repository: repository)
+
+        // when
+        let precondition = await service.checkPrecondition()
+
+        // then
+        #expect(precondition == .ready)
+    }
+
+    @Test("앞선 요청이 있으면 usage 조회 전에 그 판정이 우선한다")
+    func service_whenPreviousRequestPending_doesNotCheckCredit() async {
+        // given
+        let repository = makeStubAICommandRepository(
+            pending: .init(jobId: "job-1", isConfirmJob: false),
+            usageLoadResult: self.exhaustedUsage()
+        )
+        let (service, _) = self.makeService(repository: repository)
+
+        // when
+        let precondition = await service.checkPrecondition()
+
+        // then
+        #expect(precondition == .previousRequestPending)
+        #expect(repository.didLoadUsage == false)
+    }
+}
+
+
 // MARK: - doubles
 
 // AICommandRepository 구현체는 앱 타겟 테스트(IntentCommandSubmitServiceTests)에도
@@ -318,11 +398,14 @@ final class StubAICommandRepository: AICommandRepository, @unchecked Sendable {
     var shouldFailLoadPending: Bool = false
     var shouldFailUpdatePending: Bool = false
     var stubProcessError: (any Error)?
+    var stubUsageLoadResult: AIAgentUsageLoadResult?
+    var shouldFailLoadUsage: Bool = false
 
     var didProcessInterpretText: String?
     var didProcessInterpretAdditionalInstruction: String?
     var didProcessInterpretWithInputSource: AICommandInputSource?
     var didUpdatePendingJobId: String?
+    var didLoadUsage: Bool = false
 
     func processInterpretCommand(
         text: String,
@@ -361,7 +444,15 @@ final class StubAICommandRepository: AICommandRepository, @unchecked Sendable {
     func rejectConfirmCommand(_ action: AIConfirmCommandAction) async throws { }
     func cancelCommand(_ jobId: String) async throws { }
     func loadJob(_ jobId: String) async throws -> AIJob { throw RuntimeError("not used") }
-    func loadUsage() async throws -> AIAgentUsageLoadResult { throw RuntimeError("not used") }
+    func loadUsage() async throws -> AIAgentUsageLoadResult {
+        self.didLoadUsage = true
+        guard !self.shouldFailLoadUsage
+        else { throw RuntimeError("failed to load usage") }
+        return self.stubUsageLoadResult ?? AIAgentUsageLoadResult(
+            usage: AIAgentUsage(input: 0, output: 0, limit: 3000),
+            userPlan: BillingUserPlan() |> \.topupRemaining .~ 0
+        )
+    }
 }
 
 // ShareCommandSubmitServiceTests·ShareCommandViewModelTests가 공유하는 팩토리 —
@@ -370,13 +461,17 @@ func makeStubAICommandRepository(
     pending: ProcessingAICommand? = nil,
     processFailWith error: (any Error)? = nil,
     shouldFailLoadPending: Bool = false,
-    shouldFailUpdatePending: Bool = false
+    shouldFailUpdatePending: Bool = false,
+    usageLoadResult: AIAgentUsageLoadResult? = nil,
+    shouldFailLoadUsage: Bool = false
 ) -> StubAICommandRepository {
     let repository = StubAICommandRepository()
     repository.stubPendingCommand = pending
     repository.stubProcessError = error
     repository.shouldFailLoadPending = shouldFailLoadPending
     repository.shouldFailUpdatePending = shouldFailUpdatePending
+    repository.stubUsageLoadResult = usageLoadResult
+    repository.shouldFailLoadUsage = shouldFailLoadUsage
     return repository
 }
 

--- a/TodoCalendarApp/AppExtensions/Share/Tests/ShareCommandViewModelTests.swift
+++ b/TodoCalendarApp/AppExtensions/Share/Tests/ShareCommandViewModelTests.swift
@@ -9,6 +9,8 @@
 import Foundation
 import Combine
 import Testing
+import Prelude
+import Optics
 import Domain
 import Extensions
 import UnitTestHelpKit
@@ -281,6 +283,38 @@ extension ShareCommandViewModelTests {
 
         // then
         #expect(repository.didProcessInterpretWithInputSource == .imageOcr)
+    }
+}
+
+
+// MARK: - 크레딧 소진
+
+extension ShareCommandViewModelTests {
+
+    private func exhaustedRepository() -> StubAICommandRepository {
+        return makeStubAICommandRepository(
+            usageLoadResult: AIAgentUsageLoadResult(
+                usage: AIAgentUsage(input: 0, output: 0, limit: 3000)
+                    |> \.creditsUsed .~ 3000,
+                userPlan: BillingUserPlan() |> \.topupRemaining .~ 0
+            )
+        )
+    }
+
+    @Test("크레딧이 소진됐으면 준비 단계에서 차단 문구를 노출한다")
+    func prepare_whenCreditExhausted_showsBlockedMessage() async throws {
+        // given
+        let expect = expectConfirm("차단 문구 방출")
+        expect.count = 2
+        let viewModel = self.makeViewModel(repository: self.exhaustedRepository())
+
+        // when
+        let messages = try await self.outputs(expect, for: viewModel.blockedMessage) {
+            viewModel.prepare()
+        }
+
+        // then
+        #expect(messages.last ?? nil == "share.ai::limitExceeded".localized())
     }
 }
 

--- a/TodoCalendarApp/Sources/AppIntents/IntentCommandSubmitService.swift
+++ b/TodoCalendarApp/Sources/AppIntents/IntentCommandSubmitService.swift
@@ -34,6 +34,9 @@ struct IntentCommandSubmitService: Sendable {
         guard await self.hasNoPendingRequest()
         else { throw AICommandSubmitFailReason.previousRequestPending }
 
+        guard await self.hasRemainingCredit()
+        else { throw AICommandSubmitFailReason.limitExceeded }
+
         let timeZone = self.settingRepository.loadUserSelectedTImeZone() ?? .current
         let jobId: String
         do {
@@ -53,6 +56,12 @@ struct IntentCommandSubmitService: Sendable {
         } catch {
             return false
         }
+    }
+
+    private func hasRemainingCredit() async -> Bool {
+        // 조회 실패는 통과 — 서버가 최종 판정한다.
+        guard let usage = try? await self.repository.loadUsage() else { return true }
+        return !usage.isCreditExhausted
     }
 
     private func updateProcessingCommand(jobId: String) async throws {

--- a/TodoCalendarApp/TodoCalendarAppTests/AppIntents/IntentCommandSubmitServiceTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/AppIntents/IntentCommandSubmitServiceTests.swift
@@ -40,13 +40,17 @@ final class IntentCommandSubmitServiceTests {
         processFailWith error: (any Error)? = nil,
         pending: ProcessingAICommand? = nil,
         shouldFailLoadPending: Bool = false,
-        shouldFailUpdatePending: Bool = false
+        shouldFailUpdatePending: Bool = false,
+        usageLoadResult: AIAgentUsageLoadResult? = nil,
+        shouldFailLoadUsage: Bool = false
     ) -> StubAICommandRepository {
         let repository = StubAICommandRepository()
         repository.stubProcessError = error
         repository.stubPendingCommand = pending
         repository.shouldFailLoadPending = shouldFailLoadPending
         repository.shouldFailUpdatePending = shouldFailUpdatePending
+        repository.stubUsageLoadResult = usageLoadResult
+        repository.shouldFailLoadUsage = shouldFailLoadUsage
         return repository
     }
 
@@ -202,6 +206,47 @@ extension IntentCommandSubmitServiceTests {
     }
 }
 
+// MARK: - 크레딧 소진 사전 차단
+
+extension IntentCommandSubmitServiceTests {
+
+    private func exhaustedUsage() -> AIAgentUsageLoadResult {
+        return AIAgentUsageLoadResult(
+            usage: AIAgentUsage(input: 0, output: 0, limit: 3000)
+                |> \.creditsUsed .~ 3000,
+            userPlan: BillingUserPlan() |> \.topupRemaining .~ 0
+        )
+    }
+
+    @Test("크레딧이 소진됐으면 요청 없이 한도 초과로 실패한다")
+    func service_whenCreditExhausted_failsWithLimitExceeded() async {
+        // given
+        let repository = self.makeRepository(usageLoadResult: self.exhaustedUsage())
+        let (service, _) = self.makeService(stubRepository: repository)
+
+        // when
+        let reason = await self.failReason { try await service.submit("내일 3시 회의") }
+
+        // then
+        #expect(reason == .limitExceeded)
+        #expect(repository.didProcessCommandText == nil)
+    }
+
+    @Test("usage 조회에 실패하면 막지 않고 제출한다")
+    func service_whenUsageLoadFails_submitsCommand() async {
+        // given
+        let repository = self.makeRepository(shouldFailLoadUsage: true)
+        let (service, _) = self.makeService(stubRepository: repository)
+
+        // when
+        let reason = await self.failReason { try await service.submit("내일 3시 회의") }
+
+        // then
+        #expect(reason == nil)
+        #expect(repository.didProcessCommandText == "내일 3시 회의")
+    }
+}
+
 
 private final class StubAuthStore: AuthStore, @unchecked Sendable {
 
@@ -229,6 +274,8 @@ private final class StubAICommandRepository: AICommandRepository, @unchecked Sen
     var stubPendingCommand: ProcessingAICommand?
     var shouldFailLoadPending: Bool = false
     var shouldFailUpdatePending: Bool = false
+    var stubUsageLoadResult: AIAgentUsageLoadResult?
+    var shouldFailLoadUsage: Bool = false
 
     var didProcessCommandText: String?
     var didProcessTimeZone: String?
@@ -277,6 +324,11 @@ private final class StubAICommandRepository: AICommandRepository, @unchecked Sen
     }
 
     func loadUsage() async throws -> AIAgentUsageLoadResult {
-        throw RuntimeError("not imple")
+        guard !self.shouldFailLoadUsage
+        else { throw RuntimeError("failed to load usage") }
+        return self.stubUsageLoadResult ?? AIAgentUsageLoadResult(
+            usage: AIAgentUsage(input: 0, output: 0, limit: 3000),
+            userPlan: BillingUserPlan() |> \.topupRemaining .~ 0
+        )
     }
 }


### PR DESCRIPTION
## 문제

AI 크레딧이 소진된 상태에서도 클라이언트는 command를 그대로 서버에 보냈다. 서버는 요청을 받아 job을 FAILED로 만들어 돌려주므로 결과적으로 왕복 한 번이 통째로 낭비되고, 유저는 응답을 기다린 끝에 실패를 본다.

세 제출 경로 중 어느 것도 사전 판단을 하지 않았다. 앱은 이미 `SharedDataStore`에 usage·plan을 캐싱하고 있었는데도 쓰지 않았고, Share 확장과 Siri 단축어는 조회 자체를 안 했다.

## 접근

판정식을 Domain 순수 파생 하나로 정의하고, 세 경로가 각자 컨텍스트에서 그 값을 얻어 소비한다.

**판정식은 서버 예산 계산과 같은 식이어야 한다.** 서버(`aiUsageService.getRemainingCredits`)는 `remaining = max(0, daily_limit - credits_used) + topup_remaining`, `remaining <= 0`으로 차단한다. 이걸 풀면 `credits_used >= daily_limit && topup_remaining <= 0`이다.

여기 함정이 하나 있다 — `credits_used < daily_limit + topup_remaining` 형태로 쓰면 틀린다. `topup_remaining`은 이미 차감된 실시간 잔량인데 `credits_used`는 그 차감분까지 포함한 누계라, 초과분이 양쪽에서 이중 반영된다. 기존 `AIAgentUsage.isLimitExceeded`(일일 한도만 비교)를 그대로 쓰는 것도 안 된다 — top-up 보유자의 정상 요청을 막는 회귀가 된다. 그래서 게이지 표시용인 `isLimitExceeded`는 그대로 두고 전송 가능 판정을 별도로 뒀다.

**값이 없는 구간은 전부 fail-open이다.** 콜드스타트(캐시 nil), plan 정보 부재(`topupRemaining` nil), 조회 실패(오프라인) — 셋 다 차단하지 않고 서버 판정에 맡긴다. 잘못 막는 쪽이 잘못 통과시키는 쪽보다 나쁘다.

**경로별 차단 표현은 각자 이미 가진 실패 표면을 재사용한다.**

| 경로 | 판정 근거 | 차단 표현 |
|---|---|---|
| 앱 `AIAgentOrchestrationUsecaseImple` | `SharedDataStore` 캐시 동기 조회 | 요청 없이 `.failed(errorCode: .dailyLimitExceeded)` 방출 → 기존 결과 시트가 모래시계 + View Plans로 표시 |
| Share 확장 | `GET /v1/ai/usage` 직접 조회 (별도 프로세스라 캐시 접근 불가) | `blockedMessage` — 입력 UI를 걷어 재시도를 권하지 않음 |
| Siri 단축어 | 같은 조회 | 기존 `AICommandSubmitFailReason.limitExceeded` 다이얼로그 |

앱 경로에서 throw가 아니라 상태 방출을 고른 건 음성 입력이 `try? submit(text)`으로 에러를 삼키기 때문이다. 상태로 내보내면 `CalendarViewModelImple.bindShowAICommandResultIfNeed`가 이미 걸려 있어 시트가 자동으로 뜨고, 세 입력 시트는 제출 성공 시 닫히므로 서버 거절 때와 동선이 같아진다. Presentation 배선 추가가 없다.

## 리뷰에서 잡혀 걷어낸 것

Share에 "서버가 `DailyLimitExceeded`로 거절하는 경우"의 사후 매핑을 함께 넣었다가 제거했다. 서버는 크레딧 소진 시 HTTP 에러를 주지 않는다 — `202 + job_id`를 그대로 주고 job을 FAILED-born으로 만든다(`jobService.js:66`). 클라는 2xx에서 `job_id`만 뽑으므로 그 분기는 도달 불가능한 코드였다. 레이스 상황은 앱이 그 FAILED job을 받아 이미 정확히 표시한다.

## 검증

Domain·AIAgentScene·CalendarScenes·TodoCalendarApp·TodoCalendarAppShare 5개 스킴 통과.

유닛테스트로 덮이지 않는 항목(확장 프로세스의 인증 토큰 seed가 런타임에 실제로 동작하는지, top-up 보유자가 차단되지 않는지)은 #782 코멘트에 검증 방법과 함께 인계했다.

신규 문구 2키는 en·ko만 반영, 나머지 29개 언어는 #810 대기 목록에 등록.

Closes #782
