### PR TITLE
[#917] RRULE ↔ 앱 반복 옵션 왕복 계층 — 표현 불가 규칙은 매핑에서 잠근다

### DIFF
--- a/Domain/Sources/Utils/RRule+EventRepeating.swift
+++ b/Domain/Sources/Utils/RRule+EventRepeating.swift
@@ -1,0 +1,356 @@
+//
+//  RRule+EventRepeating.swift
+//  Domain
+//
+//  Created by sudo.park on 8/17/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Prelude
+import Optics
+
+
+// MARK: - RRULE → 앱 반복 옵션
+
+extension RRule {
+
+    public func asEventRepeating(startTime: TimeInterval, timeZone: TimeZone) -> EventRepeating? {
+        guard self.unsupportedKeys.isEmpty, self.interval > 0,
+              let option = self.asEventRepeatingOption(startTime: startTime, timeZone: timeZone)
+        else { return nil }
+
+        return EventRepeating(repeatingStartTime: startTime, repeatOption: option)
+            |> \.repeatingEndOption .~ self.asRepeatEndOption()
+    }
+
+    private func asEventRepeatingOption(
+        startTime: TimeInterval, timeZone: TimeZone
+    ) -> (any EventRepeatingOption)? {
+        switch self.freq {
+        case .DAILY: return self.asEveryDayOption()
+        case .WEEKLY: return self.asEveryWeekOption(startTime: startTime, timeZone: timeZone)
+        case .MONTHLY: return self.asEveryMonthOption(startTime: startTime, timeZone: timeZone)
+        case .YEARLY: return self.asEveryYearOption(startTime: startTime, timeZone: timeZone)
+        }
+    }
+
+    private func asEveryDayOption() -> (any EventRepeatingOption)? {
+        guard self.byDays.isEmpty, self.byMonthDays.isEmpty, self.byMonths.isEmpty
+        else { return nil }
+        return EventRepeatingOptions.EveryDay() |> \.interval .~ self.interval
+    }
+
+    private func asEveryWeekOption(
+        startTime: TimeInterval, timeZone: TimeZone
+    ) -> (any EventRepeatingOption)? {
+        guard self.byMonthDays.isEmpty, self.byMonths.isEmpty,
+              self.byDays.allSatisfy({ $0.ordinal == nil })
+        else { return nil }
+
+        let days: [DayOfWeeks] = self.byDays.isEmpty
+            ? [startTime.weekdayComponent(in: timeZone)]
+            : self.byDays.map { $0.weekDay.asDayOfWeeks }
+        return EventRepeatingOptions.EveryWeek(timeZone)
+            |> \.interval .~ self.interval
+            |> \.dayOfWeeks .~ days
+    }
+
+    private func asEveryMonthOption(
+        startTime: TimeInterval, timeZone: TimeZone
+    ) -> (any EventRepeatingOption)? {
+        guard let selection = self.asMonthlySelection(startTime: startTime, timeZone: timeZone)
+        else { return nil }
+        return EventRepeatingOptions.EveryMonth(timeZone: timeZone)
+            |> \.interval .~ self.interval
+            |> \.selection .~ selection
+    }
+
+    private func asMonthlySelection(
+        startTime: TimeInterval, timeZone: TimeZone
+    ) -> EventRepeatingOptions.EveryMonth.DateSelector? {
+        switch (self.byDays.isEmpty, self.byMonthDays.isEmpty, self.byMonths.isEmpty) {
+        case (true, false, true):
+            guard let monthDays = self.byMonthDays.asMonthDays() else { return nil }
+            return .days(monthDays)
+
+        case (false, true, true):
+            guard let selector = self.byDays.asWeekSelector() else { return nil }
+            return .week(selector.ordinals, selector.weekDays)
+
+        case (true, true, true):
+            return .days([startTime.dayComponent(in: timeZone)])
+
+        default:
+            return nil
+        }
+    }
+
+    private func asEveryYearOption(
+        startTime: TimeInterval, timeZone: TimeZone
+    ) -> (any EventRepeatingOption)? {
+        if self.byMonths.count == 1, self.byMonthDays.count == 1, self.byDays.isEmpty {
+            guard let months = self.byMonths.asMonths(), let monthDays = self.byMonthDays.asMonthDays()
+            else { return nil }
+            return EventRepeatingOptions.EveryYearSomeDay(timeZone, months[0].rawValue, monthDays[0])
+                |> \.interval .~ self.interval
+        }
+        if self.byMonths.isEmpty, self.byMonthDays.isEmpty, self.byDays.isEmpty {
+            let (month, day) = startTime.monthAndDayComponents(in: timeZone)
+            return EventRepeatingOptions.EveryYearSomeDay(timeZone, month, day)
+                |> \.interval .~ self.interval
+        }
+        guard self.byMonths.isEmpty == false, self.byMonthDays.isEmpty, self.byDays.isEmpty == false,
+              let months = self.byMonths.asMonths(),
+              let selector = self.byDays.asWeekSelector()
+        else { return nil }
+
+        return EventRepeatingOptions.EveryYear(timeZone: timeZone)
+            |> \.interval .~ self.interval
+            |> \.months .~ months
+            |> \.weekOrdinals .~ selector.ordinals
+            |> \.dayOfWeek .~ selector.weekDays
+    }
+
+    private func asRepeatEndOption() -> EventRepeating.RepeatEndOption? {
+        if let until = self.until {
+            return .until(until.timeIntervalSince1970)
+        }
+        if let count = self.count {
+            return .count(count)
+        }
+        return nil
+    }
+}
+
+
+// MARK: - 앱 반복 옵션 → RRULE
+
+extension EventRepeating {
+
+    public func asRRuleText(_ timeZone: TimeZone) -> String? {
+        guard let rrule = self.repeatOptionAsRRule() else { return nil }
+        return (
+            rrule
+                |> \.until .~ self.repeatingEndOption?.endTime.map(Date.init(timeIntervalSince1970:))
+                |> \.count .~ self.repeatingEndOption?.endCount
+        )
+        .asRRuleText()
+    }
+
+    private func repeatOptionAsRRule() -> RRule? {
+        if let option = self.repeatOption as? EventRepeatingOptions.EveryDay {
+            return option.asRRule()
+        }
+        if let option = self.repeatOption as? EventRepeatingOptions.EveryWeek {
+            return option.asRRule()
+        }
+        if let option = self.repeatOption as? EventRepeatingOptions.EveryMonth {
+            return option.asRRule()
+        }
+        if let option = self.repeatOption as? EventRepeatingOptions.EveryYear {
+            return option.asRRule()
+        }
+        if let option = self.repeatOption as? EventRepeatingOptions.EveryYearSomeDay {
+            return option.asRRule()
+        }
+        return nil
+    }
+}
+
+extension EventRepeatingOptions.EveryDay {
+
+    fileprivate func asRRule() -> RRule? {
+        guard self.interval > 0 else { return nil }
+        return RRule(freq: .DAILY, interval: self.interval)
+    }
+}
+
+extension EventRepeatingOptions.EveryWeek {
+
+    fileprivate func asRRule() -> RRule? {
+        guard self.interval > 0, self.dayOfWeeks.isEmpty == false else { return nil }
+        return RRule(
+            freq: .WEEKLY, interval: self.interval,
+            byDays: self.dayOfWeeks.map { RRule.ByDay(weekDay: $0.asRRuleWeekDay) }
+        )
+    }
+}
+
+extension EventRepeatingOptions.EveryMonth {
+
+    fileprivate func asRRule() -> RRule? {
+        guard self.interval > 0 else { return nil }
+        switch self.selection {
+        case .days(let days):
+            guard days.isEmpty == false else { return nil }
+            return RRule(freq: .MONTHLY, interval: self.interval, byMonthDays: days)
+
+        case .week(let ordinals, let weekDays):
+            guard ordinals.isEmpty == false, weekDays.isEmpty == false else { return nil }
+            return RRule(
+                freq: .MONTHLY, interval: self.interval,
+                byDays: ordinals.asRRuleByDays(weekDays)
+            )
+        }
+    }
+}
+
+extension EventRepeatingOptions.EveryYear {
+
+    fileprivate func asRRule() -> RRule? {
+        guard self.interval > 0,
+              self.months.isEmpty == false,
+              self.weekOrdinals.isEmpty == false,
+              self.dayOfWeek.isEmpty == false
+        else { return nil }
+        return RRule(
+            freq: .YEARLY, interval: self.interval,
+            byDays: self.weekOrdinals.asRRuleByDays(self.dayOfWeek),
+            byMonths: self.months.map { $0.rawValue }
+        )
+    }
+}
+
+extension EventRepeatingOptions.EveryYearSomeDay {
+
+    fileprivate func asRRule() -> RRule? {
+        guard self.interval > 0 else { return nil }
+        return RRule(
+            freq: .YEARLY, interval: self.interval,
+            byMonthDays: [self.day], byMonths: [self.month]
+        )
+    }
+}
+
+
+// MARK: - RRule.ByDay ↔ WeekOrdinal · DayOfWeeks 변환
+
+extension Array where Element: Equatable {
+
+    fileprivate func uniqueInOrder() -> [Element] {
+        return self.reduce(into: [Element]()) { acc, element in
+            guard acc.contains(element) == false else { return }
+            acc.append(element)
+        }
+    }
+}
+
+extension Array where Element == RRule.ByDay {
+
+    fileprivate func asWeekSelector() -> (ordinals: [WeekOrdinal], weekDays: [DayOfWeeks])? {
+        let parsedOrdinals = self.compactMap { $0.ordinal }
+        guard parsedOrdinals.count == self.count else { return nil }
+
+        let ordinalValues = parsedOrdinals.uniqueInOrder()
+        let weekDayValues = self.map { $0.weekDay }.uniqueInOrder()
+
+        guard self.count == ordinalValues.count * weekDayValues.count else { return nil }
+
+        let expectedKeys = Set(
+            ordinalValues.flatMap { ordinal in weekDayValues.map { "\(ordinal)-\($0.rawValue)" } }
+        )
+        let actualKeys = Set(Swift.zip(parsedOrdinals, self.map { $0.weekDay }).map { "\($0)-\($1.rawValue)" })
+        guard expectedKeys == actualKeys else { return nil }
+
+        let ordinals = ordinalValues.compactMap { WeekOrdinal(rruleOrdinal: $0) }
+        guard ordinals.count == ordinalValues.count else { return nil }
+
+        return (ordinals, weekDayValues.map { $0.asDayOfWeeks })
+    }
+}
+
+extension Array where Element == WeekOrdinal {
+
+    fileprivate func asRRuleByDays(_ weekDays: [DayOfWeeks]) -> [RRule.ByDay] {
+        return self.flatMap { ordinal in
+            weekDays.map { RRule.ByDay(ordinal: ordinal.asRRuleOrdinal, weekDay: $0.asRRuleWeekDay) }
+        }
+    }
+}
+
+extension Array where Element == Int {
+
+    fileprivate func asMonths() -> [Months]? {
+        let months = self.compactMap { Months(rawValue: $0) }
+        return months.count == self.count ? months : nil
+    }
+
+    fileprivate func asMonthDays() -> [Int]? {
+        let monthDays = self.filter { (1...31).contains($0) }
+        return monthDays.count == self.count ? monthDays : nil
+    }
+}
+
+extension WeekOrdinal {
+
+    fileprivate init?(rruleOrdinal ordinal: Int) {
+        switch ordinal {
+        case -1: self = .last
+        case let n where n > 0: self = .seq(n)
+        default: return nil
+        }
+    }
+
+    fileprivate var asRRuleOrdinal: Int {
+        switch self {
+        case .last: return -1
+        case .seq(let n): return n
+        }
+    }
+}
+
+extension RRule.ByDay.WeekDay {
+
+    fileprivate var asDayOfWeeks: DayOfWeeks {
+        switch self {
+        case .SU: return .sunday
+        case .MO: return .monday
+        case .TU: return .tuesday
+        case .WE: return .wednesday
+        case .TH: return .thursday
+        case .FR: return .friday
+        case .SA: return .saturday
+        }
+    }
+}
+
+extension DayOfWeeks {
+
+    fileprivate var asRRuleWeekDay: RRule.ByDay.WeekDay {
+        switch self {
+        case .sunday: return .SU
+        case .monday: return .MO
+        case .tuesday: return .TU
+        case .wednesday: return .WE
+        case .thursday: return .TH
+        case .friday: return .FR
+        case .saturday: return .SA
+        }
+    }
+}
+
+
+// MARK: - TimeInterval → 반복 시작 시각의 요일·일자
+
+extension TimeInterval {
+
+    fileprivate func weekdayComponent(in timeZone: TimeZone) -> DayOfWeeks {
+        let value = self.dateComponents([.weekday], in: timeZone).weekday ?? DayOfWeeks.sunday.rawValue
+        return DayOfWeeks(rawValue: value) ?? .sunday
+    }
+
+    fileprivate func dayComponent(in timeZone: TimeZone) -> Int {
+        return self.dateComponents([.day], in: timeZone).day ?? 1
+    }
+
+    fileprivate func monthAndDayComponents(in timeZone: TimeZone) -> (month: Int, day: Int) {
+        let components = self.dateComponents([.month, .day], in: timeZone)
+        return (components.month ?? 1, components.day ?? 1)
+    }
+
+    private func dateComponents(_ units: Set<Calendar.Component>, in timeZone: TimeZone) -> DateComponents {
+        let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
+        return calendar.dateComponents(units, from: Date(timeIntervalSince1970: self))
+    }
+}

--- a/Domain/Sources/Utils/RRuleParser.swift
+++ b/Domain/Sources/Utils/RRuleParser.swift
@@ -56,8 +56,11 @@ public struct RRule: Sendable {
     public let freq: Frequency
     public var interval: Int = 1
     public var byDays: [ByDay] = []
+    public var byMonthDays: [Int] = []
+    public var byMonths: [Int] = []
     public var until: Date?
     public var count: Int?
+    public var unsupportedKeys: [String] = []
 }
 
 // MARK: - RFC5545 RRULE parser
@@ -76,37 +79,98 @@ public struct RRuleParser: Sendable {
         var rule = RRule(freq: freq)
         rules.forEach { key, value in
             switch key {
+            case "FREQ":
+                break
+
             case "INTERVAL":
                 rule.interval = Int(value) ?? 1
-                
+
             case "BYDAY":
                 let byDays = value.components(separatedBy: ",")
                     .compactMap { RRule.ByDay(text: $0) }
                 rule.byDays = byDays
-                
+
+            case "BYMONTHDAY":
+                rule.byMonthDays = value.components(separatedBy: ",").compactMap { Int($0) }
+
+            case "BYMONTH":
+                rule.byMonths = value.components(separatedBy: ",").compactMap { Int($0) }
+
             case "UNTIL":
                 let formatter = DateFormatter()
                 formatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
                 formatter.timeZone = TimeZone(abbreviation: "UTC")
                 rule.until = formatter.date(from: value)
-                
+
             case "COUNT":
                 rule.count = Int(value)
-                
-            default: break
+
+            default:
+                rule.unsupportedKeys.append(key)
             }
         }
         return rule
     }
     
     private static func splitRules(_ ruleText: String) -> [String: String]? {
-        
+
         let components = ruleText.components(separatedBy: ";")
         return components.reduce(into: [String: String]()) { acc, pair in
             let kv = pair.components(separatedBy: "=")
             if kv.count == 2 {
                 acc[kv[0]] = kv[1]
             }
+        }
+    }
+}
+
+// MARK: - RRule serialization
+
+extension RRule.ByDay {
+
+    fileprivate var asRRuleText: String {
+        guard let ordinal = self.ordinal else { return self.weekDay.rawValue }
+        return "\(ordinal)\(self.weekDay.rawValue)"
+    }
+}
+
+extension RRule {
+
+    public func asRRuleText() -> String {
+        var parts = ["FREQ=\(self.freq.rawValue)", "INTERVAL=\(self.interval)"]
+        if self.byMonths.isEmpty == false {
+            parts.append("BYMONTH=\(self.byMonths.map(String.init).joined(separator: ","))")
+        }
+        if self.byMonthDays.isEmpty == false {
+            parts.append("BYMONTHDAY=\(self.byMonthDays.map(String.init).joined(separator: ","))")
+        }
+        if self.byDays.isEmpty == false {
+            parts.append("BYDAY=\(self.byDays.map { $0.asRRuleText }.joined(separator: ","))")
+        }
+        if let until = self.until {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
+            formatter.timeZone = TimeZone(abbreviation: "UTC")
+            parts.append("UNTIL=\(formatter.string(from: until))")
+        } else if let count = self.count {
+            parts.append("COUNT=\(count)")
+        }
+        return "RRULE:\(parts.joined(separator: ";"))"
+    }
+}
+
+// MARK: - recurrence 배열의 RRULE 줄 교체
+
+extension Array where Element == String {
+
+    public func replacingRRuleLine(_ newRRuleText: String?) -> [String] {
+        guard self.contains(where: { $0.hasPrefix("RRULE:") }) else {
+            guard let newRRuleText else { return self }
+            return [newRRuleText] + self
+        }
+        return self.compactMap { line in
+            guard line.hasPrefix("RRULE:") else { return line }
+            return newRRuleText
         }
     }
 }

