### PR TITLE
[#874] 이벤트 상세 단건 공유 — 비활성화된 more action 되살리기

### DIFF
--- a/Presentations/EventDetailScene/Sources/EventDetailRouter.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailRouter.swift
@@ -18,15 +18,17 @@ import CommonPresentation
 // MARK: - Routing
 
 protocol EventDetailRouting: Routing, Sendable, AnyObject {
-    
+
     func attachInput(
         // TODO: listener 삭제해도됨
         _ listener: (any EventDetailInputListener)?
     ) -> (any EventDetailInputInteractor)?
-    
+
     func showTodoEventGuide()
-    
+
     func showForemostEventGuide()
+
+    func showShareSheet(text: String)
 }
 
 

--- a/Presentations/EventDetailScene/Sources/EventDetailShareTextBuilder.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailShareTextBuilder.swift
@@ -1,0 +1,85 @@
+//
+//  EventDetailShareTextBuilder.swift
+//  EventDetailScene
+//
+//  Created by sudo.park on 8/15/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Extensions
+
+
+struct EventDetailShareModel: Equatable {
+    let name: String
+    var isTodo: Bool = false
+    var timeText: String?
+    var repeatText: String?
+    var tagName: String?
+    var placeName: String?
+    var url: String?
+    var memo: String?
+}
+
+struct EventDetailShareTextBuilder {
+
+    private enum Constant {
+        static let labelSeparator: String = ": "
+        static let tagLabelKey: String = "eventTag.title"
+        static let todoTextKey: String = "calendar::event_time::todo"
+        static let periodSeparator: String = " ~ "
+        static let lineSeparator: String = "\n"
+        static let allDayTextKey: String = "calendar::event_time::allday"
+    }
+
+    func build(_ model: EventDetailShareModel) -> String {
+        let fields: [(labelKey: String, value: String?)] = [
+            ("event_detail::share::field::time", model.timeText),
+            ("event_detail::share::field::repeating", model.repeatText),
+            (Constant.tagLabelKey, model.tagName),
+            ("event_detail::share::field::place", model.placeName),
+            ("event_detail::share::field::url", model.url),
+            ("event_detail::share::field::memo", model.memo)
+        ]
+        let fieldLines = fields.compactMap { field in
+            field.value.map { "\(field.labelKey.localized())\(Constant.labelSeparator)\($0)" }
+        }
+        return ([self.nameLine(model)] + fieldLines).joined(separator: Constant.lineSeparator)
+    }
+
+    private func nameLine(_ model: EventDetailShareModel) -> String {
+        guard model.isTodo else { return model.name }
+        return "(\(Constant.todoTextKey.localized())) \(model.name)"
+    }
+
+    func timeText(from selectedTime: SelectedTime) -> String {
+        switch selectedTime {
+        case .at(let time):
+            return self.joinedParts(time)
+
+        case .period(let start, let end) where start.day == end.day:
+            return [self.joinedParts(start), end.time ?? ""]
+                .joined(separator: Constant.periodSeparator)
+
+        case .period(let start, let end):
+            return [self.joinedParts(start), self.joinedParts(end)]
+                .joined(separator: Constant.periodSeparator)
+
+        case .singleAllDay(let time):
+            return [self.joinedParts(time), Constant.allDayTextKey.localized()]
+                .joined(separator: " ")
+
+        case .alldayPeriod(let start, let end):
+            let period = [self.joinedParts(start), self.joinedParts(end)]
+                .joined(separator: Constant.periodSeparator)
+            return [period, Constant.allDayTextKey.localized()]
+                .joined(separator: " ")
+        }
+    }
+
+    private func joinedParts(_ text: SelectTimeText) -> String {
+        return [text.year, text.day, text.time]
+            .compactMap { $0 }
+            .joined(separator: " ")
+    }
+}

--- a/Presentations/EventDetailScene/Sources/EventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailView.swift
@@ -1159,7 +1159,7 @@ extension EventDetailMoreAction: Identifiable {
                 : "calendar::event::more_action:dday_candidate:register:item_name".localized()
         case .copy: return "calendar::event::more_action:copy:item_name".localized()
         case .addToTemplate: return "add to template".localized()
-        case .share: return "share".localized()
+        case .share: return "calendar::event::more_action:share:item_name".localized()
         case .transformToSchedule: return "calendar::event::more_action:transform_to::schedule".localized()
         case .transformToTodo: return "calendar::event::more_action:transform_to::todo".localized()
         }

--- a/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
@@ -162,11 +162,39 @@ extension EditScheduleEventDetailViewModelImple: EventDetailInputListener {
             // TODO:
             break
         case .share:
-            // TODO:
-            break
-            
+            self.shareEvent()
+
         default: break
         }
+    }
+
+    private func shareEvent() {
+        guard let basic = self.subject.basicData.value?.current,
+              let name = basic.name
+        else { return }
+
+        let addition = self.subject.additionalData.value?.current
+        let builder = EventDetailShareTextBuilder()
+        let timeText = basic.selectedTime.map(builder.timeText(from:))
+
+        self.eventTagUsecase.eventTag(id: basic.eventTagId)
+            .first()
+            .sink { [weak self] tag in
+                let model = EventDetailShareModel(
+                    name: name,
+                    isTodo: false,
+                    timeText: timeText,
+                    repeatText: basic.eventRepeating?.text.emptyAsNil(),
+                    tagName: tag?.name.emptyAsNil(),
+                    placeName: addition?.place?.placeName.emptyAsNil(),
+                    url: addition?.url?.emptyAsNil(),
+                    memo: addition?.memo?.emptyAsNil()
+                )
+                let text = builder.build(model)
+                guard !text.isEmpty else { return }
+                self?.router?.showShareSheet(text: text)
+            }
+            .store(in: &self.cancellables)
     }
     
     private func removeEventAfterConfirm(onlyThisTime: Bool) {
@@ -570,12 +598,9 @@ extension EditScheduleEventDetailViewModelImple {
                     )
                 ]
                 : []
