### PR TITLE
[#885] 구매 실패 직후 복구 배너를 띄운다

### DIFF
--- a/Presentations/BillingScenes/Sources/Paywall/PaywallViewModel.swift
+++ b/Presentations/BillingScenes/Sources/Paywall/PaywallViewModel.swift
@@ -233,7 +233,7 @@ extension PaywallViewModelImple {
                     self.showPendingDialog()
                 }
             } catch {
-                self.showFailure(error)
+                await self.showFailureAndRecheckUnfinished(error)
             }
         }
     }
@@ -257,7 +257,7 @@ extension PaywallViewModelImple {
                     self.showPendingDialog()
                 }
             } catch {
-                self.showFailure(error)
+                await self.showFailureAndRecheckUnfinished(error)
             }
         }
     }
@@ -282,7 +282,7 @@ extension PaywallViewModelImple {
                     break
                 }
             } catch {
-                self.showFailure(error)
+                await self.showFailureAndRecheckUnfinished(error)
             }
         }
     }
@@ -350,6 +350,12 @@ extension PaywallViewModelImple {
             |> \.message .~ pure(reason.message)
             |> \.withCancel .~ false
         self.router?.showConfirm(dialog: info)
+    }
+
+    // 서버 반영만 실패해도 미완료 거래가 남을 수 있어 실패 직후 다시 조회한다
+    private func showFailureAndRecheckUnfinished(_ error: any Error) async {
+        self.showFailure(error)
+        await self.loadUnfinishedState()
     }
 }
 