--- a/Domain/Tests/Utils/RRuleEventRepeatingMappingTests.swift
+++ b/Domain/Tests/Utils/RRuleEventRepeatingMappingTests.swift
@@ -1,0 +1,457 @@
+//
+//  RRuleEventRepeatingMappingTests.swift
+//  DomainTests
+//
+//  Created by sudo.park on 8/17/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Prelude
+import Optics
+import Extensions
+import UnitTestHelpKit
+
+@testable import Domain
+
+private let testTimeZone = TimeZone(abbreviation: "KST")!
+private let testStartTime: TimeInterval = 1773532800   // 2026-03-15 09:00:00 KST, Sunday
+
+struct RRuleEventRepeatingMappingTests { }
+
+
+// MARK: - RRULE → 앱 옵션
+
+extension RRuleEventRepeatingMappingTests {
+
+    @Test func asEventRepeating_everyDay() {
+        // given
+        let rrule = RRuleParser.parse("RRULE:FREQ=DAILY;INTERVAL=3")
+
+        // when
+        let repeating = rrule?.asEventRepeating(startTime: testStartTime, timeZone: testTimeZone)
+
+        // then
+        let expected = EventRepeating(
+            repeatingStartTime: testStartTime,
+            repeatOption: EventRepeatingOptions.EveryDay() |> \.interval .~ 3
+        )
+        #expect(repeating == expected)
+    }
+
+    @Test func asEventRepeating_everyWeek() {
+        // given
+        let rrule = RRuleParser.parse("RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,FR")
+
+        // when
+        let repeating = rrule?.asEventRepeating(startTime: testStartTime, timeZone: testTimeZone)
+
+        // then
+        let expected = EventRepeating(
+            repeatingStartTime: testStartTime,
+            repeatOption: EventRepeatingOptions.EveryWeek(testTimeZone)
+                |> \.interval .~ 2
+                |> \.dayOfWeeks .~ [.monday, .friday]
+        )
+        #expect(repeating == expected)
+    }
+
+    @Test func asEventRepeating_everyMonthByDays() {
+        // given
+        let rrule = RRuleParser.parse("RRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15")
+
+        // when
+        let repeating = rrule?.asEventRepeating(startTime: testStartTime, timeZone: testTimeZone)
+
+        // then
+        let expected = EventRepeating(
+            repeatingStartTime: testStartTime,
+            repeatOption: EventRepeatingOptions.EveryMonth(timeZone: testTimeZone)
+                |> \.interval .~ 1
+                |> \.selection .~ .days([15])
+        )
+        #expect(repeating == expected)
+    }
+
+    @Test func asEventRepeating_everyMonthByWeek() {
+        // given
+        let rrule = RRuleParser.parse("RRULE:FREQ=MONTHLY;INTERVAL=1;BYDAY=1MO,-1MO")
+
+        // when
+        let repeating = rrule?.asEventRepeating(startTime: testStartTime, timeZone: testTimeZone)
+
+        // then
+        let expected = EventRepeating(
+            repeatingStartTime: testStartTime,
+            repeatOption: EventRepeatingOptions.EveryMonth(timeZone: testTimeZone)
+                |> \.interval .~ 1
+                |> \.selection .~ .week([.seq(1), .last], [.monday])
+        )
+        #expect(repeating == expected)
+    }
+
+    @Test func asEventRepeating_everyYearSomeDay() {
+        // given
+        let rrule = RRuleParser.parse("RRULE:FREQ=YEARLY;INTERVAL=1;BYMONTH=3;BYMONTHDAY=15")
+
+        // when
+        let repeating = rrule?.asEventRepeating(startTime: testStartTime, timeZone: testTimeZone)
+
+        // then
+        let expected = EventRepeating(
+            repeatingStartTime: testStartTime,
+            repeatOption: EventRepeatingOptions.EveryYearSomeDay(testTimeZone, 3, 15)
+                |> \.interval .~ 1
+        )
+        #expect(repeating == expected)
+    }
+
+    @Test func asEventRepeating_everyYearByWeek() {
+        // given
+        let rrule = RRuleParser.parse("RRULE:FREQ=YEARLY;INTERVAL=1;BYMONTH=3;BYDAY=1MO,-1MO")
+
+        // when
+        let repeating = rrule?.asEventRepeating(startTime: testStartTime, timeZone: testTimeZone)
+
+        // then
+        let expected = EventRepeating(
+            repeatingStartTime: testStartTime,
+            repeatOption: EventRepeatingOptions.EveryYear(timeZone: testTimeZone)
+                |> \.interval .~ 1
+                |> \.months .~ [.march]
+                |> \.weekOrdinals .~ [.seq(1), .last]
+                |> \.dayOfWeek .~ [.monday]
+        )
+        #expect(repeating == expected)
+    }
+
+    @Test func asEventRepeating_weeklyWithoutByDay_usesStartWeekday() {
+        // given
+        let rrule = RRuleParser.parse("RRULE:FREQ=WEEKLY;INTERVAL=1")
+
+        // when
+        let repeating = rrule?.asEventRepeating(startTime: testStartTime, timeZone: testTimeZone)
+
+        // then
+        let expected = EventRepeating(
+            repeatingStartTime: testStartTime,
+            repeatOption: EventRepeatingOptions.EveryWeek(testTimeZone)
+                |> \.interval .~ 1
+                |> \.dayOfWeeks .~ [.sunday]
+        )
+        #expect(repeating == expected)
+    }
+
+    @Test func asEventRepeating_monthlyWithoutSelectors_usesStartDay() {
+        // given
+        let rrule = RRuleParser.parse("RRULE:FREQ=MONTHLY;INTERVAL=1")
+
+        // when
+        let repeating = rrule?.asEventRepeating(startTime: testStartTime, timeZone: testTimeZone)
+
+        // then
+        let expected = EventRepeating(
+            repeatingStartTime: testStartTime,
+            repeatOption: EventRepeatingOptions.EveryMonth(timeZone: testTimeZone)
+                |> \.interval .~ 1
+                |> \.selection .~ .days([15])
+        )
+        #expect(repeating == expected)
+    }
+
+    @Test func asEventRepeating_everyYearWithoutSelectors_usesStartMonthDay() {
+        // given
+        let rrule = RRuleParser.parse("RRULE:FREQ=YEARLY;INTERVAL=2")
+
+        // when
+        let repeating = rrule?.asEventRepeating(startTime: testStartTime, timeZone: testTimeZone)
+
+        // then
+        let expected = EventRepeating(
+            repeatingStartTime: testStartTime,
+            repeatOption: EventRepeatingOptions.EveryYearSomeDay(testTimeZone, 3, 15)
+                |> \.interval .~ 2
+        )
+        #expect(repeating == expected)
+    }
+
+    @Test func asEventRepeating_untilBecomesEndOption() {
+        // given
+        let rrule = RRuleParser.parse("RRULE:FREQ=DAILY;INTERVAL=1;UNTIL=20260401T000000Z")
+
+        // when
+        let repeating = rrule?.asEventRepeating(startTime: testStartTime, timeZone: testTimeZone)
+
+        // then
+        #expect(repeating?.repeatingEndOption?.endTime != nil)
+        #expect(repeating?.repeatingEndOption?.endCount == nil)
+    }
+
+    @Test func asEventRepeating_countBecomesEndOption() {
+        // given
+        let rrule = RRuleParser.parse("RRULE:FREQ=DAILY;INTERVAL=1;COUNT=5")
+
+        // when
+        let repeating = rrule?.asEventRepeating(startTime: testStartTime, timeZone: testTimeZone)
+
+        // then
+        #expect(repeating?.repeatingEndOption?.endCount == 5)
+        #expect(repeating?.repeatingEndOption?.endTime == nil)
+    }
+
+    @Test func asEventRepeating_whenUnsupportedKeyExists_isNil() {
+        // given
+        let rrule = RRuleParser.parse("RRULE:FREQ=MONTHLY;BYSETPOS=-1;BYDAY=MO")
+
+        // when
+        let repeating = rrule?.asEventRepeating(startTime: testStartTime, timeZone: testTimeZone)
+
+        // then
+        #expect(repeating == nil)
+    }
+
+    @Test func asEventRepeating_whenByDayOrdinalMixed_isNil() {
+        // given
+        let rrule = RRuleParser.parse("RRULE:FREQ=MONTHLY;BYDAY=1MO,FR")
+
+        // when
+        let repeating = rrule?.asEventRepeating(startTime: testStartTime, timeZone: testTimeZone)
+
+        // then
+        #expect(repeating == nil)
+    }
+
+    @Test func asEventRepeating_whenByMonthDayIsNegative_isNil() {
+        // given
+        let rrule = RRuleParser.parse("RRULE:FREQ=MONTHLY;BYMONTHDAY=-1")
+
+        // when
+        let repeating = rrule?.asEventRepeating(startTime: testStartTime, timeZone: testTimeZone)
+
+        // then
+        #expect(repeating == nil)
+    }
+
+    @Test func asEventRepeating_whenYearlyByMonthDayIsNegative_isNil() {
+        // given
+        let rrule = RRuleParser.parse("RRULE:FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=-1")
+
+        // when
+        let repeating = rrule?.asEventRepeating(startTime: testStartTime, timeZone: testTimeZone)
+
+        // then
+        #expect(repeating == nil)
+    }
+
+    @Test func asEventRepeating_whenByMonthIsOutOfRange_isNil() {
+        // given
+        let rrule = RRuleParser.parse("RRULE:FREQ=YEARLY;BYMONTH=13;BYMONTHDAY=15")
+
+        // when
+        let repeating = rrule?.asEventRepeating(startTime: testStartTime, timeZone: testTimeZone)
+
+        // then
+        #expect(repeating == nil)
+    }
+
+    @Test func asEventRepeating_whenIntervalIsZero_isNil() {
+        // given
+        let rrule = RRuleParser.parse("RRULE:FREQ=DAILY;INTERVAL=0")
+
+        // when
+        let repeating = rrule?.asEventRepeating(startTime: testStartTime, timeZone: testTimeZone)
+
+        // then
+        #expect(repeating == nil)
+    }
+}
+
+
+// MARK: - 앱 옵션 → RRULE
+
+extension RRuleEventRepeatingMappingTests {
+
+    @Test func asRRuleText_everyDay() {
+        // given
+        let repeating = EventRepeating(
+            repeatingStartTime: testStartTime,
+            repeatOption: EventRepeatingOptions.EveryDay() |> \.interval .~ 3
+        )
+
+        // when
+        let text = repeating.asRRuleText(testTimeZone)
+
+        // then
+        #expect(text == "RRULE:FREQ=DAILY;INTERVAL=3")
+    }
+
+    @Test func asRRuleText_everyWeek() {
+        // given
+        let repeating = EventRepeating(
+            repeatingStartTime: testStartTime,
+            repeatOption: EventRepeatingOptions.EveryWeek(testTimeZone)
+                |> \.interval .~ 2
+                |> \.dayOfWeeks .~ [.monday, .friday]
+        )
+
+        // when
+        let text = repeating.asRRuleText(testTimeZone)
+
+        // then
+        #expect(text == "RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,FR")
+    }
+
+    @Test func asRRuleText_everyMonthByDays() {
+        // given
+        let repeating = EventRepeating(
+            repeatingStartTime: testStartTime,
+            repeatOption: EventRepeatingOptions.EveryMonth(timeZone: testTimeZone)
+                |> \.interval .~ 1
+                |> \.selection .~ .days([15])
+        )
+
+        // when
+        let text = repeating.asRRuleText(testTimeZone)
+
+        // then
+        #expect(text == "RRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15")
+    }
+
+    @Test func asRRuleText_everyMonthByWeek() {
+        // given
+        let repeating = EventRepeating(
+            repeatingStartTime: testStartTime,
+            repeatOption: EventRepeatingOptions.EveryMonth(timeZone: testTimeZone)
+                |> \.interval .~ 1
+                |> \.selection .~ .week([.seq(1), .last], [.monday])
+        )
+
+        // when
+        let text = repeating.asRRuleText(testTimeZone)
+
+        // then
+        #expect(text == "RRULE:FREQ=MONTHLY;INTERVAL=1;BYDAY=1MO,-1MO")
+    }
+
+    @Test func asRRuleText_everyYear() {
+        // given
+        let repeating = EventRepeating(
+            repeatingStartTime: testStartTime,
+            repeatOption: EventRepeatingOptions.EveryYear(timeZone: testTimeZone)
+                |> \.interval .~ 1
+                |> \.months .~ [.march]
+                |> \.weekOrdinals .~ [.seq(1), .last]
+                |> \.dayOfWeek .~ [.monday]
+        )
+
+        // when
+        let text = repeating.asRRuleText(testTimeZone)
+
+        // then
+        #expect(text == "RRULE:FREQ=YEARLY;INTERVAL=1;BYMONTH=3;BYDAY=1MO,-1MO")
+    }
+
+    @Test func asRRuleText_everyYearSomeDay() {
+        // given
+        let repeating = EventRepeating(
+            repeatingStartTime: testStartTime,
+            repeatOption: EventRepeatingOptions.EveryYearSomeDay(testTimeZone, 3, 15)
+                |> \.interval .~ 1
+        )
+
+        // when
+        let text = repeating.asRRuleText(testTimeZone)
+
+        // then
+        #expect(text == "RRULE:FREQ=YEARLY;INTERVAL=1;BYMONTH=3;BYMONTHDAY=15")
+    }
+
+    @Test func asRRuleText_lunarCalendar_isNil() {
+        // given
+        let repeating = EventRepeating(
+            repeatingStartTime: testStartTime,
+            repeatOption: EventRepeatingOptions.LunarCalendarEveryYear(testTimeZone, 3, 15)
+        )
+
+        // when
+        let text = repeating.asRRuleText(testTimeZone)
+
+        // then
+        #expect(text == nil)
+    }
+
+    @Test func asRRuleText_everyWeekWithoutDays_isNil() {
+        // given
+        let repeating = EventRepeating(
+            repeatingStartTime: testStartTime,
+            repeatOption: EventRepeatingOptions.EveryWeek(testTimeZone)
+        )
+
+        // when
+        let text = repeating.asRRuleText(testTimeZone)
+
+        // then
+        #expect(text == nil)
+    }
+
+    @Test func asRRuleText_endOptionUntil() {
+        // given
+        let repeating = EventRepeating(
+            repeatingStartTime: testStartTime,
+            repeatOption: EventRepeatingOptions.EveryDay() |> \.interval .~ 1
+        )
+        |> \.repeatingEndOption .~ .until(testStartTime + .days(30))
+
+        // when
+        let text = repeating.asRRuleText(testTimeZone)
+
+        // then
+        #expect(text?.contains("UNTIL=") == true)
+        #expect(text?.contains("COUNT=") == false)
+    }
+
+    @Test func asRRuleText_endOptionCount() {
+        // given
+        let repeating = EventRepeating(
+            repeatingStartTime: testStartTime,
+            repeatOption: EventRepeatingOptions.EveryDay() |> \.interval .~ 1
+        )
+        |> \.repeatingEndOption .~ .count(5)
+
+        // when
+        let text = repeating.asRRuleText(testTimeZone)
+
+        // then
+        #expect(text?.contains("COUNT=5") == true)
+        #expect(text?.contains("UNTIL=") == false)
+    }
+}
+
+
+// MARK: - 왕복
+
+extension RRuleEventRepeatingMappingTests {
+
+    @Test(
+        "RRULE round trip through app repeat options",
+        arguments: [
+            "RRULE:FREQ=DAILY;INTERVAL=5",
+            "RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,FR",
+            "RRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15",
+            "RRULE:FREQ=MONTHLY;INTERVAL=1;BYDAY=1MO,-1MO",
+            "RRULE:FREQ=YEARLY;INTERVAL=1;BYMONTH=3;BYMONTHDAY=15;COUNT=10",
+            "RRULE:FREQ=YEARLY;INTERVAL=1;BYMONTH=3;BYDAY=1MO,-1MO"
+        ]
+    )
+    func roundTrip_preservesRule(_ text: String) {
+        // given
+        let rrule = RRuleParser.parse(text)
+
+        // when
+        let repeating = rrule?.asEventRepeating(startTime: testStartTime, timeZone: testTimeZone)
+        let serialized = repeating?.asRRuleText(testTimeZone)
+
+        // then
+        #expect(serialized == text)
+    }
+}

