### PR TITLE
[#887] 한도 초과 시트를 닫고 paywall 로 보낸다

### DIFF
--- a/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandBuilderImple.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandBuilderImple.swift
@@ -13,29 +13,29 @@ public final class AIAgentCommandBuilderImple: AIAgentCommandSceneBuilder {
 
     private let usecaseFactory: any UsecaseFactory
     private let viewAppearance: ViewAppearance
-    private let paywallSceneBuilder: any PaywallSceneBuilder
 
     public init(
         usecaseFactory: any UsecaseFactory,
-        viewAppearance: ViewAppearance,
-        paywallSceneBuilder: any PaywallSceneBuilder
+        viewAppearance: ViewAppearance
     ) {
         self.usecaseFactory = usecaseFactory
         self.viewAppearance = viewAppearance
-        self.paywallSceneBuilder = paywallSceneBuilder
     }
 
     @MainActor
-    public func makeCommandScene() -> any AIAgentCommandScene {
+    public func makeCommandScene(
+        listener: (any AIAgentCommandSceneListener)?
+    ) -> any AIAgentCommandScene {
         let viewModel = AIAgentCommandViewModelImple(
             orchestrationUsecase: self.usecaseFactory.aiAgentOrchestrationUsecase,
             billingUsecase: self.usecaseFactory.billingUsecase
         )
+        viewModel.listener = listener
         let viewController = AIAgentCommandViewController(
             viewModel: viewModel,
             viewAppearance: self.viewAppearance
         )
-        let router = AIAgentRouter(paywallSceneBuilder: self.paywallSceneBuilder)
+        let router = AIAgentRouter()
         router.scene = viewController
         viewModel.router = router
         return viewController

--- a/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandViewModel.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandViewModel.swift
@@ -52,6 +52,7 @@ final class AIAgentCommandViewModelImple: AIAgentCommandViewModel, @unchecked Se
     private let orchestrationUsecase: any AIAgentOrchestrationUsecase
     private let billingUsecase: any BillingUsecase
     var router: (any AIAgentRouting)?
+    weak var listener: (any AIAgentCommandSceneListener)?
 
     private var cancellables: Set<AnyCancellable> = []
 
@@ -114,7 +115,9 @@ extension AIAgentCommandViewModelImple {
     }
 
     func showPlans() {
-        self.router?.routeToPaywall()
+        // reset 없이 idle로 안 돌아가면 다음 한도 초과 때 상위의 false→true 재전이 감지가 막혀 시트가 안 뜬다
+        self.orchestrationUsecase.reset()
+        self.listener?.aiAgentCommandDidRequestPaywall()
     }
 }
 

--- a/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentRouter.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentRouter.swift
@@ -8,28 +8,18 @@
 
 import UIKit
 import Scenes
-import CommonPresentation
 
 
 // MARK: - AIAgentRouting
 
 protocol AIAgentRouting: Routing, Sendable {
     func openSystemSetting()
-    func routeToPaywall()
 }
 
 
 // MARK: - AIAgentRouter
 
-final class AIAgentRouter: BaseRouterImple, AIAgentRouting, @unchecked Sendable {
-
-    private let paywallSceneBuilder: any PaywallSceneBuilder
-
-    init(paywallSceneBuilder: any PaywallSceneBuilder) {
-        self.paywallSceneBuilder = paywallSceneBuilder
-        super.init()
-    }
-}
+final class AIAgentRouter: BaseRouterImple, AIAgentRouting, @unchecked Sendable { }
 
 extension AIAgentRouter {
 
@@ -39,13 +29,6 @@ extension AIAgentRouter {
                   UIApplication.shared.canOpenURL(url)
             else { return }
             UIApplication.shared.open(url)
-        }
-    }
-
-    func routeToPaywall() {
-        Task { @MainActor in
-            let next = self.paywallSceneBuilder.makePaywallScene(closesAfterPurchase: true)
-            self.showFullScreen(next)
         }
     }
 }

--- a/Presentations/AIAgentScene/Tests/AIAgentCommandViewModelImpleTests.swift
+++ b/Presentations/AIAgentScene/Tests/AIAgentCommandViewModelImpleTests.swift
@@ -21,17 +21,20 @@ class AIAgentCommandViewModelImpleTests: BaseTestCase, PublisherWaitable {
     var cancelBag: Set<AnyCancellable>!
     private var stubAgent: StubAIAgentOrchestrationUsecase!
     private var spyRouter: SpyAIAgentRouter!
+    private var spyListener: SpyAIAgentCommandSceneListener!
 
     override func setUpWithError() throws {
         self.cancelBag = .init()
         self.stubAgent = .init()
         self.spyRouter = .init()
+        self.spyListener = .init()
     }
 
     override func tearDownWithError() throws {
         self.cancelBag = nil
         self.stubAgent = nil
         self.spyRouter = nil
+        self.spyListener = nil
         FeatureFlag.disable(.billingPaywall)
     }
 
@@ -41,6 +44,7 @@ class AIAgentCommandViewModelImpleTests: BaseTestCase, PublisherWaitable {
             billingUsecase: StubBillingUsecase(stubUserPlan: userPlan)
         )
         viewModel.router = self.spyRouter
+        viewModel.listener = self.spyListener
         return viewModel
     }
 
@@ -302,13 +306,24 @@ extension AIAgentCommandViewModelImpleTests {
         XCTAssertEqual(isAvailable, true)
     }
 
-    func test_showPlans_routesToPaywall() {
+    func test_showPlans_requestsPaywallViaListener() {
+        // given
+        let viewModel = self.makeViewModel()
+        // when
+        viewModel.showPlans()
+        // then — 자기 router로 직접 열지 않고 부모(Listener)에게 위임한다
+        XCTAssertEqual(self.spyListener.didRequestPaywall, true)
+    }
+
+    // reset 누락 시 다음 한도 초과에서 bindShowAICommandResultIfNeed의 false→true 전이가
+    // 다시 발생하지 않아 시트가 영영 안 뜨는 회귀가 생긴다
+    func test_showPlans_resetsOrchestrationState() {
         // given
         let viewModel = self.makeViewModel()
         // when
         viewModel.showPlans()
         // then
-        XCTAssertEqual(self.spyRouter.didRouteToPaywall, true)
+        XCTAssertEqual(self.stubAgent.didReset, true)
     }
 }
 

--- a/Presentations/AIAgentScene/Tests/Doubles/SpyAIAgentCommandSceneListener.swift
+++ b/Presentations/AIAgentScene/Tests/Doubles/SpyAIAgentCommandSceneListener.swift
@@ -1,0 +1,19 @@
+//
+//  SpyAIAgentCommandSceneListener.swift
+//  AIAgentSceneTests
+//
+//  Created by sudo.park on 8/15/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Scenes
+
+
+final class SpyAIAgentCommandSceneListener: AIAgentCommandSceneListener, @unchecked Sendable {
+
+    var didRequestPaywall = false
+    func aiAgentCommandDidRequestPaywall() {
+        self.didRequestPaywall = true
+    }
+}

--- a/Presentations/AIAgentScene/Tests/Doubles/SpyAIAgentRouter.swift
+++ b/Presentations/AIAgentScene/Tests/Doubles/SpyAIAgentRouter.swift
@@ -19,9 +19,4 @@ final class SpyAIAgentRouter: BaseSpyRouter, AIAgentRouting, @unchecked Sendable
     func openSystemSetting() {
         self.didOpenSystemSetting = true
     }
-
-    var didRouteToPaywall: Bool?
-    func routeToPaywall() {
-        self.didRouteToPaywall = true
-    }
 }

--- a/Presentations/CalendarScenes/Sources/CalendarSceneBuilderImple.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarSceneBuilderImple.swift
@@ -21,6 +21,7 @@ public struct CalendarSceneBuilderImple {
     private let aiAgentCommandSceneBuilder: any AIAgentCommandSceneBuilder
     private let aiAgentKeyboardInputSceneBuilder: any AIAgentKeyboardInputSceneBuilder
     private let aiAgentImageCommandSceneBuilder: any AIAgentImageCommandSceneBuilder
+    private let paywallSceneBuilder: any PaywallSceneBuilder
     private let pendingCompleteTodoState: PendingCompleteTodoState = .init()
     public let calendarDeepLinkHandler = CalendarDeepLinkHandlerImple()
     private let eventDeepLinkHandler = EventDeepLinkHandlerImple()
@@ -34,7 +35,8 @@ public struct CalendarSceneBuilderImple {
         memberSceneBuilder: any MemberSceneBuilder,
         aiAgentCommandSceneBuilder: any AIAgentCommandSceneBuilder,
         aiAgentKeyboardInputSceneBuilder: any AIAgentKeyboardInputSceneBuilder,
-        aiAgentImageCommandSceneBuilder: any AIAgentImageCommandSceneBuilder
+        aiAgentImageCommandSceneBuilder: any AIAgentImageCommandSceneBuilder,
+        paywallSceneBuilder: any PaywallSceneBuilder
     ) {
         self.usecaseFactory = usecaseFactory
         self.viewAppearance = viewAppearance
@@ -45,6 +47,7 @@ public struct CalendarSceneBuilderImple {
         self.aiAgentCommandSceneBuilder = aiAgentCommandSceneBuilder
         self.aiAgentKeyboardInputSceneBuilder = aiAgentKeyboardInputSceneBuilder
         self.aiAgentImageCommandSceneBuilder = aiAgentImageCommandSceneBuilder
+        self.paywallSceneBuilder = paywallSceneBuilder
     }
 
     private var eventListCellEventHanleViewModelBuilder: (any EventListCellEventHanleViewModelBuilder)?
@@ -116,7 +119,8 @@ extension CalendarSceneBuilderImple: CalendarSceneBuilder {
         let router = CalendarViewRouterImple(
             paperSceneBuilder,
             aiAgentCommandSceneBuilder: self.aiAgentCommandSceneBuilder,
-            memberSceneBuilder: self.memberSceneBuilder
+            memberSceneBuilder: self.memberSceneBuilder,
+            paywallSceneBuilder: self.paywallSceneBuilder
         )
         router.scene = viewController
         viewModel.router = router

--- a/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
@@ -494,7 +494,15 @@ extension CalendarViewModelImple: CalendarPaperSceneListener {
     }
 
     func calendarPaperDidRequestShowAICommand() {
-        self.router?.routeToAICommand()
+        self.router?.routeToAICommand(listener: self)
+    }
+}
+
+
+extension CalendarViewModelImple: AIAgentCommandSceneListener {
+
+    func aiAgentCommandDidRequestPaywall() {
+        self.router?.routeToPaywall()
     }
 }
 
@@ -509,7 +517,8 @@ extension CalendarViewModelImple {
             .removeDuplicates()
             .filter { $0 }
             .sink { [weak self] _ in
-                self?.router?.routeToAICommand()
+                guard let self else { return }
+                self.router?.routeToAICommand(listener: self)
             }
             .store(in: &self.cancellables)
     }
@@ -560,7 +569,7 @@ extension CalendarViewModelImple {
             guard let self = self else { return }
             let state = self.subject.aiAgentState.value ?? .idle
             if Self.isAICommandPhase(state) {
-                self.router?.routeToAICommand()
+                self.router?.routeToAICommand(listener: self)
             } else if self.subject.isSignedIn.value {
                 self.aiAgentOrchestrationUsecase.enterVoiceInput()
             } else {

--- a/Presentations/CalendarScenes/Sources/CalendarViewRouter.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewRouter.swift
@@ -20,7 +20,9 @@ protocol CalendarViewRouting: Routing, Sendable {
     @MainActor
     func slideFocus(to index: Int, isNext: Bool, completed: @escaping @Sendable () -> Void)
 
-    func routeToAICommand()
+    func routeToAICommand(listener: (any AIAgentCommandSceneListener)?)
+
+    func routeToPaywall()
 
     func routeToSignIn()
 
@@ -32,14 +34,17 @@ final class CalendarViewRouterImple: BaseRouterImple, CalendarViewRouting, @unch
     private let paperSceneBuilder: any CalendarPaperSceneBuiler
     private let aiAgentCommandSceneBuilder: any AIAgentCommandSceneBuilder
     private let memberSceneBuilder: any MemberSceneBuilder
+    private let paywallSceneBuilder: any PaywallSceneBuilder
     init(
         _ paperSceneBuilder: any CalendarPaperSceneBuiler,
         aiAgentCommandSceneBuilder: any AIAgentCommandSceneBuilder,
-        memberSceneBuilder: any MemberSceneBuilder
+        memberSceneBuilder: any MemberSceneBuilder,
+        paywallSceneBuilder: any PaywallSceneBuilder
     ) {
         self.paperSceneBuilder = paperSceneBuilder
         self.aiAgentCommandSceneBuilder = aiAgentCommandSceneBuilder
         self.memberSceneBuilder = memberSceneBuilder
+        self.paywallSceneBuilder = paywallSceneBuilder
     }
     private var currentScene: (any CalendarScene)? { self.scene as? (any CalendarScene) }
 
@@ -68,18 +73,33 @@ final class CalendarViewRouterImple: BaseRouterImple, CalendarViewRouting, @unch
         current.slideFocus(to: index, isNext: isNext, completed: completed)
     }
 
-    func routeToAICommand() {
+    func routeToAICommand(listener: (any AIAgentCommandSceneListener)?) {
         self.dismissPresented(animated: true) { [weak self] in
             Task { @MainActor in
-                self?.presentAICommandScene()
+                self?.presentAICommandScene(listener: listener)
             }
         }
     }
 
     @MainActor
-    private func presentAICommandScene() {
-        let next = self.aiAgentCommandSceneBuilder.makeCommandScene()
+    private func presentAICommandScene(listener: (any AIAgentCommandSceneListener)?) {
+        let next = self.aiAgentCommandSceneBuilder.makeCommandScene(listener: listener)
         self.showBottomSlide(next)
+    }
+
+    // 시트를 얹은 채로 paywall을 올리면 top-up 후 복귀해도 시트가 다시 드러난다
+    func routeToPaywall() {
+        self.dismissPresented(animated: true) { [weak self] in
+            Task { @MainActor in
+                self?.presentPaywallScene()
+            }
+        }
+    }
+
+    @MainActor
+    private func presentPaywallScene() {
+        let next = self.paywallSceneBuilder.makePaywallScene(closesAfterPurchase: true)
+        self.showFullScreen(next)
     }
 
     func routeToSignIn() {

--- a/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
@@ -1123,6 +1123,34 @@ extension CalendarViewModelImpleTests {
         // then
         XCTAssertEqual(self.spyRouter.didRouteToAICommandCount, 1)
     }
+
+    // AI 커맨드 시트가 paywall 요청을 되돌려 보낼 대상은 자기 자신(AIAgentCommandSceneListener)이어야 한다
+    func testViewModel_whenRoutingToAICommand_passesSelfAsListener() {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        viewModel.calendarPaperDidRequestShowAICommand()
+
+        // then
+        XCTAssertTrue(self.spyRouter.didRouteToAICommandListener === viewModel)
+    }
+}
+
+// MARK: - 한도 초과 시트 → paywall 진입 위임 (#887)
+
+extension CalendarViewModelImpleTests {
+
+    func testViewModel_whenAIAgentCommandRequestsPaywall_routesToPaywall() {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        viewModel.aiAgentCommandDidRequestPaywall()
+
+        // then
+        XCTAssertEqual(self.spyRouter.didRouteToPaywallCount, 1)
+    }
 }
 
 // MARK: - 음성 입력 진입 시 포커스된 달만 스크롤
@@ -1343,8 +1371,15 @@ private extension CalendarViewModelImpleTests {
         }
 
         var didRouteToAICommandCount: Int = 0
-        func routeToAICommand() {
+        var didRouteToAICommandListener: (any AIAgentCommandSceneListener)?
+        func routeToAICommand(listener: (any AIAgentCommandSceneListener)?) {
             self.didRouteToAICommandCount += 1
+            self.didRouteToAICommandListener = listener
+        }
+
+        var didRouteToPaywallCount: Int = 0
+        func routeToPaywall() {
+            self.didRouteToPaywallCount += 1
         }
 
         var didRouteToSignIn: Bool?

--- a/Presentations/Scenes/Sources/Scenes+AIAgent.swift
+++ b/Presentations/Scenes/Sources/Scenes+AIAgent.swift
@@ -12,6 +12,12 @@ import Domain
 public protocol AIAgentCommandSceneInteractor: AnyObject { }
 
 
+public protocol AIAgentCommandSceneListener: AnyObject, Sendable {
+
+    func aiAgentCommandDidRequestPaywall()
+}
+
+
 // MARK: - AIAgentCommandScene
 
 public protocol AIAgentCommandScene: Scene where Interactor == any AIAgentCommandSceneInteractor { }
@@ -22,7 +28,7 @@ public protocol AIAgentCommandScene: Scene where Interactor == any AIAgentComman
 public protocol AIAgentCommandSceneBuilder: AnyObject {
 
     @MainActor
-    func makeCommandScene() -> any AIAgentCommandScene
+    func makeCommandScene(listener: (any AIAgentCommandSceneListener)?) -> any AIAgentCommandScene
 }
 
 

--- a/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
@@ -408,7 +408,8 @@ extension ApplicationRootRouter {
             memberSceneBuilder: self.memberSceneBuilder(),
             aiAgentCommandSceneBuilder: self.aiAgentCommandSceneBuilder(),
             aiAgentKeyboardInputSceneBuilder: self.aiAgentKeyboardInputSceneBuilder(),
-            aiAgentImageCommandSceneBuilder: self.aiAgentImageCommandSceneBuilder()
+            aiAgentImageCommandSceneBuilder: self.aiAgentImageCommandSceneBuilder(),
+            paywallSceneBuilder: self.paywallSceneBuilder()
         )
         self.deepLinkHandler.attach(calendarHandler: builder.calendarDeepLinkHandler)
         return builder
@@ -474,8 +475,7 @@ extension ApplicationRootRouter {
     private func aiAgentCommandSceneBuilder() -> any AIAgentCommandSceneBuilder {
         return AIAgentCommandBuilderImple(
             usecaseFactory: self.usecaseFactory,
-            viewAppearance: self.viewAppearanceStore.appearance,
-            paywallSceneBuilder: self.paywallSceneBuilder()
+            viewAppearance: self.viewAppearanceStore.appearance
         )
     }
 


### PR DESCRIPTION
closes #887

## 문제

크레딧이 부족해 사전 차단되면 한도 초과 바텀시트가 뜬다. 거기서 "플랜 보기"로 paywall 에 가 top-up 을 사고 돌아오면, 잔여 크레딧은 갱신되지만 **다시 한도 초과 시트가 드러난다.** 유저가 원한 건 입력인데 막다른 화면으로 돌아오는 셈이다.

원인은 두 겹이었다.

- `AIAgentRouter.routeToPaywall` 이 `showFullScreen` 으로 **시트 위에** paywall 을 올린다. paywall 이 닫히면 시트가 그대로 남는다
- 시트의 표시 여부는 시트가 아니라 **orchestration 상태**가 결정한다 (`CalendarViewModelImple.bindShowAICommandResultIfNeed` 가 AI command phase 진입 전이에서 띄운다). 상태가 `.failed` 로 남아 있는 한 시트는 유효한 화면이다

## 접근

paywall 을 여는 주체를 시트에서 **부모(CalendarScenes)** 로 옮겼다. 시트를 먼저 닫아야 하는데, paywall 을 띄우던 presenter 가 그 시트 자신이라 시트가 스스로는 할 수 없다.

- `Scenes` 에 `AIAgentCommandSceneListener` 를 신설해 시트가 "paywall 을 열어달라"만 요청한다 (`presentations-rules §6` — Child→Parent 는 Listener, child 가 weak)
- 부모가 `dismissPresented` 로 시트를 닫고 그 completion 에서 paywall 을 present 한다. 바로 위 `routeToAICommand` 가 이미 쓰던 관용구를 그대로 따랐다
- `showPlans()` 가 `orchestrationUsecase.reset()` 으로 상태를 `.idle` 로 되돌린다. **이게 없으면 다음 한도 초과 때 false→true 전이가 다시 일어나지 않아 시트가 영영 안 뜬다** — done/failed 를 확인하는 `acknowledge()` 와 같은 의미다

`AIAgentRouter.routeToPaywall` 과 그 `paywallSceneBuilder` 주입은 소비자가 없어져 제거했다. 프로토콜에서 지웠으므로 옛 경로로 되돌리면 빌드가 깨진다.

## 검증

`AIAgentScene`(29) · `CalendarScenes`(156) · `TodoCalendarApp`(17) 통과. `reset()` 호출과 listener 호출을 각각 지우면 대응 TC 가 빨개지는 것을 확인했고, `routeToAICommand` 3개 호출부가 모두 자기를 listener 로 넘기는지도 신원 비교로 덮었다.

## 유저 검증 대기

`dismissPresented` completion 에서 present 하는 실제 전환 순서 — 시트가 먼저 닫히고 paywall 이 뜨는지, 애니메이션이 겹치지 않는지. 그리고 top-up 구매 후 paywall 이 닫히면 입력 가능한 상태로 돌아오는지. UIKit 표시 순서라 유닛 테스트가 닿지 않는다.