### PR TITLE
[#873] 캘린더 그리드 날짜 롱프레스 — 일·주·월 공유 범위 선택

### DIFF
--- a/Domain/Sources/Models/Calendar/CalendarComponent.swift
+++ b/Domain/Sources/Models/Calendar/CalendarComponent.swift
@@ -92,12 +92,41 @@ public struct CalendarComponent: Equatable {
 
 
 extension Calendar {
-    
+
     public func date(from day: CalendarComponent.Day) -> Date? {
         let components = DateComponents(
             year: day.year, month: day.month, day: day.day,
             hour: 0, minute: 0, second: 0
         )
         return self.date(from: components)
+    }
+}
+
+
+extension CalendarComponent.Week {
+
+    public func range(_ timeZone: TimeZone) -> Range<TimeInterval>? {
+        let calendar = Calendar(identifier: .gregorian)
+        |> \.timeZone .~ timeZone
+        guard let firstDay = self.days.first, let lastDay = self.days.last,
+              let lowerBoundDate = calendar.date(from: firstDay).map(calendar.startOfDay(for:)),
+              let upperBoundDate = calendar.date(from: lastDay).flatMap(calendar.endOfDay(for:))
+        else { return nil }
+        return lowerBoundDate.timeIntervalSince1970..<upperBoundDate.timeIntervalSince1970
+    }
+}
+
+extension CalendarComponent {
+
+    public func monthRange(_ timeZone: TimeZone) -> Range<TimeInterval>? {
+        let calendar = Calendar(identifier: .gregorian)
+        |> \.timeZone .~ timeZone
+        let firstDay = CalendarComponent.Day(year: self.year, month: self.month, day: 1, weekDay: 1)
+        guard let referenceDate = calendar.date(from: firstDay),
+              let monthStart = calendar.firstDayOfMonth(from: referenceDate),
+              let lastDayOfMonth = calendar.lastDayOfMonth(from: referenceDate),
+              let monthEnd = calendar.endOfDay(for: lastDayOfMonth)
+        else { return nil }
+        return monthStart.timeIntervalSince1970..<monthEnd.timeIntervalSince1970
     }
 }

--- a/Domain/Tests/Models/Calendar/CalendarComponentTests.swift
+++ b/Domain/Tests/Models/Calendar/CalendarComponentTests.swift
@@ -1,0 +1,158 @@
+//
+//  CalendarComponentTests.swift
+//  DomainTests
+//
+//  Created by sudo.park on 8/15/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Prelude
+import Optics
+
+@testable import Domain
+
+
+struct CalendarComponentTests {
+
+    private let utc = TimeZone(identifier: "UTC")!
+    private let seoul = TimeZone(identifier: "Asia/Seoul")!
+
+    private func day(_ year: Int, _ month: Int, _ day: Int) -> CalendarComponent.Day {
+        return .init(year: year, month: month, day: day, weekDay: 1)
+    }
+
+    private func dayRange(_ year: Int, _ month: Int, _ day: Int, _ timeZone: TimeZone) -> Range<TimeInterval>? {
+        return self.day(year, month, day).dayRange(timeZone)
+    }
+}
+
+
+// MARK: - Week.range
+
+extension CalendarComponentTests {
+
+    @Test("7일짜리 주의 range는 첫날 00:00부터 마지막날 23:59:59까지다")
+    func week_range_spansFromFirstDayStartToLastDayEnd() throws {
+        // given
+        let days = (10...16).map { self.day(2026, 8, $0) }
+        let week = CalendarComponent.Week(days: days)
+
+        // when
+        let range = try #require(week.range(self.utc))
+
+        // then
+        let expectedStart = try #require(self.dayRange(2026, 8, 10, self.utc)?.lowerBound)
+        let expectedEnd = try #require(self.dayRange(2026, 8, 16, self.utc)?.upperBound)
+        #expect(range.lowerBound == expectedStart)
+        #expect(range.upperBound == expectedEnd)
+    }
+
+    @Test("days가 비어 있으면 nil을 반환한다")
+    func week_range_whenDaysAreEmpty_returnsNil() {
+        // given
+        let week = CalendarComponent.Week(days: [])
+
+        // when
+        let range = week.range(self.utc)
+
+        // then
+        #expect(range == nil)
+    }
+
+    @Test("timeZone을 반영해 경계가 이동한다")
+    func week_range_respectsTimeZone() throws {
+        // given
+        let days = (10...16).map { self.day(2026, 8, $0) }
+        let week = CalendarComponent.Week(days: days)
+
+        // when
+        let utcRange = try #require(week.range(self.utc))
+        let seoulRange = try #require(week.range(self.seoul))
+
+        // then
+        #expect(utcRange.lowerBound - seoulRange.lowerBound == 9 * 3600)
+        #expect(utcRange.upperBound - seoulRange.upperBound == 9 * 3600)
+    }
+}
+
+
+// MARK: - CalendarComponent.monthRange
+
+extension CalendarComponentTests {
+
+    @Test("8/1 00:00부터 8/31 23:59:59까지고, 그리드에 딸린 7월·9월 날짜는 포함하지 않는다")
+    func monthRange_coversFirstDayToLastDayOfMonth() throws {
+        // given
+        let fringeWeekWithPreviousMonth = CalendarComponent.Week(
+            days: (26...31).map { self.day(2026, 7, $0) } + [self.day(2026, 8, 1)]
+        )
+        let fringeWeekWithNextMonth = CalendarComponent.Week(
+            days: [self.day(2026, 8, 30), self.day(2026, 8, 31)] + (1...5).map { self.day(2026, 9, $0) }
+        )
+        let component = CalendarComponent(
+            year: 2026, month: 8, weeks: [fringeWeekWithPreviousMonth, fringeWeekWithNextMonth]
+        )
+
+        // when
+        let range = try #require(component.monthRange(self.utc))
+
+        // then
+        let expectedStart = try #require(self.dayRange(2026, 8, 1, self.utc)?.lowerBound)
+        let expectedEnd = try #require(self.dayRange(2026, 8, 31, self.utc)?.upperBound)
+        #expect(range.lowerBound == expectedStart)
+        #expect(range.upperBound == expectedEnd)
+
+        let julyFringeDay = try #require(self.dayRange(2026, 7, 31, self.utc))
+        let septemberFringeDay = try #require(self.dayRange(2026, 9, 1, self.utc))
+        #expect(julyFringeDay.upperBound <= range.lowerBound)
+        #expect(septemberFringeDay.lowerBound >= range.upperBound)
+    }
+
+    @Test("2024년 2월(윤년)은 29일에서 끝난다")
+    func monthRange_forFebruary_leapYear_endsOnDay29() throws {
+        // given
+        let component = CalendarComponent(
+            year: 2024, month: 2, weeks: [CalendarComponent.Week(days: [self.day(2024, 2, 1)])]
+        )
+
+        // when
+        let range = try #require(component.monthRange(self.utc))
+
+        // then
+        let expectedEnd = try #require(self.dayRange(2024, 2, 29, self.utc)?.upperBound)
+        #expect(range.upperBound == expectedEnd)
+    }
+
+    @Test("2026년 2월(평년)은 28일에서 끝난다")
+    func monthRange_forFebruary_commonYear_endsOnDay28() throws {
+        // given
+        let component = CalendarComponent(
+            year: 2026, month: 2, weeks: [CalendarComponent.Week(days: [self.day(2026, 2, 1)])]
+        )
+
+        // when
+        let range = try #require(component.monthRange(self.utc))
+
+        // then
+        let expectedEnd = try #require(self.dayRange(2026, 2, 28, self.utc)?.upperBound)
+        #expect(range.upperBound == expectedEnd)
+    }
+
+    @Test("timeZone을 반영해 경계가 이동한다")
+    func monthRange_respectsTimeZone() throws {
+        // given
+        let component = CalendarComponent(
+            year: 2026, month: 8, weeks: [CalendarComponent.Week(days: [self.day(2026, 8, 1)])]
+        )
+
+        // when
+        let utcRange = try #require(component.monthRange(self.utc))
+        let seoulRange = try #require(component.monthRange(self.seoul))
+
+        // then
+        #expect(utcRange.lowerBound - seoulRange.lowerBound == 9 * 3600)
+        #expect(utcRange.upperBound - seoulRange.upperBound == 9 * 3600)
+    }
+}

--- a/Presentations/CalendarScenes/Snapshots/SharePreviewSnapshots.swift
+++ b/Presentations/CalendarScenes/Snapshots/SharePreviewSnapshots.swift
@@ -258,6 +258,11 @@ private final class FakeSharePreviewViewModel: SharePreviewViewModel, @unchecked
     var lineModels: AnyPublisher<[SharePreviewLineModel], Never> {
         Just(self.stubLineModels).eraseToAnyPublisher()
     }
+    var sectionModels: AnyPublisher<[SharePreviewSectionModel], Never> {
+        let sections = SharePreviewSectionComposer(timeZone: TimeZone(abbreviation: "KST")!)
+            .sections(of: self.stubLineModels)
+        return Just(sections).eraseToAnyPublisher()
+    }
     var dateHeaderText: AnyPublisher<String, Never> {
         Just(self.stubDateHeaderText).eraseToAnyPublisher()
     }

--- a/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperBuilderImple.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperBuilderImple.swift
@@ -22,6 +22,7 @@ final class CalendarPaperSceneBuilerImple {
     private let monthSceneBuilder: any MonthSceneBuilder
     private let eventListSceneBuilder: any DayEventListSceneBuiler
     private let eventListCellEventHanleViewModelBuilder: any EventListCellEventHanleViewModelBuilder
+    private let sharePreviewSceneBuilder: any SharePreviewSceneBuilder
     private let pendingCompleteTodoState: PendingCompleteTodoState
     
     init(
@@ -30,6 +31,7 @@ final class CalendarPaperSceneBuilerImple {
         monthSceneBuilder: any MonthSceneBuilder,
         eventListSceneBuilder: any DayEventListSceneBuiler,
         eventListCellEventHanleViewModelBuilder: any EventListCellEventHanleViewModelBuilder,
+        sharePreviewSceneBuilder: any SharePreviewSceneBuilder,
         pendingCompleteTodoState: PendingCompleteTodoState
     ) {
         self.usecaseFactory = usecaseFactory
@@ -37,6 +39,7 @@ final class CalendarPaperSceneBuilerImple {
         self.monthSceneBuilder = monthSceneBuilder
         self.eventListSceneBuilder = eventListSceneBuilder
         self.eventListCellEventHanleViewModelBuilder = eventListCellEventHanleViewModelBuilder
+        self.sharePreviewSceneBuilder = sharePreviewSceneBuilder
         self.pendingCompleteTodoState = pendingCompleteTodoState
     }
 }
@@ -70,8 +73,8 @@ extension CalendarPaperSceneBuilerImple: CalendarPaperSceneBuiler {
             viewAppearance: self.viewAppearance
         )
         (eventListComponents.router as? BaseRouterImple)?.scene = viewController
-        
-        let router = CalendarPaperRouter()
+
+        let router = CalendarPaperRouter(sharePreviewSceneBuilder: self.sharePreviewSceneBuilder)
         router.scene = viewController
         viewModel.router = router
         

--- a/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperRouter.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperRouter.swift
@@ -17,7 +17,7 @@ import CommonPresentation
 
 protocol CalendarPaperRouting: Routing, Sendable {
 
-    func showSharePreview(range: Range<TimeInterval>)
+    func showSharePreview(range: Range<TimeInterval>, kind: CalendarShareRangeKind)
 }
 
 // MARK: - Router
@@ -38,9 +38,9 @@ extension CalendarPaperRouter {
         self.scene as? (any CalendarPaperScene)
     }
 
-    func showSharePreview(range: Range<TimeInterval>) {
+    func showSharePreview(range: Range<TimeInterval>, kind: CalendarShareRangeKind) {
         Task { @MainActor in
-            let next = self.sharePreviewSceneBuilder.makeSharePreviewScene(range: range)
+            let next = self.sharePreviewSceneBuilder.makeSharePreviewScene(range: range, kind: kind)
             self.scene?.present(next, animated: true)
         }
     }

--- a/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperRouter.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperRouter.swift
@@ -16,21 +16,32 @@ import CommonPresentation
 // MARK: - Routing
 
 protocol CalendarPaperRouting: Routing, Sendable {
-    
+
+    func showSharePreview(range: Range<TimeInterval>)
 }
 
 // MARK: - Router
 
 final class CalendarPaperRouter: BaseRouterImple, CalendarPaperRouting, @unchecked Sendable {
-    
+
+    private let sharePreviewSceneBuilder: any SharePreviewSceneBuilder
+
+    init(sharePreviewSceneBuilder: any SharePreviewSceneBuilder) {
+        self.sharePreviewSceneBuilder = sharePreviewSceneBuilder
+    }
 }
 
 
 extension CalendarPaperRouter {
-    
+
     private var currentScene: (any CalendarPaperScene)? {
         self.scene as? (any CalendarPaperScene)
     }
-    
-    // TODO: router implememnts
+
+    func showSharePreview(range: Range<TimeInterval>) {
+        Task { @MainActor in
+            let next = self.sharePreviewSceneBuilder.makeSharePreviewScene(range: range)
+            self.scene?.present(next, animated: true)
+        }
+    }
 }

--- a/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperViewModel.swift
@@ -91,8 +91,8 @@ extension CalendarPaperViewModelImple {
         self.listener?.calendarPaperDidRequestShowAICommand()
     }
 
-    func monthScene(didRequestShare range: Range<TimeInterval>) {
-        self.router?.showSharePreview(range: range)
+    func monthScene(didRequestShare range: Range<TimeInterval>, kind: CalendarShareRangeKind) {
+        self.router?.showSharePreview(range: range, kind: kind)
     }
 
     func scrollToVoiceInput() {

--- a/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperViewModel.swift
@@ -91,6 +91,10 @@ extension CalendarPaperViewModelImple {
         self.listener?.calendarPaperDidRequestShowAICommand()
     }
 
+    func monthScene(didRequestShare range: Range<TimeInterval>) {
+        self.router?.showSharePreview(range: range)
+    }
+
     func scrollToVoiceInput() {
         self.subject.requestScrollToVoiceInput.send(())
     }

--- a/Presentations/CalendarScenes/Sources/CalendarSceneBuilderImple.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarSceneBuilderImple.swift
@@ -87,6 +87,10 @@ extension CalendarSceneBuilderImple: CalendarSceneBuilder {
             usecaseFactory: self.usecaseFactory,
             viewAppearance: self.viewAppearance
         )
+        let sharePreviewSceneBuilder = SharePreviewSceneBuilerImple(
+            usecaseFactory: self.usecaseFactory,
+            viewAppearance: self.viewAppearance
+        )
         let eventListSceneBuilder = DayEventListSceneBuilerImple(
             usecaseFactory: self.usecaseFactory,
             viewAppearance: self.viewAppearance,
@@ -95,7 +99,8 @@ extension CalendarSceneBuilderImple: CalendarSceneBuilder {
             accountUsecase: self.accountUsecase,
             memberSceneBuilder: self.memberSceneBuilder,
             aiKeyboardInputSceneBuilder: self.aiAgentKeyboardInputSceneBuilder,
-            aiImageCommandSceneBuilder: self.aiAgentImageCommandSceneBuilder
+            aiImageCommandSceneBuilder: self.aiAgentImageCommandSceneBuilder,
+            sharePreviewSceneBuilder: sharePreviewSceneBuilder
         )
 
         let handleViewModelBuilder = EventListCellEventHanleViewModelBuilderImple(
@@ -114,6 +119,7 @@ extension CalendarSceneBuilderImple: CalendarSceneBuilder {
             monthSceneBuilder: monthSceneBuilder,
             eventListSceneBuilder: eventListSceneBuilder,
             eventListCellEventHanleViewModelBuilder: handleViewModelBuilder,
+            sharePreviewSceneBuilder: sharePreviewSceneBuilder,
             pendingCompleteTodoState: pendingCompleteTodoState
         )
         let router = CalendarViewRouterImple(

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListBuilderImple.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListBuilderImple.swift
@@ -25,6 +25,7 @@ final class DayEventListSceneBuilerImple {
     private let memberSceneBuilder: any MemberSceneBuilder
     private let aiKeyboardInputSceneBuilder: any AIAgentKeyboardInputSceneBuilder
     private let aiImageCommandSceneBuilder: any AIAgentImageCommandSceneBuilder
+    private let sharePreviewSceneBuilder: any SharePreviewSceneBuilder
 
     init(
         usecaseFactory: any UsecaseFactory,
@@ -34,7 +35,8 @@ final class DayEventListSceneBuilerImple {
         accountUsecase: any AccountUsecase,
         memberSceneBuilder: any MemberSceneBuilder,
         aiKeyboardInputSceneBuilder: any AIAgentKeyboardInputSceneBuilder,
-        aiImageCommandSceneBuilder: any AIAgentImageCommandSceneBuilder
+        aiImageCommandSceneBuilder: any AIAgentImageCommandSceneBuilder,
+        sharePreviewSceneBuilder: any SharePreviewSceneBuilder
     ) {
         self.usecaseFactory = usecaseFactory
         self.viewAppearance = viewAppearance
@@ -44,6 +46,7 @@ final class DayEventListSceneBuilerImple {
         self.memberSceneBuilder = memberSceneBuilder
         self.aiKeyboardInputSceneBuilder = aiKeyboardInputSceneBuilder
         self.aiImageCommandSceneBuilder = aiImageCommandSceneBuilder
+        self.sharePreviewSceneBuilder = sharePreviewSceneBuilder
     }
 }
 
@@ -75,17 +78,13 @@ extension DayEventListSceneBuilerImple: DayEventListSceneBuiler {
             accountUsecase: self.accountUsecase,
             aiAgentOrchestrationUsecase: self.usecaseFactory.aiAgentOrchestrationUsecase
         )
-        let sharePreviewSceneBuilder = SharePreviewSceneBuilerImple(
-            usecaseFactory: self.usecaseFactory,
-            viewAppearance: self.viewAppearance
-        )
         let router = DayEventListRouter(
             eventDetailSceneBuilder: self.eventDetailSceneBuilder,
             eventListSceneBuilder: self.eventListSceneBuilder,
             memberSceneBuilder: self.memberSceneBuilder,
             aiKeyboardInputSceneBuilder: self.aiKeyboardInputSceneBuilder,
             aiImageCommandSceneBuilder: self.aiImageCommandSceneBuilder,
-            sharePreviewSceneBuilder: sharePreviewSceneBuilder,
+            sharePreviewSceneBuilder: self.sharePreviewSceneBuilder,
             viewAppearance: self.viewAppearance
         )
         viewModel.router = router

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListRouter.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListRouter.swift
@@ -89,7 +89,7 @@ extension DayEventListRouter {
 
     func showSharePreview(range: Range<TimeInterval>) {
         Task { @MainActor in
-            let next = self.sharePreviewSceneBuilder.makeSharePreviewScene(range: range)
+            let next = self.sharePreviewSceneBuilder.makeSharePreviewScene(range: range, kind: .day)
             self.scene?.present(next, animated: true)
         }
     }

--- a/Presentations/CalendarScenes/Sources/Month/MonthScene+Builder.swift
+++ b/Presentations/CalendarScenes/Sources/Month/MonthScene+Builder.swift
@@ -44,12 +44,19 @@ protocol MonthSceneInteractor: AnyObject {
     func selectDay(_ day: CalendarDay)
 }
 
+enum CalendarShareRangeKind {
+    case day
+    case week
+    case month
+}
+
 protocol MonthSceneListener: AnyObject {
-    
+
     func monthScene(
         didChange currentSelectedDay: CurrentSelectDayModel,
         and eventsThatDay: [any CalendarEvent]
     )
+    func monthScene(didRequestShare range: Range<TimeInterval>)
 }
 
 protocol MonthScene: Scene where Interactor == any MonthSceneInteractor {

--- a/Presentations/CalendarScenes/Sources/Month/MonthScene+Builder.swift
+++ b/Presentations/CalendarScenes/Sources/Month/MonthScene+Builder.swift
@@ -44,19 +44,13 @@ protocol MonthSceneInteractor: AnyObject {
     func selectDay(_ day: CalendarDay)
 }
 
-enum CalendarShareRangeKind {
-    case day
-    case week
-    case month
-}
-
 protocol MonthSceneListener: AnyObject {
 
     func monthScene(
         didChange currentSelectedDay: CurrentSelectDayModel,
         and eventsThatDay: [any CalendarEvent]
     )
-    func monthScene(didRequestShare range: Range<TimeInterval>)
+    func monthScene(didRequestShare range: Range<TimeInterval>, kind: CalendarShareRangeKind)
 }
 
 protocol MonthScene: Scene where Interactor == any MonthSceneInteractor {

--- a/Presentations/CalendarScenes/Sources/Month/MonthView.swift
+++ b/Presentations/CalendarScenes/Sources/Month/MonthView.swift
@@ -67,9 +67,11 @@ import CommonPresentation
 
 final class MonthViewEventHandler: Observable {
     var daySelected: (DayCellViewModel) -> Void = { _ in }
-    
+    var shareEvents: (CalendarShareRangeKind, DayCellViewModel) -> Void = { _, _ in }
+
     func bind(_ viewModel: any MonthViewModel) {
         self.daySelected = viewModel.select(_:)
+        self.shareEvents = viewModel.shareEvents(_:for:)
     }
 }
 
@@ -151,6 +153,7 @@ struct MonthView: View {
             ForEach(self.state.weeks, id: \.id) {
                 WeekRowView(week: $0, expectSize)
                     .eventHandler(\.daySelected, eventHandler.daySelected)
+                    .eventHandler(\.shareEvents, eventHandler.shareEvents)
                     .environment(state)
                     .environment(appearance)
             }
@@ -177,7 +180,8 @@ private struct WeekRowView: View {
     @State private var eventsPerDays: [[any CalendarEvent]] = []
     
     fileprivate var daySelected: (DayCellViewModel) -> Void = { _ in }
-    
+    fileprivate var shareEvents: (CalendarShareRangeKind, DayCellViewModel) -> Void = { _, _ in }
+
     init(
         week: WeekRowModel,
         _ expectSize: CGSize
@@ -187,6 +191,17 @@ private struct WeekRowView: View {
     }
     
     var body: some View {
+        self.weekContentView()
+            .overlay { self.dayInteractionLayer() }
+            .onReceive(state.eventsPerDay(week.id).receive(on: RunLoop.main)) {
+                self.eventsPerDays = $0
+            }
+            .onReceive(state.eventStacks(week.id).receive(on: RunLoop.main)) {
+                self.eventStackModel = $0
+            }
+    }
+
+    private func weekContentView() -> some View {
         ZStack(alignment: .top) {
             HStack(spacing: 0) {
                 ForEach(week.days, id: \.identifier) { dayView($0) }
@@ -197,14 +212,56 @@ private struct WeekRowView: View {
                 eventStackView()
             }
         }
-        .onReceive(state.eventsPerDay(week.id).receive(on: RunLoop.main)) {
-            self.eventsPerDays = $0
-        }
-        .onReceive(state.eventStacks(week.id).receive(on: RunLoop.main)) {
-            self.eventStackModel = $0
+    }
+
+    // 이벤트 바가 날짜 칸 위에 겹쳐 그려져 있어, 탭·롱프레스는 그 위를 덮는 별도 레이어가 받는다
+    private func dayInteractionLayer() -> some View {
+        HStack(spacing: 0) {
+            ForEach(Array(week.days.enumerated()), id: \.element.identifier) { sequence, day in
+                Color.clear
+                    .frame(width: dayWidth)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        appearance.impactIfNeed()
+                        self.daySelected(day)
+                    }
+                    .contextMenu {
+                        self.shareEventsMenuItems(day)
+                    } preview: {
+                        self.dayColumnPreview(at: sequence)
+                    }
+            }
         }
     }
-    
+
+    @ViewBuilder
+    private func shareEventsMenuItems(_ day: DayCellViewModel) -> some View {
+        Button {
+            self.shareEvents(.day, day)
+        } label: {
+            Text("calendar::share::this_day".localized())
+        }
+        Button {
+            self.shareEvents(.week, day)
+        } label: {
+            Text("calendar::share::this_week".localized())
+        }
+        Button {
+            self.shareEvents(.month, day)
+        } label: {
+            Text("calendar::share::this_month".localized())
+        }
+    }
+
+    private func dayColumnPreview(at sequence: Int) -> some View {
+        self.weekContentView()
+            .frame(width: expectSize.width, height: expectSize.height, alignment: .topLeading)
+            .offset(x: -self.dayWidth * CGFloat(sequence))
+            .frame(width: self.dayWidth, height: expectSize.height, alignment: .leading)
+            .clipped()
+            .background(self.appearance.colorSet.dayBackground.asColor)
+    }
+
     private func dayView(
         _ day: DayCellViewModel
     ) -> some View {
@@ -254,10 +311,6 @@ private struct WeekRowView: View {
                 .fill(backgroundColor)
         )
         .opacity(opacity)
-        .onTapGesture {
-            appearance.impactIfNeed()
-            self.daySelected(day)
-        }
     }
     
     

--- a/Presentations/CalendarScenes/Sources/Month/MonthView.swift
+++ b/Presentations/CalendarScenes/Sources/Month/MonthView.swift
@@ -439,7 +439,10 @@ final class DummyMonthViewModel: MonthViewModel, @unchecked Sendable {
     func select(_ day: DayCellViewModel) {
         self.selectedDay.send(day.identifier)
     }
-    
+
+    func shareEvents(_ kind: CalendarShareRangeKind, for day: DayCellViewModel) {
+    }
+
     func selectDay(_ day: CalendarDay) {
         self.selectedDay.send("\(day.year)-\(day.month)-\(day.day)")
     }

--- a/Presentations/CalendarScenes/Sources/Month/MonthViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/Month/MonthViewModel.swift
@@ -344,7 +344,7 @@ extension MonthViewModelImple {
         guard let info = self.subject.currentMonthInfo.value,
               let range = info.shareRange(kind, for: day)
         else { return }
-        self.listener?.monthScene(didRequestShare: range)
+        self.listener?.monthScene(didRequestShare: range, kind: kind)
     }
 
     func clearDaySelection() {

--- a/Presentations/CalendarScenes/Sources/Month/MonthViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/Month/MonthViewModel.swift
@@ -162,7 +162,8 @@ protocol MonthViewModel: AnyObject, Sendable, MonthSceneInteractor {
     
     func attachListener(_ listener: any MonthSceneListener)
     func select(_ day: DayCellViewModel)
-    
+    func shareEvents(_ kind: CalendarShareRangeKind, for day: DayCellViewModel)
+
     var weekDays: AnyPublisher<[WeekDayModel], Never> { get }
     var weekModels: AnyPublisher<[WeekRowModel], Never> { get }
     var currentSelectDayIdentifier: AnyPublisher<String, Never> { get }
@@ -204,6 +205,25 @@ final class MonthViewModelImple: MonthViewModel, @unchecked Sendable {
         let timeZone: TimeZone
         let component: CalendarComponent
         let range: Range<TimeInterval>
+
+        func shareRange(
+            _ kind: CalendarShareRangeKind, for day: DayCellViewModel
+        ) -> Range<TimeInterval>? {
+            switch kind {
+            case .day:
+                return CalendarComponent.Day(
+                    year: day.year, month: day.month, day: day.day, weekDay: 1
+                ).dayRange(self.timeZone)
+
+            case .week:
+                return self.component.weeks
+                    .first(where: { week in week.days.contains(where: { $0.identifier == day.identifier }) })?
+                    .range(self.timeZone)
+
+            case .month:
+                return self.component.monthRange(self.timeZone)
+            }
+        }
     }
     
     private struct Subject: @unchecked Sendable {
@@ -319,7 +339,14 @@ extension MonthViewModelImple {
             .init(day.year, day.month, day.day)
         )
     }
-    
+
+    func shareEvents(_ kind: CalendarShareRangeKind, for day: DayCellViewModel) {
+        guard let info = self.subject.currentMonthInfo.value,
+              let range = info.shareRange(kind, for: day)
+        else { return }
+        self.listener?.monthScene(didRequestShare: range)
+    }
+
     func clearDaySelection() {
         self.subject.userSelectedDay.send(nil)
     }

--- a/Presentations/CalendarScenes/Sources/Month/WeekEventStackBuilder.swift
+++ b/Presentations/CalendarScenes/Sources/Month/WeekEventStackBuilder.swift
@@ -87,7 +87,7 @@ public struct WeekEventStackBuilder {
 extension WeekEventStackBuilder {
     
     public func build(_ week: CalendarComponent.Week, events: [any CalendarEvent]) -> WeekEventStack {
-        guard let weekRange = self.calendar.weekRange(week)
+        guard let weekRange = week.range(self.calendar.timeZone)
         else { return .init(eventStacks: [], eventsPerDay: []) }
         
         let eventsOnThisWeek = events
@@ -199,16 +199,7 @@ extension WeekEventStackBuilder {
 
 
 private extension Calendar {
-    
-    // this_week_monday.start..<next_week_monday.start
-    func weekRange(_ week: CalendarComponent.Week) -> Range<TimeInterval>? {
-        guard let firstDay = week.days.first, let lastDay = week.days.last,
-              let lowerBoundDate = self.date(from: firstDay).flatMap(self.startOfDay(for:)),
-              let upperBoundDate = self.date(from: lastDay).flatMap(self.endOfDay(for:))
-        else { return nil }
-        return lowerBoundDate.timeIntervalSince1970..<upperBoundDate.timeIntervalSince1970
-    }
-    
+
     func overlapEventDays(
         _ eventOnWeekRange: Range<TimeInterval>,
         _ weekRange: Range<TimeInterval>

--- a/Presentations/CalendarScenes/Sources/SharePreview/EventShareTextBuilder.swift
+++ b/Presentations/CalendarScenes/Sources/SharePreview/EventShareTextBuilder.swift
@@ -19,48 +19,33 @@ struct EventShareTextBuilder {
     func build(
         _ lines: [SharePreviewLineModel],
         in range: Range<TimeInterval>,
+        kind: CalendarShareRangeKind,
         includeTagName: Bool
     ) -> String {
         let visibleLines = lines.filter { !$0.isExcluded }
         guard !visibleLines.isEmpty else { return "" }
 
-        let groups = Dictionary(grouping: visibleLines, by: \.dayStart)
-        let sortedDayStarts = groups.keys.sorted()
-
-        let headerDateText = sortedDayStarts.count == 1
-            ? self.dateHeaderText(for: sortedDayStarts[0])
-            : self.rangeHeaderText(for: range.lowerBound)
-        let header = "\(Constant.calendarEmoji)\(headerDateText)"
-
-        let body = sortedDayStarts.count == 1
-            ? self.renderSingleDayBody(groups[sortedDayStarts[0]] ?? [], includeTagName: includeTagName)
-            : self.renderMultiDayBody(sortedDayStarts, groups: groups, includeTagName: includeTagName)
+        let composer = SharePreviewSectionComposer(timeZone: self.timeZone)
+        let sections = composer.sections(of: visibleLines)
+        let header = "\(Constant.calendarEmoji)\(composer.rangeHeaderText(of: sections, in: range, kind: kind))"
+        // 날짜 헤더가 없으면 섹션 경계가 드러나지 않아 빈 줄 없이 한 덩어리로 잇는다
+        let sectionSeparator = sections.contains { $0.dayHeaderText != nil } ? "\n\n" : "\n"
+        let body = sections
+            .map { self.renderSection($0, includeTagName: includeTagName) }
+            .joined(separator: sectionSeparator)
 
         return "\(header)\n\n\(body)"
     }
 
-    private func renderSingleDayBody(
-        _ lines: [SharePreviewLineModel],
+    private func renderSection(
+        _ section: SharePreviewSectionModel,
         includeTagName: Bool
     ) -> String {
-        return lines
+        let bullets = section.lines
             .map { self.bulletLine($0, includeTagName: includeTagName) }
             .joined(separator: "\n")
-    }
-
-    private func renderMultiDayBody(
-        _ sortedDayStarts: [TimeInterval],
-        groups: [TimeInterval: [SharePreviewLineModel]],
-        includeTagName: Bool
-    ) -> String {
-        return sortedDayStarts
-            .map { dayStart -> String in
-                let groupLines = groups[dayStart] ?? []
-                let groupHeader = "\(Constant.groupMarker)\(self.groupHeaderText(for: dayStart))"
-                let bullets = self.renderSingleDayBody(groupLines, includeTagName: includeTagName)
-                return "\(groupHeader)\n\(bullets)"
-            }
-            .joined(separator: "\n\n")
+        guard let dayHeaderText = section.dayHeaderText else { return bullets }
+        return "\(dayHeaderText)\n\(bullets)"
     }
 
     private func bulletLine(_ line: SharePreviewLineModel, includeTagName: Bool) -> String {
@@ -70,28 +55,10 @@ struct EventShareTextBuilder {
         return "\(Constant.bullet)\(todoPrefix)\(timePrefix)\(line.name)\(tagSuffix)"
     }
 
-    private func dateHeaderText(for dayStart: TimeInterval) -> String {
-        return self.formattedDate(dayStart, format: "date_form::yyyy_MM_dd_E_".localized())
-    }
-
-    private func groupHeaderText(for dayStart: TimeInterval) -> String {
-        return self.formattedDate(dayStart, format: "date_form.MMM_dd_E".localized())
-    }
-
-    private func rangeHeaderText(for time: TimeInterval) -> String {
-        return self.formattedDate(time, format: "date_form.MMM_yyyy".localized())
-    }
-
-    private func formattedDate(_ time: TimeInterval, format: String) -> String {
-        let formatter = DateFormatter() |> \.timeZone .~ self.timeZone
-        formatter.dateFormat = format
-        return formatter.string(from: Date(timeIntervalSince1970: time))
-    }
 }
 
 private enum Constant {
     static let calendarEmoji: String = "📅 "
-    static let groupMarker: String = "▸ "
     static let bullet: String = "• "
     static let tagSeparator: String = " · "
 }

--- a/Presentations/CalendarScenes/Sources/SharePreview/SharePreviewBuilderImple.swift
+++ b/Presentations/CalendarScenes/Sources/SharePreview/SharePreviewBuilderImple.swift
@@ -32,7 +32,9 @@ final class SharePreviewSceneBuilerImple: @unchecked Sendable {
 extension SharePreviewSceneBuilerImple: SharePreviewSceneBuilder {
 
     @MainActor
-    func makeSharePreviewScene(range: Range<TimeInterval>) -> any SharePreviewScene {
+    func makeSharePreviewScene(
+        range: Range<TimeInterval>, kind: CalendarShareRangeKind
+    ) -> any SharePreviewScene {
         let calendarSettingUsecase = self.usecaseFactory.makeCalendarSettingUsecase()
         let uiSettingUsecase = self.usecaseFactory.makeUISettingUsecase()
         let eventTagUsecase = self.usecaseFactory.makeEventTagUsecase()
@@ -50,6 +52,7 @@ extension SharePreviewSceneBuilerImple: SharePreviewSceneBuilder {
         )
         let viewModel = SharePreviewViewModelImple(
             range: range,
+            kind: kind,
             eventListUsecase: eventListUsecase,
             calendarSettingUsecase: calendarSettingUsecase,
             uiSettingUsecase: uiSettingUsecase,

--- a/Presentations/CalendarScenes/Sources/SharePreview/SharePreviewLineModel.swift
+++ b/Presentations/CalendarScenes/Sources/SharePreview/SharePreviewLineModel.swift
@@ -13,7 +13,8 @@ import Extensions
 
 struct SharePreviewLineModel: Equatable, Sendable, Identifiable {
     let eventId: String
-    let dayStart: TimeInterval
+    /// nil = 날짜에 매이지 않는 할일 (시간 없는 current todo)
+    let dayStart: TimeInterval?
     let name: String
     var timeText: String?
     var tagId: EventTagId?
@@ -26,7 +27,7 @@ struct SharePreviewLineModel: Equatable, Sendable, Identifiable {
 
     init(
         eventId: String,
-        dayStart: TimeInterval,
+        dayStart: TimeInterval?,
         name: String,
         timeText: String? = nil,
         tagId: EventTagId? = nil,
@@ -53,7 +54,9 @@ struct SharePreviewLineModel: Equatable, Sendable, Identifiable {
         isShort: Bool
     ) {
         let dayStart = SharePreviewLineModelFactory.dayStart(for: calendarEvent, in: range, timeZone: timeZone)
-        let dayRange = SharePreviewLineModelFactory.dayRange(startingAt: dayStart, timeZone: timeZone)
+        let dayRange = SharePreviewLineModelFactory.dayRange(
+            startingAt: dayStart ?? range.lowerBound, timeZone: timeZone
+        )
         let timeText = SharePreviewLineModelFactory.timeText(
             eventTime: calendarEvent.eventTime, dayRange: dayRange, timeZone: timeZone, isShort: isShort
         )
@@ -75,8 +78,9 @@ private enum SharePreviewLineModelFactory {
 
     static func dayStart(
         for calendarEvent: any CalendarEvent, in range: Range<TimeInterval>, timeZone: TimeZone
-    ) -> TimeInterval {
-        let anchor = calendarEvent.eventTimeOnCalendar?.clamped(to: range)?.lowerBound ?? range.lowerBound
+    ) -> TimeInterval? {
+        guard let anchor = calendarEvent.eventTimeOnCalendar?.clamped(to: range)?.lowerBound
+        else { return nil }
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = timeZone
         return calendar.startOfDay(for: Date(timeIntervalSince1970: anchor)).timeIntervalSince1970

--- a/Presentations/CalendarScenes/Sources/SharePreview/SharePreviewScene+Builder.swift
+++ b/Presentations/CalendarScenes/Sources/SharePreview/SharePreviewScene+Builder.swift
@@ -20,10 +20,21 @@ protocol SharePreviewSceneInteractor: AnyObject { }
 protocol SharePreviewScene: Scene where Interactor == any SharePreviewSceneInteractor { }
 
 
+// MARK: - CalendarShareRangeKind
+
+enum CalendarShareRangeKind {
+    case day
+    case week
+    case month
+}
+
+
 // MARK: - Builder
 
 protocol SharePreviewSceneBuilder: Sendable {
 
     @MainActor
-    func makeSharePreviewScene(range: Range<TimeInterval>) -> any SharePreviewScene
+    func makeSharePreviewScene(
+        range: Range<TimeInterval>, kind: CalendarShareRangeKind
+    ) -> any SharePreviewScene
 }

--- a/Presentations/CalendarScenes/Sources/SharePreview/SharePreviewSectionModel.swift
+++ b/Presentations/CalendarScenes/Sources/SharePreview/SharePreviewSectionModel.swift
@@ -1,0 +1,130 @@
+//
+//  SharePreviewSectionModel.swift
+//  CalendarScenes
+//
+//  Created by sudo.park on 8/17/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Prelude
+import Optics
+import Extensions
+
+
+struct SharePreviewSectionModel: Equatable, Sendable, Identifiable {
+
+    /// nil = 날짜에 매이지 않는 할일 섹션
+    let dayStart: TimeInterval?
+    var dayHeaderText: String?
+    var lines: [SharePreviewLineModel]
+
+    var id: String { self.dayStart.map { "\($0)" } ?? "undated" }
+}
+
+
+// MARK: - SharePreviewSectionComposer
+
+struct SharePreviewSectionComposer {
+
+    let timeZone: TimeZone
+    var now: Date = Date()
+
+    private var calendar: Calendar {
+        return Calendar(identifier: .gregorian) |> \.timeZone .~ self.timeZone
+    }
+
+    func sections(of lines: [SharePreviewLineModel]) -> [SharePreviewSectionModel] {
+        let undatedLines = lines.filter { $0.dayStart == nil }
+        let groups = Dictionary(grouping: lines.filter { $0.dayStart != nil }, by: { $0.dayStart! })
+        let sortedDayStarts = groups.keys.sorted()
+        let isMultiDay = sortedDayStarts.count > 1
+
+        let undatedSection = undatedLines.isEmpty ? nil : SharePreviewSectionModel(
+            dayStart: nil, dayHeaderText: nil, lines: undatedLines
+        )
+        let daySections = sortedDayStarts.map { dayStart in
+            SharePreviewSectionModel(
+                dayStart: dayStart,
+                dayHeaderText: isMultiDay ? self.dayHeaderText(for: dayStart) : nil,
+                lines: groups[dayStart] ?? []
+            )
+        }
+        return [undatedSection].compactMap { $0 } + daySections
+    }
+
+    func rangeHeaderText(
+        of sections: [SharePreviewSectionModel],
+        in range: Range<TimeInterval>,
+        kind: CalendarShareRangeKind
+    ) -> String {
+        let dayStarts = sections.compactMap { $0.dayStart }
+        guard dayStarts.count > 1 else {
+            let dayStart = dayStarts.first ?? range.lowerBound
+            return self.formattedDate(dayStart, format: "date_form::yyyy_MM_dd_E_".localized())
+        }
+        switch kind {
+        case .week: return self.weekHeaderText(for: range)
+        case .day, .month: return self.formattedDate(range.lowerBound, format: "date_form.MMM_yyyy".localized())
+        }
+    }
+
+    private func weekHeaderText(for range: Range<TimeInterval>) -> String {
+        let nowTime = self.now.timeIntervalSince1970
+        let calendar = self.calendar
+        let shiftedByWeeks: (TimeInterval, Int) -> TimeInterval? = { time, weeks in
+            calendar.date(byAdding: .day, value: weeks * 7, to: Date(timeIntervalSince1970: time))?
+                .timeIntervalSince1970
+        }
+        if range.contains(nowTime) {
+            return "share_preview::header::this_week".localized()
+        }
+        if let nextWeekEnd = shiftedByWeeks(range.upperBound, 1),
+           (range.upperBound..<nextWeekEnd).contains(nowTime) {
+            return "share_preview::header::last_week".localized()
+        }
+        if let previousWeekStart = shiftedByWeeks(range.lowerBound, -1),
+           (previousWeekStart..<range.lowerBound).contains(nowTime) {
+            return "share_preview::header::next_week".localized()
+        }
+        return self.weekOfMonthText(for: range.lowerBound)
+    }
+
+    // 주차는 그 주의 시작일이 속한 달 기준 — 달 1일이 포함된 주가 1주차다
+    private func weekOfMonthText(for weekStartTime: TimeInterval) -> String {
+        let monthText = self.formattedDate(weekStartTime, format: "date_form.MMM".localized())
+        guard let ordinal = self.weekOrdinalInMonth(of: weekStartTime) else {
+            return self.formattedDate(weekStartTime, format: "date_form.MMM_yyyy".localized())
+        }
+        return "share_preview::header::week_of_month".localized(with: monthText, ordinal)
+    }
+
+    private func weekOrdinalInMonth(of weekStartTime: TimeInterval) -> Int? {
+        let calendar = self.calendar
+        let weekStart = Date(timeIntervalSince1970: weekStartTime)
+        guard let monthStart = calendar.date(from: calendar.dateComponents([.year, .month], from: weekStart))
+        else { return nil }
+        let daysBackToWeekStart = (
+            calendar.component(.weekday, from: monthStart) - calendar.component(.weekday, from: weekStart) + 7
+        ) % 7
+        guard let firstWeekStart = calendar.date(byAdding: .day, value: -daysBackToWeekStart, to: monthStart),
+              let elapsedDays = calendar.dateComponents([.day], from: firstWeekStart, to: weekStart).day
+        else { return nil }
+        return elapsedDays / 7 + 1
+    }
+
+    private func dayHeaderText(for dayStart: TimeInterval) -> String {
+        let dateText = self.formattedDate(dayStart, format: "date_form.MMM_dd_E".localized())
+        return "\(Constant.dayHeaderMarker)\(dateText)"
+    }
+
+    private func formattedDate(_ time: TimeInterval, format: String) -> String {
+        let formatter = DateFormatter() |> \.timeZone .~ self.timeZone
+        formatter.dateFormat = format
+        return formatter.string(from: Date(timeIntervalSince1970: time))
+    }
+}
+
+private enum Constant {
+    static let dayHeaderMarker: String = "▸ "
+}

--- a/Presentations/CalendarScenes/Sources/SharePreview/SharePreviewView.swift
+++ b/Presentations/CalendarScenes/Sources/SharePreview/SharePreviewView.swift
@@ -23,7 +23,7 @@ import Extensions
 
     fileprivate var isTagFilterExpanded: Bool = false
     fileprivate var tagCellViewModels: [SharePreviewTagCellViewModel] = []
-    fileprivate var lineModels: [SharePreviewLineModel] = []
+    fileprivate var sectionModels: [SharePreviewSectionModel] = []
     fileprivate var dateHeaderText: String = ""
     fileprivate var includeTagName: Bool = false
     fileprivate var isShareEnabled: Bool = false
@@ -43,9 +43,9 @@ import Extensions
             .sink { [weak self] models in self?.tagCellViewModels = models }
             .store(in: &self.cancellables)
 
-        viewModel.lineModels
+        viewModel.sectionModels
             .receive(on: RunLoop.main)
-            .sink { [weak self] lines in self?.lineModels = lines }
+            .sink { [weak self] sections in self?.sectionModels = sections }
             .store(in: &self.cancellables)
 
         viewModel.dateHeaderText
@@ -255,12 +255,26 @@ struct SharePreviewView: View {
                 .font(self.appearance.fontSet.size(16, weight: .semibold).asFont)
                 .foregroundStyle(self.appearance.colorSet.text0.asColor)
 
-            if self.state.lineModels.isEmpty {
+            if self.state.sectionModels.isEmpty {
                 self.emptyView()
             } else {
-                ForEach(self.state.lineModels) { line in
-                    self.lineRowView(line)
+                ForEach(self.state.sectionModels) { section in
+                    self.sectionView(section)
                 }
+            }
+        }
+    }
+
+    private func sectionView(_ section: SharePreviewSectionModel) -> some View {
+        VStack(alignment: .leading, spacing: Metric.Spacing.small) {
+            if let dayHeaderText = section.dayHeaderText {
+                Text(dayHeaderText)
+                    .font(self.appearance.fontSet.normal.asFont)
+                    .foregroundStyle(self.appearance.colorSet.text1.asColor)
+                    .padding(.top, spacing: .small)
+            }
+            ForEach(section.lines) { line in
+                self.lineRowView(line)
             }
         }
     }

--- a/Presentations/CalendarScenes/Sources/SharePreview/SharePreviewViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/SharePreview/SharePreviewViewModel.swift
@@ -44,6 +44,7 @@ protocol SharePreviewViewModel: AnyObject, Sendable, SharePreviewSceneInteractor
     var isTagFilterExpanded: AnyPublisher<Bool, Never> { get }
     var tagCellViewModels: AnyPublisher<[SharePreviewTagCellViewModel], Never> { get }
     var lineModels: AnyPublisher<[SharePreviewLineModel], Never> { get }
+    var sectionModels: AnyPublisher<[SharePreviewSectionModel], Never> { get }
     var dateHeaderText: AnyPublisher<String, Never> { get }
     var includeTagName: AnyPublisher<Bool, Never> { get }
     var isShareEnabled: AnyPublisher<Bool, Never> { get }
@@ -55,6 +56,7 @@ protocol SharePreviewViewModel: AnyObject, Sendable, SharePreviewSceneInteractor
 final class SharePreviewViewModelImple: SharePreviewViewModel, @unchecked Sendable {
 
     private let range: Range<TimeInterval>
+    private let kind: CalendarShareRangeKind
     private let eventListUsecase: any CalendarEventListhUsecase
     private let calendarSettingUsecase: any CalendarSettingUsecase
     private let uiSettingUsecase: any UISettingUsecase
@@ -66,6 +68,7 @@ final class SharePreviewViewModelImple: SharePreviewViewModel, @unchecked Sendab
 
     init(
         range: Range<TimeInterval>,
+        kind: CalendarShareRangeKind,
         eventListUsecase: any CalendarEventListhUsecase,
         calendarSettingUsecase: any CalendarSettingUsecase,
         uiSettingUsecase: any UISettingUsecase,
@@ -75,6 +78,7 @@ final class SharePreviewViewModelImple: SharePreviewViewModel, @unchecked Sendab
         appleCalendarUsecase: any AppleCalendarUsecase
     ) {
         self.range = range
+        self.kind = kind
         self.eventListUsecase = eventListUsecase
         self.calendarSettingUsecase = calendarSettingUsecase
         self.uiSettingUsecase = uiSettingUsecase
@@ -166,7 +170,8 @@ extension SharePreviewViewModelImple {
             .sink { [weak self] lines, timeZone in
                 guard let self else { return }
                 let text = EventShareTextBuilder(timeZone: timeZone).build(
-                    lines, in: self.range, includeTagName: self.subject.includeTagName.value
+                    lines, in: self.range, kind: self.kind,
+                    includeTagName: self.subject.includeTagName.value
                 )
                 guard !text.isEmpty else { return }
                 self.router?.showShareSheet(text: text)
@@ -215,14 +220,25 @@ extension SharePreviewViewModelImple {
         .eraseToAnyPublisher()
     }
 
+    var sectionModels: AnyPublisher<[SharePreviewSectionModel], Never> {
+        return Publishers.CombineLatest(
+            self.lineModels, self.calendarSettingUsecase.currentTimeZone
+        )
+        .map { lines, timeZone in
+            SharePreviewSectionComposer(timeZone: timeZone).sections(of: lines)
+        }
+        .eraseToAnyPublisher()
+    }
+
     var dateHeaderText: AnyPublisher<String, Never> {
-        return self.calendarSettingUsecase.currentTimeZone
-            .map { [range] timeZone -> String in
-                let formatter = DateFormatter() |> \.timeZone .~ timeZone
-                formatter.dateFormat = "date_form::yyyy_MM_dd_E_".localized()
-                return formatter.string(from: Date(timeIntervalSince1970: range.lowerBound))
-            }
-            .eraseToAnyPublisher()
+        return Publishers.CombineLatest(
+            self.sectionModels, self.calendarSettingUsecase.currentTimeZone
+        )
+        .map { [range, kind] sections, timeZone in
+            SharePreviewSectionComposer(timeZone: timeZone)
+                .rangeHeaderText(of: sections, in: range, kind: kind)
+        }
+        .eraseToAnyPublisher()
     }
 
     var includeTagName: AnyPublisher<Bool, Never> {

--- a/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
@@ -1424,6 +1424,7 @@ private extension CalendarViewModelImpleTests {
         }
 
         func monthScene(didChange currentSelectedDay: CurrentSelectDayModel, and eventsThatDay: [any CalendarEvent]) { }
+        func monthScene(didRequestShare range: Range<TimeInterval>) { }
         func dayEventListDidRequestShowAICommand() { }
     }
     

--- a/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
@@ -1424,7 +1424,7 @@ private extension CalendarViewModelImpleTests {
         }
 
         func monthScene(didChange currentSelectedDay: CurrentSelectDayModel, and eventsThatDay: [any CalendarEvent]) { }
-        func monthScene(didRequestShare range: Range<TimeInterval>) { }
+        func monthScene(didRequestShare range: Range<TimeInterval>, kind: CalendarShareRangeKind) { }
         func dayEventListDidRequestShowAICommand() { }
     }
     

--- a/Presentations/CalendarScenes/Tests/CalendarPaper/CalendarPaperViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/CalendarPaper/CalendarPaperViewModelImpleTests.swift
@@ -130,14 +130,26 @@ extension CalendarPaperViewModelImpleTests {
     func testViewModel_selectDay() {
         // given
         let viewModel = self.makeViewModel()
-        
+
         // when
         viewModel.selectDay(.init(2023, 01, 01))
-        
+
         // then
         XCTAssertEqual(
             self.spyMonthInteractor.didSelectDay, .init(2023, 01, 01)
         )
+    }
+
+    func testViewModel_whenMonthSceneRequestsShare_routesToSharePreview() {
+        // given
+        let viewModel = self.makeViewModel()
+        let range: Range<TimeInterval> = 0..<100
+
+        // when
+        viewModel.monthScene(didRequestShare: range)
+
+        // then
+        XCTAssertEqual(self.spyRouter.didShowSharePreviewWithRange, range)
     }
 }
 
@@ -145,6 +157,11 @@ extension CalendarPaperViewModelImpleTests {
 extension CalendarPaperViewModelImpleTests {
     
     private class SpyRouter: BaseSpyRouter, CalendarPaperRouting, @unchecked Sendable {
+
+        var didShowSharePreviewWithRange: Range<TimeInterval>?
+        func showSharePreview(range: Range<TimeInterval>) {
+            self.didShowSharePreviewWithRange = range
+        }
     }
     
     private class SpyMonthSceneInteractor: MonthSceneInteractor {

--- a/Presentations/CalendarScenes/Tests/CalendarPaper/CalendarPaperViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/CalendarPaper/CalendarPaperViewModelImpleTests.swift
@@ -146,10 +146,11 @@ extension CalendarPaperViewModelImpleTests {
         let range: Range<TimeInterval> = 0..<100
 
         // when
-        viewModel.monthScene(didRequestShare: range)
+        viewModel.monthScene(didRequestShare: range, kind: .week)
 
         // then
         XCTAssertEqual(self.spyRouter.didShowSharePreviewWithRange, range)
+        XCTAssertEqual(self.spyRouter.didShowSharePreviewWithKind, .week)
     }
 }
 
@@ -159,8 +160,10 @@ extension CalendarPaperViewModelImpleTests {
     private class SpyRouter: BaseSpyRouter, CalendarPaperRouting, @unchecked Sendable {
 
         var didShowSharePreviewWithRange: Range<TimeInterval>?
-        func showSharePreview(range: Range<TimeInterval>) {
+        var didShowSharePreviewWithKind: CalendarShareRangeKind?
+        func showSharePreview(range: Range<TimeInterval>, kind: CalendarShareRangeKind) {
             self.didShowSharePreviewWithRange = range
+            self.didShowSharePreviewWithKind = kind
         }
     }
     

--- a/Presentations/CalendarScenes/Tests/Month/MonthViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Month/MonthViewModelImpleTests.swift
@@ -978,8 +978,10 @@ extension MonthViewModelImpleTests {
         }
 
         var didRequestShareRange: Range<TimeInterval>?
-        func monthScene(didRequestShare range: Range<TimeInterval>) {
+        var didRequestShareKind: CalendarShareRangeKind?
+        func monthScene(didRequestShare range: Range<TimeInterval>, kind: CalendarShareRangeKind) {
             self.didRequestShareRange = range
+            self.didRequestShareKind = kind
         }
     }
 }

--- a/Presentations/CalendarScenes/Tests/Month/MonthViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Month/MonthViewModelImpleTests.swift
@@ -717,8 +717,102 @@ extension MonthViewModelImpleTests {
     }
 }
 
+// MARK: - share range
+
 extension MonthViewModelImpleTests {
-    
+
+    private static let shareEventsTestTimeZone = TimeZone(abbreviation: "KST")!
+
+    func testViewModel_whenShareDay_notifiesListenerWithThatDayRange() {
+        // given
+        let viewModel = self.makeViewModel()
+        let day = DayCellViewModel(
+            year: 2023, month: 9, day: 15, isNotCurrentMonth: false, accentDay: nil
+        )
+        let expectedRange = CalendarComponent.Day(
+            year: 2023, month: 9, day: 15, weekDay: 1
+        ).dayRange(Self.shareEventsTestTimeZone)
+
+        // when
+        viewModel.shareEvents(.day, for: day)
+
+        // then
+        XCTAssertNotNil(expectedRange)
+        XCTAssertEqual(self.spyListener?.didRequestShareRange, expectedRange)
+    }
+
+    func testViewModel_whenShareWeek_notifiesListenerWithThatWeekRange() {
+        // given
+        let viewModel = self.makeViewModel()
+        let day = DayCellViewModel(
+            year: 2023, month: 9, day: 15, isNotCurrentMonth: false, accentDay: nil
+        )
+        let expectedRange = CalendarComponent.dummy2023_9().weeks[safe: 2]?
+            .range(Self.shareEventsTestTimeZone)
+
+        // when
+        viewModel.shareEvents(.week, for: day)
+
+        // then
+        XCTAssertNotNil(expectedRange)
+        XCTAssertEqual(self.spyListener?.didRequestShareRange, expectedRange)
+    }
+
+    func testViewModel_whenShareMonth_notifiesListenerWithCurrentMonthRange() {
+        // given
+        let viewModel = self.makeViewModel()
+        let day = DayCellViewModel(
+            year: 2023, month: 9, day: 15, isNotCurrentMonth: false, accentDay: nil
+        )
+        let expectedRange = CalendarComponent.dummy2023_9()
+            .monthRange(Self.shareEventsTestTimeZone)
+
+        // when
+        viewModel.shareEvents(.month, for: day)
+
+        // then
+        XCTAssertNotNil(expectedRange)
+        XCTAssertEqual(self.spyListener?.didRequestShareRange, expectedRange)
+    }
+
+    // 8월 그리드에 딸린 7/31 대신, 9월 그리드에 딸린 8/31 셀로 같은 스펙을 검증한다(더미 픽스처가 그 형태로만 존재).
+    func testViewModel_whenShareMonth_fromAdjacentMonthCell_stillUsesCurrentMonth() {
+        // given
+        let viewModel = self.makeViewModel()
+        let adjacentMonthDay = DayCellViewModel(
+            year: 2023, month: 8, day: 31, isNotCurrentMonth: true, accentDay: nil
+        )
+        let expectedRange = CalendarComponent.dummy2023_9()
+            .monthRange(Self.shareEventsTestTimeZone)
+        let wrongRange = CalendarComponent.dummy2023_8()
+            .monthRange(Self.shareEventsTestTimeZone)
+
+        // when
+        viewModel.shareEvents(.month, for: adjacentMonthDay)
+
+        // then
+        XCTAssertNotEqual(expectedRange, wrongRange)
+        XCTAssertEqual(self.spyListener?.didRequestShareRange, expectedRange)
+    }
+
+    func testViewModel_whenShareWeekForDayNotInGrid_doesNotNotifyListener() {
+        // given
+        let viewModel = self.makeViewModel()
+        let dayNotInGrid = DayCellViewModel(
+            year: 2099, month: 1, day: 1, isNotCurrentMonth: true, accentDay: nil
+        )
+
+        // when
+        viewModel.shareEvents(.week, for: dayNotInGrid)
+
+        // then
+        XCTAssertNil(self.spyListener?.didRequestShareRange)
+    }
+}
+
+
+extension MonthViewModelImpleTests {
+
     private func makeViewModelWith8Loaded() -> MonthViewModelImple {
         // given
         let expect = expectation(description: "wait")
@@ -877,10 +971,15 @@ extension MonthViewModelImpleTests {
     }
     
     private class SpyListener: MonthSceneListener {
-        
+
         var didCurrentDayChanged: ((CurrentSelectDayModel, [any CalendarEvent]) -> Void)?
         func monthScene(didChange currentSelectedDay: CurrentSelectDayModel, and eventsThatDay: [any CalendarEvent]) {
             self.didCurrentDayChanged?(currentSelectedDay, eventsThatDay)
+        }
+
+        var didRequestShareRange: Range<TimeInterval>?
+        func monthScene(didRequestShare range: Range<TimeInterval>) {
+            self.didRequestShareRange = range
         }
     }
 }

--- a/Presentations/CalendarScenes/Tests/SharePreview/EventShareTextBuilderTests.swift
+++ b/Presentations/CalendarScenes/Tests/SharePreview/EventShareTextBuilderTests.swift
@@ -45,7 +45,7 @@ extension EventShareTextBuilderTests {
         let builder = self.makeBuilder()
 
         // when
-        let text = builder.build(lines, in: day..<(day + 86_400), includeTagName: false)
+        let text = builder.build(lines, in: day..<(day + 86_400), kind: .day, includeTagName: false)
 
         // then
         let resultLines = text.components(separatedBy: "\n")
@@ -66,7 +66,7 @@ extension EventShareTextBuilderTests {
         let builder = self.makeBuilder()
 
         // when
-        let text = builder.build(lines, in: day..<(day + 86_400), includeTagName: false)
+        let text = builder.build(lines, in: day..<(day + 86_400), kind: .day, includeTagName: false)
 
         // then
         let resultLines = text.components(separatedBy: "\n")
@@ -84,7 +84,7 @@ extension EventShareTextBuilderTests {
         let builder = self.makeBuilder()
 
         // when
-        let text = builder.build(lines, in: day..<(day + 86_400), includeTagName: false)
+        let text = builder.build(lines, in: day..<(day + 86_400), kind: .day, includeTagName: false)
 
         // then
         let resultLines = text.components(separatedBy: "\n")
@@ -109,7 +109,7 @@ extension EventShareTextBuilderTests {
         let builder = self.makeBuilder()
 
         // when
-        let text = builder.build(lines, in: day..<(day + 86_400), includeTagName: true)
+        let text = builder.build(lines, in: day..<(day + 86_400), kind: .day, includeTagName: true)
 
         // then
         let resultLines = text.components(separatedBy: "\n")
@@ -125,7 +125,7 @@ extension EventShareTextBuilderTests {
         let builder = self.makeBuilder()
 
         // when
-        let text = builder.build(lines, in: day..<(day + 86_400), includeTagName: true)
+        let text = builder.build(lines, in: day..<(day + 86_400), kind: .day, includeTagName: true)
 
         // then
         let resultLines = text.components(separatedBy: "\n")
@@ -150,7 +150,7 @@ extension EventShareTextBuilderTests {
         let builder = self.makeBuilder()
 
         // when
-        let text = builder.build(lines, in: day1..<(day2 + 86_400), includeTagName: false)
+        let text = builder.build(lines, in: day1..<(day2 + 86_400), kind: .month, includeTagName: false)
 
         // then
         let resultLines = text.components(separatedBy: "\n")
@@ -162,6 +162,27 @@ extension EventShareTextBuilderTests {
         #expect(resultLines[4] == "")
         #expect(resultLines[5].hasPrefix("▸ "))
         #expect(resultLines[6] == "• 종일 워크숍")
+    }
+
+    @Test func builder_undatedTodos_renderBeforeAnyDayGroup() {
+        // given
+        let day1 = self.dayStart(year: 2026, month: 8, day: 15)
+        let day2 = self.dayStart(year: 2026, month: 8, day: 16)
+        let lines = [
+            SharePreviewLineModel(eventId: "e1", dayStart: day1, name: "팀 스탠드업", timeText: "09:00"),
+            SharePreviewLineModel(eventId: "t1", dayStart: nil, name: "장보기", isTodo: true),
+            SharePreviewLineModel(eventId: "e2", dayStart: day2, name: "워크숍", timeText: "종일")
+        ]
+        let builder = self.makeBuilder()
+
+        // when
+        let text = builder.build(lines, in: day1..<(day2 + 86_400), kind: .month, includeTagName: false)
+
+        // then
+        let resultLines = text.components(separatedBy: "\n")
+        #expect(resultLines[2] == "• \(R.String.calendarEventTimeTodo) 장보기")
+        #expect(resultLines[3] == "")
+        #expect(resultLines[4].hasPrefix("▸ "))
     }
 }
 
@@ -179,7 +200,7 @@ extension EventShareTextBuilderTests {
         let builder = self.makeBuilder()
 
         // when
-        let text = builder.build(lines, in: day..<(day + 86_400), includeTagName: false)
+        let text = builder.build(lines, in: day..<(day + 86_400), kind: .day, includeTagName: false)
 
         // then
         let resultLines = text.components(separatedBy: "\n")
@@ -195,7 +216,7 @@ extension EventShareTextBuilderTests {
         let builder = self.makeBuilder()
 
         // when
-        let text = builder.build(lines, in: day..<(day + 86_400), includeTagName: false)
+        let text = builder.build(lines, in: day..<(day + 86_400), kind: .day, includeTagName: false)
 
         // then
         let resultLines = text.components(separatedBy: "\n")
@@ -211,7 +232,7 @@ extension EventShareTextBuilderTests {
         let builder = self.makeBuilder()
 
         // when
-        let text = builder.build(lines, in: day..<(day + 86_400), includeTagName: false)
+        let text = builder.build(lines, in: day..<(day + 86_400), kind: .day, includeTagName: false)
 
         // then
         let resultLines = text.components(separatedBy: "\n")
@@ -234,7 +255,7 @@ extension EventShareTextBuilderTests {
         let builder = self.makeBuilder()
 
         // when
-        let text = builder.build(lines, in: day..<(day + 86_400), includeTagName: false)
+        let text = builder.build(lines, in: day..<(day + 86_400), kind: .day, includeTagName: false)
 
         // then
         #expect(text == "")
@@ -247,7 +268,7 @@ extension EventShareTextBuilderTests {
         let builder = self.makeBuilder()
 
         // when
-        let text = builder.build(lines, in: day..<(day + 86_400), includeTagName: false)
+        let text = builder.build(lines, in: day..<(day + 86_400), kind: .day, includeTagName: false)
 
         // then
         #expect(text == "")

--- a/Presentations/CalendarScenes/Tests/SharePreview/SharePreviewSectionComposerTests.swift
+++ b/Presentations/CalendarScenes/Tests/SharePreview/SharePreviewSectionComposerTests.swift
@@ -1,0 +1,200 @@
+//
+//  SharePreviewSectionComposerTests.swift
+//  CalendarScenesTests
+//
+//  Created by sudo.park on 8/17/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Prelude
+import Optics
+import Extensions
+
+@testable import CalendarScenes
+
+
+final class SharePreviewSectionComposerTests {
+
+    private let timeZone: TimeZone = TimeZone(abbreviation: "KST")!
+
+    private var calendar: Calendar {
+        return Calendar(identifier: .gregorian) |> \.timeZone .~ self.timeZone
+    }
+
+    private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        return self.calendar.date(from: DateComponents(year: year, month: month, day: day))!
+    }
+
+    private func weekRange(startingAt start: Date) -> Range<TimeInterval> {
+        let end = self.calendar.date(byAdding: .day, value: 7, to: start)!
+        return start.timeIntervalSince1970..<end.timeIntervalSince1970
+    }
+
+    private func twoSections(in range: Range<TimeInterval>) -> [SharePreviewSectionModel] {
+        return [
+            .init(dayStart: range.lowerBound, dayHeaderText: "day1", lines: []),
+            .init(dayStart: range.lowerBound + 3600 * 24, dayHeaderText: "day2", lines: [])
+        ]
+    }
+
+    private func makeComposer(now: Date) -> SharePreviewSectionComposer {
+        return SharePreviewSectionComposer(timeZone: self.timeZone, now: now)
+    }
+}
+
+
+// MARK: - 주 단위 헤더
+
+extension SharePreviewSectionComposerTests {
+
+    // 2026-08-10(월)부터 한 주 — 8월 1일이 속한 주(7/27~8/2)가 8월 1주라 3주차다
+    private var augustThirdWeek: Range<TimeInterval> {
+        return self.weekRange(startingAt: self.date(2026, 8, 10))
+    }
+
+    @Test func composer_whenNowIsInSharedWeek_headerIsThisWeek() {
+        // given
+        let range = self.augustThirdWeek
+        let composer = self.makeComposer(now: self.date(2026, 8, 13))
+
+        // when
+        let header = composer.rangeHeaderText(of: self.twoSections(in: range), in: range, kind: .week)
+
+        // then
+        #expect(header == "share_preview::header::this_week".localized())
+    }
+
+    @Test func composer_whenSharedWeekIsBeforeNowWeek_headerIsLastWeek() {
+        // given
+        let range = self.augustThirdWeek
+        let composer = self.makeComposer(now: self.date(2026, 8, 19))
+
+        // when
+        let header = composer.rangeHeaderText(of: self.twoSections(in: range), in: range, kind: .week)
+
+        // then
+        #expect(header == "share_preview::header::last_week".localized())
+    }
+
+    @Test func composer_whenSharedWeekIsAfterNowWeek_headerIsNextWeek() {
+        // given
+        let range = self.augustThirdWeek
+        let composer = self.makeComposer(now: self.date(2026, 8, 5))
+
+        // when
+        let header = composer.rangeHeaderText(of: self.twoSections(in: range), in: range, kind: .week)
+
+        // then
+        #expect(header == "share_preview::header::next_week".localized())
+    }
+
+    @Test func composer_whenSharedWeekIsFarFromNow_headerIsWeekOrdinalOfStartingMonth() {
+        // given
+        let range = self.augustThirdWeek
+        let composer = self.makeComposer(now: self.date(2026, 10, 1))
+
+        // when
+        let header = composer.rangeHeaderText(of: self.twoSections(in: range), in: range, kind: .week)
+
+        // then
+        let formatter = DateFormatter() |> \.timeZone .~ self.timeZone
+        formatter.dateFormat = "date_form.MMM".localized()
+        let monthText = formatter.string(from: self.date(2026, 8, 10))
+        #expect(header == "share_preview::header::week_of_month".localized(with: monthText, 3))
+    }
+
+    // 7/27~8/2 주는 시작일이 7월이라 7월 기준 — 7/1이 속한 주(6/29~)가 1주라 5주차다
+    @Test func composer_whenWeekSpansTwoMonths_ordinalFollowsStartingMonth() {
+        // given
+        let range = self.weekRange(startingAt: self.date(2026, 7, 27))
+        let composer = self.makeComposer(now: self.date(2026, 10, 1))
+
+        // when
+        let header = composer.rangeHeaderText(of: self.twoSections(in: range), in: range, kind: .week)
+
+        // then
+        let formatter = DateFormatter() |> \.timeZone .~ self.timeZone
+        formatter.dateFormat = "date_form.MMM".localized()
+        let monthText = formatter.string(from: self.date(2026, 7, 27))
+        #expect(header == "share_preview::header::week_of_month".localized(with: monthText, 5))
+    }
+
+    @Test func composer_whenKindIsMonth_headerIsMonthTextRegardlessOfNow() {
+        // given
+        let range = self.augustThirdWeek
+        let composer = self.makeComposer(now: self.date(2026, 8, 13))
+
+        // when
+        let header = composer.rangeHeaderText(of: self.twoSections(in: range), in: range, kind: .month)
+
+        // then
+        let formatter = DateFormatter() |> \.timeZone .~ self.timeZone
+        formatter.dateFormat = "date_form.MMM_yyyy".localized()
+        #expect(header == formatter.string(from: self.date(2026, 8, 10)))
+    }
+}
+
+
+// MARK: - 날짜 섹션 분리
+
+extension SharePreviewSectionComposerTests {
+
+    private func line(_ eventId: String, dayStart: TimeInterval?) -> SharePreviewLineModel {
+        return .init(eventId: eventId, dayStart: dayStart, name: eventId)
+    }
+
+    @Test func composer_whenAllLinesOnSameDay_makesOneSectionWithoutDayHeader() {
+        // given
+        let dayStart = self.date(2026, 8, 10).timeIntervalSince1970
+        let composer = self.makeComposer(now: self.date(2026, 8, 10))
+
+        // when
+        let sections = composer.sections(of: [
+            self.line("e1", dayStart: dayStart), self.line("e2", dayStart: dayStart)
+        ])
+
+        // then
+        #expect(sections.count == 1)
+        #expect(sections.first?.dayHeaderText == nil)
+        #expect(sections.first?.lines.count == 2)
+    }
+
+    @Test func composer_undatedLines_becomeLeadingSectionWithoutDayHeader() {
+        // given
+        let day10 = self.date(2026, 8, 10).timeIntervalSince1970
+        let day12 = self.date(2026, 8, 12).timeIntervalSince1970
+        let composer = self.makeComposer(now: self.date(2026, 8, 10))
+
+        // when
+        let sections = composer.sections(of: [
+            self.line("dated", dayStart: day10),
+            self.line("undated", dayStart: nil),
+            self.line("later", dayStart: day12)
+        ])
+
+        // then
+        #expect(sections.first?.dayStart == nil)
+        #expect(sections.first?.dayHeaderText == nil)
+        #expect(sections.first?.lines.map { $0.eventId } == ["undated"])
+        #expect(sections.dropFirst().compactMap { $0.dayStart } == [day10, day12])
+    }
+
+    @Test func composer_whenLinesSpanDays_splitsPerDaySortedWithDayHeader() {
+        // given
+        let day10 = self.date(2026, 8, 10).timeIntervalSince1970
+        let day12 = self.date(2026, 8, 12).timeIntervalSince1970
+        let composer = self.makeComposer(now: self.date(2026, 8, 10))
+
+        // when
+        let sections = composer.sections(of: [
+            self.line("later", dayStart: day12), self.line("earlier", dayStart: day10)
+        ])
+
+        // then
+        #expect(sections.map { $0.dayStart } == [day10, day12])
+        #expect(sections.allSatisfy { $0.dayHeaderText?.hasPrefix("▸ ") == true })
+        #expect(sections.first?.lines.map { $0.eventId } == ["earlier"])
+    }
+}

--- a/Presentations/CalendarScenes/Tests/SharePreview/SharePreviewViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/SharePreview/SharePreviewViewModelImpleTests.swift
@@ -42,7 +42,14 @@ final class SharePreviewViewModelImpleTests: PublisherWaitable {
             |> \.eventTagId .~ .custom("not_exists")
     }
 
+    private func septemberWeekRange() -> Range<TimeInterval> {
+        let start = self.september10thRange().lowerBound
+        return start..<(start + 3600 * 24 * 7)
+    }
+
     private func makeViewModel(
+        range customRange: Range<TimeInterval>? = nil,
+        kind: CalendarShareRangeKind = .day,
         offTagIds: [EventTagId] = [],
         foremostEventId: ForemostEventId? = nil,
         includeTagName: Bool = false,
@@ -54,7 +61,7 @@ final class SharePreviewViewModelImpleTests: PublisherWaitable {
         appleEvents: [AppleCalendar.Event]? = nil,
         appleTags: [AppleCalendar.Tag]? = nil
     ) throws -> SharePreviewViewModelImple {
-        let range = self.september10thRange()
+        let range = customRange ?? self.september10thRange()
 
         let todoUsecase = StubTodoEventUsecase()
         todoUsecase.stubTodoEventsInRange = todos ?? [
@@ -116,6 +123,7 @@ final class SharePreviewViewModelImpleTests: PublisherWaitable {
 
         let viewModel = SharePreviewViewModelImple(
             range: range,
+            kind: kind,
             eventListUsecase: eventListUsecase,
             calendarSettingUsecase: calendarSettingUsecase,
             uiSettingUsecase: self.uiSettingUsecase,
@@ -222,6 +230,105 @@ extension SharePreviewViewModelImpleTests {
         let deletedTagLine = lines?.first(where: { $0.eventId == "todo:deleted-tag" })
         #expect(deletedTagLine?.tagId == .default)
         #expect(deletedTagLine?.tagName == DefaultEventTag.default("").name)
+    }
+}
+
+
+// MARK: - 날짜 섹션 분리
+
+extension SharePreviewViewModelImpleTests {
+
+    private func threeDaySchedules() -> [ScheduleEvent] {
+        let range = self.septemberWeekRange()
+        return (0..<3).map { dayOffset in
+            ScheduleEvent(
+                uuid: "sc:day\(dayOffset)", name: "day\(dayOffset)-schedule",
+                time: .at(range.lowerBound + 3600 * (24 * TimeInterval(dayOffset) + 9))
+            )
+            |> \.eventTagId .~ .default
+        }
+    }
+
+    @Test func viewModel_whenRangeIsSingleDay_hasNoDayHeader() async throws {
+        // given
+        let expect = expectConfirm("하루 범위는 날짜 헤더가 붙지 않는다")
+        let viewModel = try self.makeViewModel(currentTodos: [])
+
+        // when
+        let sections = try await self.firstOutput(expect, for: viewModel.sectionModels) {
+            viewModel.prepare()
+        }
+
+        // then
+        #expect(sections?.count == 1)
+        #expect(sections?.first?.dayHeaderText == nil)
+    }
+
+    @Test func viewModel_currentTodos_areSeparateLeadingSectionWithoutDay() async throws {
+        // given
+        let expect = expectConfirm("시간 없는 할일은 날짜에 안 묶이고 맨 앞 섹션으로 빠진다")
+        let viewModel = try self.makeViewModel(
+            range: self.septemberWeekRange(),
+            schedules: self.threeDaySchedules()
+        )
+
+        // when
+        let sections = try await self.firstOutput(expect, for: viewModel.sectionModels) {
+            viewModel.prepare()
+        }
+
+        // then
+        #expect(sections?.first?.dayStart == nil)
+        #expect(sections?.first?.dayHeaderText == nil)
+        #expect(sections?.first?.lines.map { $0.eventId } == ["c-t:0"])
+        #expect(sections?.dropFirst().allSatisfy { $0.dayStart != nil } == true)
+    }
+
+    @Test func viewModel_whenRangeSpansMultipleDays_splitsSectionsPerDayWithHeader() async throws {
+        // given
+        let expect = expectConfirm("여러 날 범위는 날짜별 섹션으로 갈리고 각 섹션에 헤더가 붙는다")
+        let viewModel = try self.makeViewModel(
+            range: self.septemberWeekRange(),
+            currentTodos: [],
+            schedules: self.threeDaySchedules()
+        )
+
+        // when
+        let sections = try await self.firstOutput(expect, for: viewModel.sectionModels) {
+            viewModel.prepare()
+        }
+
+        // then
+        let dayStarts = sections?.compactMap { $0.dayStart }
+        #expect(dayStarts == dayStarts?.sorted())
+        #expect(sections?.count == 3)
+        #expect(sections?.allSatisfy { $0.dayHeaderText?.hasPrefix("▸ ") == true } == true)
+        #expect(sections?.flatMap { $0.lines.map { $0.eventId } }.contains("sc:day2-1") == true)
+    }
+
+    @Test func viewModel_whenRangeSpansMultipleDays_headerSwitchesFromDayToMonthText() async throws {
+        // given
+        let expect = expectConfirm("여러 날 범위의 상단 헤더는 하루 표기가 아니다")
+        let singleDayViewModel = try self.makeViewModel()
+        let multiDayViewModel = try self.makeViewModel(
+            range: self.septemberWeekRange(),
+            currentTodos: [],
+            schedules: self.threeDaySchedules()
+        )
+
+        // when
+        let singleDayHeader = try await self.firstOutput(expect, for: singleDayViewModel.dateHeaderText) {
+            singleDayViewModel.prepare()
+        }
+        let multiDayHeader = try await self.firstOutput(
+            expectConfirm("여러 날 헤더"), for: multiDayViewModel.dateHeaderText
+        ) {
+            multiDayViewModel.prepare()
+        }
+
+        // then
+        #expect(multiDayHeader?.isEmpty == false)
+        #expect(multiDayHeader != singleDayHeader)
     }
 }
 

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -145,6 +145,9 @@
 "calednar::event::skip_todo_until" = "Select a time to skip this to-do";
 "calednar::event::copy" = "Copy event";
 "calendar::move_date" = "Move date";
+"calendar::share::this_day" = "Share this day";
+"calendar::share::this_week" = "Share this week";
+"calendar::share::this_month" = "Share this month";
 "calednar::event::google::edit" = "Edit Google Calendar Event";
 
 

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -323,6 +323,10 @@
 "share_preview::option::include_tag_name" = "Include tag name";
 "share_preview::share_button" = "Share";
 "share_preview::empty" = "No events to share";
+"share_preview::header::this_week" = "This week";
+"share_preview::header::last_week" = "Last week";
+"share_preview::header::next_week" = "Next week";
+"share_preview::header::week_of_month" = "%1$@ week %2$d";
 
 
 // MARK: - account

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -145,6 +145,9 @@
 "calednar::event::skip_todo_until" = "할일 건너뛰기할 날짜 선택";
 "calednar::event::copy" = "이벤트 복사";
 "calendar::move_date" = "날짜 이동";
+"calendar::share::this_day" = "이 날 일정 공유";
+"calendar::share::this_week" = "이 주 일정 공유";
+"calendar::share::this_month" = "이 달 일정 공유";
 "calednar::event::google::edit" = "구글캘린더 이벤트 수정";
 
 

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -323,6 +323,10 @@
 "share_preview::option::include_tag_name" = "태그명 함께 표시";
 "share_preview::share_button" = "공유하기";
 "share_preview::empty" = "공유할 일정이 없어요";
+"share_preview::header::this_week" = "이번주";
+"share_preview::header::last_week" = "저번주";
+"share_preview::header::next_week" = "다음주";
+"share_preview::header::week_of_month" = "%1$@ %2$d주";
 
 
 // MARK: - account

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/WeekEventsWidget/WeekEventsWidgetViewModelProvider.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/WeekEventsWidget/WeekEventsWidgetViewModelProvider.swift
@@ -31,17 +31,13 @@ enum WeekEventsRange {
 private struct WeeksWithRange {
     let weeks: [CalendarComponent.Week]
     let range: Range<TimeInterval>
-    
-    init(_ weeks: [CalendarComponent.Week], _ calendar: Calendar) throws {
+
+    init(_ weeks: [CalendarComponent.Week], _ timeZone: TimeZone) throws {
         self.weeks = weeks
-        guard let startDay = weeks.first?.days.first,
-              let endDay = weeks.last?.days.last,
-              let startDate = calendar.date(from: startDay),
-              let endDate = calendar.date(from: endDay)
+        guard let firstWeekRange = weeks.first?.range(timeZone),
+              let lastWeekRange = weeks.last?.range(timeZone)
         else { throw RuntimeError("invalid period") }
-        let startTime = calendar.startOfDay(for: startDate)
-        let endTime = try calendar.endOfDay(for: endDate).unwrap()
-        self.range = startTime.timeIntervalSince1970..<endTime.timeIntervalSince1970
+        self.range = firstWeekRange.lowerBound..<lastWeekRange.upperBound
     }
 }
 
@@ -291,7 +287,7 @@ extension WeekEventsWidgetViewModelProvider {
         case .wholeMonth(let selection): try wholeWeeks(selection)
         }
         
-        return try WeeksWithRange(weeks, calendar)
+        return try WeeksWithRange(weeks, calendar.timeZone)
     }
     
     private func convertToWeekRowModels(


### PR DESCRIPTION
캘린더 그리드의 날짜를 길게 누르면 일·주·월 메뉴가 뜨고, 고른 범위의 공유 미리보기 화면이 열린다.

> base가 `features/872-share-preview-scene`인 stacked PR이다. #880이 머지되면 base를 develop으로 바꾼다.

## 접근

**Month는 Router 없는 Component라 셀에서 직접 모달을 못 연다.** `MonthSceneComponent`는 viewModel만 반환하고 `MonthViewModelImple`엔 `router`가 없다. 그래서 `Month(.contextMenu) → MonthSceneListener(신규 메서드) → CalendarPaperViewModelImple → CalendarPaperRouter → SharePreviewSceneBuilder` 체인을 탄다. `CalendarPaperRouting`은 지금까지 빈 프로토콜(`// TODO: router implememnts`)이었는데 이번에 첫 라우팅이 들어갔다.

**범위 계산은 Month가 한다.** 그리드 데이터(`weeks`·`component`·`timeZone`)를 들고 있는 쪽이 Month라, Listener로는 종류가 아니라 이미 계산된 `Range<TimeInterval>`을 올린다. 부모가 종류를 받아 다시 계산하면 그리드 상태를 또 알아야 한다.

**주 range 계산이 이미 두 곳에 private으로 중복돼 있어 Domain으로 올렸다.** `WeekEventStackBuilder`(Presentation)와 주간 위젯이 각자 "첫날 00:00 ~ 마지막날 23:59:59"를 구현하고 있었다. 이번이 세 번째라 `CalendarComponent.Week.range(_:)`로 승격하고 그 둘을 교체했다 — `Day.dayRange(_:)`와 대칭이 맞는 자리다.

**순수 월 range는 새로 만들었다.** 기존 계산(`MonthViewModel.intervalRange(at:)`·`MonthWidgetViewModel`)은 전부 그리드 6주 범위라 앞뒤 달 날짜가 섞인다. `CalendarComponent.monthRange(_:)`는 `weeks`를 보지 않고 `year`·`month`로 1일~말일을 만든다.

## 확정한 스펙

- **그리드의 앞뒤 달 셀에서 "월 공유"는 지금 보고 있는 달을 쓴다.** 8월 그리드에서 7/31을 길게 눌러도 8월 전체가 나간다 — "화면에 보이는 달을 공유"라는 멘탈 모델을 따랐다. 일은 그 셀의 날짜, 주는 그 셀이 속한 그리드 행이다.
- 주 시작 요일 설정을 따로 읽지 않는다. 그리드 행(`CalendarComponent.Week`) 자체가 이미 그 설정의 결과물이다.
- 메뉴는 `.contextMenu`다. Month가 Router 없는 순수 SwiftUI 셀이라 `showActionSheet`(Router 보유 화면용 관례)를 못 쓴다. 기존 `.onTapGesture`(날짜 선택)와 공존하며, 같은 조합이 `EventListCellView`에 선례로 있다.
- 메뉴 항목에 아이콘을 넣지 않았다. 세 항목이 같은 성격이라 서로 구분되는 아이콘을 고르기 어렵고, 하나만 넣으면 나머지와 어긋난다.

## 검증

`CalendarScenes` 235케이스 · `Domain` 304케이스 · `TodoCalendarAppWidget` 65케이스 · `CalendarScenesSnapshots` 8케이스 통과. 로컬라이즈 en·ko 파리티 통과.

**스냅샷 케이스는 추가하지 않았다** — `contextMenu`는 시스템 오버레이라 촬영되지 않는다.

**유저 실물 확인 대상**: 날짜 셀 롱프레스가 월 페이징 스와이프(`UIPageViewController`)와 제스처 충돌 없이 동작하는지. 유닛 테스트가 못 잡는 영역이다.

## 남은 과제

**이미지 내보내기**는 #753의 미분해 항목으로 남아 있다 — 공유용 레이아웃 디자인이 선행돼야 한다.

선행: #872 (PR #880 — 미리보기 화면·`SharePreviewSceneBuilder`)
상위 이슈: #753
