### PR TITLE
[#857] 약관·개인정보처리방침을 앱에서 인앱웹뷰로 연다

### DIFF
--- a/Domain/Sources/Utils/AIUsageGuideLink.swift
+++ b/Domain/Sources/Utils/AIUsageGuideLink.swift
@@ -14,7 +14,6 @@ public enum AIUsageGuideLink {
     public static let enPath = HelpLink.enPath
 
     public static var currentPath: String {
-        let isKorean = Locale.current.language.languageCode == .korean
-        return isKorean ? self.koPath : self.enPath
+        return Locale.isCurrentKorean ? self.koPath : self.enPath
     }
 }

--- a/Domain/Sources/Utils/HelpLink.swift
+++ b/Domain/Sources/Utils/HelpLink.swift
@@ -14,7 +14,6 @@ public enum HelpLink {
     public static let enPath = "https://readmind.notion.site/To-do-Calendar-Help-a2183ee1a41946faa8e0658640fb4c6a?pvs=4"
 
     public static var currentPath: String {
-        let isKorean = Locale.current.language.languageCode == .korean
-        return isKorean ? self.koPath : self.enPath
+        return Locale.isCurrentKorean ? self.koPath : self.enPath
     }
 }

--- a/Domain/Sources/Utils/LegalLink.swift
+++ b/Domain/Sources/Utils/LegalLink.swift
@@ -1,0 +1,20 @@
+//
+//  LegalLink.swift
+//  Domain
+//
+//  Created by sudo.park on 8/15/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+public enum LegalLink {
+
+    public static var termsPath: String { self.documentPath("terms") }
+    public static var privacyPolicyPath: String { self.documentPath("privacy") }
+
+    private static func documentPath(_ document: String) -> String {
+        let language = Locale.isCurrentKorean ? "ko" : "en"
+        return "https://todo-calendar.com/\(document)/\(language)"
+    }
+}

--- a/Domain/Sources/Utils/Locale+AppLanguage.swift
+++ b/Domain/Sources/Utils/Locale+AppLanguage.swift
@@ -1,0 +1,16 @@
+//
+//  Locale+AppLanguage.swift
+//  Domain
+//
+//  Created by sudo.park on 8/15/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+extension Locale {
+
+    public static var isCurrentKorean: Bool {
+        return Locale.current.language.languageCode == .korean
+    }
+}

--- a/Domain/Tests/Utils/LegalLinkTests.swift
+++ b/Domain/Tests/Utils/LegalLinkTests.swift
@@ -1,0 +1,36 @@
+//
+//  LegalLinkTests.swift
+//  DomainTests
+//
+//  Created by sudo.park on 8/15/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+
+@testable import Domain
+
+
+struct LegalLinkTests {
+
+    private var languagePath: String {
+        return Locale.isCurrentKorean ? "ko" : "en"
+    }
+
+    @Test func termsPath_pointsToPublishedTermsRoute() {
+        // given + when
+        let path = LegalLink.termsPath
+
+        // then
+        #expect(path == "https://todo-calendar.com/terms/\(self.languagePath)")
+    }
+
+    @Test func privacyPolicyPath_pointsToPublishedPrivacyRoute() {
+        // given + when
+        let path = LegalLink.privacyPolicyPath
+
+        // then
+        #expect(path == "https://todo-calendar.com/privacy/\(self.languagePath)")
+    }
+}

