### PR TITLE
[#850] 로거 콘솔 진입점을 전 화면 공통 플로팅 버튼으로 이전

### DIFF
--- a/TodoCalendarApp/Sources/Debug/DebugFloatingLoggerWindow.swift
+++ b/TodoCalendarApp/Sources/Debug/DebugFloatingLoggerWindow.swift
@@ -1,0 +1,141 @@
+//
+//  DebugFloatingLoggerWindow.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 8/12/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+#if DEBUG
+
+import UIKit
+import Extensions
+
+
+private enum Constant {
+    static let buttonSize: CGFloat = 44
+    static let edgeInset: CGFloat = 8
+    static let centerStoreKey: String = "debug.floatingLoggerButton.center"
+}
+
+
+// MARK: - DebugFloatingLoggerWindow
+
+final class DebugFloatingLoggerWindow: UIWindow {
+
+    override init(windowScene: UIWindowScene) {
+        super.init(windowScene: windowScene)
+        self.windowLevel = .alert + 1
+        self.backgroundColor = .clear
+        self.rootViewController = DebugFloatingLoggerViewController()
+        self.isHidden = false
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard let hitView = super.hitTest(point, with: event) else { return nil }
+        let isEmptyArea = hitView === self || hitView === self.rootViewController?.view
+        return isEmptyArea ? nil : hitView
+    }
+}
+
+
+// MARK: - DebugFloatingLoggerViewController
+
+private final class DebugFloatingLoggerViewController: UIViewController {
+
+    private let logButton = UIButton(type: .custom)
+    private var didPlaceLogButton: Bool = false
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .clear
+        self.setupLogButton()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        let center = self.didPlaceLogButton
+            ? self.logButton.center
+            : self.storedCenter ?? self.defaultCenter
+        self.logButton.center = self.clampedCenter(center)
+        self.didPlaceLogButton = true
+    }
+
+    private func setupLogButton() {
+        self.logButton.frame = .init(
+            origin: .zero,
+            size: .init(width: Constant.buttonSize, height: Constant.buttonSize)
+        )
+        self.logButton.setTitle("Log", for: .normal)
+        self.logButton.setTitleColor(.red, for: .normal)
+        self.logButton.titleLabel?.font = .systemFont(ofSize: 12, weight: .bold)
+        self.logButton.backgroundColor = UIColor.systemBackground.withAlphaComponent(0.8)
+        self.logButton.layer.cornerRadius = Constant.buttonSize / 2
+        self.logButton.layer.borderWidth = 1
+        self.logButton.layer.borderColor = UIColor.red.withAlphaComponent(0.6).cgColor
+
+        self.logButton.addTarget(self, action: #selector(self.showConsole), for: .touchUpInside)
+        self.logButton.addGestureRecognizer(
+            UIPanGestureRecognizer(target: self, action: #selector(self.handleLogButtonPan(_:)))
+        )
+        self.view.addSubview(logButton)
+    }
+
+    @objc private func showConsole() {
+        guard self.presentedViewController == nil else { return }
+        let consoleViewController = LoggerConsoleBuilder().makeConsoleView()
+        self.present(consoleViewController, animated: true)
+    }
+}
+
+
+// MARK: - move log button
+
+extension DebugFloatingLoggerViewController {
+
+    @objc fileprivate func handleLogButtonPan(_ gesture: UIPanGestureRecognizer) {
+        let translation = gesture.translation(in: self.view)
+        let movedCenter = CGPoint(
+            x: self.logButton.center.x + translation.x,
+            y: self.logButton.center.y + translation.y
+        )
+        self.logButton.center = self.clampedCenter(movedCenter)
+        gesture.setTranslation(.zero, in: self.view)
+
+        guard gesture.state == .ended || gesture.state == .cancelled else { return }
+        self.storeCenter(self.logButton.center)
+    }
+
+    private var defaultCenter: CGPoint {
+        return .init(x: self.view.bounds.maxX, y: self.view.bounds.maxY)
+    }
+
+    private var storedCenter: CGPoint? {
+        return UserDefaults.standard.string(forKey: Constant.centerStoreKey)
+            .map { NSCoder.cgPoint(for: $0) }
+    }
+
+    private func storeCenter(_ center: CGPoint) {
+        UserDefaults.standard.set(NSCoder.string(for: center), forKey: Constant.centerStoreKey)
+    }
+
+    private func clampedCenter(_ center: CGPoint) -> CGPoint {
+        let insets = self.view.safeAreaInsets
+        let margin = Constant.buttonSize / 2 + Constant.edgeInset
+        let minX = self.view.bounds.minX + insets.left + margin
+        let maxX = self.view.bounds.maxX - insets.right - margin
+        let minY = self.view.bounds.minY + insets.top + margin
+        let maxY = self.view.bounds.maxY - insets.bottom - margin
+        return .init(
+            x: min(max(center.x, minX), maxX),
+            y: min(max(center.y, minY), maxY)
+        )
+    }
+}
+
+#endif

--- a/TodoCalendarApp/Sources/Main/MainViewController.swift
+++ b/TodoCalendarApp/Sources/Main/MainViewController.swift
@@ -146,15 +146,6 @@ extension MainViewController {
                 self?.viewModel.jumpDate()
             }
             .store(in: &self.cancellables)
-        
-        self.headerView.logButton.addTapGestureRecognizerPublisher()
-            .sink(receiveValue: { [weak self] in
-                self?.viewAppearance.impactIfNeed()
-                let consoleBuilder = LoggerConsoleBuilder()
-                let consoleVC = consoleBuilder.makeConsoleView()
-                self?.present(consoleVC, animated: true)
-            })
-            .store(in: &self.cancellables)
     }
 }
 
