### PR TITLE
[#883][#884] top-up 크레딧 수치를 유저가 읽을 수 있게 만든다

### DIFF
--- a/Presentations/BillingScenes/Snapshots/BillingScenesSnapshots.swift
+++ b/Presentations/BillingScenes/Snapshots/BillingScenesSnapshots.swift
@@ -435,6 +435,7 @@ extension BillingScenesSnapshots {
                     self.topupCell(credits: 165000, price: "$4.99", bonusPercent: 10),
                     self.topupCell(credits: 432000, price: "$9.99", bonusPercent: 20)
                 ]
+                state.topupTitle = "billing::paywall::topup::title".localized()
                 state.isPurchasing = false
             }
         }
@@ -480,6 +481,7 @@ extension BillingScenesSnapshots {
                     self.topupCell(credits: 165000, price: "$4.99", bonusPercent: 10),
                     self.topupCell(credits: 432000, price: "$9.99", bonusPercent: 20)
                 ]
+                state.topupTitle = "billing::paywall::topup::title".localized()
                 state.isPurchasing = false
             }
         }

--- a/Presentations/BillingScenes/Sources/Paywall/PaywallView.swift
+++ b/Presentations/BillingScenes/Sources/Paywall/PaywallView.swift
@@ -26,6 +26,7 @@ import CommonPresentation
     var catalogState: PaywallCatalogState = .loading
     var cellModels: [PaywallPlanCellModel] = []
     var topupCellModels: [PaywallTopupCellModel] = []
+    var topupTitle: String = ""
     var selectedPlanId: BillingPlanId?
     var selectedPlanDetail: PaywallPlanDetailModel?
     var isPurchasing: Bool = false
@@ -69,6 +70,11 @@ import CommonPresentation
         viewModel.topupCellModels
             .receive(on: RunLoop.main)
             .sink { [weak self] in self?.topupCellModels = $0 }
+            .store(in: &self.cancellables)
+
+        viewModel.topupTitle
+            .receive(on: RunLoop.main)
+            .sink { [weak self] in self?.topupTitle = $0 }
             .store(in: &self.cancellables)
 
         viewModel.selectedPlanId