--- a/Presentations/BillingScenes/Sources/Paywall/PaywallViewModel.swift
+++ b/Presentations/BillingScenes/Sources/Paywall/PaywallViewModel.swift
@@ -315,13 +315,11 @@ extension PaywallViewModelImple {
     }
 
     func openTerms() {
-        // TODO: 약관 URL 확정 후 반영 — 리젝 직결 항목이라 진입점 개방 전 필수(이번 스코프 밖, #739)
-        self.router?.openSafari("")
+        self.router?.showWebView(LegalLink.termsPath)
     }
 
     func openPrivacyPolicy() {
-        // TODO: 개인정보처리방침 URL 확정 후 반영 — 리젝 직결 항목이라 진입점 개방 전 필수(이번 스코프 밖, #739)
-        self.router?.openSafari("")
+        self.router?.showWebView(LegalLink.privacyPolicyPath)
     }
 
     func close() {

--- a/Presentations/BillingScenes/Tests/Paywall/PaywallViewModelImpleTests.swift
+++ b/Presentations/BillingScenes/Tests/Paywall/PaywallViewModelImpleTests.swift
@@ -13,6 +13,7 @@ import Optics
 import Domain
 import Extensions
 import UnitTestHelpKit
+import TestDoubles
 
 @testable import BillingScenes
 
@@ -1324,5 +1325,35 @@ extension PaywallViewModelImpleTests {
 
         // then
         #expect((published ?? nil) == nil)
+    }
+}
+
+
+// MARK: - 약관·개인정보처리방침 (#857)
+
+extension PaywallViewModelImpleTests {
+
+    @Test func openTerms_showsTermsPageOnInAppWebView() {
+        // given
+        let (viewModel, _, spyRouter) = self.makeViewModel()
+
+        // when
+        viewModel.openTerms()
+
+        // then
+        #expect(spyRouter.didShowWebViewPath == LegalLink.termsPath)
+        #expect(spyRouter.didOpenSafariPath == nil)
+    }
+
+    @Test func openPrivacyPolicy_showsPrivacyPageOnInAppWebView() {
+        // given
+        let (viewModel, _, spyRouter) = self.makeViewModel()
+
+        // when
+        viewModel.openPrivacyPolicy()
+
+        // then
+        #expect(spyRouter.didShowWebViewPath == LegalLink.privacyPolicyPath)
+        #expect(spyRouter.didOpenSafariPath == nil)
     }
 }

--- a/Presentations/Scenes/Sources/BaseComponents.swift
+++ b/Presentations/Scenes/Sources/BaseComponents.swift
@@ -108,6 +108,7 @@ public protocol Routing: AnyObject {
     func showConfirm(dialog info: ConfirmDialogInfo)
     func showActionSheet(_ form: ActionSheetForm)
     func openSafari(_ path: String)
+    func showWebView(_ path: String)
     func dismissPresented(animated: Bool, _ completed: (@Sendable () -> Void)?)
 }
 
@@ -193,10 +194,11 @@ open class BaseRouterImple: Routing, @unchecked Sendable {
         }
     }
     
