### PR TITLE
[#806] 앱 안에서 웹 페이지를 여는 웹뷰 화면 도입

### DIFF
--- a/.claude/rules/presentations-rules.md
+++ b/.claude/rules/presentations-rules.md
@@ -43,6 +43,7 @@ paths:
 | `BillingPlanChipView` | 플랜 이름 칩 — 무료 회색/유료 accentAI (사용량 게이지·paywall 공유, #739) | 없음 (표시 전용) |
 | `BillingScheduledChangeView` | 하향·만료 예정 안내 한 줄 — info 아이콘 + "N월 d일부터 X 플랜" (사용량 게이지·paywall 공유, #852) | 없음 (표시 전용) |
 | `ImagePicker` | 사진 라이브러리(PHPicker)·카메라 피커 뷰컨트롤러 팩토리 — 선택 결과를 `Data`로 전달 | `makeViewController(source:onPick:)` 클로저 |
+| `InAppWebViewController` | 인앱 웹뷰 화면 (UIKit) — 진행바·문서 타이틀·뒤로/앞으로·브라우저로 열기 + 로드 실패 폴백 (#806) | 모달은 `BaseRouterImple.showWebView(_:)` / `init` = push·child VC |
 
 - 이벤트 연결 주류는 `.eventHandler(\.키패스)` (기본값 있는 var 클로저) — 신규 컴포넌트도 이 패턴으로. 표의 예외(init 클로저·render-prop·체이닝)는 기존 API 존중.
 - 카탈로그가 낡았을 수 있다 — `ls Presentations/CommonPresentation/Sources/UIComponents/`로 실물 확인. 표에 없는 파일을 발견하면 이 표를 갱신한다.
@@ -157,7 +158,7 @@ case .command: builder.makeCommandView()
 ✅ self.router?.routeToSomewhere(param)
 ```
 
-Router는 `BaseRouterImple` 상속 + `XxxRouting` 채택. 공통 메서드(`showError`, `showToast`, `closeScene`, `showConfirm`, `showActionSheet`, `openSafari`, `showBottomSlide`, `dismissPresented`)는 먼저 재사용.
+Router는 `BaseRouterImple` 상속 + `XxxRouting` 채택. 공통 메서드(`showError`, `showToast`, `closeScene`, `showConfirm`, `showActionSheet`, `openSafari`, `showWebView`, `showBottomSlide`, `dismissPresented`)는 먼저 재사용.
 
 ### SwiftUI 타입 직접 참조 금지
 ViewModel에 `@Published` / `ObservableObject` / `@StateObject` ❌. 상태 노출은 **Combine `AnyPublisher`**, SwiftUI 변환은 `ViewState`가 담당.

--- a/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandViewController.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandViewController.swift
@@ -15,7 +15,7 @@ final class AIAgentCommandViewController: UIHostingController<AIAgentCommandStag
     var interactor: (any AIAgentCommandSceneInteractor)? { nil }
 
     private let viewModel: any AIAgentCommandViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
 
     init(
         viewModel: any AIAgentCommandViewModel,

--- a/Presentations/AIAgentScene/Sources/AIAgentImageCommand/AIAgentImageCommandViewController.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentImageCommand/AIAgentImageCommandViewController.swift
@@ -18,7 +18,7 @@ final class AIAgentImageCommandViewController: UIHostingController<AIAgentImageC
     var interactor: (any AIAgentImageCommandSceneInteractor)? { nil }
 
     private let viewModel: any AIAgentImageCommandViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
 
     init(
         viewModel: any AIAgentImageCommandViewModel,

--- a/Presentations/AIAgentScene/Sources/AIAgentKeyboardInput/AIAgentKeyboardInputViewController.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentKeyboardInput/AIAgentKeyboardInputViewController.swift
@@ -15,7 +15,7 @@ final class AIAgentKeyboardInputViewController: UIHostingController<AIAgentKeybo
     var interactor: (any AIAgentKeyboardInputSceneInteractor)? { nil }
 
     private let viewModel: any AIAgentKeyboardInputViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
 
     init(
         viewModel: any AIAgentKeyboardInputViewModel,

--- a/Presentations/BillingScenes/Sources/Paywall/PaywallViewController.swift
+++ b/Presentations/BillingScenes/Sources/Paywall/PaywallViewController.swift
@@ -17,7 +17,7 @@ final class PaywallViewController: UIHostingController<PaywallContainerView>, Pa
     var interactor: (any PaywallSceneInteractor)? { nil }
 
     private let viewModel: any PaywallViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
 
     init(
         viewModel: any PaywallViewModel,

--- a/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperViewController.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperViewController.swift
@@ -19,7 +19,7 @@ import CommonPresentation
 final class CalendarPaperViewController: UIHostingController<CalenarPaperContainerView>, CalendarPaperScene {
     
     private let viewModel: any CalendarPaperViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     private var cancellables: Set<AnyCancellable> = []
     

--- a/Presentations/CalendarScenes/Sources/CalendarViewController.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewController.swift
@@ -14,7 +14,7 @@ import CommonPresentation
 final class CalendarViewController: UIPageViewController, CalendarScene {
     
     private let viewModel: any CalendarViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any CalendarSceneInteractor)? { self.viewModel }

--- a/Presentations/CalendarScenes/Sources/SelectDay/SelectDayDialogViewController.swift
+++ b/Presentations/CalendarScenes/Sources/SelectDay/SelectDayDialogViewController.swift
@@ -17,7 +17,7 @@ final class SelectDayDialogViewController: UIHostingController<SelectDayDialogCo
     var interactor: EmptyInteractor? { nil }
     
     private let viewModel: any SelectDayDialogViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     public init(
         viewModel: any SelectDayDialogViewModel,

--- a/Presentations/CommonPresentation/Sources/UIComponents/InAppWebViewController.swift
+++ b/Presentations/CommonPresentation/Sources/UIComponents/InAppWebViewController.swift
@@ -1,0 +1,313 @@
+//
+//  InAppWebViewController.swift
+//  CommonPresentation
+//
+//  Created by sudo.park on 8/13/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import UIKit
+import WebKit
+import Extensions
+
+
+// MARK: - InAppWebViewController
+
+public final class InAppWebViewController: UIViewController {
+
+    private enum Constant {
+        static let progressHeight: CGFloat = 2
+    }
+
+    private let url: URL
+    private let appearance: ViewAppearance
+
+    private let webView = WKWebView()
+    private let progressView = UIProgressView(progressViewStyle: .bar)
+    private let toolBar = UIToolbar()
+    private let errorView: WebViewErrorView
+
+    private lazy var goBackButton = UIBarButtonItem(
+        image: UIImage(systemName: "chevron.backward"),
+        style: .plain, target: self, action: #selector(self.goBack)
+    )
+    private lazy var goForwardButton = UIBarButtonItem(
+        image: UIImage(systemName: "chevron.forward"),
+        style: .plain, target: self, action: #selector(self.goForward)
+    )
+    private lazy var openInBrowserButton = UIBarButtonItem(
+        image: UIImage(systemName: "safari"),
+        style: .plain, target: self, action: #selector(self.openInBrowser)
+    )
+
+    private var observations: [NSKeyValueObservation] = []
+    private var lastFailedURL: URL?
+
+    public init(url: URL, appearance: ViewAppearance) {
+        self.url = url
+        self.appearance = appearance
+        self.errorView = WebViewErrorView(appearance: appearance)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.setupLayout()
+        self.setupStyling()
+        self.bindErrorViewActions()
+        self.bindWebViewStates()
+
+        self.webView.navigationDelegate = self
+        self.loadPage(self.url)
+    }
+}
+
+
+// MARK: - actions
+
+extension InAppWebViewController {
+
+    /// 로드 실패 시 webView.url 은 직전 성공 페이지로 남아 실패한 URL 을 잃는다.
+    private var targetURL: URL {
+        return self.lastFailedURL ?? self.webView.url ?? self.url
+    }
+
+    private func loadPage(_ url: URL) {
+        self.errorView.isHidden = true
+        self.webView.load(URLRequest(url: url))
+    }
+
+    @objc private func goBack() {
+        self.webView.goBack()
+    }
+
+    @objc private func goForward() {
+        self.webView.goForward()
+    }
+
+    @objc private func openInBrowser() {
+        UIApplication.shared.open(self.targetURL)
+    }
+}
+
+
+// MARK: - WKNavigationDelegate
+
+extension InAppWebViewController: WKNavigationDelegate {
+
+    public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        self.lastFailedURL = nil
+        self.errorView.isHidden = true
+    }
+
+    public func webView(
+        _ webView: WKWebView, didFail navigation: WKNavigation!, withError error: any Error
+    ) {
+        self.showErrorIfNeed(error)
+    }
+
+    public func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: any Error
+    ) {
+        self.showErrorIfNeed(error)
+    }
+
+    /// 다른 링크 이동으로 진행 중인 로드가 취소된 경우는 실패가 아니다.
+    private func showErrorIfNeed(_ error: any Error) {
+        let error = error as NSError
+        guard error.code != NSURLErrorCancelled else { return }
+        self.lastFailedURL = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL
+        self.errorView.isHidden = false
+    }
+}
+
+
+// MARK: - states
+
+extension InAppWebViewController {
+
+    private func bindErrorViewActions() {
+
+        self.errorView.retry = { [weak self] in
+            guard let self = self else { return }
+            self.loadPage(self.targetURL)
+        }
+        self.errorView.openInBrowser = { [weak self] in
+            self?.openInBrowser()
+        }
+    }
+
+    private func bindWebViewStates() {
+
+        self.observations = [
+            self.webView.observe(\.title, options: [.initial, .new]) { [weak self] webView, _ in
+                self?.navigationItem.title = webView.title
+            },
+            self.webView.observe(\.estimatedProgress, options: [.initial, .new]) { [weak self] webView, _ in
+                self?.progressView.setProgress(Float(webView.estimatedProgress), animated: true)
+            },
+            self.webView.observe(\.isLoading, options: [.initial, .new]) { [weak self] webView, _ in
+                self?.progressView.isHidden = !webView.isLoading
+            },
+            self.webView.observe(\.canGoBack, options: [.initial, .new]) { [weak self] webView, _ in
+                self?.goBackButton.isEnabled = webView.canGoBack
+            },
+            self.webView.observe(\.canGoForward, options: [.initial, .new]) { [weak self] webView, _ in
+                self?.goForwardButton.isEnabled = webView.canGoForward
+            }
+        ]
+    }
+}
+
+
+// MARK: - setup
+
+extension InAppWebViewController {
+
+    private func setupLayout() {
+
+        self.view.addSubview(self.webView)
+        self.webView.autoLayout.active(with: self.view) {
+            $0.leadingAnchor.constraint(equalTo: $1.leadingAnchor)
+            $0.trailingAnchor.constraint(equalTo: $1.trailingAnchor)
+            $0.topAnchor.constraint(equalTo: $1.safeAreaLayoutGuide.topAnchor)
+        }
+
+        self.view.addSubview(self.toolBar)
+        self.toolBar.autoLayout.active(with: self.view) {
+            $0.leadingAnchor.constraint(equalTo: $1.leadingAnchor)
+            $0.trailingAnchor.constraint(equalTo: $1.trailingAnchor)
+            $0.bottomAnchor.constraint(equalTo: $1.safeAreaLayoutGuide.bottomAnchor)
+            $0.topAnchor.constraint(equalTo: self.webView.bottomAnchor)
+        }
+
+        self.view.addSubview(self.progressView)
+        self.progressView.autoLayout.active(with: self.view) {
+            $0.leadingAnchor.constraint(equalTo: $1.leadingAnchor)
+            $0.trailingAnchor.constraint(equalTo: $1.trailingAnchor)
+            $0.topAnchor.constraint(equalTo: self.webView.topAnchor)
+            $0.heightAnchor.constraint(equalToConstant: Constant.progressHeight)
+        }
+
+        self.view.addSubview(self.errorView)
+        self.errorView.autoLayout.active(with: self.webView) {
+            $0.leadingAnchor.constraint(equalTo: $1.leadingAnchor)
+            $0.trailingAnchor.constraint(equalTo: $1.trailingAnchor)
+            $0.topAnchor.constraint(equalTo: $1.topAnchor)
+            $0.bottomAnchor.constraint(equalTo: $1.bottomAnchor)
+        }
+    }
+
+    private func setupStyling() {
+
+        self.view.backgroundColor = self.appearance.colorSet.bg0
+        self.webView.backgroundColor = self.appearance.colorSet.bg0
+        self.webView.isOpaque = false
+
+        self.progressView.progressTintColor = self.appearance.colorSet.accent
+        self.progressView.trackTintColor = .clear
+        self.progressView.isHidden = true
+
+        self.toolBar.tintColor = self.appearance.colorSet.text0
+        self.toolBar.barTintColor = self.appearance.colorSet.bg0
+        self.toolBar.items = [
+            self.goBackButton,
+            self.goForwardButton,
+            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil),
+            self.openInBrowserButton
+        ]
+
+        self.errorView.isHidden = true
+    }
+}
+
+
+// MARK: - WebViewErrorView
+
+private final class WebViewErrorView: UIView {
+
+    private enum Constant {
+        static let contentWidth: CGFloat = 260
+        static let buttonHeight: CGFloat = 44
+    }
+
+    private let appearance: ViewAppearance
+    private let messageLabel = UILabel()
+    private let retryButton = UIButton(type: .system)
+    private let openInBrowserButton = UIButton(type: .system)
+
+    var retry: (() -> Void)?
+    var openInBrowser: (() -> Void)?
+
+    init(appearance: ViewAppearance) {
+        self.appearance = appearance
+        super.init(frame: .zero)
+        self.setupLayout()
+        self.setupStyling()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupLayout() {
+
+        let stackView = UIStackView(
+            arrangedSubviews: [self.messageLabel, self.retryButton, self.openInBrowserButton]
+        )
+        stackView.axis = .vertical
+        stackView.alignment = .fill
+        stackView.spacing = Metric.Spacing.small
+        stackView.setCustomSpacing(Metric.Spacing.large, after: self.messageLabel)
+
+        self.addSubview(stackView)
+        stackView.autoLayout.active(with: self) {
+            $0.centerXAnchor.constraint(equalTo: $1.centerXAnchor)
+            $0.centerYAnchor.constraint(equalTo: $1.centerYAnchor)
+            $0.widthAnchor.constraint(equalToConstant: Constant.contentWidth)
+        }
+
+        self.retryButton.autoLayout.active {
+            $0.heightAnchor.constraint(equalToConstant: Constant.buttonHeight)
+        }
+        self.openInBrowserButton.autoLayout.active {
+            $0.heightAnchor.constraint(equalToConstant: Constant.buttonHeight)
+        }
+    }
+
+    private func setupStyling() {
+
+        self.backgroundColor = self.appearance.colorSet.bg0
+
+        self.messageLabel.text = "webview::error::message".localized()
+        self.messageLabel.textColor = self.appearance.colorSet.text1
+        self.messageLabel.font = self.appearance.fontSet.normal
+        self.messageLabel.textAlignment = .center
+        self.messageLabel.numberOfLines = 0
+
+        self.retryButton.setTitle("webview::error::retry".localized(), for: .normal)
+        self.retryButton.setTitleColor(self.appearance.colorSet.primaryBtnText, for: .normal)
+        self.retryButton.titleLabel?.font = self.appearance.fontSet.normal
+        self.retryButton.backgroundColor = self.appearance.colorSet.primaryBtnBackground
+        self.retryButton.layer.cornerRadius = Metric.Radius.regular
+        self.retryButton.addAction(
+            UIAction { [weak self] _ in self?.retry?() }, for: .touchUpInside
+        )
+
+        self.openInBrowserButton.setTitle("webview::openInBrowser".localized(), for: .normal)
+        self.openInBrowserButton.setTitleColor(self.appearance.colorSet.text2, for: .normal)
+        self.openInBrowserButton.titleLabel?.font = self.appearance.fontSet.subNormal
+        self.openInBrowserButton.addAction(
+            UIAction { [weak self] _ in self?.openInBrowser?() }, for: .touchUpInside
+        )
+    }
+}

--- a/Presentations/EventDetailScene/Sources/DoneTodoDetail/DoneTodoDetailViewController.swift
+++ b/Presentations/EventDetailScene/Sources/DoneTodoDetail/DoneTodoDetailViewController.swift
@@ -20,7 +20,7 @@ import CommonPresentation
 final class DoneTodoDetailViewController: UIHostingController<DoneTodoDetailContainerView>, DoneTodoDetailScene {
     
     private let viewModel: any DoneTodoDetailViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any DoneTodoDetailSceneInteractor)? { self.viewModel }

--- a/Presentations/EventDetailScene/Sources/EventDetailInput/SelectMapApp/SelectMapAppDialogViewController.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailInput/SelectMapApp/SelectMapAppDialogViewController.swift
@@ -20,7 +20,7 @@ import CommonPresentation
 final class SelectMapAppDialogViewController: UIHostingController<SelectMapAppDialogContainerView>, SelectMapAppDialogScene {
     
     private let viewModel: any SelectMapAppDialogViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any SelectMapAppDialogSceneInteractor)? { self.viewModel }

--- a/Presentations/EventDetailScene/Sources/EventDetailViewController.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailViewController.swift
@@ -22,7 +22,7 @@ final class EventDetailViewController: UIHostingController<EventDetailContainerV
     
     private let viewModel: any EventDetailViewModel
     private let inputViewModel: any EventDetailInputViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     weak var router: (any EventDetailRouting)?
     
     private var isSaving: Bool = false

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewController.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewController.swift
@@ -18,7 +18,7 @@ import CommonPresentation
 final class AppleCalendarEventDetailViewController: UIHostingController<AppleCalendarEventDetailContainerView>, AppleCalendarEventDetailScene {
 
     private let viewModel: any AppleCalendarEventDetailViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
 
     @MainActor
     var interactor: (any AppleCalendarEventDetailSceneInteractor)? { self.viewModel }

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewController.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewController.swift
@@ -20,7 +20,7 @@ import CommonPresentation
 final class GoogleCalendarEventDetailViewController: UIHostingController<GoogleCalendarEventDetailContainerView>, GoogleCalendarEventDetailScene {
     
     private let viewModel: any GoogleCalendarEventDetailViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any GoogleCalendarEventDetailSceneInteractor)? { self.viewModel }

--- a/Presentations/EventDetailScene/Sources/GuideView/GuideViewHostingViewController.swift
+++ b/Presentations/EventDetailScene/Sources/GuideView/GuideViewHostingViewController.swift
@@ -26,7 +26,7 @@ final class GuideViewRouter: BaseRouterImple { }
 
 final class GuideSceneBuilderImple: GuideSceneBuilder {
     
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     init(viewAppearance: ViewAppearance) {
         self.viewAppearance = viewAppearance
     }
@@ -38,7 +38,7 @@ final class GuideSceneBuilderImple: GuideSceneBuilder {
             .eventHandler(\.onClose) { [weak router] in
                 router?.closeScene()
             }
-        let viewController = GuideViewHostingViewController(guideView, router)
+        let viewController = GuideViewHostingViewController(guideView, router, self.viewAppearance)
         router.scene = viewController
         return viewController
     }
@@ -50,7 +50,7 @@ final class GuideSceneBuilderImple: GuideSceneBuilder {
             .eventHandler(\.onClose) { [weak router] in
                 router?.closeScene()
             }
-        let viewController = GuideViewHostingViewController(guideView, router)
+        let viewController = GuideViewHostingViewController(guideView, router, self.viewAppearance)
         router.scene = viewController
         return viewController
     }
@@ -59,10 +59,12 @@ final class GuideSceneBuilderImple: GuideSceneBuilder {
 final class GuideViewHostingViewController<GuideView: View>: UIHostingController<GuideView>, GuideScene {
     typealias Interactor = EmptyInteractor
     var interactor: EmptyInteractor?
+    let viewAppearance: ViewAppearance
     private let router: GuideViewRouter
-    
-    init(_ guideView: GuideView, _ router: GuideViewRouter) {
+
+    init(_ guideView: GuideView, _ router: GuideViewRouter, _ viewAppearance: ViewAppearance) {
         self.router = router
+        self.viewAppearance = viewAppearance
         super.init(rootView: guideView)
         self.view.backgroundColor = .clear
     }

--- a/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailViewController.swift
+++ b/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailViewController.swift
@@ -20,7 +20,7 @@ import CommonPresentation
 final class HolidayEventDetailViewController: UIHostingController<HolidayEventDetailContainerView>, HolidayEventDetailScene {
     
     private let viewModel: any HolidayEventDetailViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any HolidayEventDetailSceneInteractor)? { self.viewModel }

--- a/Presentations/EventDetailScene/Sources/Selections/SelectEventNotificationTime/SelectEventNotificationTimeViewController.swift
+++ b/Presentations/EventDetailScene/Sources/Selections/SelectEventNotificationTime/SelectEventNotificationTimeViewController.swift
@@ -20,7 +20,7 @@ import CommonPresentation
 final class SelectEventNotificationTimeViewController: UIHostingController<SelectEventNotificationTimeContainerView>, SelectEventNotificationTimeScene {
     
     private let viewModel: any SelectEventNotificationTimeViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any SelectEventNotificationTimeSceneInteractor)? { self.viewModel }

--- a/Presentations/EventDetailScene/Sources/Selections/SelectEventRepeatOption/SelectEventRepeatOptionViewController.swift
+++ b/Presentations/EventDetailScene/Sources/Selections/SelectEventRepeatOption/SelectEventRepeatOptionViewController.swift
@@ -19,7 +19,7 @@ import CommonPresentation
 final class SelectEventRepeatOptionViewController: UIHostingController<SelectEventRepeatOptionContainerView>, SelectEventRepeatOptionScene {
     
     private let viewModel: any SelectEventRepeatOptionViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any SelectEventRepeatOptionSceneInteractor)? { self.viewModel }

--- a/Presentations/EventDetailScene/Sources/Selections/SelectEventTag/SelectEventTagViewController.swift
+++ b/Presentations/EventDetailScene/Sources/Selections/SelectEventTag/SelectEventTagViewController.swift
@@ -19,7 +19,7 @@ import CommonPresentation
 final class SelectEventTagViewController: UIHostingController<SelectEventTagContainerView>, SelectEventTagScene {
     
     private let viewModel: any SelectEventTagViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any SelectEventTagSceneInteractor)? { self.viewModel }

--- a/Presentations/EventListScenes/Sources/DoneTodoList/DoneTodoEventListViewController.swift
+++ b/Presentations/EventListScenes/Sources/DoneTodoList/DoneTodoEventListViewController.swift
@@ -20,7 +20,7 @@ import CommonPresentation
 final class DoneTodoEventListViewController: UIHostingController<DoneTodoEventListContainerView>, DoneTodoEventListScene {
     
     private let viewModel: any DoneTodoEventListViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any DoneTodoEventListSceneInteractor)? { self.viewModel }

--- a/Presentations/MemberScenes/Sources/ManageAccount/ManageAccountViewController.swift
+++ b/Presentations/MemberScenes/Sources/ManageAccount/ManageAccountViewController.swift
@@ -20,7 +20,7 @@ import CommonPresentation
 final class ManageAccountViewController: UIHostingController<ManageAccountContainerView>, ManageAccountScene {
     
     private let viewModel: any ManageAccountViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any ManageAccountSceneInteractor)? { self.viewModel }

--- a/Presentations/MemberScenes/Sources/SignIn/SignInViewController.swift
+++ b/Presentations/MemberScenes/Sources/SignIn/SignInViewController.swift
@@ -20,7 +20,7 @@ import CommonPresentation
 final class SignInViewController: UIHostingController<SignInContainerView>, SignInScene {
     
     private let viewModel: any SignInViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any SignInSceneInteractor)? { self.viewModel }

--- a/Presentations/Scenes/Sources/BaseComponents.swift
+++ b/Presentations/Scenes/Sources/BaseComponents.swift
@@ -94,6 +94,7 @@ public struct EmptyInteractor: Sendable { }
 public protocol Scene: UIViewController {
     associatedtype Interactor
     @MainActor var interactor: Interactor? { get }
+    @MainActor var viewAppearance: ViewAppearance { get }
 }
 
 
@@ -192,6 +193,28 @@ open class BaseRouterImple: Routing, @unchecked Sendable {
         }
     }
     
+    public func showWebView(_ url: URL) {
+        Task { @MainActor in
+
+            guard let appearance = self.scene?.viewAppearance else { return }
+            let controller = InAppWebViewController(url: url, appearance: appearance)
+            let navigationController = UINavigationController(rootViewController: controller)
+            controller.navigationItem.leftBarButtonItem = UIBarButtonItem(
+                title: "common.close".localized(),
+                primaryAction: UIAction { [weak navigationController] _ in
+                    navigationController?.dismiss(animated: true)
+                }
+            )
+            navigationController.navigationBar.tintColor = appearance.colorSet.text0
+            navigationController.navigationBar.titleTextAttributes = [
+                .foregroundColor: appearance.colorSet.text0,
+                .font: appearance.fontSet.subNormalWithBold
+            ]
+
+            self.scene?.present(navigationController, animated: true)
+        }
+    }
+
     @MainActor
     public func showBottomSlide(_ slide: UIViewController) {
         slide.modalPresentationStyle = .custom

--- a/Presentations/SettingScene/Sources/Event/EventDefaultMapApp/EventDefaultMapAppViewController.swift
+++ b/Presentations/SettingScene/Sources/Event/EventDefaultMapApp/EventDefaultMapAppViewController.swift
@@ -20,7 +20,7 @@ import CommonPresentation
 final class EventDefaultMapAppViewController: UIHostingController<EventDefaultMapAppContainerView>, EventDefaultMapAppScene {
     
     private let viewModel: any EventDefaultMapAppViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any EventDefaultMapAppSceneInteractor)? { self.viewModel }

--- a/Presentations/SettingScene/Sources/Event/EventNotificationDefaultTimeOption/EventNotificationDefaultTimeOptionViewController.swift
+++ b/Presentations/SettingScene/Sources/Event/EventNotificationDefaultTimeOption/EventNotificationDefaultTimeOptionViewController.swift
@@ -20,7 +20,7 @@ import CommonPresentation
 final class EventNotificationDefaultTimeOptionViewController: UIHostingController<EventNotificationDefaultTimeOptionContainerView>, EventNotificationDefaultTimeOptionScene {
     
     private let viewModel: any EventNotificationDefaultTimeOptionViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any EventNotificationDefaultTimeOptionSceneInteractor)? { self.viewModel }

--- a/Presentations/SettingScene/Sources/Event/EventSettingViewController.swift
+++ b/Presentations/SettingScene/Sources/Event/EventSettingViewController.swift
@@ -20,7 +20,7 @@ import CommonPresentation
 final class EventSettingViewController: UIHostingController<EventSettingContainerView>, EventSettingScene {
     
     private let viewModel: any EventSettingViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any EventSettingSceneInteractor)? { self.viewModel }

--- a/Presentations/SettingScene/Sources/EventTag/EventDefaultTagSelect/EventDefaultTagSelectViewController.swift
+++ b/Presentations/SettingScene/Sources/EventTag/EventDefaultTagSelect/EventDefaultTagSelectViewController.swift
@@ -20,7 +20,7 @@ import CommonPresentation
 final class EventDefaultTagSelectViewController: UIHostingController<EventDefaultTagSelectContainerView>, EventDefaultTagSelectScene {
     
     private let viewModel: any EventDefaultTagSelectViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any EventDefaultTagSelectSceneInteractor)? { self.viewModel }

--- a/Presentations/SettingScene/Sources/EventTag/EventTagDetail/EventTagDetailViewController.swift
+++ b/Presentations/SettingScene/Sources/EventTag/EventTagDetail/EventTagDetailViewController.swift
@@ -19,7 +19,7 @@ import CommonPresentation
 final class EventTagDetailViewController: UIHostingController<EventTagDetailContainerView>, EventTagDetailScene {
     
     private let viewModel: any EventTagDetailViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any EventTagDetailSceneInteractor)? { self.viewModel }

--- a/Presentations/SettingScene/Sources/EventTag/EventTagList/EventTagListViewController.swift
+++ b/Presentations/SettingScene/Sources/EventTag/EventTagList/EventTagListViewController.swift
@@ -19,7 +19,7 @@ import CommonPresentation
 final class EventTagListViewController: UIHostingController<EventTagListContainerView>, EventTagListScene {
     
     private let viewModel: any EventTagListViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any EventTagListSceneInteractor)? { self.viewModel }

--- a/Presentations/SettingScene/Sources/Setting/Appearance/AppearanceSettingViewController.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/AppearanceSettingViewController.swift
@@ -23,7 +23,7 @@ final class AppearanceSettingViewController: UIHostingController<AppearanceSetti
     private let calendarSectionViewModel: any CalendarSectionAppearnaceSettingViewModel
     private let eventOnCalednarSectionViewModel: any EventOnCalendarViewModel
     private let eventListAppearanceSettingViewModel: any EventListAppearnaceSettingViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any AppearanceSettingSceneInteractor)? { self.viewModel }

--- a/Presentations/SettingScene/Sources/Setting/Appearance/ColorTheme/ColorThemeSelectViewController.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/ColorTheme/ColorThemeSelectViewController.swift
@@ -20,7 +20,7 @@ import CommonPresentation
 final class ColorThemeSelectViewController: UIHostingController<ColorThemeSelectContainerView>, ColorThemeSelectScene {
     
     private let viewModel: any ColorThemeSelectViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any ColorThemeSelectSceneInteractor)? { self.viewModel }

--- a/Presentations/SettingScene/Sources/Setting/Appearance/TimeZone/TimeZoneSelectViewController.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/TimeZone/TimeZoneSelectViewController.swift
@@ -20,7 +20,7 @@ import CommonPresentation
 final class TimeZoneSelectViewController: UIHostingController<TimeZoneSelectContainerView>, TimeZoneSelectScene {
     
     private let viewModel: any TimeZoneSelectViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any TimeZoneSelectSceneInteractor)? { self.viewModel }

--- a/Presentations/SettingScene/Sources/Setting/Appearance/Widget/WidgetAppearanceSettingViewController.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/Widget/WidgetAppearanceSettingViewController.swift
@@ -16,7 +16,7 @@ import CommonPresentation
 final class WidgetAppearanceSettingViewController: UIHostingController<WidgetAppearanceSettingContainerView>, WidgetAppearanceSettingScene {
     
     private let viewModel: any WidgetAppearanceSettingViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any WidgetAppearanceSettingSceneInteractor)? { self.viewModel }

--- a/Presentations/SettingScene/Sources/Setting/Holiday/CountrySelectViewController.swift
+++ b/Presentations/SettingScene/Sources/Setting/Holiday/CountrySelectViewController.swift
@@ -19,7 +19,7 @@ import CommonPresentation
 final class CountrySelectViewController: UIHostingController<CountrySelectContainerView>, CountrySelectScene {
     
     private let viewModel: any CountrySelectViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any CountrySelectSceneInteractor)? { self.viewModel }

--- a/Presentations/SettingScene/Sources/Setting/Holiday/HolidayListViewController.swift
+++ b/Presentations/SettingScene/Sources/Setting/Holiday/HolidayListViewController.swift
@@ -19,7 +19,7 @@ import CommonPresentation
 final class HolidayListViewController: UIHostingController<HolidayListContainerView>, HolidayListScene {
     
     private let viewModel: any HolidayListViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any HolidayListSceneInteractor)? { self.viewModel }

--- a/Presentations/SettingScene/Sources/Setting/SettingItemListViewController.swift
+++ b/Presentations/SettingScene/Sources/Setting/SettingItemListViewController.swift
@@ -19,7 +19,7 @@ import CommonPresentation
 final class SettingItemListViewController: UIHostingController<SettingItemListContainerView>, SettingItemListScene {
     
     private let viewModel: any SettingItemListViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any SettingItemListSceneInteractor)? { self.viewModel }

--- a/Presentations/SettingScene/Sources/Support/Feedback/FeedbackPostViewController.swift
+++ b/Presentations/SettingScene/Sources/Support/Feedback/FeedbackPostViewController.swift
@@ -20,7 +20,7 @@ import CommonPresentation
 final class FeedbackPostViewController: UIHostingController<FeedbackPostContainerView>, FeedbackPostScene {
     
     private let viewModel: any FeedbackPostViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any FeedbackPostSceneInteractor)? { self.viewModel }

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -658,3 +658,9 @@
 "share.ai::image::text::caption" = "Text read from the image — edit it if anything looks off.";
 "share.ai::image::text::placeholder" = "Text read from the image";
 "share.ai::image::noTextFound" = "Couldn't find any text in this image. Type what you want to add.";
+
+// MARK: - webview
+
+"webview::error::message" = "Couldn't load this page.";
+"webview::error::retry" = "Try again";
+"webview::openInBrowser" = "Open in browser";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -658,3 +658,9 @@
 "share.ai::image::text::caption" = "이미지에서 읽은 텍스트예요 — 어색한 부분이 있으면 수정해 주세요.";
 "share.ai::image::text::placeholder" = "이미지에서 읽은 텍스트";
 "share.ai::image::noTextFound" = "이 이미지에서 텍스트를 찾지 못했어요. 추가하고 싶은 내용을 입력해 주세요.";
+
+// MARK: - webview
+
+"webview::error::message" = "페이지를 불러오지 못했어요.";
+"webview::error::retry" = "다시 시도";
+"webview::openInBrowser" = "브라우저로 열기";

--- a/Template/Todo-Calendar-Scene.xctemplate/Default/___FILEBASENAME___ViewController.swift
+++ b/Template/Todo-Calendar-Scene.xctemplate/Default/___FILEBASENAME___ViewController.swift
@@ -13,7 +13,7 @@ import CommonPresentation
 final class ___VARIABLE_sceneName___ViewController: UIViewController, ___VARIABLE_sceneName___Scene {
     
     private let viewModel: any ___VARIABLE_sceneName___ViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any ___VARIABLE_sceneName___SceneInteractor)? { self.viewModel }

--- a/Template/Todo-Calendar-Scene.xctemplate/SwiftUI/___FILEBASENAME___ViewController.swift
+++ b/Template/Todo-Calendar-Scene.xctemplate/SwiftUI/___FILEBASENAME___ViewController.swift
@@ -14,7 +14,7 @@ import CommonPresentation
 final class ___VARIABLE_sceneName___ViewController: UIHostingController<___VARIABLE_sceneName___ContainerView>, ___VARIABLE_sceneName___Scene {
     
     private let viewModel: any ___VARIABLE_sceneName___ViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any ___VARIABLE_sceneName___SceneInteractor)? { self.viewModel }

--- a/TodoCalendarApp/Sources/Main/MainViewController.swift
+++ b/TodoCalendarApp/Sources/Main/MainViewController.swift
@@ -26,7 +26,7 @@ final class MainViewController: UIViewController, MainScene {
     private let compositeLoadingBarView = CompositeLoadingBarView()
     
     private let viewModel: any MainViewModel
-    private let viewAppearance: ViewAppearance
+    let viewAppearance: ViewAppearance
     
     @MainActor
     var interactor: (any MainSceneInteractor)? { self.viewModel }

--- a/docs/scene-spec.md
+++ b/docs/scene-spec.md
@@ -64,6 +64,8 @@ protocol XXXSceneBuilder: AnyObject {
 }
 ```
 
+**Scene 요구사항**: `Scene`은 `interactor`와 `viewAppearance`를 요구한다. ViewController가 보관하는 `viewAppearance`는 `private`이면 안 된다 — Router가 `self.scene?.viewAppearance`로 읽어 `showWebView` 같은 공통 화면의 테마를 맞춘다.
+
 **공유 Scene 프로토콜**: 다른 Presentation 모듈에서 참조해야 하는 Scene은 `Scenes` 프레임워크의 `Scenes+*.swift`에 정의한다. 모듈 내부에서만 쓰이는 Scene은 해당 모듈 내에 정의한다.
 
 | 파일 | 포함 Scene |
@@ -135,7 +137,7 @@ final class XXXRouter: BaseRouterImple, XXXRouting {
 }
 ```
 
-**BaseRouterImple 제공 메서드**: `showError`, `showToast`, `closeScene`, `showConfirm`, `showActionSheet`, `openSafari`, `showBottomSlide`, `dismissPresented`
+**BaseRouterImple 제공 메서드**: `showError`, `showToast`, `closeScene`, `showConfirm`, `showActionSheet`, `openSafari`, `showWebView`, `showBottomSlide`, `dismissPresented`
 
 ### 2-4. SwiftUI 통합 (`XXXView.swift`)
 


### PR DESCRIPTION
close #806

## 문제

앱의 모든 웹 링크가 `Routing.openSafari` → `UIApplication.shared.open` 으로 외부 사파리를 띄운다. 약관·도움말·이벤트에 붙은 링크 하나를 보려 해도 앱을 벗어난다. 앱 안에서 페이지를 보여줄 수단이 아예 없었다.

## 접근

`CommonPresentation` 에 웹뷰 화면 `WebViewController` 를 만들었다. 필요한 자리에서 꺼내 쓰는 부품이라, 대상 링크를 화면 쪽에서 제한하지 않는다.

- `WKWebView` 에 진행바·문서 타이틀·뒤로/앞으로·브라우저로 열기를 붙였다. 타이틀·진행률·히스토리 가용 여부는 전부 KVO 로 받는다.
- 로드 실패 시 웹뷰를 덮는 폴백 뷰가 재시도와 브라우저로 열기를 준다. 링크를 연달아 눌러 이전 로드가 취소된 경우(`NSURLErrorCancelled`)는 실패로 치지 않는다.
- 모달은 `presentable(url:appearance:)` 가 `UINavigationController` 로 감싸 주고, 다른 화면에 얹을 땐 `init` 을 직접 쓴다.

SwiftUI 로 감싸지 않았다. 웹뷰 상태가 전부 KVO·delegate 로 나오고 `ColorSet`·`FontSet` 원본이 `UIColor`/`UIFont` 라, `UIViewRepresentable` + Coordinator + `@State` 미러링은 껍데기만 늘린다.

## 남은 과제

- **적용처 연결** — 이번엔 화면만 만들고 호출처는 붙이지 않았다. 기존 `openSafari` 호출처 12곳은 그대로 외부 사파리다.
- **실물 검증** — 호출처가 없어 화면을 띄워보지 못했다. `CommonPresentation` 은 테스트 타겟이 없는 프레임워크라(형제 `ImagePicker`·`LandmarkMapView` 도 동일) TC 도 생략했다. 확인 항목은 sudopark/TodoCalendar#806 에 인계.
- 나머지 29개 언어 번역은 #810 대기.
