### PR TITLE
[#822] 캘린더 헤더 월 표시 좌우에 달 이동 버튼 추가

### DIFF
--- a/Presentations/CalendarScenes/CLAUDE.md
+++ b/Presentations/CalendarScenes/CLAUDE.md
@@ -32,7 +32,7 @@ UIPageViewController로 월별 페이지를 좌우 스와이프로 전환한다.
 
 | 항목 | 설명 |
 |---|---|
-| Interactor | `moveFocusToToday()`, `moveDay(_:withClearPresented:)` |
+| Interactor | `moveFocusToToday()`, `moveDay(_:withClearPresented:)`, `moveToPreviousMonth()`, `moveToNextMonth()` |
 | Listener | `CalendarSceneListener` — 포커스 월 변경 알림 |
 | 주요 Usecase | Calendar, Holiday, TodoEvent, ScheduleEvent, GoogleCalendar, ForemostEvent, EventTag, EventSync |
 

--- a/Presentations/CalendarScenes/Sources/CalendarViewController.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewController.swift
@@ -66,7 +66,27 @@ final class CalendarViewController: UIPageViewController, CalendarScene {
         guard let center = self.monthViewControllers?[safe: index] else { return }
         self.setViewControllers([center], direction: .forward, animated: false)
     }
-    
+
+    // 애니메이션 중 setViewControllers를 재호출하면 이후 스와이프가 엉뚱한 페이지를 보여준다
+    private var isSlidingFocus: Bool = false
+
+    func slideFocus(to index: Int, isNext: Bool, completed: @escaping @Sendable () -> Void) {
+        guard !self.isSlidingFocus,
+              let target = self.monthViewControllers?[safe: index]
+        else { return }
+
+        self.isSlidingFocus = true
+        self.setViewControllers(
+            [target],
+            direction: isNext ? .forward : .reverse,
+            animated: true
+        ) { [weak self] finished in
+            self?.isSlidingFocus = false
+            guard finished else { return }
+            completed()
+        }
+    }
+
     private func bind() {
      
         self.viewAppearance.didUpdated

--- a/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
@@ -393,6 +393,32 @@ extension CalendarViewModelImple {
         }
     }
     
+    func moveToPreviousMonth() {
+        self.slideFocusedMonth(isNext: false)
+    }
+
+    func moveToNextMonth() {
+        self.slideFocusedMonth(isNext: true)
+    }
+
+    private func slideFocusedMonth(isNext: Bool) {
+        Task { @MainActor in
+            guard let range = self.subject.monthsInCurrentRange.value,
+                  !range.totalMonths.isEmpty
+            else { return }
+
+            let count = range.totalMonths.count
+            let currentIndex = range.focusedIndex
+            let targetIndex = isNext
+                ? (currentIndex + 1) % count
+                : (currentIndex - 1 + count) % count
+
+            self.router?.slideFocus(to: targetIndex, isNext: isNext) { [weak self] in
+                self?.focusChanged(from: currentIndex, to: targetIndex)
+            }
+        }
+    }
+
     private func changeChilds(
         _ totalMonths: TotalMonthsInRange,
         andSelectDay: @Sendable @escaping ((any CalendarPaperSceneInteractor)?) -> Void

--- a/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
@@ -99,6 +99,8 @@ final class CalendarViewModelImple: CalendarViewModel, @unchecked Sendable {
     }
     private var cancellables: Set<AnyCancellable> = []
     private let subject = Subject()
+    // 슬라이드 도중 포커스가 통째로 바뀌면 뒤늦은 완료 콜백이 낡은 인덱스를 적용하지 않게 한다
+    private var focusGeneration: Int = 0
     
     private var monthsWithSort: AnyPublisher<[CalendarMonth], Never> {
         return self.subject.monthsInCurrentRange
@@ -413,8 +415,10 @@ extension CalendarViewModelImple {
                 ? (currentIndex + 1) % count
                 : (currentIndex - 1 + count) % count
 
+            let generationAtSlideStart = self.focusGeneration
             self.router?.slideFocus(to: targetIndex, isNext: isNext) { [weak self] in
-                self?.focusChanged(from: currentIndex, to: targetIndex)
+                guard let self = self, self.focusGeneration == generationAtSlideStart else { return }
+                self.focusChanged(from: currentIndex, to: targetIndex)
             }
         }
     }
@@ -424,6 +428,7 @@ extension CalendarViewModelImple {
         andSelectDay: @Sendable @escaping ((any CalendarPaperSceneInteractor)?) -> Void
     ) {
         Task { @MainActor in
+            self.focusGeneration += 1
             self.router?.changeFocus(at: totalMonths.focusedIndex)
             self.subject.monthsInCurrentRange.send(totalMonths)
             totalMonths.totalMonths.enumerated().forEach { offset, month in

--- a/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
@@ -406,15 +406,14 @@ extension CalendarViewModelImple {
     private func slideFocusedMonth(isNext: Bool) {
         Task { @MainActor in
             guard let range = self.subject.monthsInCurrentRange.value,
-                  !range.totalMonths.isEmpty
+                  let focusedMonth = range.focusedMonth
             else { return }
 
-            let count = range.totalMonths.count
-            let currentIndex = range.focusedIndex
-            let targetIndex = isNext
-                ? (currentIndex + 1) % count
-                : (currentIndex - 1 + count) % count
+            let targetMonth = isNext ? focusedMonth.nextMonth() : focusedMonth.previousMonth()
+            guard let targetIndex = range.totalMonths.firstIndex(of: targetMonth)
+            else { return }
 
+            let currentIndex = range.focusedIndex
             let generationAtSlideStart = self.focusGeneration
             self.router?.slideFocus(to: targetIndex, isNext: isNext) { [weak self] in
                 guard let self = self, self.focusGeneration == generationAtSlideStart else { return }

--- a/Presentations/CalendarScenes/Sources/CalendarViewRouter.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewRouter.swift
@@ -17,6 +17,9 @@ protocol CalendarViewRouting: Routing, Sendable {
     @MainActor
     func changeFocus(at index: Int)
 
+    @MainActor
+    func slideFocus(to index: Int, isNext: Bool, completed: @escaping @Sendable () -> Void)
+
     func routeToAICommand()
 
     func routeToSignIn()
@@ -57,6 +60,12 @@ final class CalendarViewRouterImple: BaseRouterImple, CalendarViewRouting, @unch
     func changeFocus(at index: Int) {
         guard let current = self.currentScene else { return }
         current.changeFocus(at: index)
+    }
+
+    @MainActor
+    func slideFocus(to index: Int, isNext: Bool, completed: @escaping @Sendable () -> Void) {
+        guard let current = self.currentScene else { return }
+        current.slideFocus(to: index, isNext: isNext, completed: completed)
     }
 
     func routeToAICommand() {

--- a/Presentations/CalendarScenes/Tests/Calendar/CalendarDeepLinkHandlerImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Calendar/CalendarDeepLinkHandlerImpleTests.swift
@@ -181,6 +181,16 @@ private final class SpyCalendarInteractor: CalendarSceneInteractor, @unchecked S
 
     func moveFocusToToday() { }
 
+    var didMoveToPreviousMonth: Bool?
+    func moveToPreviousMonth() {
+        self.didMoveToPreviousMonth = true
+    }
+
+    var didMoveToNextMonth: Bool?
+    func moveToNextMonth() {
+        self.didMoveToNextMonth = true
+    }
+
     var didMoveToDay: CalendarDay?
     var didMoveToDayWithClearPresented: Bool?
     func moveDay(_ day: CalendarDay, withClearPresented: Bool) {

--- a/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
@@ -410,7 +410,72 @@ extension CalendarViewModelImpleTests {
         let requesteds = self.spyRouter.spyInteractors.map { $0.didSelectTodayRequested }
         XCTAssertEqual(requesteds, [nil, true, nil])
     }
-    
+
+    func testViewModel_whenMoveToNextMonth_slideToNextPageAndUpdateMonths() {
+        // given
+        let expect = expectation(description: "다음달로 슬라이드 이동")
+        let viewModel = self.makeViewModelWithInitialSetup(
+            .init(year: 2023, month: 08, day: 02, weekDay: 3)
+        )
+        self.spyRouter.didSlideFocusCallback = { expect.fulfill() }
+
+        // when
+        viewModel.moveToNextMonth()
+        self.wait(for: [expect], timeout: self.timeout)
+
+        // then
+        XCTAssertEqual(self.spyRouter.didSlideFocusToIndex, 2)
+        XCTAssertEqual(self.spyRouter.didSlideFocusToNext, true)
+        let currentMonths = self.spyRouter.spyInteractors.map { $0.currentMonth }
+        XCTAssertEqual(currentMonths, [
+            .init(year: 2023, month: 10), .init(year: 2023, month: 08), .init(year: 2023, month: 09)
+        ])
+    }
+
+    func testViewModel_whenMoveToPreviousMonth_slideToPreviousPageAndUpdateMonths() {
+        // given
+        let expect = expectation(description: "이전달로 슬라이드 이동")
+        let viewModel = self.makeViewModelWithInitialSetup(
+            .init(year: 2023, month: 08, day: 02, weekDay: 3)
+        )
+        self.spyRouter.didSlideFocusCallback = { expect.fulfill() }
+
+        // when
+        viewModel.moveToPreviousMonth()
+        self.wait(for: [expect], timeout: self.timeout)
+
+        // then
+        XCTAssertEqual(self.spyRouter.didSlideFocusToIndex, 0)
+        XCTAssertEqual(self.spyRouter.didSlideFocusToNext, false)
+        let currentMonths = self.spyRouter.spyInteractors.map { $0.currentMonth }
+        XCTAssertEqual(currentMonths, [
+            .init(year: 2023, month: 07), .init(year: 2023, month: 08), .init(year: 2023, month: 06)
+        ])
+    }
+
+    func testViewModel_whenMoveToPreviousMonthTwice_slideAcrossPageBoundary() {
+        // given
+        let expect = expectation(description: "페이지 경계를 넘어 연속 이동")
+        expect.expectedFulfillmentCount = 2
+        let viewModel = self.makeViewModelWithInitialSetup(
+            .init(year: 2023, month: 08, day: 02, weekDay: 3)
+        )
+        self.spyRouter.didSlideFocusCallback = { expect.fulfill() }
+
+        // when
+        viewModel.moveToPreviousMonth()
+        viewModel.moveToPreviousMonth()
+        self.wait(for: [expect], timeout: self.timeout)
+
+        // then
+        XCTAssertEqual(self.spyRouter.didSlideFocusToIndex, 2)
+        XCTAssertEqual(self.spyRouter.didSlideFocusToNext, false)
+        let currentMonths = self.spyRouter.spyInteractors.map { $0.currentMonth }
+        XCTAssertEqual(currentMonths, [
+            .init(year: 2023, month: 07), .init(year: 2023, month: 05), .init(year: 2023, month: 06)
+        ])
+    }
+
     func testViewModel_moveDay() {
         // given
         let expect = expectation(description: "특정 일자로 이동")
@@ -1229,6 +1294,16 @@ private extension CalendarViewModelImpleTests {
         var didChangedFocusIndex: Int?
         func changeFocus(at index: Int) {
             self.didChangedFocusIndex = index
+        }
+
+        var didSlideFocusToIndex: Int?
+        var didSlideFocusToNext: Bool?
+        var didSlideFocusCallback: (() -> Void)?
+        func slideFocus(to index: Int, isNext: Bool, completed: @escaping @Sendable () -> Void) {
+            self.didSlideFocusToIndex = index
+            self.didSlideFocusToNext = isNext
+            completed()
+            self.didSlideFocusCallback?()
         }
 
         var didRouteToAICommandCount: Int = 0

--- a/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
@@ -417,7 +417,10 @@ extension CalendarViewModelImpleTests {
         let viewModel = self.makeViewModelWithInitialSetup(
             .init(year: 2023, month: 08, day: 02, weekDay: 3)
         )
-        self.spyRouter.didSlideFocusCallback = { expect.fulfill() }
+        self.spyRouter.didSlideFocusCallback = { [weak self] in
+            self?.spyRouter.slideFocusCompletion?()
+            expect.fulfill()
+        }
 
         // when
         viewModel.moveToNextMonth()
@@ -438,7 +441,10 @@ extension CalendarViewModelImpleTests {
         let viewModel = self.makeViewModelWithInitialSetup(
             .init(year: 2023, month: 08, day: 02, weekDay: 3)
         )
-        self.spyRouter.didSlideFocusCallback = { expect.fulfill() }
+        self.spyRouter.didSlideFocusCallback = { [weak self] in
+            self?.spyRouter.slideFocusCompletion?()
+            expect.fulfill()
+        }
 
         // when
         viewModel.moveToPreviousMonth()
@@ -460,7 +466,10 @@ extension CalendarViewModelImpleTests {
         let viewModel = self.makeViewModelWithInitialSetup(
             .init(year: 2023, month: 08, day: 02, weekDay: 3)
         )
-        self.spyRouter.didSlideFocusCallback = { expect.fulfill() }
+        self.spyRouter.didSlideFocusCallback = { [weak self] in
+            self?.spyRouter.slideFocusCompletion?()
+            expect.fulfill()
+        }
 
         // when
         viewModel.moveToPreviousMonth()
@@ -474,6 +483,32 @@ extension CalendarViewModelImpleTests {
         XCTAssertEqual(currentMonths, [
             .init(year: 2023, month: 07), .init(year: 2023, month: 05), .init(year: 2023, month: 06)
         ])
+    }
+
+    func testViewModel_whenTodayRequestedDuringSlideAnimation_staleSlideCompletionDoesNotOverwriteFocus() {
+        // given
+        let viewModel = self.makeViewModelWithInitialSetup(
+            .init(year: 2023, month: 08, day: 02, weekDay: 3)
+        )
+        let slideRequested = expectation(description: "슬라이드 요청 도착 대기")
+        self.spyRouter.didSlideFocusCallback = { slideRequested.fulfill() }
+        viewModel.moveToNextMonth()
+        self.wait(for: [slideRequested], timeout: self.timeout)
+
+        // when
+        let todayApplied = expectation(description: "애니메이션 진행 중 TODAY 복귀 완료 대기")
+        self.spyRouter.spyInteractors[1].didSelectTodayRequestedCallback = { todayApplied.fulfill() }
+        viewModel.moveFocusToToday()
+        self.wait(for: [todayApplied], timeout: self.timeout)
+        // 슬라이드 애니메이션 완료 콜백이 TODAY 복귀보다 늦게 도착
+        self.spyRouter.slideFocusCompletion?()
+
+        // then
+        let currentMonths = self.spyRouter.spyInteractors.map { $0.currentMonth }
+        XCTAssertEqual(currentMonths, [
+            .init(year: 2023, month: 07), .init(year: 2023, month: 08), .init(year: 2023, month: 09)
+        ])
+        XCTAssertEqual(self.spyRouter.spyInteractors[1].didSelectTodayRequested, true)
     }
 
     func testViewModel_moveDay() {
@@ -1299,10 +1334,11 @@ private extension CalendarViewModelImpleTests {
         var didSlideFocusToIndex: Int?
         var didSlideFocusToNext: Bool?
         var didSlideFocusCallback: (() -> Void)?
+        var slideFocusCompletion: (() -> Void)?
         func slideFocus(to index: Int, isNext: Bool, completed: @escaping @Sendable () -> Void) {
             self.didSlideFocusToIndex = index
             self.didSlideFocusToNext = isNext
-            completed()
+            self.slideFocusCompletion = completed
             self.didSlideFocusCallback?()
         }
 

--- a/Presentations/Scenes/Sources/Scenes+Calendar.swift
+++ b/Presentations/Scenes/Sources/Scenes+Calendar.swift
@@ -15,6 +15,8 @@ public protocol CalendarSceneInteractor: Sendable, AnyObject {
 
     func moveFocusToToday()
     func moveDay(_ day: CalendarDay, withClearPresented: Bool)
+    func moveToPreviousMonth()
+    func moveToNextMonth()
     func requestAIEntry()
 }
 
@@ -37,6 +39,9 @@ public protocol CalendarScene: Scene where Interactor == any CalendarSceneIntera
     
     @MainActor
     func changeFocus(at index: Int)
+
+    @MainActor
+    func slideFocus(to index: Int, isNext: Bool, completed: @escaping @Sendable () -> Void)
 }
 
 

--- a/TodoCalendarApp/Sources/Main/MainViewController.swift
+++ b/TodoCalendarApp/Sources/Main/MainViewController.swift
@@ -88,6 +88,7 @@ extension MainViewController {
             .sink(receiveValue: { [weak self] month in
                 self?.headerView.monthLabel.text = month.monthText
                 self?.headerView.yearLabel.text = month.yearText
+                self?.headerView.yearLabel.isHidden = month.yearText == nil
             })
             .store(in: &self.cancellables)
         
@@ -146,6 +147,20 @@ extension MainViewController {
                 self?.viewModel.jumpDate()
             }
             .store(in: &self.cancellables)
+
+        self.headerView.previousMonthButton.addTapGestureRecognizerPublisher()
+            .sink { [weak self] in
+                self?.viewAppearance.impactIfNeed()
+                self?.viewModel.moveToPreviousMonth()
+            }
+            .store(in: &self.cancellables)
+
+        self.headerView.nextMonthButton.addTapGestureRecognizerPublisher()
+            .sink { [weak self] in
+                self?.viewAppearance.impactIfNeed()
+                self?.viewModel.moveToNextMonth()
+            }
+            .store(in: &self.cancellables)
     }
 }
 
@@ -200,6 +215,9 @@ private final class HeaderView: UIView {
     
     let monthLabel = UILabel()
     let yearLabel = UILabel()
+    private let titleStackView = UIStackView()
+    let previousMonthButton = UIButton()
+    let nextMonthButton = UIButton()
     let returnTodayView = UIView()
     private let returnTodayImage = UIImageView()
     private let returnTodayLabel = UILabel()
@@ -247,21 +265,38 @@ private final class HeaderView: UIView {
     
     func setupLayout() {
         
-        self.addSubview(monthLabel)
-        monthLabel.autoLayout.active(with: self) {
-            $0.centerYAnchor.constraint(equalTo: $1.centerYAnchor)
+        self.addSubview(previousMonthButton)
+        previousMonthButton.autoLayout.active(with: self) {
             $0.leadingAnchor.constraint(equalTo: $1.leadingAnchor, constant: 16)
+            $0.centerYAnchor.constraint(equalTo: $1.centerYAnchor)
+            $0.widthAnchor.constraint(equalToConstant: 24)
+            $0.heightAnchor.constraint(equalToConstant: 44)
         }
-        self.addSubview(yearLabel)
-        yearLabel.autoLayout.active(with: self.monthLabel) {
-            $0.bottomAnchor.constraint(equalTo: $1.lastBaselineAnchor)
-            $0.leadingAnchor.constraint(equalTo: $1.trailingAnchor, constant: 4)
+
+        self.addSubview(titleStackView)
+        titleStackView.autoLayout.active(with: self) {
+            $0.leadingAnchor.constraint(equalTo: self.previousMonthButton.trailingAnchor, constant: 8)
+            $0.centerYAnchor.constraint(equalTo: $1.centerYAnchor)
         }
-        
+        titleStackView.axis = .horizontal
+        titleStackView.alignment = .lastBaseline
+        titleStackView.spacing = 4
+        titleStackView.addArrangedSubview(monthLabel)
+        titleStackView.addArrangedSubview(yearLabel)
+
+        self.addSubview(nextMonthButton)
+        nextMonthButton.autoLayout.active(with: self) {
+            $0.leadingAnchor.constraint(equalTo: self.titleStackView.trailingAnchor, constant: 8)
+            $0.centerYAnchor.constraint(equalTo: $1.centerYAnchor)
+            $0.widthAnchor.constraint(equalToConstant: 24)
+            $0.heightAnchor.constraint(equalToConstant: 44)
+        }
+
         self.addSubview(returnTodayView)
         returnTodayView.autoLayout.active(with: self) {
             $0.centerXAnchor.constraint(equalTo: $1.centerXAnchor).setupPriority(.defaultLow)
             $0.centerYAnchor.constraint(equalTo: $1.centerYAnchor)
+            $0.leadingAnchor.constraint(greaterThanOrEqualTo: self.nextMonthButton.trailingAnchor, constant: 8)
         }
         
         self.returnTodayView.addSubview(returnTodayImage)
@@ -346,6 +381,15 @@ private final class HeaderView: UIView {
             self.migrationButton.tintColor = colorSet.accentInfo
         default: break
         }
+        let chevronConfiguration = UIImage.SymbolConfiguration(pointSize: 13, weight: .semibold)
+        self.previousMonthButton.tintColor = colorSet.text2
+        self.previousMonthButton.setImage(
+            UIImage(systemName: "chevron.left", withConfiguration: chevronConfiguration), for: .normal
+        )
+        self.nextMonthButton.tintColor = colorSet.text2
+        self.nextMonthButton.setImage(
+            UIImage(systemName: "chevron.right", withConfiguration: chevronConfiguration), for: .normal
+        )
         self.jumpButton.tintColor = colorSet.text0
         self.jumpButton.setImage(UIImage(systemName: "calendar"), for: .normal)
         self.eventTypeFilterButton.tintColor = colorSet.text0

--- a/TodoCalendarApp/Sources/Main/MainViewController.swift
+++ b/TodoCalendarApp/Sources/Main/MainViewController.swift
@@ -283,6 +283,7 @@ private final class HeaderView: UIView {
         titleStackView.spacing = 4
         titleStackView.addArrangedSubview(monthLabel)
         titleStackView.addArrangedSubview(yearLabel)
+        monthLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
 
         self.addSubview(nextMonthButton)
         nextMonthButton.autoLayout.active(with: self) {
@@ -296,7 +297,7 @@ private final class HeaderView: UIView {
         returnTodayView.autoLayout.active(with: self) {
             $0.centerXAnchor.constraint(equalTo: $1.centerXAnchor).setupPriority(.defaultLow)
             $0.centerYAnchor.constraint(equalTo: $1.centerYAnchor)
-            $0.leadingAnchor.constraint(greaterThanOrEqualTo: self.nextMonthButton.trailingAnchor, constant: 8)
+            $0.leadingAnchor.constraint(greaterThanOrEqualTo: self.nextMonthButton.trailingAnchor, constant: 8).setupPriority(.defaultHigh)
         }
         
         self.returnTodayView.addSubview(returnTodayImage)

--- a/TodoCalendarApp/Sources/Main/MainViewModel.swift
+++ b/TodoCalendarApp/Sources/Main/MainViewModel.swift
@@ -33,11 +33,13 @@ protocol MainViewModel: AnyObject, Sendable, MainSceneInteractor {
     // interactor
     func prepare()
     func returnToToday()
+    func moveToPreviousMonth()
+    func moveToNextMonth()
     func handleMigration()
     func moveToEventTypeFilterSetting()
     func moveToSetting()
     func jumpDate()
-    
+
     // presenter
     var currentMonth: AnyPublisher<CurrentMonth, Never> { get }
     var isShowReturnToToday: AnyPublisher<Bool, Never> { get }
@@ -171,7 +173,15 @@ extension MainViewModelImple {
     func returnToToday() {
         self.calendarSceneInteractor?.moveFocusToToday()
     }
-    
+
+    func moveToPreviousMonth() {
+        self.calendarSceneInteractor?.moveToPreviousMonth()
+    }
+
+    func moveToNextMonth() {
+        self.calendarSceneInteractor?.moveToNextMonth()
+    }
+
     func handleMigration() {
         guard let status = self.subject.temporaryUserDataMigrationStatus.value,
               case .need(let count) = status

--- a/TodoCalendarApp/TodoCalendarAppTests/MainViewModelImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/MainViewModelImpleTests.swift
@@ -275,12 +275,34 @@ extension MainViewModelImpleTests {
     func testViewModel_routeToSettingScene() {
         // given
         let viewModel = self.makeViewModel()
-        
+
         // when
         viewModel.moveToSetting()
-        
+
         // then
         XCTAssertEqual(self.spyRouter.didRouteToSetting, true)
+    }
+
+    func testViewModel_whenMoveToPreviousMonth_requestToCalendar() {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        viewModel.moveToPreviousMonth()
+
+        // then
+        XCTAssertEqual(self.spyRouter.interactor.didMoveToPreviousMonth, true)
+    }
+
+    func testViewModel_whenMoveToNextMonth_requestToCalendar() {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        viewModel.moveToNextMonth()
+
+        // then
+        XCTAssertEqual(self.spyRouter.interactor.didMoveToNextMonth, true)
     }
 }
 

--- a/TodoCalendarApp/TodoCalendarAppTests/MainViewModelImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/MainViewModelImpleTests.swift
@@ -409,7 +409,17 @@ extension MainViewModelImpleTests {
         func moveFocusToToday() {
             self.didFocusMovedToToday = true
         }
-        
+
+        var didMoveToPreviousMonth: Bool?
+        func moveToPreviousMonth() {
+            self.didMoveToPreviousMonth = true
+        }
+
+        var didMoveToNextMonth: Bool?
+        func moveToNextMonth() {
+            self.didMoveToNextMonth = true
+        }
+
         var didRequestMoveDay: CalendarDay?
         func moveDay(_ day: CalendarDay, withClearPresented: Bool) {
             self.didRequestMoveDay = day


### PR DESCRIPTION
closes #822

달을 옮기려면 스와이프밖에 방법이 없었다. 헤더의 월 표시(`AUG 2026`) 좌우에 chevron 버튼을 달아 탭으로도 이동하게 한다.

## 접근

달력은 `UIPageViewController` 3페이지 순환 버퍼다. 스와이프는 델리게이트가 `focusChanged(from:to:)`를 불러 반대편 페이지의 달을 갱신하는데, 프로그래매틱 `setViewControllers`는 그 델리게이트를 타지 않는다. 그래서 버튼은 같은 페이저를 애니메이션으로 밀고 **완료 콜백에서 `focusChanged`를 직접 호출**한다 — 이동 후 상태(월 텍스트·TODAY 칩·선택일)가 스와이프와 같아지는 건 이 경로를 공유하기 때문이다.

버튼 룩앤필은 시안 3종(미니멀 chevron / 타이틀 동급 chevron / 테두리 칩)을 목업으로 대조해 첫 번째로 확정했다. 13pt semibold·`text2`로 우측 아이콘군보다 가볍게 눌러, 월 텍스트가 헤더의 주인공으로 남게 했다.

## 셀프 리뷰에서 잡아 고친 것

- **슬라이드 중 TODAY 탭 → 상태 desync**: 애니메이션이 도는 동안 `changeChilds`(TODAY 복귀·날짜 점프·딥링크)가 포커스를 통째로 갈아끼우면, 뒤늦게 도착한 완료 콜백이 낡은 인덱스로 `focusChanged`를 적용해 헤더 월과 표시 페이지가 어긋났다. `focusGeneration` 세대 가드로 차단하고 회귀 테스트를 붙였다.
- **헤더 과제약**: TODAY 칩과의 최소 간격을 required로 넣었더니 헤더 좌우 체인이 닫혀, 좁은 화면이나 월 이름이 긴 언어(fi·ru)에서 월 텍스트·`TODAY`가 잘렸다. 간격 제약을 `.defaultHigh`로 낮추고 월 라벨 압축 저항을 `.required`로 올렸다.

## 남은 검증

시뮬레이터 육안 확인 항목(전환 모션, 버튼 이동 직후 스와이프 연속성, 연타, 애니메이션 중 TODAY 탭, 좁은 화면 잘림)은 #822 코멘트에 판정 기준과 함께 인계돼 있다.
