### PR TITLE
[#847] SpeechRecognizeService teardown 동시 진입 크래시 해소

### DIFF
--- a/Services/SpeechService/Sources/SpeechRecognizeServiceImple.swift
+++ b/Services/SpeechService/Sources/SpeechRecognizeServiceImple.swift
@@ -17,6 +17,7 @@ import Domain
 public final class SpeechRecognizeServiceImple: SpeechRecognizeService, @unchecked Sendable {
 
     private let recognizer: SFSpeechRecognizer?
+    private let serialQueue = DispatchQueue(label: "speech-recognize-service")
     private var audioEngine = AVAudioEngine()
     private var request: SFSpeechAudioBufferRecognitionRequest?
     private var task: SFSpeechRecognitionTask?
@@ -43,20 +44,22 @@ public final class SpeechRecognizeServiceImple: SpeechRecognizeService, @uncheck
 extension SpeechRecognizeServiceImple {
     
     public func start() throws {
-        do {
-            guard let recognizer, recognizer.isAvailable else {
-                throw RuntimeError(key: "recognizerUnavailable", "speech recognizer unavailable")
+        try self.serialQueue.sync {
+            do {
+                guard let recognizer, recognizer.isAvailable else {
+                    throw RuntimeError(key: "recognizerUnavailable", "speech recognizer unavailable")
+                }
+                try self.configureAudioSession()
+                self.observeAudioDisruption()
+                let request = self.makeRequest()
+                self.installInputTap()
+                self.task = self.makeRecognitionTask(recognizer: recognizer, request: request)
+                try self.startEngine()
+            } catch {
+                // start 도중 실패하면 설치된 tap/세션을 되돌려 완전 초기 상태로 리셋 후 전파
+                self.teardownAudio()
+                throw error
             }
-            try self.configureAudioSession()
-            self.observeAudioDisruption()
-            let request = self.makeRequest()
-            self.installInputTap()
-            self.task = self.makeRecognitionTask(recognizer: recognizer, request: request)
-            try self.startEngine()
-        } catch {
-            // start 도중 실패하면 설치된 tap/세션을 되돌려 완전 초기 상태로 리셋 후 전파
-            self.teardownAudio()
-            throw error
         }
     }
 
@@ -118,8 +121,10 @@ extension SpeechRecognizeServiceImple {
         let inputNode = self.audioEngine.inputNode
         let format = inputNode.outputFormat(forBus: 0)
         inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
-            self?.request?.append(buffer)
-            self?.updateVoiceLevel(buffer)
+            self?.serialQueue.async {
+                self?.request?.append(buffer)
+                self?.updateVoiceLevel(buffer)
+            }
         }
     }
 
@@ -128,7 +133,9 @@ extension SpeechRecognizeServiceImple {
         request: SFSpeechAudioBufferRecognitionRequest
     ) -> SFSpeechRecognitionTask {
         return recognizer.recognitionTask(with: request) { [weak self] result, error in
-            self?.handleRecognition(result: result, error: error)
+            self?.serialQueue.async {
+                self?.handleRecognition(result: result, error: error)
+            }
         }
     }
 
@@ -152,8 +159,10 @@ extension SpeechRecognizeServiceImple {
     }
 
     public func stop() {
-        self.request?.endAudio()
-        self.teardownAudio()
+        self.serialQueue.async {
+            self.request?.endAudio()
+            self.teardownAudio()
+        }
     }
 
     // 무조건 호출해도 안전(idempotent): stop/cancel/removeTap 모두 미동작·미설치 상태에서 호출해도 무해.


### PR DESCRIPTION
## 문제

로그아웃 시 `stop()` → `teardownAudio()` 경로에서 `required condition is false: NULL != engine` abort 크래시 (#847).

`teardownAudio()`가 두 스레드에서 동시에 돈다 — `stop()` 호출 스레드와, 그 안의 `task?.cancel()`이 SFSpeechRecognizer 내부 큐에서 발화시킨 error 콜백(`handleRecognition` → self-teardown). 동기화가 없어 한쪽이 `audioEngine`을 새 인스턴스로 교체해 기존 engine의 dealloc이 시작된 사이, 다른 쪽이 그 engine의 `inputNode.removeTap`을 호출하면서 assert abort.

## 접근

내부 상태 접근 전체를 전용 시리얼 큐로 직렬화한다 (`EventNotificationUsecase.serialWorkQueue` 선례 패턴).

- `start()`는 `queue.sync` — sync 인터페이스와 throw 전파 유지
- `stop()`·recognition 콜백·tap 콜백은 `queue.async` hop — cancel이 유발한 error 콜백의 re-teardown이 진행 중 teardown **뒤로** 줄 서면서 순차 실행되고, 그 시점엔 engine이 교체된 초기 상태라 idempotent 하게 무해
- tap의 `request?.append`도 큐로 이동해 teardown의 `request = nil`과의 레이스 동반 해소

소비처는 `SpeechRecognizeUsecaseImple` 하나 — stop 직후 재시작은 큐 FIFO로 순서 보존되고, stop 후 늦은 방출은 소비처가 `serviceBinding = []`로 즉시 끊어 관찰 불가. 앱 내 다른 AVAudioSession 사용자 없음.

검증: SpeechService는 테스트 타겟이 없는 모듈이라 빌드 검증 (스킴 테스트는 CI가 수행).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsSsa2VygKArMgxVgAzvdd