--- a/Domain/Tests/Utils/RRuleParserTests.swift
+++ b/Domain/Tests/Utils/RRuleParserTests.swift
@@ -131,15 +131,159 @@ struct RRuleParserTests {
     @Test func parse_endCount() {
         // given
         let text = "RRULE:FREQ=DAILY;COUNT=3"
-        
+
         // when
         let rrule = RRuleParser.parse(text)
-        
+
         // then
         #expect(rrule?.freq == .DAILY)
         #expect(rrule?.interval == 1)
         #expect(rrule?.byDays == [])
         #expect(rrule?.until == nil)
         #expect(rrule?.count == 3)
+    }
+}
+
+// MARK: - 월·일 지정 키 파싱
+
+extension RRuleParserTests {
+
+    @Test func parse_byMonthDayAndByMonth() {
+        // given
+        let text = "RRULE:FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=15"
+
+        // when
+        let rrule = RRuleParser.parse(text)
+
+        // then
+        #expect(rrule?.byMonths == [3])
+        #expect(rrule?.byMonthDays == [15])
+        #expect(rrule?.unsupportedKeys.isEmpty == true)
+    }
+}
+
+// MARK: - 미지원 키 수집
+
+extension RRuleParserTests {
+
+    @Test func parse_collectsUnsupportedKeys() {
+        // given
+        let text = "RRULE:FREQ=MONTHLY;BYSETPOS=-1;BYDAY=MO;WKST=SU"
+
+        // when
+        let rrule = RRuleParser.parse(text)
+
+        // then
+        let unsupportedKeys = Set(rrule?.unsupportedKeys ?? [])
+        #expect(unsupportedKeys == Set(["BYSETPOS", "WKST"]))
+    }
+
+    @Test func parse_knownKeysLeaveUnsupportedEmpty() {
+        // given
+        let text = "RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,FR;COUNT=10"
+
+        // when
+        let rrule = RRuleParser.parse(text)
+
+        // then
+        #expect(rrule?.unsupportedKeys.isEmpty == true)
+    }
+}
+
+// MARK: - 직렬화
+
+extension RRuleParserTests {
+
+    @Test(
+        "asRRuleText round trip",
+        arguments: [
+            "RRULE:FREQ=DAILY;INTERVAL=5",
+            "RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,FR",
+            "RRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=15",
+            "RRULE:FREQ=YEARLY;INTERVAL=1;BYMONTH=3;BYMONTHDAY=15;COUNT=10"
+        ]
+    )
+    func asRRuleText_roundTrip(_ text: String) {
+        // given
+        let rrule = RRuleParser.parse(text)
+
+        // when
+        let serialized = rrule?.asRRuleText()
+
+        // then
+        #expect(serialized == text)
+    }
+
+    @Test func asRRuleText_untilWinsOverCount() {
+        // given
+        var rule = RRule(freq: .WEEKLY)
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
+        formatter.timeZone = TimeZone(abbreviation: "UTC")
+        rule.until = formatter.date(from: "20260101T000000Z")
+        rule.count = 10
+
+        // when
+        let text = rule.asRRuleText()
+
+        // then
+        #expect(text.contains("UNTIL=20260101T000000Z") == true)
+        #expect(text.contains("COUNT=") == false)
+    }
+}
+
+// MARK: - recurrence 배열에서 RRULE 줄 교체
+
+extension RRuleParserTests {
+
+    @Test func replacingRRuleLine_keepsOtherLines() {
+        // given
+        let lines = [
+            "RRULE:FREQ=DAILY",
+            "EXDATE;TZID=Asia/Seoul:20260101T090000",
+            "RDATE:20260201T090000"
+        ]
+
+        // when
+        let replaced = lines.replacingRRuleLine("RRULE:FREQ=WEEKLY;INTERVAL=2")
+
+        // then
+        #expect(replaced == [
+            "RRULE:FREQ=WEEKLY;INTERVAL=2",
+            "EXDATE;TZID=Asia/Seoul:20260101T090000",
+            "RDATE:20260201T090000"
+        ])
+    }
+
+    @Test func replacingRRuleLine_removesWhenNil() {
+        // given
+        let lines = [
+            "RRULE:FREQ=DAILY",
+            "EXDATE;TZID=Asia/Seoul:20260101T090000",
+            "RDATE:20260201T090000"
+        ]
+
+        // when
+        let replaced = lines.replacingRRuleLine(nil)
+
+        // then
+        #expect(replaced == [
+            "EXDATE;TZID=Asia/Seoul:20260101T090000",
+            "RDATE:20260201T090000"
+        ])
+    }
+
+    @Test func replacingRRuleLine_appendsWhenAbsent() {
+        // given
+        let lines = ["EXDATE;TZID=Asia/Seoul:20260101T090000"]
+
+        // when
+        let replaced = lines.replacingRRuleLine("RRULE:FREQ=DAILY")
+
+        // then
+        #expect(replaced == [
+            "RRULE:FREQ=DAILY",
+            "EXDATE;TZID=Asia/Seoul:20260101T090000"
+        ])
     }
 }