-            // TODO: share 기능 일단 비활성화
             let otherActions: [EventDetailMoreAction] = isRepeating
-//                ? [.share]
-//                : [.toggleTo(isForemost: !isForemost), .share]
-                ? ddayActions + [.copy, .transformToTodo]
-                : [.toggleTo(isForemost: !isForemost)] + ddayActions + [.copy, .transformToTodo]
+                ? ddayActions + [.copy, .transformToTodo, .share]
+                : [.toggleTo(isForemost: !isForemost)] + ddayActions + [.copy, .transformToTodo, .share]
             return [removeActions, otherActions]
         }
         return Publishers.CombineLatest3(

--- a/Presentations/EventDetailScene/Sources/ViewModels/EditTodoEventDetailViewModelImple.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/EditTodoEventDetailViewModelImple.swift
@@ -150,11 +150,39 @@ extension EditTodoEventDetailViewModelImple: EventDetailInputListener {
             // TODO:
             break
         case .share:
-            // TODO:
-            break
-            
+            self.shareEvent()
+
         default: break
         }
+    }
+
+    private func shareEvent() {
+        guard let basic = self.subject.basicData.value?.current,
+              let name = basic.name
+        else { return }
+
+        let addition = self.subject.additionalData.value?.current
+        let builder = EventDetailShareTextBuilder()
+        let timeText = basic.selectedTime.map(builder.timeText(from:))
+
+        self.eventTagUsecase.eventTag(id: basic.eventTagId)
+            .first()
+            .sink { [weak self] tag in
+                let model = EventDetailShareModel(
+                    name: name,
+                    isTodo: true,
+                    timeText: timeText,
+                    repeatText: basic.eventRepeating?.text.emptyAsNil(),
+                    tagName: tag?.name.emptyAsNil(),
+                    placeName: addition?.place?.placeName.emptyAsNil(),
+                    url: addition?.url?.emptyAsNil(),
+                    memo: addition?.memo?.emptyAsNil()
+                )
+                let text = builder.build(model)
+                guard !text.isEmpty else { return }
+                self?.router?.showShareSheet(text: text)
+            }
+            .store(in: &self.cancellables)
     }
     
     private func removeEventAfterConfirm(onlyThisTime: Bool) {
@@ -482,9 +510,7 @@ extension EditTodoEventDetailViewModelImple {
             let removeActions: [EventDetailMoreAction] = isRepeating
                 ? [.remove(onlyThisEvent: true), .remove(onlyThisEvent: false)]
                 : [.remove(onlyThisEvent: false)]
-            // TODO: share 기능 일단 비활성화
-//            return [removeActions, [.toggleTo(isForemost: !isForemost), .share]]
-            return [removeActions, [.toggleTo(isForemost: !isForemost), .copy, .transformToSchedule]]
+            return [removeActions, [.toggleTo(isForemost: !isForemost), .copy, .transformToSchedule, .share]]
         }
         return Publishers.CombineLatest(
             self.subject.basicData.compactMap{ $0?.origin },

--- a/Presentations/EventDetailScene/Tests/EditScheduleEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/EditScheduleEventDetailViewModelImpleTests.swift
@@ -11,6 +11,7 @@ import Prelude
 import Optics
 import Domain
 import Scenes
+import Extensions
 import UnitTestHelpKit
 import TestDoubles
 
@@ -246,14 +247,14 @@ extension EditScheduleEventDetailViewModelImpleTests {
             self.makeViewModel(customSchedule: schedule),
             expect: [
                 [.remove(onlyThisEvent: true), .remove(onlyThisEvent: false)],
-                [.copy, .transformToTodo]
+                [.copy, .transformToTodo, .share]
             ]
         )
         parameterizeTest(
             self.makeViewModel(customSchedule: schedule, isForemost: true),
             expect: [
                 [.remove(onlyThisEvent: true), .remove(onlyThisEvent: false)],
-                [.copy, .transformToTodo]
+                [.copy, .transformToTodo, .share]
             ]
         )
         let scheduleNotRepeating = schedule |> \.repeating .~ nil
@@ -261,16 +262,83 @@ extension EditScheduleEventDetailViewModelImpleTests {
             self.makeViewModel(customSchedule: scheduleNotRepeating),
             expect: [
                 [.remove(onlyThisEvent: false)],
-                [.toggleTo(isForemost: true), .copy, .transformToTodo]
+                [.toggleTo(isForemost: true), .copy, .transformToTodo, .share]
             ]
         )
         parameterizeTest(
             self.makeViewModel(customSchedule: scheduleNotRepeating, isForemost: true),
             expect: [
                 [.remove(onlyThisEvent: false)],
-                [.toggleTo(isForemost: false), .copy, .transformToTodo]
+                [.toggleTo(isForemost: false), .copy, .transformToTodo, .share]
             ]
         )
+    }
+
+    func testViewModel_moreActions_containShare() {
+        // given
+        let expect = expectation(description: "more action에 공유 포함")
+        let viewModel = self.makeViewModel()
+
+        // when
+        let actions = self.waitFirstOutput(expect, for: viewModel.moreActions) {
+            viewModel.prepare()
+        }
+
+        // then
+        XCTAssertEqual(actions?.flatMap { $0 }.contains(.share), true)
+    }
+
+    func testViewModel_whenHandleShareAction_routesWithAssembledText() {
+        // given
+        let viewModel = self.makeViewModelWithPrepare()
+
+        // when
+        viewModel.handleMoreAction(.share)
+
+        // then
+        XCTAssertEqual(self.spyRouter.didShareText?.contains(self.dummyRepeatingSchedule.name), true)
+    }
+
+    func testViewModel_whenHandleShareAction_includesTagName() {
+        // given
+        let viewModel = self.makeViewModelWithPrepare()
+
+        // when
+        viewModel.handleMoreAction(.share)
+
+        // then
+        XCTAssertEqual(self.spyRouter.didShareText?.contains("some"), true)
+    }
+
+    func testViewModel_whenHandleShareAction_includesUrlAndMemoFields() {
+        // given
+        let viewModel = self.makeViewModelWithPrepare()
+
+        // when
+        viewModel.handleMoreAction(.share)
+
+        // then
+        let text = self.spyRouter.didShareText
+        XCTAssertEqual(text?.contains("\(self.shareFieldLabel("url")): url"), true)
+        XCTAssertEqual(text?.contains("\(self.shareFieldLabel("memo")): memo"), true)
+    }
+
+    func testViewModel_whenHandleShareAction_hasNoTodoMarkerOnName() {
+        // given
+        let viewModel = self.makeViewModelWithPrepare()
+
+        // when
+        viewModel.handleMoreAction(.share)
+
+        // then
+        let todoText = "calendar::event_time::todo".localized()
+        let text = self.spyRouter.didShareText
+        XCTAssertEqual(text?.hasPrefix(self.dummyRepeatingSchedule.name), true)
+        XCTAssertEqual(text?.contains("(\(todoText))"), false)
+    }
+
+    private func shareFieldLabel(_ key: String) -> String {
+        return "event_detail::share::field::\(key)".localized()
     }
 
     // #741 배포 보류 — 플래그가 꺼진 동안 후보 등록 메뉴가 새어나가면 안 된다

--- a/Presentations/EventDetailScene/Tests/EditTodoEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/EditTodoEventDetailViewModelImpleTests.swift
@@ -11,6 +11,7 @@ import Prelude
 import Optics
 import Domain
 import Scenes
+import Extensions
 import UnitTestHelpKit
 import TestDoubles
 
@@ -239,15 +240,15 @@ extension EditTodoEventDetailViewModelImpleTests {
         parameterizeTest(
             self.makeViewModel(customTodo: todo),
             expect: [
-                [.remove(onlyThisEvent: true), .remove(onlyThisEvent: false)], 
-                [.toggleTo(isForemost: true), .copy, .transformToSchedule]
+                [.remove(onlyThisEvent: true), .remove(onlyThisEvent: false)],
+                [.toggleTo(isForemost: true), .copy, .transformToSchedule, .share]
             ]
         )
         parameterizeTest(
             self.makeViewModel(customTodo: todo, isForemost: true),
             expect: [
                 [.remove(onlyThisEvent: true), .remove(onlyThisEvent: false)],
-                [.toggleTo(isForemost: false), .copy, .transformToSchedule]
+                [.toggleTo(isForemost: false), .copy, .transformToSchedule, .share]
             ]
         )
         let todoNotRepeating = todo |> \.repeating .~ nil
@@ -255,9 +256,76 @@ extension EditTodoEventDetailViewModelImpleTests {
             self.makeViewModel(customTodo: todoNotRepeating),
             expect: [
                 [.remove(onlyThisEvent: false)],
-                [.toggleTo(isForemost: true), .copy, .transformToSchedule]
+                [.toggleTo(isForemost: true), .copy, .transformToSchedule, .share]
             ]
         )
+    }
+
+    func testViewModel_moreActions_containShare() {
+        // given
+        let expect = expectation(description: "more action에 공유 포함")
+        let viewModel = self.makeViewModel()
+
+        // when
+        let actions = self.waitFirstOutput(expect, for: viewModel.moreActions) {
+            viewModel.prepare()
+        }
+
+        // then
+        XCTAssertEqual(actions?.flatMap { $0 }.contains(.share), true)
+    }
+
+    func testViewModel_whenHandleShareAction_routesWithAssembledText() {
+        // given
+        let viewModel = self.makeViewModelWithPrepare()
+
+        // when
+        viewModel.handleMoreAction(.share)
+
+        // then
+        XCTAssertEqual(self.spyRouter.didShareText?.contains(self.dummyRepeatingTodo.name), true)
+    }
+
+    func testViewModel_whenHandleShareAction_includesTagName() {
+        // given
+        let viewModel = self.makeViewModelWithPrepare()
+
+        // when
+        viewModel.handleMoreAction(.share)
+
+        // then
+        XCTAssertEqual(self.spyRouter.didShareText?.contains("some"), true)
+    }
+
+    func testViewModel_whenHandleShareAction_includesUrlAndMemoFields() {
+        // given
+        let viewModel = self.makeViewModelWithPrepare()
+
+        // when
+        viewModel.handleMoreAction(.share)
+
+        // then
+        let text = self.spyRouter.didShareText
+        XCTAssertEqual(text?.contains("\(self.shareFieldLabel("url")): url"), true)
+        XCTAssertEqual(text?.contains("\(self.shareFieldLabel("memo")): memo"), true)
+    }
+
+    func testViewModel_whenHandleShareAction_prefixesTodoMarkerToNameAndIncludesRepeatOption() {
+        // given
+        let viewModel = self.makeViewModelWithPrepare()
+
+        // when
+        viewModel.handleMoreAction(.share)
+
+        // then
+        let text = self.spyRouter.didShareText
+        let todoText = "calendar::event_time::todo".localized()
+        XCTAssertEqual(text?.hasPrefix("(\(todoText)) \(self.dummyRepeatingTodo.name)"), true)
+        XCTAssertEqual(text?.contains("\(self.shareFieldLabel("repeating")): "), true)
+    }
+
+    private func shareFieldLabel(_ key: String) -> String {
+        return "event_detail::share::field::\(key)".localized()
     }
     
     func testViewModel_whenAfterRemoveTodo_closeScene() {

--- a/Presentations/EventDetailScene/Tests/EventDetailShareTextBuilderTests.swift
+++ b/Presentations/EventDetailScene/Tests/EventDetailShareTextBuilderTests.swift
@@ -1,0 +1,257 @@
+//
+//  EventDetailShareTextBuilderTests.swift
+//  EventDetailSceneTests
+//
+//  Created by sudo.park on 8/15/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Extensions
+
+@testable import EventDetailScene
+
+
+struct EventDetailShareTextBuilderTests {
+
+    private let builder = EventDetailShareTextBuilder()
+    private let timeZone = TimeZone(abbreviation: "KST")!
+}
+
+
+// MARK: - build(_:) 라벨 필드 조립
+
+extension EventDetailShareTextBuilderTests {
+
+    private func label(_ key: String) -> String {
+        return "event_detail::share::field::\(key)".localized()
+    }
+
+    private var tagLabel: String { "eventTag.title".localized() }
+    private var todoText: String { "calendar::event_time::todo".localized() }
+
+    private func fullModel() -> EventDetailShareModel {
+        return EventDetailShareModel(
+            name: "약먹기",
+            isTodo: true,
+            timeText: "2026.08.15 (금) 09:00 ~ 10:00",
+            repeatText: "매일",
+            tagName: "건강",
+            placeName: "강남약국",
+            url: "https://example.com",
+            memo: "식후 30분"
+        )
+    }
+
+    @Test func builder_rendersNameThenLabeledFieldsInOrder() {
+        // given
+        let model = self.fullModel()
+
+        // when
+        let result = self.builder.build(model)
+
+        // then
+        let expected = [
+            "(\(self.todoText)) 약먹기",
+            "\(self.label("time")): 2026.08.15 (금) 09:00 ~ 10:00",
+            "\(self.label("repeating")): 매일",
+            "\(self.tagLabel): 건강",
+            "\(self.label("place")): 강남약국",
+            "\(self.label("url")): https://example.com",
+            "\(self.label("memo")): 식후 30분"
+        ].joined(separator: "\n")
+        #expect(result == expected)
+    }
+
+    @Test func builder_whenFieldIsNil_omitsThatLine() {
+        // given
+        let model = EventDetailShareModel(
+            name: "이름", timeText: "시간", repeatText: nil,
+            tagName: nil, placeName: nil, url: nil, memo: nil
+        )
+
+        // when
+        let result = self.builder.build(model)
+
+        // then
+        #expect(result == "이름\n\(self.label("time")): 시간")
+    }
+
+    @Test func builder_whenEventIsNotTodo_hasNoTodoPrefix() {
+        // given
+        let model = EventDetailShareModel(name: "이름", isTodo: false, timeText: "시간")
+
+        // when
+        let result = self.builder.build(model)
+
+        // then
+        #expect(result.components(separatedBy: "\n").first == "이름")
+    }
+
+    @Test func builder_whenOnlyNameExists_rendersNameAlone() {
+        // given
+        let model = EventDetailShareModel(name: "이름")
+
+        // when
+        let result = self.builder.build(model)
+
+        // then
+        #expect(result == "이름")
+    }
+
+    @Test func builder_whenMemoHasMultipleLines_keepsThemAfterLabel() {
+        // given
+        let model = EventDetailShareModel(name: "이름", memo: "첫째 줄\n둘째 줄")
+
+        // when
+        let result = self.builder.build(model)
+
+        // then
+        #expect(result == "이름\n\(self.label("memo")): 첫째 줄\n둘째 줄")
+    }
+
+    @Test func builder_hasNoBlankLineBetweenFields() {
+        // given
+        let model = self.fullModel()
+
+        // when
+        let result = self.builder.build(model)
+
+        // then
+        #expect(!result.contains("\n\n"))
+        #expect(!result.hasSuffix("\n"))
+    }
+}
+
+
+// MARK: - timeText(from:) at
+
+extension EventDetailShareTextBuilderTests {
+
+    @Test func timeText_at_joinsDayAndTime() {
+        // given
+        let time = SelectTimeText(Date().timeIntervalSince1970, self.timeZone)
+        let selectedTime = SelectedTime.at(time)
+
+        // when
+        let result = self.builder.timeText(from: selectedTime)
+
+        // then
+        #expect(time.year == nil)
+        let expected = [time.day, time.time].compactMap { $0 }.joined(separator: " ")
+        #expect(result == expected)
+    }
+
+    @Test func timeText_at_whenNotCurrentYear_includesYear() {
+        // given
+        let pastDate = Date().addingTimeInterval(-20 * 365 * 24 * 3600)
+        let time = SelectTimeText(pastDate.timeIntervalSince1970, self.timeZone)
+        let selectedTime = SelectedTime.at(time)
+
+        // when
+        let result = self.builder.timeText(from: selectedTime)
+
+        // then
+        let year = try? #require(time.year)
+        #expect(year != nil)
+        #expect(result.hasPrefix(year ?? ""))
+        let expected = [time.year, time.day, time.time].compactMap { $0 }.joined(separator: " ")
+        #expect(result == expected)
+    }
+}
+
+
+// MARK: - timeText(from:) period
+
+extension EventDetailShareTextBuilderTests {
+
+    @Test func timeText_period_sameDay_showsDayOnceWithTildeTimes() throws {
+        // given
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = self.timeZone
+        let startDate = try #require(calendar.date(bySettingHour: 9, minute: 0, second: 0, of: Date()))
+        let endDate = try #require(calendar.date(byAdding: .hour, value: 1, to: startDate))
+        let start = SelectTimeText(startDate.timeIntervalSince1970, self.timeZone)
+        let end = SelectTimeText(endDate.timeIntervalSince1970, self.timeZone)
+        let selectedTime = SelectedTime.period(start, end)
+
+        // when
+        let result = self.builder.timeText(from: selectedTime)
+
+        // then
+        #expect(start.day == end.day)
+        let components = result.components(separatedBy: " ~ ")
+        #expect(components.count == 2)
+        #expect(components[0].contains(start.day))
+        #expect(components[0].hasSuffix(start.time ?? "__missing__"))
+        #expect(components[1] == (end.time ?? ""))
+        #expect(result.components(separatedBy: start.day).count - 1 == 1)
+    }
+
+    @Test func timeText_period_differentDays_showsBothSides() throws {
+        // given
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = self.timeZone
+        let startDate = try #require(calendar.date(bySettingHour: 9, minute: 0, second: 0, of: Date()))
+        let nextDay = try #require(calendar.date(byAdding: .day, value: 1, to: startDate))
+        let endDate = try #require(calendar.date(bySettingHour: 10, minute: 0, second: 0, of: nextDay))
+        let start = SelectTimeText(startDate.timeIntervalSince1970, self.timeZone)
+        let end = SelectTimeText(endDate.timeIntervalSince1970, self.timeZone)
+        let selectedTime = SelectedTime.period(start, end)
+
+        // when
+        let result = self.builder.timeText(from: selectedTime)
+
+        // then
+        #expect(start.day != end.day)
+        let components = result.components(separatedBy: " ~ ")
+        #expect(components.count == 2)
+        #expect(components[0].contains(start.day))
+        #expect(components[0].hasSuffix(start.time ?? "__missing__"))
+        #expect(components[1].contains(end.day))
+        #expect(components[1].hasSuffix(end.time ?? "__missing__"))
+    }
+}
+
+
+// MARK: - timeText(from:) allday
+
+extension EventDetailShareTextBuilderTests {
+
+    @Test func timeText_singleAllDay_appendsAllDayText() {
+        // given
+        let time = SelectTimeText(Date().timeIntervalSince1970, self.timeZone, withoutTime: true)
+        let selectedTime = SelectedTime.singleAllDay(time)
+
+        // when
+        let result = self.builder.timeText(from: selectedTime)
+
+        // then
+        let allDayText = "calendar::event_time::allday".localized()
+        #expect(result.hasSuffix(allDayText))
+        #expect(result.contains(time.day))
+    }
+
+    @Test func timeText_alldayPeriod_joinsBothDaysWithAllDayText() throws {
+        // given
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = self.timeZone
+        let startDate = Date()
+        let endDate = try #require(calendar.date(byAdding: .day, value: 2, to: startDate))
+        let start = SelectTimeText(startDate.timeIntervalSince1970, self.timeZone, withoutTime: true)
+        let end = SelectTimeText(endDate.timeIntervalSince1970, self.timeZone, withoutTime: true)
+        let selectedTime = SelectedTime.alldayPeriod(start, end)
+
+        // when
+        let result = self.builder.timeText(from: selectedTime)
+
+        // then
+        let allDayText = "calendar::event_time::allday".localized()
+        #expect(result.hasSuffix(allDayText))
+        #expect(result.contains(start.day))
+        #expect(result.contains(end.day))
+        let components = result.components(separatedBy: " ~ ")
+        #expect(components.count == 2)
+    }
+}

--- a/Presentations/EventDetailScene/Tests/SpyEventDetailRouter.swift
+++ b/Presentations/EventDetailScene/Tests/SpyEventDetailRouter.swift
@@ -40,7 +40,12 @@ final class SpyEventDetailRouter: BaseSpyRouter, EventDetailRouting, @unchecked 
     }
     
     func showForemostEventGuide() {
-        
+
+    }
+
+    var didShareText: String?
+    func showShareSheet(text: String) {
+        self.didShareText = text
     }
 }
 

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -136,6 +136,11 @@
 "calendar::event::more_action:dday_candidate:register:message" = "Add this event as a D-day widget candidate? It will appear at the top of the list when you edit the widget.";
 "calendar::event::more_action:dday_candidate:unregister:message" = "Remove this event from D-day widget candidates?";
 "calendar::event::more_action:copy:item_name" = "Copy event";