-    public func showWebView(_ url: URL) {
+    public func showWebView(_ path: String) {
         Task { @MainActor in
 
-            guard let appearance = self.scene?.viewAppearance else { return }
+            guard let url = path.asURL(), let appearance = self.scene?.viewAppearance
+            else { return }
             let controller = InAppWebViewController(url: url, appearance: appearance)
             let navigationController = UINavigationController(rootViewController: controller)
             controller.navigationItem.leftBarButtonItem = UIBarButtonItem(

--- a/Presentations/SettingScene/Sources/Setting/SettingItemListViewModel.swift
+++ b/Presentations/SettingScene/Sources/Setting/SettingItemListViewModel.swift
@@ -29,6 +29,8 @@ struct SettingItemModel: SettingItemModelType {
         case addReview
         case sourceCode
         case billingPlan
+        case terms
+        case privacyPolicy
     }
     
     let itemId: ItemId
@@ -68,6 +70,12 @@ struct SettingItemModel: SettingItemModelType {
         case .billingPlan:
             self.iconNamge = "creditcard"
             self.text = "setting.billing.plan::name".localized()
+        case .terms:
+            self.iconNamge = "doc.text"
+            self.text = "setting.terms::name".localized()
+        case .privacyPolicy:
+            self.iconNamge = "hand.raised"
+            self.text = "setting.privacyPolicy::name".localized()
         }
     }
     
@@ -251,6 +259,12 @@ extension SettingItemListViewModelImple {
 
         case .billingPlan:
             self.router?.routeToPaywall()
+
+        case .terms:
+            self.router?.showWebView(LegalLink.termsPath)
+
+        case .privacyPolicy:
+            self.router?.showWebView(LegalLink.privacyPolicyPath)
         }
     }
     
@@ -299,7 +313,9 @@ extension SettingItemListViewModelImple {
             let appInfoSectionItems: [SettingItemModel] = [
                 .init(.shareApp),
                 .init(.addReview),
-                .init(.sourceCode)
+                .init(.sourceCode),
+                .init(.terms),
+                .init(.privacyPolicy)
             ]
             let appInfoSection = AppInfoSectionModel(
                 headerText: "setting.section.app::name".localized(),

--- a/Presentations/SettingScene/Tests/Setting/SettingItemListViewModelImpleTests.swift
+++ b/Presentations/SettingScene/Tests/Setting/SettingItemListViewModelImpleTests.swift
@@ -105,7 +105,7 @@ extension SettingItemListViewModelImpleTests {
         let appInfoSection = sections?[safe: 2]
         let infoItemIds = appInfoSection?.items.compactMap { $0 as? SettingItemModel }.map { $0.itemId }
         XCTAssertEqual(infoItemIds, [
-            .shareApp, .addReview, .sourceCode
+            .shareApp, .addReview, .sourceCode, .terms, .privacyPolicy
         ])
 
         let suggestSection = sections?[safe: 3]
@@ -148,7 +148,7 @@ extension SettingItemListViewModelImpleTests {
         XCTAssertEqual(appInfoSection is AppInfoSectionModel, true)
         let infoItemIds = appInfoSection?.items.compactMap { $0 as? SettingItemModel }.map { $0.itemId }
         XCTAssertEqual(infoItemIds, [
-            .shareApp, .addReview, .sourceCode
+            .shareApp, .addReview, .sourceCode, .terms, .privacyPolicy
         ])
         
         let suggestSection = sections?[safe: 3]
@@ -574,5 +574,65 @@ extension SettingItemListViewModelImpleTests {
 
         // then — Setting 화면은 구독만, checkUpdateIsNeed 호출 안 함
         XCTAssertFalse(self.stubAppUpdateCheckUsecase.didCheckUpdateIsNeed)
+    }
+}
+
+
+// MARK: - 약관·개인정보처리방침 진입점 (#857)
+
+extension SettingItemListViewModelImpleTests {
+
+    private func settingItem(
+        _ itemId: SettingItemModel.ItemId, from viewModel: SettingItemListViewModelImple
+    ) -> SettingItemModel? {
+        let items = self.WaitItemLoaded(viewModel)
+        return items.compactMap { $0 as? SettingItemModel }.first(where: { $0.itemId == itemId })
+    }
+
+    func testViewModel_provideTermsAndPrivacyPolicyItems() {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        let terms = self.settingItem(.terms, from: viewModel)
+        let privacyPolicy = self.settingItem(.privacyPolicy, from: viewModel)
+
+        // then
+        XCTAssertNotNil(terms)
+        XCTAssertNotNil(privacyPolicy)
+    }
+
+    func testViewModel_whenSelectTerms_showTermsPageOnInAppWebView() {
+        // given
+        let viewModel = self.makeViewModel()
+        guard let terms = self.settingItem(.terms, from: viewModel)
+        else {
+            XCTAssert(false)
+            return
+        }
+
+        // when
+        viewModel.selectItem(terms)
+
+        // then
+        XCTAssertEqual(self.spyRouter.didShowWebViewPath, LegalLink.termsPath)
+        XCTAssertNil(self.spyRouter.didOpenSafariPath)
+    }
+
+    func testViewModel_whenSelectPrivacyPolicy_showPrivacyPageOnInAppWebView() {
+        // given
+        let viewModel = self.makeViewModel()
+        guard let privacyPolicy = self.settingItem(.privacyPolicy, from: viewModel)
+        else {
+            XCTAssert(false)
+            return
+        }
+
+        // when
+        viewModel.selectItem(privacyPolicy)
+
+        // then
+        XCTAssertEqual(self.spyRouter.didShowWebViewPath, LegalLink.privacyPolicyPath)
+        XCTAssertNil(self.spyRouter.didOpenSafariPath)
     }
 }

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -416,6 +416,8 @@
 "setting.share::name" = "Share App";
 "setting.write_review::name" = "Write an app review";
 "setting.billing.plan::name" = "Plan";
+"setting.terms::name" = "Terms of Use";
+"setting.privacyPolicy::name" = "Privacy Policy";
 "setting.account.signedIn::manageAccount" = "Account";
 "setting.account.needSignIn" = "Login";
 "setting.suggest::readmind::appName" = "Readminds";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -416,6 +416,8 @@
 "setting.share::name" = "앱 공유";
 "setting.write_review::name" = "앱 리뷰쓰기";
 "setting.billing.plan::name" = "플랜";
+"setting.terms::name" = "이용약관";
+"setting.privacyPolicy::name" = "개인정보처리방침";
 "setting.account.signedIn::manageAccount" = "계정";
 "setting.account.needSignIn" = "로그인";
 "setting.suggest::readmind::appName" = "Readmind";

--- a/Supports/TestDoubles/Sources/Scenes/BaseSpyRouter.swift
+++ b/Supports/TestDoubles/Sources/Scenes/BaseSpyRouter.swift
@@ -61,6 +61,11 @@ open class BaseSpyRouter: Routing {
         self.didOpenSafariPath = path
     }
     
+    public var didShowWebViewPath: String?
+    public func showWebView(_ path: String) {
+        self.didShowWebViewPath = path
+    }
+
     public var didDismissPresented: Bool?
     public func dismissPresented(animated: Bool, _ completed: (() -> Void)?) {
         

--- a/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
@@ -269,6 +269,10 @@ final class ApplicationRootRouter: ApplicationRouting, @unchecked Sendable {
         }
     }
     
+    func showWebView(_ path: String) {
+        // ignore
+    }
+
     func pop(animate: Bool) {
         // ignore
     }


### PR DESCRIPTION
#857 꼭지 4. 웹 주소가 sudopark/TodoCalendar-Web#206 에서 확정돼 앱이 그걸 연다.

## 문제

두 문서로 가는 길이 사실상 없었다.

- paywall 하단 약관·개인정보처리방침 링크가 **빈 문자열을 연다** — 탭해도 아무 일도 일어나지 않는다. App Store 3.1.2 는 구독 앱이 바이너리 안에서 두 링크를 열 것을 요구하고, 이게 `FeatureFlag.billingPaywall` 개방의 선행 조건이다
- paywall 밖에는 진입점이 아예 없다 — 무료 유저와 심사관은 도달할 수단이 없다

## 접근

**주소는 앱이 결정한다.** `LegalLink` 가 `todo-calendar.com/{terms,privacy}/{ko,en}` 를 조립한다. 웹도 언어 리다이렉트를 하지만 앱이 아는 기기 언어로 고정하는 편이 결정적이고, `HelpLink` 선례와도 맞다. 소비측 TC 는 같은 상수를 참조해 오타를 못 잡으므로 **주소 리터럴을 박는 TC 를 Domain 에 따로 뒀다** — 웹 라우트와의 짝이 조용히 어긋나는 걸 막는 자리다.

**여는 방식은 인앱웹뷰.** #806 이 만들어둔 `InAppWebViewController` 의 첫 소비자다. 구매 흐름 중 약관을 보려고 앱을 이탈시키지 않는다. 다만 그 웹뷰는 `BaseRouterImple` 만 알고 있어 ViewModel 에서 부를 수 없었다 — `Routing` 프로토콜 요구사항으로 승격하고, 인자를 `URL` 에서 경로 문자열로 바꿔 옆자리 `openSafari(_:)` 와 형태를 맞췄다. 경로 파싱 실패 가드도 프레젠테이션 직전으로 흡수했다.

**진입점은 넷.** paywall 하단 둘 + 설정 > 앱 섹션에 신설한 둘. 설정 쪽은 로그인 여부·플랜과 무관하게 항상 보인다.

## 검증

전 스킴 통과. 실물 확인은 sudopark/TodoCalendar-Web#206 배포에 막혀 있다 — 지금 두 라우트는 404 라 웹뷰 에러 화면(재시도·브라우저로 열기)까지가 확인 가능한 범위다. 검증 항목·판정 기준은 #857 에 코멘트로 인계했다.

로컬라이즈 2키(en·ko)는 #810 대기 목록에 등록.
