### PR TITLE
[#889] 플랜 값이 실제로 바뀔 때만 usage 를 다시 조회한다

### DIFF
--- a/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandViewModel.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandViewModel.swift
@@ -63,6 +63,7 @@ final class AIAgentCommandViewModelImple: AIAgentCommandViewModel, @unchecked Se
         self.billingUsecase = billingUsecase
 
         self.billingUsecase.currentUserPlan
+            .removeDuplicates()
             .dropFirst()
             .sink { [weak self] _ in self?.orchestrationUsecase.loadUsage() }
             .store(in: &self.cancellables)

--- a/Presentations/AIAgentScene/Tests/AIAgentCommandViewModelImpleTests.swift
+++ b/Presentations/AIAgentScene/Tests/AIAgentCommandViewModelImpleTests.swift
@@ -357,4 +357,44 @@ extension AIAgentCommandViewModelImpleTests {
         XCTAssertTrue(self.stubAgent.didLoadUsage)
         _ = viewModel
     }
+
+    // 서버 응답이 같은 플랜을 재기록하는 경우를 재현
+    func test_currentUserPlanSameValueAsSeed_doesNotRefreshUsage() {
+        // given
+        let (viewModel, billingStub) = self.makeViewModelWithBillingStub(
+            userPlan: BillingUserPlan() |> \.planId .~ .free
+        )
+        // when
+        billingStub.currentUserPlanSubject.send(BillingUserPlan() |> \.planId .~ .free)
+        // then
+        XCTAssertEqual(self.stubAgent.didLoadUsageCount, 0)
+        _ = viewModel
+    }
+
+    func test_currentUserPlanSameValuePutTwice_refreshesUsageOnlyOnce() {
+        // given
+        let (viewModel, billingStub) = self.makeViewModelWithBillingStub(
+            userPlan: BillingUserPlan() |> \.planId .~ .free
+        )
+        // when
+        billingStub.currentUserPlanSubject.send(BillingUserPlan() |> \.planId .~ .standard)
+        billingStub.currentUserPlanSubject.send(BillingUserPlan() |> \.planId .~ .standard)
+        // then
+        XCTAssertEqual(self.stubAgent.didLoadUsageCount, 1)
+        _ = viewModel
+    }
+
+    // dedup이 정상적인 플랜 변경까지 막지는 않는다
+    func test_currentUserPlanDifferentValues_refreshesUsageForEachChange() {
+        // given
+        let (viewModel, billingStub) = self.makeViewModelWithBillingStub(
+            userPlan: BillingUserPlan() |> \.planId .~ .free
+        )
+        // when
+        billingStub.currentUserPlanSubject.send(BillingUserPlan() |> \.planId .~ .standard)
+        billingStub.currentUserPlanSubject.send(BillingUserPlan() |> \.planId .~ .lifetime)
+        // then
+        XCTAssertEqual(self.stubAgent.didLoadUsageCount, 2)
+        _ = viewModel
+    }
 }

--- a/Presentations/AIAgentScene/Tests/Doubles/StubAIAgentOrchestrationUsecase.swift
+++ b/Presentations/AIAgentScene/Tests/Doubles/StubAIAgentOrchestrationUsecase.swift
@@ -31,7 +31,8 @@ final class StubAIAgentOrchestrationUsecase: AIAgentOrchestrationUsecase, @unche
     private(set) var didDecline = false
     private(set) var didReset = false
     private(set) var didRestore = false
-    private(set) var didLoadUsage = false
+    private(set) var didLoadUsageCount = 0
+    var didLoadUsage: Bool { self.didLoadUsageCount > 0 }
 
     var stubSubmitError: (any Error)?
     var stubImageSubmitError: (any Error)?
@@ -63,7 +64,7 @@ final class StubAIAgentOrchestrationUsecase: AIAgentOrchestrationUsecase, @unche
     func decline() { self.didDecline = true }
     func reset() { self.didReset = true; self.stateSubject.send(.idle) }
     func restoreIfNeeded() { self.didRestore = true }
-    func loadUsage() { self.didLoadUsage = true }
+    func loadUsage() { self.didLoadUsageCount += 1 }
 
     private(set) var didHandleJobStatusChangedWith: String?
     func handleJobStatusChanged(_ jobId: String) {


### PR DESCRIPTION
AI 입력 시트가 떠 있는 동안 `GET /v1/ai/usage` 가 네트워크 왕복 속도로 무한히 재호출되던 것을 끊는다.

closes #889

## 문제

`AIAgentCommandViewModelImple` 이 자기 자신을 트리거하는 고리를 만들고 있었다.

1. init 이 `billingUsecase.currentUserPlan` 을 구독해 sink 에서 `loadUsage()` 를 부른다
2. `AIAgentUsageUsecaseImple.loadUsage` 가 응답의 플랜을 **같은** `billingUserPlan` 키에 다시 put 한다 (usage 응답이 plan 을 함께 내려주므로)
3. `SharedDataStore.observe` 에는 dedup 이 없어 같은 값이어도 방출된다
4. → 1번 구독이 재발화

`dropFirst()` 는 구독 시점 시드 한 번만 거르므로 그 뒤 put 은 전부 통과했다. 한도 초과 바텀시트는 유저가 오래 머무는 화면이라 여기서 육안으로 드러났지만, 실제로는 done/failed 시트 어디서나 돌던 문제다.

## 접근

해당 구독에 `.removeDuplicates()` 를 `.dropFirst()` **앞에** 붙였다. 뒤에 두면 시드 다음 첫 put 이 dedup 기준 없이 통과해 불필요한 조회가 한 번 더 돈다.

소스인 `BillingUsecaseImple.currentUserPlan` 이 아니라 이 화면에 건 이유는, `billingPaywall` 플래그 off 빌드에서 주입되는 `NotNeedBillingUsecase` 도 같은 키를 관찰하기 때문이다. 화면 쪽에 걸어야 두 구현이 함께 덮인다.

`SharedDataStore.observe` 에 dedup 이 없는 것은 의도된 스펙이라 건드리지 않았다.

## 검증

회귀 테스트 3건을 붙였고, 수정 전 코드에서 실패를 확인한 뒤 통과시켰다.

- 같은 값이 시드와 동일하게 다시 put 돼도 재조회하지 않는다
- 값이 바뀐 뒤 같은 값이 반복 put 돼도 그 변경 1회만 조회한다
- 서로 다른 값은 각각 조회한다 — dedup 이 정상 갱신까지 막지 않는다는 과교정 방지

`.removeDuplicates()` 를 지우면 앞 두 건이, `.dropFirst()` 뒤로 옮기면 첫 건이 빨개지는 것까지 실측했다. 호출 횟수를 세려고 `StubAIAgentOrchestrationUsecase` 의 `didLoadUsage` 를 카운트 기반 파생 프로퍼티로 바꿨다 — 기존 소비처는 그대로 통과한다.