+"event_detail::share::field::time" = "Time";
+"event_detail::share::field::repeating" = "Repeat";
+"event_detail::share::field::place" = "Location";
+"event_detail::share::field::url" = "Link";
+"event_detail::share::field::memo" = "Memo";
 "calendar::event::more_action:transform_to::schedule" = "Convert to schedule";
 "calendar::event::more_action:transform_to::todo" = "Convert to to-do";
 "calendar::event::more_action:edit:item_name" = "Edit";

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -136,6 +136,7 @@
 "calendar::event::more_action:dday_candidate:register:message" = "Add this event as a D-day widget candidate? It will appear at the top of the list when you edit the widget.";
 "calendar::event::more_action:dday_candidate:unregister:message" = "Remove this event from D-day widget candidates?";
 "calendar::event::more_action:copy:item_name" = "Copy event";
+"calendar::event::more_action:share:item_name" = "Share";
 "event_detail::share::field::time" = "Time";
 "event_detail::share::field::repeating" = "Repeat";
 "event_detail::share::field::place" = "Location";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -136,6 +136,7 @@
 "calendar::event::more_action:dday_candidate:register:message" = "이 일정을 D-day 위젯 후보로 추가할까요? 위젯을 편집할 때 목록 맨 위에 표시됩니다.";
 "calendar::event::more_action:dday_candidate:unregister:message" = "이 일정을 D-day 위젯 후보에서 제거할까요?";
 "calendar::event::more_action:copy:item_name" = "이벤트 복사";
