### PR TITLE
[#835] pending done 테이블 커서 오프셋 교정 — repeating_turn 추가·컬럼 순서 교정

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -22,7 +22,7 @@ dispatch 프롬프트가 제공한다:
 diff의 변경 파일 경로를 기준으로 적용 규칙을 로드해 검사한다:
 
 1. `.claude/rules/*.md` 각 파일의 frontmatter `paths:`를 읽고 변경 경로와 매칭 — 매칭되는 rules 파일을 Read해 조항 위반을 검사한다. 파일 목록을 외우지 말고 매번 디렉토리를 나열한다 (rules는 추가된다).
-2. 루트 `CLAUDE.md` §1 **짝지어진 두 위치** — 한쪽만 바뀐 짝이 있는지 확인한다 (dbVersion↔migrateStatement, CI 스킴 매핑↔실행 step, 테스트 스킴↔스킴 목록 하드코딩, init 시그니처↔콜사이트).
+2. 루트 `CLAUDE.md` §1 **짝지어진 두 위치** — 한쪽만 바뀐 짝이 있는지 확인한다 (dbVersion↔migrateStatement↔AppDataMigrationImple 스텝, CI 스킴 매핑↔실행 step, 테스트 스킴↔스킴 목록 하드코딩, init 시그니처↔콜사이트).
 3. `Domain/`·`Repository/` 하위 변경이면 해당 child CLAUDE.md도 참조한다.
 4. 설계·스타일 원칙은 `docs/coding-style-and-philosophy.md` 기준.
 

--- a/.claude/skills/implement/scripts/impact-check.sh
+++ b/.claude/skills/implement/scripts/impact-check.sh
@@ -143,9 +143,17 @@ if printf '%s\n' "$FILES" | grep -q "^\.github/workflows/pr_test\.yml$"; then
   warns+=("- ⚠️ pr_test.yml 변경 — detect-changes 매핑 ↔ Test step ↔ impact-check.sh 매핑 3곳 동기화 확인")
 fi
 if [ "$MODE" = "git" ] && printf '%s\n' "$FILES" | grep -q "^TodoCalendarApp/Sources/AppEnvironment\.swift$"; then
-  if git diff "$BASE" -- TodoCalendarApp/Sources/AppEnvironment.swift 2>/dev/null | grep -qi '^[+-].*dbVersion'; then
-    if ! git diff "$BASE" -- Repository 2>/dev/null | grep -q 'migrateStatement'; then
-      warns+=("- ⚠️ dbVersion 변경 감지 — Table.migrateStatement(for:) case 추가가 함께 안 됨. 짝 확인 필요")
+  # 떠나는 버전 N 을 뽑아 case N 추가 여부로 판정한다. migrateStatement 문자열 grep 은
+  # 컨텍스트를 좁히면 case 만 추가한 변경을 놓치고, 넓히면 무관한 테이블 편집이 누락을 가린다.
+  # let dbVersion 앵커 — googleCalendarDBVersion·appleCalendarDBVersion 은 별개 짝이다.
+  oldMainDBVersion=$(git diff "$BASE" -- TodoCalendarApp/Sources/AppEnvironment.swift 2>/dev/null \
+    | sed -n 's/^-[[:space:]]*static let dbVersion: Int32 = \([0-9][0-9]*\).*/\1/p' | head -1)
+  if [ -n "$oldMainDBVersion" ]; then
+    if ! git diff "$BASE" -- Repository 2>/dev/null | grep -qE "^\+[[:space:]]*case ${oldMainDBVersion}:"; then
+      warns+=("- ⚠️ dbVersion 변경 감지 — Table.migrateStatement(for:) 에 case ${oldMainDBVersion} 추가가 함께 안 됨. 짝 확인 필요")
+    fi
+    if ! printf '%s\n' "$FILES" | grep -q 'AppDataMigrationImple\.swift$'; then
+      warns+=("- ⚠️ dbVersion 변경 감지 — AppDataMigrationImple 의 runDBMigration case + runMigrationVersionNtoM 이 함께 안 됨. 없으면 migrateStatement 가 호출조차 안 된다")
     fi
   fi
 fi

--- a/.claude/skills/implement/scripts/impact-check.test.sh
+++ b/.claude/skills/implement/scripts/impact-check.test.sh
@@ -68,6 +68,32 @@ assert_contains "Package.swift 수정(M) → 필요" "필요" "$(tuist_for 'M\tP
 assert_contains "pr_test.yml 변경 → 3곳 동기화 경고" "impact-check.sh" "$(pairs_for 'M\t.github/workflows/pr_test.yml')"
 assert_eq "경고 없음 → 해당 없음" "(해당 없음)" "$(pairs_for 'M\tdocs/foo.md')"
 
+# --- dbVersion 짝 경고 (git 모드 전용 — 임시 repo 를 만들어 --base 로 돌린다) ---
+SCRIPT_DIR="$(pwd)"
+pairs_in_repo() { # migrateCase(빈문자열이면 미추가) migrationImpleTouched(y/n) → 짝 섹션
+  local repo; repo=$(mktemp -d)
+  (
+    cd "$repo" || exit 1
+    git init -q .; git config user.email t@t; git config user.name t
+    mkdir -p TodoCalendarApp/Sources Repository/A Repository/B "Repository/Setting/Migration"
+    printf '    static let dbVersion: Int32 = 6\n    static let googleCalendarDBVersion: Int32 = 0\n' > TodoCalendarApp/Sources/AppEnvironment.swift
+    printf 'struct TableA {\n    static func migrateStatement(for v: Int32) -> String? {\n        switch v {\n        case 0: return nil\n        default: return nil\n        }\n    }\n    var pad = 0\n}\n' > Repository/A/TableA.swift
+    cp Repository/A/TableA.swift Repository/B/TableB.swift
+    printf 'final class AppDataMigrationImple {\n    var pad = 0\n}\n' > Repository/Setting/Migration/AppDataMigrationImple.swift
+    git add -A; git commit -qm base
+    sed -i '' 's/dbVersion: Int32 = 6/dbVersion: Int32 = 7/' TodoCalendarApp/Sources/AppEnvironment.swift
+    # 무관한 테이블의 migrateStatement 근처를 항상 건드린다 — 컨텍스트 확장 미탐 회귀 감시
+    sed -i '' 's/var pad = 0/var pad = 1/' Repository/B/TableB.swift
+    [ -n "$1" ] && sed -i '' "s/        case 0: return nil/        case $1: return nil\n        case 0: return nil/" Repository/A/TableA.swift
+    [ "$2" = "y" ] && sed -i '' 's/var pad = 0/var pad = 1/' Repository/Setting/Migration/AppDataMigrationImple.swift
+    bash "$SCRIPT_DIR/impact-check.sh" --base HEAD | awk '/^## 짝지어진 두 위치/{flag=1; next} flag'
+  )
+  rm -rf "$repo"
+}
+assert_contains "dbVersion↑ + case 미추가 → migrateStatement 경고" "case 6 추가가 함께 안 됨" "$(pairs_in_repo '' y)"
+assert_contains "dbVersion↑ + 마이그레이션 스텝 미변경 → AppDataMigrationImple 경고" "AppDataMigrationImple" "$(pairs_in_repo 6 n)"
+assert_eq "dbVersion↑ + 세 위치 전부 → 경고 없음" "(해당 없음)" "$(pairs_in_repo 6 y)"
+
 echo "---"
 echo "PASS: $PASS / FAIL: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 - **Query/Command 분리.** 읽기와 사이드이펙트를 한 흐름에 섞지 말 것.
 - **객체 변경 시** 참조하는 다른 객체 영향도 확인 (빌드 + 테스트) — 절차는 implement 스킬의 impact-check가 기계화.
 - **짝지어진 두 위치는 함께 갱신.** 한쪽만 바꾸면 무효가 되는 쌍은 추가/변경 시 대응처도 반드시 확인:
-  - `AppEnvironment.dbVersion` ↔ `Table.migrateStatement(for:)` case
+  - `AppEnvironment.dbVersion` ↔ `Table.migrateStatement(for:)` case ↔ `AppDataMigrationImple`의 `runDBMigration` case + `runMigrationVersionNtoM` (셋 다여야 한다 — 마지막이 빠지면 `migrateStatement`가 호출조차 안 되고 조용히 안 돈다)
   - CI `pr_test.yml` — `detect-changes`의 scheme 매핑(grep) ↔ `test` job의 `Test <scheme>` 실행 step (둘 중 하나만 추가하면 감지만 되고 실행 안 됨)
   - 신규 테스트 스킴 ↔ 스킴 목록 하드코딩 전부 (`pr_test.yml` 3곳·`scripts/run-all-tests.sh`·`impact-check.sh`+테스트·`run-tests` 스킬 — 상세는 add-framework 스킬. 단 `<Name>Snapshots` 스킴은 의도된 예외 — 로컬 전용, snapshot-check 스킬)
   - init 시그니처 ↔ 콜사이트
@@ -93,7 +93,7 @@ tuist generate --no-open      # 파일 추가/삭제 후 재실행 필수
 | ForemostEvent | [`docs/spec/tags-foremost-notifications.md`](docs/spec/tags-foremost-notifications.md) |
 | SharedDataStore 키·구독 | [`Domain/CLAUDE.md`](Domain/CLAUDE.md) |
 | 앱 버전 체크 | [`docs/spec/infrastructure.md §7`](docs/spec/infrastructure.md) |
-| DB 마이그레이션 | §1 짝규칙 (`dbVersion` ↔ `migrateStatement`) + [`Repository/CLAUDE.md`](Repository/CLAUDE.md) |
+| DB 마이그레이션 | §1 짝규칙 (`dbVersion` ↔ `migrateStatement` ↔ `AppDataMigrationImple` 스텝) + [`Repository/CLAUDE.md`](Repository/CLAUDE.md) |
 
 ---
 

--- a/Repository/CLAUDE.md
+++ b/Repository/CLAUDE.md
@@ -60,24 +60,23 @@ extension TodoEvent: RowValueType {
 }
 ```
 
+### 컬럼 순서 = 읽기 순서 (위치 결합)
+
+`Columns` enum의 **case 선언 순서가 곧 물리 컬럼 순서**이고, `init(_ cursor:)`는 `cursor.next()`를 부른 횟수로 위치를 센다. 둘이 어긋나면 크래시가 아니라 **조용한 nil**이다 — 값은 SQLite 저장 타입으로 만들어진 뒤 `as? T`로 캐스팅되므로, 타입이 안 맞거나 컬럼 수를 넘어가면 그냥 nil이 된다.
+
+**한 `RowValueType.init(cursor)`를 여러 테이블이 공유하면 컬럼 추가가 다른 테이블을 깨뜨린다.** `TodoEvent.init(cursor)`는 `TodoEventTable`과 `PendingDoneTodoEventTable` 둘이 쓴다 — 한쪽에 컬럼을 붙이며 그 init에 읽기를 더하면 다른 쪽은 읽기만 늘어 그 지점부터 전부 밀린다 (#355·#544 → #835). 컬럼 추가 시 그 `init(cursor)`를 쓰는 **모든 테이블**을 grep해 각각의 `Columns`도 함께 갱신한다.
+
 ### DB 마이그레이션
 
-**두 가지를 반드시 함께 변경:**
+**세 위치를 반드시 함께 변경한다:**
 
 1. `AppEnvironment.dbVersion` 증가 (in `TodoCalendarApp`)
-2. 해당 `Table`의 `migrateStatement(for version:)`에 case 추가
+2. 해당 `Table`의 `migrateStatement(for version:)`에 case 추가 — 받는 숫자는 **떠나는 버전**이다 (`case 5`는 5 → 6에서 돈다)
+3. `AppDataMigrationImple` — `runDBMigration`의 switch에 case 추가 + `runMigrationVersionNtoM` 메서드 작성
 
-**중앙 오케스트레이터**: `SQLiteLocalStorage+Migration.swift`가 버전별로 모든 테이블의 마이그레이션을 실행.
+**3번이 빠지면 `migrateStatement`는 호출조차 되지 않는다.** 컴파일도 테스트도 통과하고 마이그레이션만 조용히 안 돈다.
 
-```swift
-// 예: v5 → v6 (repeatingTurn 컬럼 추가)
-static func migrateStatement(for version: Int32) -> String? {
-    switch version {
-    case 5: return Self.addColumnStatement(.repeatingTurn)
-    default: return nil
-    }
-}
-```
+절차 상세·버전 이력·컬럼 순서 변경(temp 테이블 재생성)은 [`docs/spec/infrastructure.md §5`](../docs/spec/infrastructure.md) 정본.
 
 ---
 

--- a/Repository/Sources/Repository+Imple/Event/Todo/Local/PendingDoneTodoEventTable.swift
+++ b/Repository/Sources/Repository+Imple/Event/Todo/Local/PendingDoneTodoEventTable.swift
@@ -23,12 +23,13 @@ struct PendingDoneTodoEventTable: Table {
         case repeatingOption = "repeating_option"
         case repeatingEnd = "repeating_end"
         case notificationOptions = "notification_options"
+        case repeatingEndCount = "repeating_count"
+        case repeatingTurn = "repeating_turn"
         case timeType = "time_type"
         case timeLowerBound = "time_lower_bound"
         case timeUpperBound = "time_upper_bound"
         case secondsFromGMT = "seconds_from_gmt"
-        case repeatingEndCount = "repeating_count"
-        
+
         var dataType: ColumnDataType {
             switch self {
             case .uuid: return .text([.primaryKey(autoIncrement: false), .unique, .notNull])
@@ -39,11 +40,12 @@ struct PendingDoneTodoEventTable: Table {
             case .repeatingOption: return .text([])
             case .repeatingEnd: return .real([])
             case .notificationOptions: return .text([])
+            case .repeatingEndCount: return .integer([])
+            case .repeatingTurn: return .integer([])
             case .timeType: return .text([])
             case .timeLowerBound: return .real([])
             case .timeUpperBound: return .real([])
             case .secondsFromGMT: return .real([])
-            case .repeatingEndCount: return .integer([])
             }
         }
     }
@@ -91,6 +93,13 @@ struct PendingDoneTodoEventTable: Table {
         switch version {
         case 0:
             return Self.addColumnStatement(.repeatingEndCount)
+        case 6:
+            let columnNames = PendingDoneTodoEventTableV6TempTable.columnNamesExistsInV6
+            return Self.modfiyColumns(
+                tempTable: PendingDoneTodoEventTableV6TempTable.tableName,
+                to: columnNames,
+                from: columnNames
+            )
         default: return nil
         }
     }
@@ -112,11 +121,68 @@ struct PendingDoneTodoEventTable: Table {
             let mappers = entity.todoEvent.notificationOptions.map { EventNotificationTimeOptionMapper(option: $0) }
             let data = try? JSONEncoder().encode(mappers)
             return data.flatMap { String(data: $0, encoding: .utf8) }
+        case .repeatingEndCount: return entity.todoEvent.repeating?.repeatingEndOption?.endCount
+        case .repeatingTurn: return entity.todoEvent.repeatingTurn
         case .timeType: return entity.todoEvent.time?.typeText
         case .timeLowerBound: return entity.todoEvent.time?.lowerBoundWithFixed
         case .timeUpperBound: return entity.todoEvent.time?.upperBoundWithFixed
         case .secondsFromGMT: return entity.todoEvent.time?.secondsFromGMT ?? 0
-        case .repeatingEndCount: return entity.todoEvent.repeating?.repeatingEndOption?.endCount
         }
+    }
+}
+
+// v7 스키마로 동결 — 살아있는 Columns 를 참조하면 이후 컬럼 추가가 v6 원본에 없는 이름을 복사 목록에 실어 깨진다
+struct PendingDoneTodoEventTableV6TempTable: Table {
+
+    enum Columns: String, TableColumn {
+        case uuid
+        case name
+        case createTimeStamp = "create_timestamp"
+        case eventTagId = "tag_id"
+        case repeatingStart = "repeating_start"
+        case repeatingOption = "repeating_option"
+        case repeatingEnd = "repeating_end"
+        case notificationOptions = "notification_options"
+        case repeatingEndCount = "repeating_count"
+        case repeatingTurn = "repeating_turn"
+        case timeType = "time_type"
+        case timeLowerBound = "time_lower_bound"
+        case timeUpperBound = "time_upper_bound"
+        case secondsFromGMT = "seconds_from_gmt"
+
+        var dataType: ColumnDataType {
+            switch self {
+            case .uuid: return .text([.primaryKey(autoIncrement: false), .unique, .notNull])
+            case .name: return .text([.notNull])
+            case .createTimeStamp: return .real([])
+            case .eventTagId: return .text([])
+            case .repeatingStart: return .real([])
+            case .repeatingOption: return .text([])
+            case .repeatingEnd: return .real([])
+            case .notificationOptions: return .text([])
+            case .repeatingEndCount: return .integer([])
+            case .repeatingTurn: return .integer([])
+            case .timeType: return .text([])
+            case .timeLowerBound: return .real([])
+            case .timeUpperBound: return .real([])
+            case .secondsFromGMT: return .real([])
+            }
+        }
+    }
+
+    typealias ColumnType = Columns
+    typealias EntityType = PendingDoneTodoEventTable.PendingDoneTodo
+    static var tableName: String { "PendingDoneTodoEvent_v6" }
+
+    static var columnNamesExistsInV6: [String] {
+        return Columns.allCases
+            .filter { $0 != .repeatingTurn }
+            .map { $0.rawValue }
+    }
+
+    static func scalar(_ entity: EntityType, for column: Columns) -> (any ScalarType)? {
+        guard let liveColumn = PendingDoneTodoEventTable.Columns(rawValue: column.rawValue)
+        else { return nil }
+        return PendingDoneTodoEventTable.scalar(entity, for: liveColumn)
     }
 }

--- a/Repository/Sources/Repository+Imple/Setting/Migration/AppDataMigrationImple.swift
+++ b/Repository/Sources/Repository+Imple/Setting/Migration/AppDataMigrationImple.swift
@@ -43,6 +43,7 @@ public final class AppDataMigrationImple: @unchecked Sendable {
                     case 3: try self?.runMigrationVersion3to4(database)
                     case 4: try? self?.runMigrationVersion4to5(database)
                     case 5: try? self?.runMigrationVersion5to6(database)
+                    case 6: try? self?.runMigrationVersion6to7(database)
                     default: break
                     }
                 },
@@ -155,6 +156,18 @@ extension AppDataMigrationImple {
         } catch {
             logger.log(.sql, level: .error, "migration version 5 -> 6 failed.. will drop TodoEventTable")
             try? database.dropTable(TodoEventTable.self)
+        }
+    }
+
+    private func runMigrationVersion6to7(_ database: any DataBase) throws {
+        do {
+            try database.createTableOrNot(PendingDoneTodoEventTable.self)
+            try database.createTableOrNot(PendingDoneTodoEventTableV6TempTable.self)
+            try database.migrate(PendingDoneTodoEventTable.self, version: 6)
+            logger.log(.sql, level: .info, "migration version 6 -> 7, PendingDoneTodoEventTable finished")
+        } catch {
+            logger.log(.sql, level: .error, "migration version 6 -> 7 failed.. will drop PendingDoneTodoEventTable")
+            try? database.dropTable(PendingDoneTodoEventTable.self)
         }
     }
 

--- a/Repository/Tests/Event/Todo/TodoLocalStorageImpleTests.swift
+++ b/Repository/Tests/Event/Todo/TodoLocalStorageImpleTests.swift
@@ -1,0 +1,168 @@
+//
+//  TodoLocalStorageImpleTests.swift
+//  RepositoryTests
+//
+//  Created by sudo.park on 8/12/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Prelude
+import Optics
+import SQLiteService
+import Domain
+import Extensions
+import UnitTestHelpKit
+
+@testable import Repository
+
+
+@Suite("TodoLocalStorageImpleTests", .serialized)
+final class TodoLocalStorageImpleTests: LocalTestable {
+
+    let sqliteService: SQLiteService = .init()
+
+    private func makeStorage() -> TodoLocalStorageImple {
+        return TodoLocalStorageImple(sqliteService: self.sqliteService)
+    }
+
+    private var dummyRepeatingTodo: TodoEvent {
+        let option = EventRepeatingOptions.EveryWeek(TimeZone(abbreviation: "KST")!)
+        let repeating = EventRepeating(repeatingStartTime: 100, repeatOption: option)
+            |> \.repeatingEndOption .~ .count(10)
+        return TodoEvent(uuid: "repeating", name: "some")
+            |> \.eventTagId .~ .custom("tag")
+            |> \.time .~ .at(300)
+            |> \.repeating .~ pure(repeating)
+            |> \.repeatingTurn .~ 3
+            |> \.notificationOptions .~ [.atTime]
+    }
+}
+
+
+// MARK: - 완료 처리 중(completing) 원본 보관
+
+extension TodoLocalStorageImpleTests {
+
+    private func saveCompletingState(
+        _ storage: TodoLocalStorageImple, _ origin: TodoEvent
+    ) async throws {
+        try await storage.saveTodoEvent(origin)
+        try await storage.updateTodoToggleState(origin.uuid, .completing(origin: origin))
+        try await storage.saveDoneTodoEvent(DoneTodoEvent(origin))
+    }
+
+    @Test func storage_whenCompleting_keepRepeatingTodoOriginWithTimeAndTurn() async throws {
+        try await self.runTestWithOpenClose("toggle-completing") {
+            // given
+            let storage = self.makeStorage()
+            let origin = self.dummyRepeatingTodo
+
+            // when
+            try await self.saveCompletingState(storage, origin)
+            let state = try await storage.todoToggleState(origin.uuid)
+
+            // then
+            guard case .completing(let restored, _) = state
+            else {
+                Issue.record("completing 상태가 아님: \(state)")
+                return
+            }
+            #expect(restored.time == .at(300))
+            #expect(restored.repeatingTurn == 3)
+            #expect(restored.repeating?.repeatingEndOption == .count(10))
+        }
+    }
+}
+
+
+// MARK: - v6 -> v7 컬럼 순서 교정 마이그레이션
+
+private struct PendingDoneTodoEventTableV6LegacyTable: Table {
+
+    enum Columns: String, TableColumn {
+        case uuid
+        case name
+        case createTimeStamp = "create_timestamp"
+        case eventTagId = "tag_id"
+        case repeatingStart = "repeating_start"
+        case repeatingOption = "repeating_option"
+        case repeatingEnd = "repeating_end"
+        case notificationOptions = "notification_options"
+        case timeType = "time_type"
+        case timeLowerBound = "time_lower_bound"
+        case timeUpperBound = "time_upper_bound"
+        case secondsFromGMT = "seconds_from_gmt"
+        case repeatingEndCount = "repeating_count"
+
+        var dataType: ColumnDataType {
+            switch self {
+            case .uuid: return .text([.primaryKey(autoIncrement: false), .unique, .notNull])
+            case .name: return .text([.notNull])
+            case .createTimeStamp, .repeatingStart, .repeatingEnd: return .real([])
+            case .eventTagId, .repeatingOption, .notificationOptions, .timeType: return .text([])
+            case .timeLowerBound, .timeUpperBound, .secondsFromGMT: return .real([])
+            case .repeatingEndCount: return .integer([])
+            }
+        }
+    }
+
+    typealias ColumnType = Columns
+    typealias EntityType = PendingDoneTodoEventTable.PendingDoneTodo
+    static var tableName: String { PendingDoneTodoEventTable.tableName }
+
+    static func scalar(_ entity: EntityType, for column: Columns) -> (any ScalarType)? {
+        guard let newColumn = PendingDoneTodoEventTable.Columns(rawValue: column.rawValue)
+        else { return nil }
+        return PendingDoneTodoEventTable.scalar(entity, for: newColumn)
+    }
+}
+
+extension TodoLocalStorageImpleTests {
+
+    private func saveLegacyPendingDoneTodo(_ origin: TodoEvent) async throws {
+        try await self.sqliteService.async.run { db in
+            typealias Legacy = PendingDoneTodoEventTableV6LegacyTable
+            let pending = PendingDoneTodoEventTable.PendingDoneTodo(todoEvent: origin)
+            try db.createTableOrNot(Legacy.self)
+            try db.insert(Legacy.self, entities: [pending], shouldReplace: true)
+
+            let state = TodoToggleStateTable.ToggleState(todoId: origin.uuid, state: .completing)
+            try db.insert(TodoToggleStateTable.self, entities: [state], shouldReplace: true)
+        }
+    }
+
+    private func migratePendingDoneTodoTable() async throws {
+        try await self.sqliteService.async.run { db in
+            try db.createTableOrNot(PendingDoneTodoEventTableV6TempTable.self)
+            try db.migrate(PendingDoneTodoEventTable.self, version: 6)
+        }
+    }
+
+    @Test func storage_whenMigrateToVersion7_keepSavedPendingOrigin() async throws {
+        try await self.runTestWithOpenClose("toggle-migration") {
+            // given
+            let storage = self.makeStorage()
+            let origin = self.dummyRepeatingTodo
+            try await storage.saveTodoEvent(origin)
+            try await storage.saveDoneTodoEvent(DoneTodoEvent(origin))
+            try await self.saveLegacyPendingDoneTodo(origin)
+
+            // when
+            try await self.migratePendingDoneTodoTable()
+
+            // then
+            let state = try await storage.todoToggleState(origin.uuid)
+            guard case .completing(let restored, _) = state
+            else {
+                Issue.record("completing 상태가 아님: \(state)")
+                return
+            }
+            #expect(restored.name == "some")
+            #expect(restored.eventTagId == .custom("tag"))
+            #expect(restored.time == .at(300))
+            #expect(restored.repeating?.repeatingEndOption == .count(10))
+            #expect(restored.repeatingTurn == nil)
+        }
+    }
+}

--- a/TodoCalendarApp/Sources/AppEnvironment.swift
+++ b/TodoCalendarApp/Sources/AppEnvironment.swift
@@ -71,7 +71,7 @@ struct AppEnvironment {
         return [googleCalendarService, appleCalendarService]
     }
 
-    static let dbVersion: Int32 = 6
+    static let dbVersion: Int32 = 7
     static let googleCalendarDBVersion: Int32 = 0
     static let appleCalendarDBVersion: Int32 = 0
     

--- a/docs/domain-notes.md
+++ b/docs/domain-notes.md
@@ -36,6 +36,4 @@
 
 ## DB 마이그레이션
 
-- `AppEnvironment.dbVersion` 증가
-- 해당 `Table` 타입의 `migrateStatement(for version:)` 에 case 추가
-- 두 가지를 함께 변경해야 마이그레이션이 실행됨
+절차·버전 이력 정본은 [`docs/spec/infrastructure.md §5`](spec/infrastructure.md). 짝은 **세 위치**다 — `AppEnvironment.dbVersion` ↔ `Table.migrateStatement(for:)` case ↔ `AppDataMigrationImple`의 `runDBMigration` case + `runMigrationVersionNtoM`. 마지막이 빠지면 `migrateStatement`가 호출조차 안 되고 조용히 안 돈다.

--- a/docs/product-specification.md
+++ b/docs/product-specification.md
@@ -299,8 +299,8 @@
 - 타임존 인지 일수 계산, 1초 타이머 실시간 업데이트
 
 ### DB 마이그레이션
-- 메인 DB v6, 외부 캘린더 DB v0
-- 버전별 `migrateStatement` + `AppEnvironment.dbVersion` 동시 변경 필수
+- 메인 DB v7, 외부 캘린더 DB v0
+- `AppEnvironment.dbVersion` + `Table.migrateStatement` + `AppDataMigrationImple` 스텝, 세 위치 동시 변경 필수
 
 ### 외부 의존성
 - Alamofire, Kingfisher, SQLiteService, Firebase(Messaging), AppAuth, Combine 등

--- a/docs/spec/infrastructure.md
+++ b/docs/spec/infrastructure.md
@@ -213,7 +213,7 @@ ApplicationDeepLinkHandlerImple:
 
 ### 5.1 메인 DB (`todo_calendar.db`)
 
-**현재 버전**: `AppEnvironment.dbVersion = 6`
+**현재 버전**: `AppEnvironment.dbVersion = 7`
 
 **마이그레이션 메커니즘** (`SQLiteService`):
 1. 앱 시작 시 `AppDataMigrationImple.runDBMigration()` 호출
@@ -234,6 +234,7 @@ ApplicationDeepLinkHandlerImple:
 | 3→4 | 구글 캘린더 이벤트 가시성 컬럼 | `google_calendar_event_origin` (레거시) | `ALTER TABLE ... ADD COLUMN visibility TEXT` |
 | 4→5 | 업로드 큐 테이블 재구성 | `event_upload_pending_queue` | 임시 테이블 생성 → 데이터 이동 → 원본 삭제 → 이름 변경 |
 | 5→6 | 할일 반복 회차 컬럼 추가 | `TodoEvents` | `ALTER TABLE ... ADD COLUMN repeating_turn INTEGER` |
+| 6→7 | 완료 처리 중 원본 보관 테이블의 컬럼 순서 교정 + 회차 컬럼 추가 | `PendingDoneTodoEvent` | 임시 테이블 생성 → 데이터 이동 → 원본 삭제 → 이름 변경 |
 
 **전체 테이블 목록** (`prepareTables()` 순서):
 
@@ -263,7 +264,7 @@ ApplicationDeepLinkHandlerImple:
 | 버전 | 에러 처리 | 이유 |
 |---|---|---|
 | 0→1, 1→2, 2→3, 3→4 | `try` (hard fail) | 핵심 스키마 변경 |
-| 4→5, 5→6 | `try?` (soft fail) | 큐 재구성/부가 컬럼, 실패해도 앱 동작에 큰 영향 없음 |
+| 4→5, 5→6, 6→7 | `try?` (soft fail) | 큐 재구성/부가 컬럼, 실패해도 앱 동작에 큰 영향 없음 |
 
 **전체 실패 시**: 최상위 try-catch에서 에러 로깅만 수행, 앱 크래시 방지.
 
@@ -286,10 +287,40 @@ ApplicationDeepLinkHandlerImple:
 
 ### 5.5 새 마이그레이션 추가 절차
 
+**세 위치를 반드시 함께 변경한다:**
+
 1. `AppEnvironment.dbVersion` (또는 `googleCalendarDBVersion`) 증가
 2. 해당 `Table` 타입의 `migrateStatement(for version:)`에 새 case 추가
-3. `AppDataMigrationImple.runDBMigration()`의 switch에 새 version case 추가
-4. 두 곳을 반드시 함께 변경해야 마이그레이션이 실행됨
+3. `AppDataMigrationImple` — `runDBMigration`의 switch에 case 추가 + `runMigrationVersionNtoM` 메서드 작성
+
+**3번이 빠지면 `migrateStatement`는 호출조차 되지 않는다.** 컴파일도 테스트도 통과하고 마이그레이션만 조용히 안 돈다.
+
+`migrateStatement(for:)`가 받는 숫자는 **떠나는 버전**이다 — `case 5`는 5 → 6 스텝에서 돈다.
+
+위 표에 새 행을 추가하고 §5.1의 "현재 버전"도 함께 올린다.
+
+### 5.6 컬럼 순서 변경·삭제 — temp 테이블 재생성
+
+SQLite의 `ALTER TABLE ADD COLUMN`은 **맨 뒤에 붙이는 것만** 된다. 순서 교정·컬럼 제거는 `modfiyColumns(tempTable:to:from:)`로 간다 — `INSERT INTO temp SELECT ... FROM 원본` → 원본 DROP → temp를 원본 이름으로 RENAME, 세 문장을 만들어준다.
+
+- **temp 테이블은 라이브러리가 안 만든다.** 마이그레이션 스텝에서 `createTableOrNot(<Temp>Table.self)`로 직접 생성한다. 새 컬럼 순서는 이 temp 테이블의 `Columns` 정의가 결정한다.
+- `to`/`from`은 컬럼 **이름** 매핑 표다. 각 이름은 해당 테이블에서 이름으로 해석되고, 두 리스트끼리는 위치로 짝지어진다. 이름이 안 바뀌면 같은 배열을 양쪽에 넘긴다.
+- **새로 추가하는 컬럼은 두 리스트에서 뺀다.** 원본에 없어 SELECT가 실패한다. 빠진 컬럼은 NULL로 남는다.
+- 선례: `EventUploadPendingQueueTableV4TempTable`(v4 → v5), `PendingDoneTodoEventTableV6TempTable`(v6 → v7)
+
+```swift
+private func runMigrationVersion6to7(_ database: any DataBase) throws {
+    do {
+        try database.createTableOrNot(PendingDoneTodoEventTable.self)
+        try database.createTableOrNot(PendingDoneTodoEventTableV6TempTable.self)
+        try database.migrate(PendingDoneTodoEventTable.self, version: 6)
+    } catch {
+        try? database.dropTable(PendingDoneTodoEventTable.self)   // 실패 시 드롭 — prepareTables가 새 스키마로 재생성
+    }
+}
+```
+
+> 컬럼 순서가 곧 cursor 읽기 순서라는 위치 결합은 [`Repository/CLAUDE.md`](../../Repository/CLAUDE.md) 참조.
 
 ---
 

--- a/docs/spec/todo-event.md
+++ b/docs/spec/todo-event.md
@@ -250,8 +250,8 @@ sequenceDiagram
 ## 5. 할일 완료 취소 (되돌리기)
 
 - DoneTodoEvent 삭제
-- 원본 TodoEvent 복원 → SharedDataStore `todos`에 추가
-- 이벤트 상세 데이터(장소, URL, 메모)도 함께 복원
+- 이름/태그/시각/알림만 승계한 **새 TodoEvent 생성**(새 ID, 반복 정보 없음) → SharedDataStore `todos`에 추가
+- 이벤트 상세 데이터(장소, URL, 메모)도 함께 복사
 
 ### RevertTodoResult (되돌리기 결과)
 
@@ -523,15 +523,16 @@ flowchart TD
 
 결과:
   1. DoneTodoEvent 삭제
-  2. 원본 TodoEvent 복원 (turn=3 시점의 상태)
-  3. 이벤트 상세 데이터(장소/URL/메모)도 복원
+  2. 새 TodoEvent 생성 — 새 ID, 반복 정보 없음
+     (이름/태그/시각/알림만 승계)
+  3. 이벤트 상세 데이터(장소/URL/메모)도 복사
   4. todos에 추가, 미완료 판정 실행
 
-주의: 완료 시 생성된 다음 인스턴스(turn=4)는
-      되돌리기로 자동 제거되지 않음.
-      → turn=3(복원)과 turn=4(이미 생성)가 공존 가능.
-      실제 코드에서는 Repository가 원본 ID로 교체하므로
-      같은 ID의 할일은 최신 상태로 덮어씀.
+주의: 되돌리기는 원본 시리즈를 되감지 않는다.
+      원본은 완료 시 이미 turn=4로 전진해 있고 그대로 남는다.
+      → 되돌린 단발 할일과 turn=4 시리즈가 공존한다.
+      DoneTodoEvent가 반복 정보·회차를 들고 있지 않으므로
+      시리즈 복원은 애초에 불가능하다.
 ```
 
 ### 13.6 위젯 TodoToggle과 반복 할일
@@ -546,7 +547,7 @@ flowchart TD
   - 위젯 캐시 리셋 + Timeline 갱신
 
 되돌리기 시:
-  - DoneTodoEvent 삭제 + 원본 복원
+  - DoneTodoEvent 삭제 + 새 TodoEvent 생성
   - 위젯 캐시 리셋
 
 isToggledCurrentTodo 판정:


### PR DESCRIPTION
`PendingDoneTodoEvent` 테이블의 컬럼 순서를 읽기 순서에 맞추고 `repeating_turn` 컬럼을 추가한다. DB 마이그레이션 6 → 7.

## 문제

이 테이블은 컬럼이 13개인데 `PendingDoneTodo.init(_ cursor:)`는 공유되는 `TodoEvent.init(cursor)`로 10번 + 직접 4번, 총 14번 읽는다. 9번째부터 전부 밀려서, 읽기가 기대하는 `repeating_count`·`repeating_turn` 자리에 실제로는 `time_type`·`time_lower_bound`가 들어온다. 타입이 안 맞으면 `as? T` 캐스팅이 nil을 내므로 크래시 없이 조용히 값만 사라진다.

`#355`가 테이블 맨 뒤에 `repeating_count`를 붙이면서 동시에 공유 cursor init에 9번째 읽기를 추가해 1칸이 밀렸고, `#544`가 `repeatingTurn` 읽기를 더해 2칸으로 커지면서 읽기 횟수가 컬럼 수 밖으로 나갔다.

결과로 `.completing` 상태에서 복원되는 origin이 `time = nil`, `repeatingTurn = nil`, `.count` 종료옵션 소실 상태가 된다. 두 군데서 관측된다:

- 그 origin이 그대로 `cancelDone` 페이로드로 나가므로 #834가 실은 회차가 이 경로에서는 **항상 nil**이었다
- `time`이 nil이면 `EventTimeTable.matchingQuery(nil)`이 where 절을 통째로 빼서, 같은 origin에 done이 여러 개일 때 `loadOne`이 임의의 행을 집는다 (과매칭)

## 접근

컬럼 순서를 읽기 순서에 맞추고 없던 `repeating_turn`을 추가했다. `ALTER TABLE ADD COLUMN`은 뒤에 붙이는 것만 되니 순서 교정은 temp 테이블 재생성으로 갔다 — v4 → v5의 `EventUploadPendingQueueTableV4TempTable` + `modfiyColumns(tempTable:to:from:)`와 같은 형태다.

**기존 행의 데이터는 이관된다.** write 경로(`scalar`)는 원래부터 컬럼별로 정확히 썼고 read 경로만 밀려 있었으므로, 저장된 값 자체는 유효하다. v6에 존재하던 12개 컬럼을 이름으로 복사한다. `repeating_turn`만 원본이 없어 NULL로 남는데, 이건 `nil = turn 1` 규약대로 해석된다.

스펙 문서(`todo-event.md`)에서 완료 취소를 "원본 TodoEvent 복원 (turn=3 시점의 상태)"라고 적어둔 부분도 함께 고쳤다. 실제 `revertDoneTodo`는 새 ID에 반복 정보 없는 별개 할일을 만들고, 그게 맞는 동작이다 — 문서만 어긋나 있어서 결함으로 오독될 소지가 있었다.

## 검증

`TodoLocalStorageImple`의 `.completing` 경로는 지금까지 테스트가 아예 없었다 (기존 테스트가 전부 스텁 스토리지를 써서 SQLite 왕복을 우회). `BaseLocalTests` 기반 실 DB 왕복 테스트 2개를 새로 뒀다:

- `storage_whenCompleting_keepRepeatingTodoOriginWithTimeAndTurn` — 반복 todo를 `.completing`으로 저장 → `todoToggleState` 재조회 시 turn·time·종료옵션이 보존된다. 수정 전 세 단언 모두 실패를 확인했다
- `storage_whenMigrateToVersion7_keepSavedPendingOrigin` — 구 스키마로 만든 테이블에 행을 넣고 마이그레이션을 태워 데이터 이관을 검증한다. migrate 호출을 빼면 실패하는 것도 확인했다

## 남은 검증

기존 v6 DB를 가진 실기기에서 앱 부팅 시 `runMigrationVersion6to7`이 실제로 도는지는 유닛 테스트 밖이다. 테스트는 `db.migrate` 직접 호출까지만 덮는다.

## 지침 정비

이번 작업에서 드러난 구멍 셋을 함께 메웠다.

- `Repository/CLAUDE.md`가 마이그레이션 정본으로 지목한 `SQLiteLocalStorage+Migration.swift`는 코드베이스에 없다. 실제 오케스트레이터인 `AppDataMigrationImple.runDBMigration`으로 정정했다
- 짝이 2위치(`dbVersion` ↔ `migrateStatement`)로 적혀 있었는데 실제로는 3위치다. `AppDataMigrationImple`의 스텝이 빠지면 `migrateStatement`는 호출조차 안 되고 컴파일·테스트는 그대로 통과한다
- `impact-check.sh`의 짝 감지가 `migrateStatement` 리터럴을 기본 diff 컨텍스트에서만 찾아, case만 추가한 이번 변경을 오탐으로 잡았다. `-U20`으로 넓히고 마이그레이션 스텝 누락 경고를 새로 뒀다

컬럼 순서가 곧 cursor 읽기 순서라는 위치 결합과, 공유 `init(cursor)`를 쓰는 테이블이 한쪽 컬럼 추가로 조용히 밀린다는 함정(이번 버그의 근본 원인)도 `Repository/CLAUDE.md`에 명시했다.

closes #835