### PR DESCRIPTION
외부 캘린더 이벤트의 반복 규칙을 앱에서 편집하려면 RRULE 문자열과 앱 반복 옵션(`EventRepeating`)을 왕복시켜야 한다. 이 PR 은 그 왕복 계층만 Domain 에 세운다 — 실제 쓰기·UI 는 후속 PR(구글·애플 상세) 소관이다.

## 문제

`RRuleParser` 가 단방향이고 손실이 있다.

- FREQ·INTERVAL·BYDAY·UNTIL·COUNT 만 읽고 나머지 키를 `default: break` 로 버린다. 버린 키의 존재조차 남지 않아 "앱이 표현 못 하는 규칙"인지 판별할 수 없다.
- 역방향(`RRule` → 문자열)이 아예 없다.
- 구글 `recurrence` 는 RRULE·EXDATE·RDATE 가 섞인 `[String]` 인데 RRULE 줄만 갈아끼울 수단이 없다.

이 상태로 쓰기를 붙이면 `RRULE:FREQ=MONTHLY;BYMONTHDAY=15` 가 `FREQ=MONTHLY` 로 덮여 유저의 원본 규칙이 파괴된다.

## 접근

**"표현 불가한 규칙은 매핑이 nil 을 낸다"로 잠금 판정을 한 곳에 모았다.** 상세 화면은 nil 여부만 보고 편집을 열거나 잠그면 되고, 판정을 다시 하지 않는다. 저장이 곧 파괴인 영역이라 fail-closed 가 기본값이다.