+"calendar::event::more_action:share:item_name" = "공유";
 "event_detail::share::field::time" = "시간";
 "event_detail::share::field::repeating" = "반복옵션";
 "event_detail::share::field::place" = "장소";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -136,6 +136,11 @@
 "calendar::event::more_action:dday_candidate:register:message" = "이 일정을 D-day 위젯 후보로 추가할까요? 위젯을 편집할 때 목록 맨 위에 표시됩니다.";
 "calendar::event::more_action:dday_candidate:unregister:message" = "이 일정을 D-day 위젯 후보에서 제거할까요?";
 "calendar::event::more_action:copy:item_name" = "이벤트 복사";
+"event_detail::share::field::time" = "시간";
+"event_detail::share::field::repeating" = "반복옵션";
+"event_detail::share::field::place" = "장소";
+"event_detail::share::field::url" = "링크";
+"event_detail::share::field::memo" = "메모";
 "calendar::event::more_action:transform_to::schedule" = "일정으로 전환";
 "calendar::event::more_action:transform_to::todo" = "할일로 전환";
 "calendar::event::more_action:edit:item_name" = "수정";


### PR DESCRIPTION
이벤트 상세의 more action에서 빠져 있던 "공유"를 되살려, 그 이벤트 하나를 텍스트로 내보낸다.