--- a/Presentations/BillingScenes/Tests/Doubles/StubBillingUsecase.swift
+++ b/Presentations/BillingScenes/Tests/Doubles/StubBillingUsecase.swift
@@ -36,7 +36,8 @@ final class StubBillingUsecase: BillingUsecase, @unchecked Sendable {
     var didRefreshUserPlanPublisher: AnyPublisher<Bool, Never> {
         self.didRefreshUserPlanSubject.eraseToAnyPublisher()
     }
-    var didCheckUnfinishedCalled: Bool = false
+    var didCheckUnfinishedTimes: Int = 0
+    var didCheckUnfinishedCalled: Bool { self.didCheckUnfinishedTimes > 0 }
     var didApplyUnfinishedTimes: Int = 0
 
     init(
@@ -112,7 +113,7 @@ final class StubBillingUsecase: BillingUsecase, @unchecked Sendable {
     func stopObservingTransactions() { }
     func recoverUnfinishedTransactions() { }
     func hasUnfinishedTransactions() async -> Bool {
-        self.didCheckUnfinishedCalled = true
+        self.didCheckUnfinishedTimes += 1
         return self.hasUnfinished
     }
 

--- a/Presentations/BillingScenes/Tests/Paywall/PaywallViewModelImpleTests.swift
+++ b/Presentations/BillingScenes/Tests/Paywall/PaywallViewModelImpleTests.swift
@@ -845,6 +845,117 @@ extension PaywallViewModelImpleTests {
 }
 
 
+// MARK: - 실패 후 미완료 거래 재조회 (#885)
+
+extension PaywallViewModelImpleTests {
+
+    @Test("구매 실패 후 미완료 거래를 다시 조회해 배너를 띄운다")
+    func viewModel_whenPurchaseFails_reChecksUnfinishedTransactions() async throws {
+        // given
+        let standard = self.purchasableOffering(.standard, productId: "product.standard")
+        let (viewModel, stub, _) = self.makeViewModel(
+            offerings: [standard], purchaseResult: .failure(TestError()), hasUnfinished: true
+        )
+        _ = try await self.waitOfferingsLoaded(viewModel)
+        viewModel.selectPlan(.standard)
+
+        // when
+        try await self.waitProcessingCompleted(viewModel) { viewModel.purchase() }
+
+        // then: prepare() 에서 1회 + 실패 후 재조회 1회
+        #expect(stub.didCheckUnfinishedTimes == 2)
+        let expect = expectConfirm("배너 노출 상태")
+        let hasUnfinished = try await self.firstOutput(expect, for: viewModel.hasUnfinishedTransactions)
+        #expect(hasUnfinished == true)
+    }
+
+    @Test("top-up 구매 실패 후 미완료 거래를 다시 조회해 배너를 띄운다")
+    func viewModel_whenPurchaseTopupFails_reChecksUnfinishedTransactions() async throws {
+        // given: prepare() 를 부르지 않아 재조회 여부가 고정 stub 만으로 판별된다
+        let (viewModel, stub, _) = self.makeViewModel(
+            purchaseResult: .failure(TestError()), hasUnfinished: true
+        )
+
+        // when
+        try await self.waitProcessingCompleted(viewModel) { viewModel.purchaseTopup("topup.tier.1") }
+
+        // then
+        #expect(stub.didCheckUnfinishedTimes == 1)
+        let expect = expectConfirm("배너 노출 상태")
+        let hasUnfinished = try await self.firstOutput(expect, for: viewModel.hasUnfinishedTransactions)
+        #expect(hasUnfinished == true)
+    }
+
+    @Test("복원 실패 후 미완료 거래를 다시 조회해 배너를 띄운다")
+    func viewModel_whenRestoreFails_reChecksUnfinishedTransactions() async throws {
+        // given
+        let (viewModel, stub, _) = self.makeViewModel(
+            restoreError: TestError(), hasUnfinished: true
+        )
+
+        // when
+        try await self.waitProcessingCompleted(viewModel) { viewModel.restore() }
+
+        // then
+        #expect(stub.didCheckUnfinishedTimes == 1)
+        let expect = expectConfirm("배너 노출 상태")
+        let hasUnfinished = try await self.firstOutput(expect, for: viewModel.hasUnfinishedTransactions)
+        #expect(hasUnfinished == true)
+    }
+
+    // 판별력 — 재조회가 무조건 배너를 켜는 게 아니라 실제 미완료 거래 유무를 그대로 반영한다
+    @Test("미완료 거래가 없으면 복원이 실패해도 배너를 띄우지 않는다")
+    func viewModel_whenRestoreFailsWithoutUnfinishedTransaction_keepsBannerHidden() async throws {
+        // given
+        let (viewModel, stub, _) = self.makeViewModel(
+            restoreError: TestError(), hasUnfinished: false
+        )
+
+        // when
+        try await self.waitProcessingCompleted(viewModel) { viewModel.restore() }
+
+        // then
+        #expect(stub.didCheckUnfinishedTimes == 1)
+        let expect = expectConfirm("배너 미노출 상태")
+        let hasUnfinished = try await self.firstOutput(expect, for: viewModel.hasUnfinishedTransactions)
+        #expect(hasUnfinished == false)
+    }
+
+    @Test("구매 실패로 뜬 배너를 재시도로 반영하면 배너가 내려간다")
+    func viewModel_whenRetryAfterPurchaseFailureSucceeds_hidesBannerAndShowsAppliedToast() async throws {
+        // given
+        let applied = BillingUserPlan() |> \.planId .~ .standard
+        let (viewModel, stub, router) = self.makeViewModel(
+            purchaseResult: .failure(TestError()),
+            hasUnfinished: true,
+            applyUnfinishedResult: .success(applied)
+        )
+
+        // when: 구매 실패
+        try await self.waitProcessingCompleted(viewModel) { viewModel.purchaseTopup("topup.tier.1") }
+
+        // then: 배너가 뜬다
+        let shownExpect = expectConfirm("배너 노출 상태")
+        let bannerShown = try await self.firstOutput(
+            shownExpect, for: viewModel.hasUnfinishedTransactions
+        )
+        #expect(bannerShown == true)
+
+        // when: 그 배너의 "지금 적용" 으로 재시도
+        try await self.waitProcessingCompleted(viewModel) { viewModel.recoverUnfinished() }
+
+        // then: 배너가 내려가고 반영을 알린다
+        let hiddenExpect = expectConfirm("배너 내려간 상태")
+        let bannerHidden = try await self.firstOutput(
+            hiddenExpect, for: viewModel.hasUnfinishedTransactions
+        )
+        #expect(bannerHidden == false)
+        #expect(stub.didApplyUnfinishedTimes == 1)
+        #expect(router.didShowToastWithMessage == "billing::paywall::unfinished::applied".localized())
+    }
+}
+
+
 // MARK: - 구독 관리 진입점 노출 조건
 
 extension PaywallViewModelImpleTests {


### PR DESCRIPTION
closes #885

## 문제

애플 결제는 성공했는데 서버 확인이 실패하면 거래가 미 finish 로 남는다. 이때 실패 팝업을 닫고 나면 paywall 에 남는 건 하단 구매 CTA 뿐이라, 유저에게는 "돈을 또 내야 하나"로 읽힌다.

정작 그 상황을 설명하는 복구 배너는 **이미 만들어져 있었다** — `반영되지 않은 결제가 있어요 / 결제는 완료됐지만 플랜에 아직 반영되지 않았어요 / 지금 반영`. 안 뜬 이유는 `subject.hasUnfinished` 를 채우는 `loadUnfinishedState()` 가 `prepare()` 에서만 돌기 때문이다. 성공 복구 시 `false` 로 내리는 코드는 있어도, 구매가 실패한 뒤 다시 조회하는 코드가 없었다. paywall 을 나갔다 다시 들어와야 배너가 보였다.

## 접근

구매·복원 실패 경로 3곳(`purchase`·`purchaseTopup`·`restore`)에서 실패를 알린 직후 미완료 거래 상태를 다시 조회한다. 세 catch 가 같은 시퀀스가 되므로 `showFailureAndRecheckUnfinished(_:)` 로 묶었다 — 새 타입 없이 기존 두 메서드를 한 문장으로 합친 것이다.

에러 종류로 분기하지 않는다. `hasUnfinishedTransactions()` 는 StoreKit 의 `Transaction.unfinished` 를 직접 읽는 authoritative 조회라, 애플 결제 자체가 실패했거나 유저가 취소한 경우엔 자연히 `false` 가 나온다.

`recoverUnfinished()` 의 실패 경로는 손대지 않았다 — 거기선 `hasUnfinished` 가 true 인 채 유지되는 게 맞다.

**하단 CTA 는 그대로 뒀다.** 배너가 위에 뜨면 오해가 풀리고, CTA 를 막으면 다른 플랜을 사려는 길까지 닫힌다.

## 검증

`PaywallViewModelImpleTests` 67건 통과. 세 경로 각각에 TC 를 붙여 어느 하나를 되돌려도 대응 TC 가 빨개진다. 미완료 거래가 **없는** 상태에서 실패하면 배너가 그대로 숨어 있는지도 덮었다 — 재조회가 무조건 배너를 켜는 게 아니라 실제 상태를 반영한다는 판별력 확인이다.