- `RRuleParser.parse` — `BYMONTHDAY`·`BYMONTH` 를 읽고, 해석 못 한 키 이름을 `RRule.unsupportedKeys` 에 남긴다. `BYSETPOS`·`WKST` 처럼 앱 모델에 대응 개념이 없는 키가 하나라도 있으면 그 규칙은 잠긴다. 값까지 보존하지 않는 이유는 잠긴 규칙의 원본 문자열을 그대로 두기 때문 — 되쓸 일이 없다.
- `RRule.asRRuleText()` — 직렬화. 파트 순서와 `UNTIL` 포맷을 기존 `EKRecurrenceRule.toRRuleString()` 에 맞췄고, RFC 5545 상 상호배타인 `until`·`count` 는 `until` 을 우선한다. 앱 옵션 → RRULE 방향도 이 함수를 거치게 해 포맷 정본을 하나로 뒀다.
- `[String].replacingRRuleLine(_:)` — 배열에서 RRULE 줄만 교체하고(`nil` 이면 제거) EXDATE·RDATE 는 순서까지 보존한다. 구글의 제외 날짜가 규칙 편집에 휩쓸리지 않게 하는 장치다.
- `RRule.asEventRepeating(startTime:timeZone:)` / `EventRepeating.asRRuleText(_:)` — 양방향 매핑. FREQ 별로 어떤 셀렉터 조합이 어느 앱 옵션이 되는지 대응시키고, **표에 없는 조합은 전부 nil** 이다.

## 잠기는 조합

왕복이 깨지는 자리를 각각 막았다.

- **미지원 키** — `BYSETPOS`·`WKST` 등. 앱에 주 시작 요일·N번째 선택 개념이 없다
- **범위 밖 `BYMONTHDAY`·`BYMONTH`** — RFC 5545 는 음수 `BYMONTHDAY`(-31~-1, "월말에서 N번째 날")를 허용하고 구글의 "매월 마지막 날" 반복이 실제로 `BYMONTHDAY=-1` 을 만든다. 앱의 `EveryMonth.DateSelector.days` 는 1~31 계약이라 이 값을 받으면 "마지막 날" 의미가 임의 날짜로 대체된다
- **비곱집합 `BYDAY`** — `1MO,2FR` 처럼 요일마다 다른 회차를 지정한 규칙. 앱 모델은 `ordinals × weekDays` 곱집합만 표현한다. 개수만 맞는 위장 케이스(`1MO,1MO,2TU,2TU`)도 조합 집합 대조로 걸러낸다
- **음력** — RRULE 에 대응 표현이 없다
- **`interval <= 0`**