```
(할일) 약먹기
시간: 2026.08.15 (금) 09:00 ~ 10:00
반복옵션: 매일
이벤트 종류: 건강
장소: 강남약국
링크: https://example.com
메모: 식후 30분
```

## 접근

**단순히 주석을 푸는 작업이 아니었다.** `.share`는 enum case·아이콘·문구 매핑까지 있었지만 세 곳이 막혀 있었다 — more action 목록에서 주석 처리, 핸들러가 빈 case, 그리고 **라벨 키가 로컬라이즈에 아예 없어 `share`라는 raw 문자열이 그대로 노출되는 상태**였다. 주석된 원본 목록도 현재 활성 목록과 구성이 달라(`.copy`·`.transformToSchedule`이 없다) 그대로 복원하면 기존 항목이 사라졌을 것이다.

**텍스트 조립은 이 프레임워크 안에서 자족한다.** #872가 만든 `EventShareTextBuilder`는 목록용 불릿 포맷(`• 09:00 팀 스탠드업`)이라 단건 상세와 목적이 다르고, 시간 텍스트는 EventDetailScene이 이미 가진 `SelectedTime`/`SelectTimeText`로 만들 수 있다. CalendarScenes를 참조하지 않는다.

**공유시트는 #872가 `BaseRouterImple`에 올려둔 걸 쓴다.** 다만 `showShareSheet(text:)`가 클래스 메서드일 뿐 프로토콜엔 없어서, `router`가 `any EventDetailRouting` 타입인 ViewModel에서는 호출이 안 됐다. `EventDetailRouting`에 선언을 추가해 해소했다(선례: `SharePreviewRouting`).