@@ -217,7 +208,6 @@ private final class HeaderView: UIView {
     let jumpButton = UIButton()
     let eventTypeFilterButton = UIButton()
     let settingButton = UIButton()
-    let logButton = UIButton()
     
     func updateMigrationStatus(_ status: TemporaryUserDataMigrationStatus?) {
          self.migrationStatus = status
@@ -303,13 +293,6 @@ private final class HeaderView: UIView {
             $0.leadingAnchor.constraint(greaterThanOrEqualTo: returnTodayView.trailingAnchor, constant: 4)
         }
         buttonsStackView.spacing = 8
-        
-        #if DEBUG
-        buttonsStackView.addArrangedSubview(logButton)
-        logButton.setTitle("Log", for: .normal)
-        logButton.setTitleColor(.red, for: .normal)
-        logButton.titleLabel?.font = .systemFont(ofSize: 12, weight: .bold)
-        #endif
         
         buttonsStackView.addArrangedSubview(migrationButton)
         migrationButton.autoLayout.active {

--- a/TodoCalendarApp/Sources/SceneDelegate.swift
+++ b/TodoCalendarApp/Sources/SceneDelegate.swift
@@ -11,6 +11,9 @@ import CommonPresentation
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
+    #if DEBUG
+    private var debugFloatingLoggerWindow: DebugFloatingLoggerWindow?
+    #endif
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
@@ -24,7 +27,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         app?.applicationRouter?.window = window
         
         app?.applicationViewModel.prepareInitialScene()
-        
+
+        #if DEBUG
+        self.debugFloatingLoggerWindow = DebugFloatingLoggerWindow(windowScene: windowScene)
+        #endif
+
         guard let url = connectionOptions.urlContexts.first?.url else { return }
         _ = app?.applicationViewModel.handle(open: url)
     }


### PR DESCRIPTION
DEBUG 로거 콘솔을 메인 화면에서만 열 수 있던 걸 어느 화면에서든 열리게 바꿨다.

## 문제

`MainViewController` 헤더의 `Log` 버튼이 유일한 진입점이라 다른 화면에선 콘솔을 볼 수 없다. 화면마다 진입점을 심는 방식은 화면 수만큼 중복되고 각 화면의 레이아웃도 건드려야 한다.

## 접근

앱 윈도우 위에 오버레이 윈도우(`.alert + 1`) 하나를 띄우고 거기에 플로팅 버튼을 둔다. 진입점이 앱 VC 계층 밖에 사니 화면 수와 무관하게 하나로 끝나고, 콘솔도 이 윈도우의 rootViewController 가 present 한다.

핵심은 오버레이가 아래 앱 조작을 막지 않는 것 — `hitTest` 에서 히트된 뷰가 rootView 자신(= 버튼 밖 빈 영역)이면 `nil` 을 반환해 터치를 아래 윈도우로 흘린다.

고정 위치는 화면을 가리므로 버튼은 드래그로 옮긴다. 놓은 자리를 그대로 두되 safe area 안쪽으로 clamp 하고, 위치를 UserDefaults 에 남겨 재실행 후에도 복원한다. 복원 값도 clamp 를 거치니 기기·회전이 바뀌어도 화면 밖으로 나가지 않는다.

메인 헤더의 기존 `Log` 버튼은 제거했다.

## 검증

TodoCalendarApp 빌드·테스트 통과. 시뮬레이터 실행으로 버튼 노출과 헤더 버튼 제거를 확인했다. 탭 진입·드래그 이동은 이 환경에 터치 자동 입력 수단이 없어 유저 확인이 남아 있다.

Closes #850