@@ -424,7 +430,7 @@ private struct PaywallView: View {
 
     private var topupSection: some View {
         VStack(alignment: .leading, spacing: Metric.Spacing.small) {
-            Text("billing::paywall::topup::title".localized())
+            Text(self.state.topupTitle)
                 .font(self.appearance.fontSet.subNormalWithBold.asFont)
                 .foregroundStyle(self.appearance.colorSet.text0.asColor)
 

--- a/Presentations/BillingScenes/Sources/Paywall/PaywallViewModel.swift
+++ b/Presentations/BillingScenes/Sources/Paywall/PaywallViewModel.swift
@@ -519,11 +519,19 @@ extension PaywallViewModelImple {
         guard let price = offering.product?.displayPrice else { return nil }
         return PaywallTopupCellModel(
             productId: offering.topup.productId,
-            creditsText: "billing::paywall::topup::credits"
-                .localized(with: offering.topup.totalCredits.formatted()),
+            creditsText: self.creditsText(of: offering.topup),
             priceText: price,
             bonusText: self.bonusText(of: offering.topup.bonusRate)
         )
+    }
+
+    private func creditsText(of topup: BillingTopup) -> String {
+        guard topup.bonusRate > 0 else {
+            return "billing::paywall::topup::credits".localized(with: topup.totalCredits.formatted())
+        }
+        let bonusCredits = topup.totalCredits - topup.credits
+        return "billing::paywall::topup::credits::split"
+            .localized(with: topup.credits.formatted(), bonusCredits.formatted())
     }
 
     private func bonusText(of rate: Double) -> String? {

--- a/Presentations/BillingScenes/Sources/Paywall/PaywallViewModel.swift
+++ b/Presentations/BillingScenes/Sources/Paywall/PaywallViewModel.swift
@@ -99,6 +99,7 @@ protocol PaywallViewModel: AnyObject, Sendable, PaywallSceneInteractor {
     var catalogState: AnyPublisher<PaywallCatalogState, Never> { get }
     var cellModels: AnyPublisher<[PaywallPlanCellModel], Never> { get }
     var topupCellModels: AnyPublisher<[PaywallTopupCellModel], Never> { get }
+    var topupTitle: AnyPublisher<String, Never> { get }
     var selectedPlanId: AnyPublisher<BillingPlanId?, Never> { get }
     var selectedPlanDetail: AnyPublisher<PaywallPlanDetailModel?, Never> { get }
     var isPurchasing: AnyPublisher<Bool, Never> { get }
@@ -124,6 +125,7 @@ final class PaywallViewModelImple: PaywallViewModel, @unchecked Sendable {
         let isPurchasing = CurrentValueSubject<Bool, Never>(false)
         let hasUnfinished = CurrentValueSubject<Bool, Never>(false)
         let topupOfferings = CurrentValueSubject<[BillingTopupOffering], Never>([])
+        let topupRemaining = CurrentValueSubject<Int?, Never>(nil)
     }
     private let subject = Subject()
     private var cancellables: Set<AnyCancellable> = []
@@ -140,6 +142,7 @@ final class PaywallViewModelImple: PaywallViewModel, @unchecked Sendable {
             .sink { [weak self] userPlan in
                 self?.subject.currentPlanId.send(userPlan.planId)
                 self?.subject.scheduledChange.send(userPlan.scheduledChange)
+                self?.subject.topupRemaining.send(userPlan.topupRemaining)
             }
             .store(in: &self.cancellables)
     }
@@ -244,7 +247,7 @@ extension PaywallViewModelImple {
             do {
                 switch try await self.billingUsecase.purchase(productId: productId) {
                 case .applied:
-                    self.router?.showToast("billing::paywall::topup::applied".localized())
+                    self.router?.showToast(self.topupAppliedMessage(productId: productId))
                     self.closeAfterPurchaseIfNeeded()
 
                 case .cancelled:
@@ -407,6 +410,15 @@ extension PaywallViewModelImple {
         .eraseToAnyPublisher()
     }
 
+    var topupTitle: AnyPublisher<String, Never> {
+        return self.subject.topupRemaining
+            .removeDuplicates()
+            .map { [weak self] remaining -> String in
+                self?.topupTitleText(remaining: remaining) ?? ""
+            }
+            .eraseToAnyPublisher()
+    }
+
     var selectedPlanId: AnyPublisher<BillingPlanId?, Never> {
         return Publishers.CombineLatest3(
             self.subject.userSelectedPlanId, self.currentPlanIdPublisher, self.offeringsPublisher
@@ -538,6 +550,24 @@ extension PaywallViewModelImple {
         guard rate > 0 else { return nil }
         let percent = Int((rate * 100).rounded())
         return "billing::paywall::topup::bonus".localized(with: percent.formatted())
+    }
+
+    private func topupTitleText(remaining: Int?) -> String {
+        guard let remaining, remaining > 0 else {
+            return "billing::paywall::topup::title".localized()
+        }
+        return "billing::paywall::topup::title::withRemaining".localized(with: remaining.formatted())
+    }
+
+    // 정상 플로우에선 productId 가 카탈로그에서 온다 — 못 찾으면 수치 없는 문구로 fail-safe
+    private func topupAppliedMessage(productId: String) -> String {
+        guard let offering = self.subject.topupOfferings.value
+            .first(where: { $0.topup.productId == productId })
+        else {
+            return "billing::paywall::topup::applied".localized()
+        }
+        return "billing::paywall::topup::applied::withCredits"
+            .localized(with: offering.topup.totalCredits.formatted())
     }
 
     private func periodText(of kind: BillingProductKind?) -> String? {

--- a/Presentations/BillingScenes/Tests/Paywall/PaywallViewModelImpleTests.swift
+++ b/Presentations/BillingScenes/Tests/Paywall/PaywallViewModelImpleTests.swift
@@ -1171,6 +1171,68 @@ extension PaywallViewModelImpleTests {
 }
 
 
+// MARK: - top-up 섹션 헤더 (#884)
+
+extension PaywallViewModelImpleTests {
+
+    // topupRemaining 이 없으면(nil) 헤더는 보유량 없이 기본 타이틀만 보여준다
+    @Test func topupTitle_whenRemainingIsNil_showsPlainTitle() async throws {
+        // given
+        let (viewModel, _, _) = self.makeViewModel(
+            userPlan: BillingUserPlan() |> \.planId .~ .standard
+        )
+
+        // when
+        let expect = expectConfirm("보유량 없는 타이틀")
+        let title = try await self.firstOutput(expect, for: viewModel.topupTitle) {
+            viewModel.prepare()
+        }
+
+        // then
+        #expect(title == "billing::paywall::topup::title".localized())
+    }
+
+    // 분기 경계 — topupRemaining 이 0 이면(비교 연산자를 뒤집으면 실패하는 지점) 여전히
+    // 기본 타이틀이다. 0 은 "보유 없음"과 같은 상태라 보유량을 붙이지 않는다
+    @Test func topupTitle_whenRemainingIsZero_showsPlainTitle() async throws {
+        // given
+        let (viewModel, _, _) = self.makeViewModel(
+            userPlan: BillingUserPlan() |> \.planId .~ .standard |> \.topupRemaining .~ 0
+        )
+
+        // when
+        let expect = expectConfirm("0 은 보유량 미표기")
+        let title = try await self.firstOutput(expect, for: viewModel.topupTitle) {
+            viewModel.prepare()
+        }
+
+        // then
+        #expect(title == "billing::paywall::topup::title".localized())
+    }
+
+    // topupRemaining 이 양수면 헤더에 보유량이 붙는다
+    @Test func topupTitle_whenRemainingIsPositive_showsTitleWithRemaining() async throws {
+        // given
+        let (viewModel, _, _) = self.makeViewModel(
+            userPlan: BillingUserPlan() |> \.planId .~ .standard |> \.topupRemaining .~ 12000
+        )
+
+        // when
+        let expect = expectConfirm("보유량 표기")
+        let title = try await self.firstOutput(expect, for: viewModel.topupTitle) {
+            viewModel.prepare()
+        }
+
+        // then
+        #expect(
+            title
+                == "billing::paywall::topup::title::withRemaining"
+                    .localized(with: 12000.formatted())
+        )
+    }
+}
+
+
 // MARK: - top-up 구매
 
 extension PaywallViewModelImpleTests {
@@ -1199,7 +1261,8 @@ extension PaywallViewModelImpleTests {
             |> \.topupRemaining .~ 30000
     }
 
-    @Test func purchaseTopup_whenApplied_showsToastAndKeepsSceneOpen() async throws {
+    // #884 — 구매한 tier 의 총 크레딧이 토스트 문구에 실린다(topup.tier.1 은 30000, 보너스 없음)
+    @Test func purchaseTopup_whenApplied_showsToastWithPurchasedCreditsAndKeepsSceneOpen() async throws {
         // given
         let (viewModel, stub, router) = self.topupPurchaseViewModel(
             purchaseResult: .success(.applied(self.appliedTopupPlan()))
@@ -1213,6 +1276,31 @@ extension PaywallViewModelImpleTests {
 
         // then
         #expect(stub.didPurchasedProductId == "topup.tier.1")
+        #expect(
+            router.didShowToastWithMessage
+                == "billing::paywall::topup::applied::withCredits".localized(with: 30000.formatted())
+        )
+        #expect(router.didClosed == nil)
+    }
+
+    // #884 — 순서 축: 구매한 productId 를 카탈로그(topupOfferings)에서 찾지 못하면(비정상 진입)
+    // 수치 없는 기존 문구로 안전하게 물러난다. 정상 플로우에선 셀이 카탈로그에서 만들어지므로
+    // purchaseTopup 에 전달되는 productId 는 항상 topupOfferings 에 존재한다 — 이 분기는
+    // 방어용이라 실사용 경로에선 도달하지 않는다
+    @Test func purchaseTopup_whenProductIdNotInCatalog_showsToastWithoutCredits() async throws {
+        // given
+        let (viewModel, stub, router) = self.topupPurchaseViewModel(
+            purchaseResult: .success(.applied(self.appliedTopupPlan()))
+        )
+        _ = try await self.waitTopupCellsLoaded(viewModel)
+
+        // when
+        try await self.waitProcessingCompleted(viewModel) {
+            viewModel.purchaseTopup("topup.unknown")
+        }
+
+        // then
+        #expect(stub.didPurchasedProductId == "topup.unknown")
         #expect(router.didShowToastWithMessage == "billing::paywall::topup::applied".localized())
         #expect(router.didClosed == nil)
     }

--- a/Presentations/BillingScenes/Tests/Paywall/PaywallViewModelImpleTests.swift
+++ b/Presentations/BillingScenes/Tests/Paywall/PaywallViewModelImpleTests.swift
@@ -1082,7 +1082,25 @@ extension PaywallViewModelImpleTests {
         #expect(cells.first?.bonusText == nil)
     }
 
-    @Test func topupCellModels_whenBonusRateGiven_showsTotalCreditsWithBonusText() async throws {
+    // #883 — 보너스가 없는 tier 는 기본·추가로 나누지 않고 단일 총량만 보여준다
+    @Test func topupCellModels_whenBonusRateIsZero_showsSingleCreditsAmount() async throws {
+        // given
+        let (viewModel, _, _) = self.standardOwnedViewModel(
+            topupOfferings: [self.topupOffering("topup.tier.1", credits: 30000)]
+        )
+
+        // when
+        let cells = try await self.waitTopupCellsLoaded(viewModel)
+
+        // then
+        #expect(
+            cells.first?.creditsText
+                == "billing::paywall::topup::credits".localized(with: 30000.formatted())
+        )
+    }
+
+    // #883 — 보너스가 있는 tier 는 기본 크레딧과 추가(보너스) 크레딧을 나눠 보여준다
+    @Test func topupCellModels_whenBonusRateGiven_showsBaseAndBonusSplitCreditsText() async throws {
         // given
         let (viewModel, _, _) = self.standardOwnedViewModel(
             topupOfferings: [
@@ -1093,9 +1111,15 @@ extension PaywallViewModelImpleTests {
         // when
         let cells = try await self.waitTopupCellsLoaded(viewModel)
 
-        // then
+        // then — 단위(크레딧)는 split 문구 자체에 한 번만 붙는다("기본 150,000 + 추가 15,000 크레딧").
+        // 인자로는 숫자만 넘긴다 — 이미 단위가 붙은 로컬라이즈 문자열을 다시 인자로 중첩하면
+        // 언어별 어순·조사가 깨지는 i18n 안티패턴이 된다
         #expect(cells.count == 1)
-        #expect(cells.first?.creditsText.contains(165000.formatted()) == true)
+        #expect(
+            cells.first?.creditsText
+                == "billing::paywall::topup::credits::split"
+                    .localized(with: 150000.formatted(), 15000.formatted())
+        )
         #expect(cells.first?.bonusText?.contains("10") == true)
     }
 

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -637,6 +637,7 @@
 "billing::paywall::fail::ownedByAnotherAccount" = "This purchase belongs to another account. Sign in with the account you bought it on.";
 "billing::paywall::fail::reflectDelayed" = "Your payment went through, but applying it is delayed. It'll be applied automatically.";
 "billing::paywall::topup::credits" = "%@ credits";
+"billing::paywall::topup::credits::split" = "Base %@ + Bonus %@ credits";
 "billing::paywall::topup::bonus" = "+%@%% bonus";
 "billing::paywall::topup::title" = "Add credits";
 "billing::paywall::topup::description" = "Extra credits are used after your daily limit runs out, and they don't expire.";

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -640,8 +640,10 @@
 "billing::paywall::topup::credits::split" = "Base %@ + Bonus %@ credits";
 "billing::paywall::topup::bonus" = "+%@%% bonus";
 "billing::paywall::topup::title" = "Add credits";
+"billing::paywall::topup::title::withRemaining" = "Add credits · %@ owned";
 "billing::paywall::topup::description" = "Extra credits are used after your daily limit runs out, and they don't expire.";
 "billing::paywall::topup::applied" = "Credits added";
+"billing::paywall::topup::applied::withCredits" = "%@ credits added";
 
 // MARK: - share extension
 

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -640,8 +640,10 @@
 "billing::paywall::topup::credits::split" = "기본 %@ + 추가 %@ 크레딧";
 "billing::paywall::topup::bonus" = "%@%% 추가 증정";
 "billing::paywall::topup::title" = "크레딧 추가 구매";
+"billing::paywall::topup::title::withRemaining" = "크레딧 추가 구매 · 보유 %@";
 "billing::paywall::topup::description" = "추가 크레딧은 일일 한도를 다 쓴 뒤에 사용되고, 만료되지 않아요.";
 "billing::paywall::topup::applied" = "크레딧이 추가됐어요";
+"billing::paywall::topup::applied::withCredits" = "%@ 크레딧이 추가됐어요";
 
 // MARK: - share extension
 

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -637,6 +637,7 @@
 "billing::paywall::fail::ownedByAnotherAccount" = "다른 계정에 등록된 결제예요. 구매한 계정으로 로그인해 주세요.";
 "billing::paywall::fail::reflectDelayed" = "결제는 완료됐어요. 반영이 지연되고 있고, 곧 자동으로 반영됩니다.";
 "billing::paywall::topup::credits" = "%@ 크레딧";
+"billing::paywall::topup::credits::split" = "기본 %@ + 추가 %@ 크레딧";
 "billing::paywall::topup::bonus" = "%@%% 추가 증정";
 "billing::paywall::topup::title" = "크레딧 추가 구매";
 "billing::paywall::topup::description" = "추가 크레딧은 일일 한도를 다 쓴 뒤에 사용되고, 만료되지 않아요.";


### PR DESCRIPTION
paywall 의 top-up 영역이 크레딧 수치를 제대로 못 보여주던 두 가지를 함께 고친다.

closes #883
closes #884

## 문제

- **티어 표기** — 보너스가 붙는 tier 가 기본과 보너스를 합산한 총량만 보여줘서, 유저가 뭘 더 받는지 알 수 없었다
- **구매 결과** — 구매하면 `크레딧이 추가됐어요` 라는 수치 없는 토스트만 뜨고 끝났다. 게다가 paywall 에는 보유 top-up 잔량 표시가 아예 없어서(AI 사용량 게이지에만 있었다) "얼마가 늘었고 지금 총 얼마인지"를 확인할 방법이 없었다

## 접근

**티어 표기** — 보너스가 있는 tier 는 `기본 600 + 추가 60 크레딧` 으로 나눠 보여준다. 보너스가 없는 tier 는 `기본 N + 추가 0` 같은 표기를 만들지 않고 단일 총량을 유지한다.

**보유 총량** — top-up 섹션 헤더를 `크레딧 추가 구매 · 보유 N` 으로 바꿨다. 잔량이 없을 땐 기존 제목 그대로다 — AI 사용량 게이지의 `remaining > 0` 관용구를 따랐다.

**증가분** — 구매 완료 토스트에 구매한 크레딧 수를 싣는다.

`topupRemaining` 은 서버 응답에 이미 들어 있고 `PaywallViewModelImple` 이 `currentUserPlan` 을 이미 구독 중이라, 새 usecase 나 추가 조회 없이 `Subject` 필드 하나로 끝났다.

## 로컬라이즈

키 3개를 추가했다 (en/ko). 나머지 29개 언어는 관례대로 #810 에서 일괄 번역한다.

| 키 | ko | en |
|---|---|---|
| `billing::paywall::topup::credits::split` | `기본 %@ + 추가 %@ 크레딧` | `Base %@ + Bonus %@ credits` |
| `billing::paywall::topup::title::withRemaining` | `크레딧 추가 구매 · 보유 %@` | `Add credits · %@ owned` |
| `billing::paywall::topup::applied::withCredits` | `%@ 크레딧이 추가됐어요` | `%@ credits added` |

포맷 인자에는 숫자만 넘긴다 — 로컬라이즈된 문자열을 다른 로컬라이즈 문자열의 인자로 중첩하면 언어에 따라 어순·조사가 깨진다.

## 검증

`PaywallViewModelImpleTests` 63건 통과. 분기 경계를 각각 찌르는 TC 를 붙였다 — 보너스 0 인 tier 는 단일 표기 유지, `topupRemaining` 이 nil·0 이면 헤더에 보유량 미표기, 양수면 표기. `remaining > 0` 을 `>=` 로 뒤집으면 빨개지는 것까지 확인했다.

스냅샷 2건(`test_paywallTopupAvailable`·`test_paywallScheduledChange`)은 헤더가 리터럴에서 상태 참조로 바뀌면서 빈 문자열로 렌더될 뻔해, 기존과 같은 텍스트를 채워 픽셀을 유지했다. 캡처 재검증(픽셀 비교)은 돌리지 않았다.