## 확정한 스펙

- **한 건만 나가는 공유라 정보를 라벨 붙여 펼친다.** 첫 줄은 이벤트 이름, 그 아래로 시간·반복옵션·이벤트 종류·장소·링크·메모를 `라벨: 값` 한 줄씩. 값이 없는 항목은 줄 자체가 빠진다. 목록 공유(#872)가 불릿 한 줄로 압축하는 것과 반대 방향인데, 여기선 이벤트가 하나뿐이라 지면을 아낄 이유가 없다.
- **할일 여부는 이름 앞 `(할일)`로 표시한다.** 별도 필드로 두면 태그 라벨("이벤트 종류")과 개념이 충돌한다 — 앱에서 "이벤트 종류"는 태그를 가리키는 이름이다.
- **표기 용어는 앱이 쓰던 키를 재사용한다.** `(할일)`은 `calendar::event_time::todo`(공유 미리보기와 같은 단어), 태그 라벨은 `eventTag.title`. 새로 만든 건 시간·반복옵션·장소·링크·메모 5키뿐이다.
- 액션 라벨 키는 형제 항목 컨벤션(`calendar::event::more_action:<name>:item_name`)에 맞추고 en·ko를 채웠다.
- 태그는 `eventTagId`뿐이라 이름을 별도 조회한다. **조회가 실패하거나 태그가 없어도 나머지 정보로 공유는 나간다.**
- 빈 문자열은 `nil`로 정규화한다 — 유저가 메모를 입력했다 지우면 `""`가 들어와 빈 라벨 줄이 남는다.

## 스코프 밖

외부 캘린더·공휴일·완료할일 상세는 `EventDetailMoreAction`을 참조조차 하지 않고(grep 0건), 신규 생성 화면은 more action이 아예 없다. 할일·일정 두 편집 화면만 대상이다. `.addToTemplate`도 여전히 미구현 상태 그대로 뒀다.

외부 캘린더 상세의 단건 공유는 #906으로 분리했다 — 같은 화면을 #853이 고치는 중이라 그 뒤에 착수한다.

## 검증

`EventDetailScene` 158케이스 통과. 로컬라이즈 en·ko 파리티 통과. 나머지 29개 언어는 #810 대기.

**유저 실물 확인 대상**: 실제 공유시트를 거쳐 메신저·메모 앱에 붙었을 때 줄바꿈이 어떻게 처리되는지.
