### PR TITLE
[#917] 구글 이벤트 반복 규칙 편집 — 반복 행 상시 표시와 시리즈 대상 저장

### DIFF
--- a/Domain/Sources/Models/Events/ExternalCalendar/GoogleCalendarEventEditParams.swift
+++ b/Domain/Sources/Models/Events/ExternalCalendar/GoogleCalendarEventEditParams.swift
@@ -18,6 +18,7 @@ extension GoogleCalendar {
         public var location: String?
         public var description: String?
         public var colorId: String?
+        public var recurrence: [String]?
 
         public init() { }
 
@@ -28,6 +29,7 @@ extension GoogleCalendar {
                 && self.location == nil
                 && self.description == nil
                 && self.colorId == nil
+                && self.recurrence == nil
         }
     }
 

--- a/Domain/Sources/Usecases/Events/ExternalCalendar/GoogleCalendarUsecase.swift
+++ b/Domain/Sources/Usecases/Events/ExternalCalendar/GoogleCalendarUsecase.swift
@@ -424,14 +424,19 @@ extension GoogleCalendarUsecaseImple {
         else {
             throw RuntimeError("failed to update google calendar event")
         }
-        // 시리즈 마스터 수정은 N개 인스턴스를 바꾸는데 응답엔 인스턴스가 없다 — 캐시에 꽂을 값이 없어 재조회로만 반영된다
-        if origin.isRecurringSeriesMaster {
+        // 판단 기준은 결과가 아니라 대상이다 — 반복 해제는 응답의 recurrence 가 nil 이 돼
+        // isRecurringSeriesMaster 가 false 로 떨어지지만, 펼쳐진 인스턴스는 여전히 걷어야 한다
+        if origin.isRecurringSeriesMaster || params.recurrence != nil {
             if let period = self.cachedEventsPeriod() {
                 self.refreshRepeatingEvent(calendarId, eventId, accountId: accountId, in: period)
             }
-            return origin
         }
-        self.cacheUpdatedEvent(origin, calendarId, accountId: accountId, timeZone: timeZone)
+        // 인스턴스 집합 재조회와 본체 키 정리는 별개 축이다 — 마스터는 표시 인스턴스가 아니다
+        if origin.isRecurringSeriesMaster {
+            self.removeCachedEventItself(eventId)
+        } else {
+            self.cacheUpdatedEvent(origin, calendarId, accountId: accountId, timeZone: timeZone)
+        }
         return origin
     }
 
@@ -458,7 +463,18 @@ extension GoogleCalendarUsecaseImple {
             [String: GoogleCalendar.Event].self,
             key: ShareDataKeys.googleCalendarEvents.rawValue
         ) { existing in
-            (existing ?? [:]) |> key(event.eventId) .~ event
+            let withoutStaleInstances = (existing ?? [:])
+                .filter { !$0.value.isInstance(of: event.eventId) }
+            return withoutStaleInstances |> key(event.eventId) .~ event
+        }
+    }
+
+    private func removeCachedEventItself(_ eventId: String) {
+        self.sharedDataStore.update(
+            [String: GoogleCalendar.Event].self,
+            key: ShareDataKeys.googleCalendarEvents.rawValue
+        ) { existing in
+            (existing ?? [:]) |> key(eventId) .~ nil
         }
     }
 

--- a/Domain/Tests/Usecases/GoogleCalendarUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/GoogleCalendarUsecaseImpleTests.swift
@@ -654,6 +654,76 @@ extension GoogleCalendarUsecaseImpleTests {
         #expect(cached?["loaded"] != nil)
     }
 
+    @Test func updateEvent_whenRecurrenceRemoved_refreshesCachedPeriod() async throws {
+        // given — 반복 해제 응답은 마스터가 아니다(recurrence == nil) — 결과만 보면 재조회가 필요 없어 보인다
+        let notMasterAnymore = GoogleCalendar.EventOrigin(id: "series1", summary: "no longer repeating")
+        let repo = PrivateStubRepository(customUpdateEventOriginStubbing: notMasterAnymore)
+        let usecase = makeUsecase(accounts: ["account@google.com"], defaultRepo: repo)
+        stubStore.put(
+            [String: GoogleCalendar.Event].self,
+            key: ShareDataKeys.googleCalendarEvents.rawValue,
+            ["loaded": dummyEvent("loaded")]
+        )
+        var params = GoogleCalendar.EventEditParams()
+        params.recurrence = []
+
+        // when
+        _ = try await usecase.updateEvent(
+            "cal1", "series1", accountId: "account@google.com",
+            at: TimeZone(identifier: "Asia/Seoul")!, params: params
+        )
+        try await Task.sleep(for: .milliseconds(100))
+
+        // then — 대상이 반복 해제 대상이었으므로 펼쳐진 인스턴스를 걷어내는 재조회가 돈다
+        #expect(repo.didLoadRepeatingInstancesWith?.eventId == "series1")
+    }
+
+    @Test func updateEvent_whenRecurrenceAdded_refreshesCachedPeriod() async throws {
+        // given — 이번 응답 자체는 마스터가 아니지만(recurringEventId nil, recurrence nil), 대상에 반복을 새로 실었다
+        let notMasterYet = GoogleCalendar.EventOrigin(id: "event1", summary: "now repeating")
+        let repo = PrivateStubRepository(customUpdateEventOriginStubbing: notMasterYet)
+        let usecase = makeUsecase(accounts: ["account@google.com"], defaultRepo: repo)
+        stubStore.put(
+            [String: GoogleCalendar.Event].self,
+            key: ShareDataKeys.googleCalendarEvents.rawValue,
+            ["loaded": dummyEvent("loaded")]
+        )
+        var params = GoogleCalendar.EventEditParams()
+        params.recurrence = ["RRULE:FREQ=DAILY;COUNT=3"]
+
+        // when
+        _ = try await usecase.updateEvent(
+            "cal1", "event1", accountId: "account@google.com",
+            at: TimeZone(identifier: "Asia/Seoul")!, params: params
+        )
+        try await Task.sleep(for: .milliseconds(100))
+
+        // then
+        #expect(repo.didLoadRepeatingInstancesWith?.eventId == "event1")
+    }
+
+    @Test func updateEvent_whenOnlyOtherFieldsChanged_cachesResponseOnly() async throws {
+        // given — 반복과 무관한 필드만 바뀌었고 응답도 인스턴스다
+        let usecase = makeUsecase(
+            accounts: ["account@google.com"],
+            defaultRepo: .init(customUpdateEventOriginStubbing: dummyUpdatedEventOrigin)
+        )
+        var params = GoogleCalendar.EventEditParams()
+        params.summary = "updated"
+
+        // when
+        _ = try await usecase.updateEvent(
+            "cal1", "event1", accountId: "account@google.com",
+            at: TimeZone(identifier: "Asia/Seoul")!, params: params
+        )
+
+        // then — 재조회 없이 응답만 캐시에 반영
+        let cached = stubStore.value(
+            [String: GoogleCalendar.Event].self, key: ShareDataKeys.googleCalendarEvents.rawValue
+        )
+        #expect(cached?["event1"]?.name == "updated")
+    }
+
     @Test func removeEvent_removesFromSharedDataStore() async throws {
         // given
         let usecase = makeUsecase(
@@ -706,6 +776,89 @@ extension GoogleCalendarUsecaseImpleTests {
         #expect(cached?["event1_100"] == nil)
         #expect(cached?["event1_200"] == nil)
         #expect(cached?["other"] != nil)
+    }
+
+    @Test func updateEvent_whenRecurrenceAdded_removesStaleSingleEventFromCache() async throws {
+        // given — 반복 없던 단일 이벤트가 eventId 키로 캐시돼 있다
+        var seriesMaster = GoogleCalendar.EventOrigin(id: "event1", summary: "now repeating")
+        seriesMaster.recurrence = ["RRULE:FREQ=DAILY;COUNT=3"]
+        let repo = PrivateStubRepository(customUpdateEventOriginStubbing: seriesMaster)
+        let usecase = makeUsecase(accounts: ["account@google.com"], defaultRepo: repo)
+        stubStore.put(
+            [String: GoogleCalendar.Event].self,
+            key: ShareDataKeys.googleCalendarEvents.rawValue,
+            ["event1": self.dummyEvent("event1")]
+        )
+        var params = GoogleCalendar.EventEditParams()
+        params.recurrence = ["RRULE:FREQ=DAILY;COUNT=3"]
+
+        // when
+        _ = try await usecase.updateEvent(
+            "cal1", "event1", accountId: "account@google.com",
+            at: TimeZone(identifier: "Asia/Seoul")!, params: params
+        )
+        try await Task.sleep(for: .milliseconds(100))
+
+        // then — 옛 단일 이벤트 캐시가 eventId 키에 남지 않는다
+        let cached = stubStore.value(
+            [String: GoogleCalendar.Event].self, key: ShareDataKeys.googleCalendarEvents.rawValue
+        )
+        #expect(cached?["event1"] == nil)
+    }
+
+    @Test func updateEvent_whenRecurrenceRemoved_cachesEventItself() async throws {
+        // given — 반복 해제 응답은 마스터가 아니다(recurrence == nil) — 반복이 풀린 단일 이벤트다
+        var notMasterAnymore = GoogleCalendar.EventOrigin(id: "series1", summary: "no longer repeating")
+        notMasterAnymore.start = .init() |> \.dateTime .~ "2023-03-05T00:00:00+09:00"
+        notMasterAnymore.end = .init() |> \.dateTime .~ "2023-03-06T00:00:00+09:00"
+        let repo = PrivateStubRepository(customUpdateEventOriginStubbing: notMasterAnymore)
+        let usecase = makeUsecase(accounts: ["account@google.com"], defaultRepo: repo)
+        var params = GoogleCalendar.EventEditParams()
+        params.recurrence = []
+
+        // when
+        _ = try await usecase.updateEvent(
+            "cal1", "series1", accountId: "account@google.com",
+            at: TimeZone(identifier: "Asia/Seoul")!, params: params
+        )
+        try await Task.sleep(for: .milliseconds(100))
+
+        // then — 본체가 eventId 키에 갱신되어 반영된다
+        let cached = stubStore.value(
+            [String: GoogleCalendar.Event].self, key: ShareDataKeys.googleCalendarEvents.rawValue
+        )
+        #expect(cached?["series1"]?.name == "no longer repeating")
+    }
+
+    @Test func updateEvent_whenRecurrenceRemoved_removesStaleInstancesFromCache() async throws {
+        // given — 기존에 펼쳐진 반복 인스턴스들이 series1_* 로 캐시돼 있다
+        var notMasterAnymore = GoogleCalendar.EventOrigin(id: "series1", summary: "no longer repeating")
+        notMasterAnymore.start = .init() |> \.dateTime .~ "2023-03-05T00:00:00+09:00"
+        notMasterAnymore.end = .init() |> \.dateTime .~ "2023-03-06T00:00:00+09:00"
+        let repo = PrivateStubRepository(customUpdateEventOriginStubbing: notMasterAnymore)
+        let usecase = makeUsecase(accounts: ["account@google.com"], defaultRepo: repo)
+        stubStore.put(
+            [String: GoogleCalendar.Event].self,
+            key: ShareDataKeys.googleCalendarEvents.rawValue,
+            ["series1_0": self.dummyEvent("series1_0"), "series1_1": self.dummyEvent("series1_1")]
+        )
+        var params = GoogleCalendar.EventEditParams()
+        params.recurrence = []
+
+        // when
+        _ = try await usecase.updateEvent(
+            "cal1", "series1", accountId: "account@google.com",
+            at: TimeZone(identifier: "Asia/Seoul")!, params: params
+        )
+        try await Task.sleep(for: .milliseconds(100))
+
+        // then — 걷힌 series1_* 옛 인스턴스는 사라지고 본체만 남는다
+        let cached = stubStore.value(
+            [String: GoogleCalendar.Event].self, key: ShareDataKeys.googleCalendarEvents.rawValue
+        )
+        #expect(cached?["series1_0"] == nil)
+        #expect(cached?["series1_1"] == nil)
+        #expect(cached?["series1"]?.name == "no longer repeating")
     }
 
     private func dummyEvent(_ eventId: String) -> GoogleCalendar.Event {

--- a/Presentations/EventDetailScene/Sources/EventDetailRouter.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailRouter.swift
@@ -114,6 +114,7 @@ extension EventDetailRouter {
             let next = self.selectRepeatOptionSceneBuilder.makeSelectEventRepeatOptionScene(
                 selectTime: selectTime,
                 previousSelected: initalOption,
+                rruleRepresentableOnly: false,
                 listener: listener
             )
             self.currentScene?.present(next, animated: true)

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailBuilderImple.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailBuilderImple.swift
@@ -50,7 +50,13 @@ extension GoogleCalendarEventDetailSceneBuilerImple: GoogleCalendarEventDetailSc
             viewAppearance: self.viewAppearance
         )
 
-        let router = GoogleCalendarEventDetailRouter()
+        let selectRepeatOptionSceneBuilder = SelectEventRepeatOptionSceneBuilerImple(
+            usecaseFactory: self.usecaseFactory,
+            viewAppearance: self.viewAppearance
+        )
+        let router = GoogleCalendarEventDetailRouter(
+            selectRepeatOptionSceneBuilder: selectRepeatOptionSceneBuilder
+        )
         router.scene = viewController
         viewModel.router = router
         viewController.router = router

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailRouter.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailRouter.swift
@@ -9,14 +9,49 @@
 //
 
 import UIKit
+import Domain
 import Scenes
 import CommonPresentation
 
 
 // MARK: - Routing
 
-protocol GoogleCalendarEventDetailRouting: Routing, Sendable { }
+protocol GoogleCalendarEventDetailRouting: Routing, Sendable {
+
+    func routeToEventRepeatOptionSelect(
+        selectTime: Date,
+        previousSelected repeating: EventRepeating?,
+        listener: (any SelectEventRepeatOptionSceneListener)?
+    )
+}
 
 // MARK: - Router
 
-final class GoogleCalendarEventDetailRouter: BaseRouterImple, GoogleCalendarEventDetailRouting, @unchecked Sendable { }
+final class GoogleCalendarEventDetailRouter: BaseRouterImple, GoogleCalendarEventDetailRouting, @unchecked Sendable {
+
+    private let selectRepeatOptionSceneBuilder: any SelectEventRepeatOptionSceneBuiler
+
+    init(selectRepeatOptionSceneBuilder: any SelectEventRepeatOptionSceneBuiler) {
+        self.selectRepeatOptionSceneBuilder = selectRepeatOptionSceneBuilder
+    }
+}
+
+
+extension GoogleCalendarEventDetailRouter {
+
+    func routeToEventRepeatOptionSelect(
+        selectTime: Date,
+        previousSelected repeating: EventRepeating?,
+        listener: (any SelectEventRepeatOptionSceneListener)?
+    ) {
+        Task { @MainActor in
+            let next = self.selectRepeatOptionSceneBuilder.makeSelectEventRepeatOptionScene(
+                selectTime: selectTime,
+                previousSelected: repeating,
+                rruleRepresentableOnly: true,
+                listener: listener
+            )
+            self.scene?.present(next, animated: true)
+        }
+    }
+}

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailView.swift
@@ -32,7 +32,7 @@ import CommonPresentation
     var eventName: String = ""
     var timeText: SelectedTime?
     var ddayText: String?
-    var repeatOptionText: String?
+    var repeatOptionText: String = ""
     var calendarModel: GoogleCalendarModel?
     var location: String = ""
     var memo: String = ""
@@ -190,6 +190,7 @@ final class GoogleCalendarEventDetailViewEventHandler: Observable {
     var save: () -> Void = { }
     var remove: () -> Void = { }
     var selectNotEditableField: () -> Void = { }
+    var selectRepeatOption: () -> Void = { }
     var startEditDescription: () -> Void = { }
 
     func bind(_ viewModel: any GoogleCalendarEventDetailViewModel) {
@@ -210,6 +211,7 @@ final class GoogleCalendarEventDetailViewEventHandler: Observable {
         save = viewModel.save
         remove = viewModel.remove
         selectNotEditableField = viewModel.selectNotEditableField
+        selectRepeatOption = viewModel.selectRepeatOption
         startEditDescription = viewModel.startEditDescription
     }
 }
@@ -282,9 +284,7 @@ struct GoogleCalendarEventDetailView: View {
                         if let dday = self.state.ddayText {
                             self.ddayView(dday)
                         }
-                        if let repeatOption = self.state.repeatOptionText {
-                            self.repeatOptionText(repeatOption)
-                        }
+                        self.repeatOptionText(state.repeatOptionText)
                     }
 
                     self.colorSelectView
@@ -459,7 +459,7 @@ struct GoogleCalendarEventDetailView: View {
         }
         .padding(.leading, spacing: .indent)
         .onTapGesture {
-            eventHandlers.selectNotEditableField()
+            eventHandlers.selectRepeatOption()
         }
     }
 

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
@@ -139,6 +139,7 @@ protocol GoogleCalendarEventDetailViewModel: AnyObject, Sendable, GoogleCalendar
     func save()
     func remove()
     func selectNotEditableField()
+    func selectRepeatOption()
     func startEditDescription()
 
     // presenter
@@ -149,7 +150,7 @@ protocol GoogleCalendarEventDetailViewModel: AnyObject, Sendable, GoogleCalendar
     var eventName: AnyPublisher<String, Never> { get }
     var timeText: AnyPublisher<SelectedTime?, Never> { get }
     var ddayText: AnyPublisher<String, Never> { get }
-    var repeatOption: AnyPublisher<String?, Never> { get }
+    var repeatOption: AnyPublisher<String, Never> { get }
     var calendarModel: AnyPublisher<GoogleCalendarModel?, Never> { get }
     var location: AnyPublisher<String?, Never> { get }
     var conferenceModel: AnyPublisher<ConferenceModel?, Never> { get }
@@ -171,6 +172,7 @@ private struct EditableFields: Equatable {
     var location: String?
     var memo: String?
     var colorId: String?
+    var repeating: EventRepeating?
 }
 
 
@@ -290,7 +292,8 @@ extension GoogleCalendarEventDetailViewModelImple {
             time: event.selectedTime(timeZone),
             location: event.location,
             memo: event.description,
-            colorId: event.colorId
+            colorId: event.colorId,
+            repeating: event.editableRepeating(timeZone)
         )
         self.subject.fields.send(.init(origin: fields))
     }
@@ -321,6 +324,41 @@ extension GoogleCalendarEventDetailViewModelImple {
 
     func selectNotEditableField() {
         self.router?.showToast("eventDetail::gogoleEvent::notEditableField::message".localized())
+    }
+
+    func selectRepeatOption() {
+        guard self.subject.writePermission.value != .readOnlyCalendar else { return }
+        guard !self.subject.isSaving.value else { return }
+        guard let origin = self.subject.origin.value,
+              let timeZone = self.subject.timeZone.value,
+              let fields = self.subject.fields.value
+        else { return }
+
+        guard origin.isRepeatLocked(timeZone) == false else {
+            self.selectNotEditableField()
+            return
+        }
+
+        let selectTime = fields.current.time?.startDate ?? Date()
+        self.router?.routeToEventRepeatOptionSelect(
+            selectTime: selectTime,
+            previousSelected: fields.current.repeating,
+            listener: self
+        )
+    }
+}
+
+
+// MARK: - GoogleCalendarEventDetailViewModelImple SelectEventRepeatOptionSceneListener
+
+extension GoogleCalendarEventDetailViewModelImple: SelectEventRepeatOptionSceneListener {
+
+    func selectEventRepeatOption(didSelect repeating: EventRepeatingTimeSelectResult) {
+        self.updateCurrentFields { $0 |> \.repeating .~ repeating.repeating }
+    }
+
+    func selectEventRepeatOptionNotRepeat() {
+        self.updateCurrentFields { $0 |> \.repeating .~ nil }
     }
 }
 
@@ -425,8 +463,14 @@ extension GoogleCalendarEventDetailViewModelImple {
     private func saveChanges() {
         guard let origin = self.subject.origin.value,
               let timeZone = self.subject.timeZone.value,
-              let params = self.editParams(timeZone), !params.isEmpty
+              let params = self.editParams(origin, timeZone), !params.isEmpty
         else {
+            return
+        }
+
+        // 반복 규칙은 시리즈 마스터의 속성이라 구글이 인스턴스 patch 의 recurrence 를 거부한다 — 범위 선택 없이 마스터를 대상으로 저장
+        guard params.recurrence == nil else {
+            self.updateEvent(origin.recurringEventId ?? origin.id, params, timeZone)
             return
         }
 
@@ -437,7 +481,9 @@ extension GoogleCalendarEventDetailViewModelImple {
         self.showUpdateScopeActionSheet(origin.id, recurringEventId, params, timeZone)
     }
 
-    private func editParams(_ timeZone: TimeZone) -> GoogleCalendar.EventEditParams? {
+    private func editParams(
+        _ origin: GoogleCalendar.EventOrigin, _ timeZone: TimeZone
+    ) -> GoogleCalendar.EventEditParams? {
         guard let fields = self.subject.fields.value, fields.isChanged else { return nil }
 
         var params = GoogleCalendar.EventEditParams()
@@ -457,6 +503,10 @@ extension GoogleCalendarEventDetailViewModelImple {
            let pair = fields.current.time?.asGoogleEventTimePair(timeZone) {
             params.start = pair.start
             params.end = pair.end
+        }
+        if fields.origin.repeating != fields.current.repeating {
+            let newRRuleText = fields.current.repeating?.asRRuleText(timeZone)
+            params.recurrence = (origin.recurrence ?? []).replacingRRuleLine(newRRuleText)
         }
         return params
     }
@@ -678,29 +728,36 @@ extension GoogleCalendarEventDetailViewModelImple {
             .eraseToAnyPublisher()
     }
     
-    var repeatOption: AnyPublisher<String?, Never> {
-        
-        let transform: (GoogleCalendar.EventOrigin, TimeZone) -> String? = { origin, timeZone in
-            guard let recurrence = origin.recurrence?.first,
-                  let rrule = RRuleParser.parse(recurrence)
-            else { return nil }
-            
-            let frequencyText = rrule.frequencyText()
-            if let endOptionText = rrule.endOptionText(timeZone) {
-                return "\(frequencyText)\n\(endOptionText)"
+    var repeatOption: AnyPublisher<String, Never> {
+
+        let transform: (GoogleCalendar.EventOrigin, TimeZone, EventRepeating?) -> String = { origin, timeZone, currentRepeating in
+            guard origin.isRepeatLocked(timeZone) == false else {
+                // rruleLine 이 있는데 파싱까지 실패하면(RRuleParser 미지원 FREQ 등) "반복 없음"이 아니라 원본 규칙을 보여준다
+                guard let rruleLine = origin.rruleLines.first else {
+                    return R.String.EventDetail.Repeating.notRepeatingTitle
+                }
+                guard let rrule = RRuleParser.parse(rruleLine) else {
+                    return rruleLine.strippingRRulePrefix
+                }
+                return rrule.appendingEndOptionText(to: rrule.frequencyText(), timeZone)
             }
-            return frequencyText
+
+            guard let repeating = currentRepeating else {
+                return R.String.EventDetail.Repeating.notRepeatingTitle
+            }
+            return repeating.repeatOptionDisplayText(timeZone)
         }
-        
-        return Publishers.CombineLatest(
+
+        return Publishers.CombineLatest3(
             self.subject.origin.compactMap { $0 },
-            self.subject.timeZone.compactMap { $0 }
+            self.subject.timeZone.compactMap { $0 },
+            self.subject.fields.compactMap { $0 }.map { $0.current.repeating }
         )
         .map(transform)
         .removeDuplicates()
         .eraseToAnyPublisher()
     }
-    
+
     var conferenceModel: AnyPublisher<ConferenceModel?, Never> {
         let transform: (GoogleCalendar.EventOrigin.ConferenceData?) -> ConferenceModel?
         transform = { conference in
@@ -835,6 +892,10 @@ private extension String {
             options: [.regularExpression, .caseInsensitive]
         ) != nil
     }
+
+    var strippingRRulePrefix: String {
+        self.hasPrefix("RRULE:") ? String(self.dropFirst("RRULE:".count)) : self
+    }
 }
 
 
@@ -893,6 +954,28 @@ private extension GoogleCalendar.EventOrigin {
             return nil
         }
     }
+
+    var rruleLines: [String] {
+        self.recurrence?.filter { $0.hasPrefix("RRULE:") } ?? []
+    }
+
+    // 저장이 규칙 배열의 모든 RRULE 줄을 한 줄로 통째 치환한다 — 복수 규칙은 편집을 열면 나머지가 조용히 지워지므로 왕복 대상에서 뺀다
+    var soleRRuleLine: String? {
+        self.rruleLines.count == 1 ? self.rruleLines.first : nil
+    }
+
+    func editableRepeating(_ timeZone: TimeZone) -> EventRepeating? {
+        guard let startTime = self.selectedTime(timeZone)?.startDate.timeIntervalSince1970,
+              let rruleLine = self.soleRRuleLine,
+              let rrule = RRuleParser.parse(rruleLine)
+        else { return nil }
+        return rrule.asEventRepeating(startTime: startTime, timeZone: timeZone)
+    }
+
+    // 규칙 텍스트는 있는데 앱 옵션으로 왕복 못 시키면(RRule+EventRepeating.swift 의 nil) 편집을 잠근다
+    func isRepeatLocked(_ timeZone: TimeZone) -> Bool {
+        self.rruleLines.isEmpty == false && self.editableRepeating(timeZone) == nil
+    }
 }
 
 private extension SelectedTime {
@@ -939,6 +1022,28 @@ private extension SelectedTime {
         }
     }
 }
+
+// MARK: - repeatOption text composition
+
+private extension EventRepeating {
+
+    func repeatOptionDisplayText(_ timeZone: TimeZone) -> String {
+        guard let rruleLine = self.asRRuleText(timeZone), let rrule = RRuleParser.parse(rruleLine)
+        else { return R.String.EventDetail.Repeating.notRepeatingTitle }
+        let frequencyText = EventRepeatingTimeSelectResult(self, timeZone: timeZone)?.text
+            ?? rrule.frequencyText()
+        return rrule.appendingEndOptionText(to: frequencyText, timeZone)
+    }
+}
+
+private extension RRule {
+
+    func appendingEndOptionText(to frequencyText: String, _ timeZone: TimeZone) -> String {
+        guard let endOptionText = self.endOptionText(timeZone) else { return frequencyText }
+        return "\(frequencyText)\n\(endOptionText)"
+    }
+}
+
 
 private extension GoogleCalendar.EventOrigin.GoogleEventTime {
 

--- a/Presentations/EventDetailScene/Sources/Selections/SelectEventRepeatOption/SelectEventRepeatOptionBuilderImple.swift
+++ b/Presentations/EventDetailScene/Sources/Selections/SelectEventRepeatOption/SelectEventRepeatOptionBuilderImple.swift
@@ -36,12 +36,14 @@ extension SelectEventRepeatOptionSceneBuilerImple: SelectEventRepeatOptionSceneB
     func makeSelectEventRepeatOptionScene(
         selectTime: Date,
         previousSelected repeating: EventRepeating?,
+        rruleRepresentableOnly: Bool,
         listener: (any SelectEventRepeatOptionSceneListener)?
     ) -> any SelectEventRepeatOptionScene {
-        
+
         let viewModel = SelectEventRepeatOptionViewModelImple(
             selectTime: selectTime,
             previousSelected: repeating,
+            rruleRepresentableOnly: rruleRepresentableOnly,
             calendarSettingUsecase: self.usecaseFactory.makeCalendarSettingUsecase()
         )
         

--- a/Presentations/EventDetailScene/Sources/Selections/SelectEventRepeatOption/SelectEventRepeatOptionScene+Builder.swift
+++ b/Presentations/EventDetailScene/Sources/Selections/SelectEventRepeatOption/SelectEventRepeatOptionScene+Builder.swift
@@ -72,6 +72,7 @@ protocol SelectEventRepeatOptionSceneBuiler: AnyObject {
     func makeSelectEventRepeatOptionScene(
         selectTime: Date,
         previousSelected repeating: EventRepeating?,
+        rruleRepresentableOnly: Bool,
         listener: (any SelectEventRepeatOptionSceneListener)?
     ) -> any SelectEventRepeatOptionScene
 }

--- a/Presentations/EventDetailScene/Sources/Selections/SelectEventRepeatOption/SelectEventRepeatOptionViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/Selections/SelectEventRepeatOption/SelectEventRepeatOptionViewModel.swift
@@ -19,57 +19,6 @@ import CommonPresentation
 
 private typealias Options = EventRepeatingOptions
 
-private enum SupportedRepeatOptions {
-
-    static func supports(from startTime: Date, timeZone: TimeZone) -> [[any EventRepeatingOption]] {
-        let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
-        let month = calendar.component(.month, from: startTime)
-        let startDay = calendar.component(.day, from: startTime)
-        guard let weekday = DayOfWeeks(rawValue: calendar.component(.weekday, from: startTime))
-        else { return [] }
-        
-        let section1: [any EventRepeatingOption] = [
-            EventRepeatingOptions.EveryDay(),
-            EventRepeatingOptions.EveryWeek(timeZone)
-                |> \.dayOfWeeks .~ [weekday],
-            EventRepeatingOptions.EveryWeek(timeZone)
-                |> \.interval .~ 2
-                |> \.dayOfWeeks .~ [weekday],
-            EventRepeatingOptions.EveryWeek(timeZone)
-                |> \.interval .~ 3
-                |> \.dayOfWeeks .~ [weekday],
-            EventRepeatingOptions.EveryWeek(timeZone)
-                |> \.interval .~ 4
-                |> \.dayOfWeeks .~ [weekday],
-            EventRepeatingOptions.EveryMonth(timeZone: timeZone)
-                |> \.selection .~ .days([startDay]),
-            EventRepeatingOptions.EveryYearSomeDay(timeZone, month, startDay),
-            EventRepeatingOptions.LunarCalendarEveryYear(timeZone, month, startDay)
-        ]
-        
-        let everyWeekDays: [any EventRepeatingOption] = if !calendar.isDateInWeekend(startTime) {
-            [Options.EveryWeek(timeZone) |> \.dayOfWeeks .~ [.monday, .tuesday, .wednesday, .thursday, .friday]]
-        } else { [] }
-        
-        let section2: [any EventRepeatingOption] = everyWeekDays + [
-            EventRepeatingOptions.EveryMonth(timeZone: timeZone)
-            |> \.selection .~ .week([.last], [.sunday, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday]),
-            EventRepeatingOptions.EveryMonth(timeZone: timeZone)
-            |> \.selection .~ .week([.seq(1)], [weekday]),
-            EventRepeatingOptions.EveryMonth(timeZone: timeZone)
-            |> \.selection .~ .week([.seq(2)], [weekday]),
-            EventRepeatingOptions.EveryMonth(timeZone: timeZone)
-            |> \.selection .~ .week([.seq(3)], [weekday]),
-            EventRepeatingOptions.EveryMonth(timeZone: timeZone)
-            |> \.selection .~ .week([.seq(4)], [weekday]),
-            EventRepeatingOptions.EveryMonth(timeZone: timeZone)
-            |> \.selection .~ .week([.last], [weekday])
-        ]
-        
-        return [section1, section2]
-    }
-}
-
 struct SelectRepeatingOptionModel: Equatable, Identifiable {
     
     let id: String
@@ -166,18 +115,21 @@ final class SelectEventRepeatOptionViewModelImple: SelectEventRepeatOptionViewMo
     
     private let selectTime: Date
     private let previousSelectOption: EventRepeating?
+    private let rruleRepresentableOnly: Bool
     private let calendarSettingUsecase: any CalendarSettingUsecase
-    
+
     var listener: (any SelectEventRepeatOptionSceneListener)?
     var router: (any SelectEventRepeatOptionRouting)?
-    
+
     init(
         selectTime: Date,
         previousSelected repeating: EventRepeating?,
+        rruleRepresentableOnly: Bool,
         calendarSettingUsecase: any CalendarSettingUsecase
     ) {
         self.selectTime = selectTime
         self.previousSelectOption = repeating
+        self.rruleRepresentableOnly = rruleRepresentableOnly
         self.calendarSettingUsecase = calendarSettingUsecase
     }
     
@@ -244,7 +196,7 @@ extension SelectEventRepeatOptionViewModelImple {
         let previousOptionModel = previousSelectOption.flatMap {
             SelectRepeatingOptionModel($0.repeatOption, self.selectTime, timeZone)
         }
-        let supportOptionModels = SupportedRepeatOptions.supports(from: self.selectTime, timeZone: timeZone)
+        let supportOptionModels = self.supportedRepeatOptions(timeZone)
             .map { options in
                 options.compactMap { SelectRepeatingOptionModel($0, self.selectTime, timeZone) }
             }
@@ -420,5 +372,62 @@ extension SelectEventRepeatOptionViewModelImple {
         .map(transform)
         .removeDuplicates()
         .eraseToAnyPublisher()
+    }
+}
+
+
+// MARK: - 지원 반복 옵션 목록
+
+private extension SelectEventRepeatOptionViewModelImple {
+
+    func supportedRepeatOptions(_ timeZone: TimeZone) -> [[any EventRepeatingOption]] {
+        let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
+        let month = calendar.component(.month, from: self.selectTime)
+        let startDay = calendar.component(.day, from: self.selectTime)
+        guard let weekday = DayOfWeeks(rawValue: calendar.component(.weekday, from: self.selectTime))
+        else { return [] }
+
+        let lunarOption: [any EventRepeatingOption] = self.rruleRepresentableOnly
+            ? []
+            : [EventRepeatingOptions.LunarCalendarEveryYear(timeZone, month, startDay)]
+
+        let section1: [any EventRepeatingOption] = [
+            EventRepeatingOptions.EveryDay(),
+            EventRepeatingOptions.EveryWeek(timeZone)
+                |> \.dayOfWeeks .~ [weekday],
+            EventRepeatingOptions.EveryWeek(timeZone)
+                |> \.interval .~ 2
+                |> \.dayOfWeeks .~ [weekday],
+            EventRepeatingOptions.EveryWeek(timeZone)
+                |> \.interval .~ 3
+                |> \.dayOfWeeks .~ [weekday],
+            EventRepeatingOptions.EveryWeek(timeZone)
+                |> \.interval .~ 4
+                |> \.dayOfWeeks .~ [weekday],
+            EventRepeatingOptions.EveryMonth(timeZone: timeZone)
+                |> \.selection .~ .days([startDay]),
+            EventRepeatingOptions.EveryYearSomeDay(timeZone, month, startDay)
+        ] + lunarOption
+
+        let everyWeekDays: [any EventRepeatingOption] = if !calendar.isDateInWeekend(self.selectTime) {
+            [Options.EveryWeek(timeZone) |> \.dayOfWeeks .~ [.monday, .tuesday, .wednesday, .thursday, .friday]]
+        } else { [] }
+        
+        let section2: [any EventRepeatingOption] = everyWeekDays + [
+            EventRepeatingOptions.EveryMonth(timeZone: timeZone)
+            |> \.selection .~ .week([.last], [.sunday, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday]),
+            EventRepeatingOptions.EveryMonth(timeZone: timeZone)
+            |> \.selection .~ .week([.seq(1)], [weekday]),
+            EventRepeatingOptions.EveryMonth(timeZone: timeZone)
+            |> \.selection .~ .week([.seq(2)], [weekday]),
+            EventRepeatingOptions.EveryMonth(timeZone: timeZone)
+            |> \.selection .~ .week([.seq(3)], [weekday]),
+            EventRepeatingOptions.EveryMonth(timeZone: timeZone)
+            |> \.selection .~ .week([.seq(4)], [weekday]),
+            EventRepeatingOptions.EveryMonth(timeZone: timeZone)
+            |> \.selection .~ .week([.last], [weekday])
+        ]
+        
+        return [section1, section2]
     }
 }

--- a/Presentations/EventDetailScene/Tests/GoogleCalendarEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/GoogleCalendarEventDetailViewModelImpleTests.swift
@@ -28,6 +28,7 @@ final class GoogleCalendarEventDetailViewModelImpleTests: PublisherWaitable {
 
     private func makeViewModel(
         recurrence: String? = nil,
+        recurrenceLines: [String]? = nil,
         isCanceled: Bool = false,
         customAttendees: [GoogleCalendar.EventOrigin.Attendee]? = nil,
         writePermission: GoogleCalendar.EventWritePermission? = .writable,
@@ -53,7 +54,7 @@ final class GoogleCalendarEventDetailViewModelImpleTests: PublisherWaitable {
         calendarUsecase.additionalStubbing = { stub in
             stub
                 |> \.attendees .~ (customAttendees ?? stub.attendees)
-                |> \.recurrence .~ (recurrence.map { [$0] })
+                |> \.recurrence .~ (recurrenceLines ?? recurrence.map { [$0] })
                 |> \.status .~ (isCanceled ? .cancelled : .confirmed)
                 |> \.recurringEventId .~ recurringEventId
                 |> \.htmlLink .~ htmlLink
@@ -221,19 +222,19 @@ extension GoogleCalendarEventDetailViewModelImpleTests {
         #expect(location == "location")
     }
     
-    private func expectRecurrenceText(_ recurrence: String?) -> String? {
+    private func expectRecurrenceText(_ recurrence: String?) -> String {
         switch recurrence {
-        case .none: return nil
+        case .none: return "No repeats"
         case "RRULE:FREQ=DAILY": return "Every day"
         case "RRULE:FREQ=DAILY;INTERVAL=5": return "Every 5 Days"
-        case "RRULE:FREQ=WEEKLY;BYDAY=TU": return "Every Week TUE"
-        case "RRULE:FREQ=WEEKLY;INTERVAL=3;BYDAY=TU": return "Every 3 Weeks TUE"
-        case "RRULE:FREQ=MONTHLY;BYDAY=-1WE": return "Every Month Last WED"
+        case "RRULE:FREQ=WEEKLY;BYDAY=TU": return "Every Tuesday"
+        case "RRULE:FREQ=WEEKLY;INTERVAL=3;BYDAY=TU": return "Every 3 Weeks Tuesday"
+        case "RRULE:FREQ=MONTHLY;BYDAY=-1WE": return "The last Wednesday of every month"
         case "RRULE:FREQ=MONTHLY;INTERVAL=3;BYDAY=2WE": return "Every 3 Months 2nd WED"
         case "RRULE:FREQ=MONTHLY;INTERVAL=2": return "Every 2 Months"
         case "RRULE:FREQ=YEARLY": return "Every Year"
         case "RRULE:FREQ=YEARLY;INTERVAL=3": return "Every 3 Years"
-        case "RRULE:FREQ=WEEKLY;BYDAY=FR,MO,TH,TU,WE": return "Every Week MON,TUE,WED,THU,FRI"
+        case "RRULE:FREQ=WEEKLY;BYDAY=FR,MO,TH,TU,WE": return "Every Weekday"
         case "RRULE:FREQ=WEEKLY;WKST=MO;UNTIL=20250816T145959Z;BYDAY=SA": return "Every Week SAT\nuntil Aug 16, 2025"
         case "RRULE:FREQ=DAILY;COUNT=3": return "Every day\n3 time(s)"
         default: return ""
@@ -1403,6 +1404,222 @@ extension GoogleCalendarEventDetailViewModelImpleTests {
 }
 
 
+// MARK: - 반복 행 표시
+
+extension GoogleCalendarEventDetailViewModelImpleTests {
+
+    @Test func viewModel_whenNoRecurrence_providesNoRepeatText() async throws {
+        // given
+        let viewModel = self.makeViewModel(recurrence: nil)
+
+        // when
+        let text = try await self.firstOutput(expectConfirm("반복 없음 텍스트"), for: viewModel.repeatOption) {
+            viewModel.refresh()
+        }
+
+        // then
+        #expect(text == R.String.EventDetail.Repeating.notRepeatingTitle)
+    }
+
+    @Test func viewModel_whenRuleIsNotMappable_stillProvidesRuleText() async throws {
+        // given — BYSETPOS 는 unsupportedKeys 로 잡혀 매핑이 실패하지만, 원본 규칙 텍스트는 그대로 보여야 한다
+        let rruleText = "RRULE:FREQ=MONTHLY;BYSETPOS=-1;BYDAY=MO"
+        let viewModel = self.makeViewModel(recurrence: rruleText)
+
+        // when
+        let text = try await self.firstOutput(expectConfirm("잠긴 규칙 텍스트"), for: viewModel.repeatOption) {
+            viewModel.refresh()
+        }
+
+        // then
+        let expected = RRuleParser.parse(rruleText)!.frequencyText()
+        #expect(text == expected)
+    }
+
+    @Test func viewModel_whenRuleIsUnparsable_doesNotSayNoRepeat() async throws {
+        // given — HOURLY 는 RRuleParser.Frequency 자체에 없어 parse 가 nil 을 낸다
+        let rruleText = "RRULE:FREQ=HOURLY;INTERVAL=2"
+        let viewModel = self.makeViewModel(recurrence: rruleText)
+
+        // when
+        let text = try await self.firstOutput(expectConfirm("파싱 불가 규칙 텍스트"), for: viewModel.repeatOption) {
+            viewModel.refresh()
+        }
+
+        // then — "반복 없음"이 아니라 원본 규칙 텍스트를 그대로 보여준다
+        #expect(text != R.String.EventDetail.Repeating.notRepeatingTitle)
+        #expect(text == "FREQ=HOURLY;INTERVAL=2")
+    }
+}
+
+
+// MARK: - 반복 편집 진입
+
+extension GoogleCalendarEventDetailViewModelImpleTests {
+
+    @Test func viewModel_whenRuleIsNotMappable_selectRepeatOptionShowsToast() async throws {
+        // given
+        let viewModel = self.makeViewModel(recurrence: "RRULE:FREQ=MONTHLY;BYSETPOS=-1;BYDAY=MO")
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+
+        // when
+        viewModel.selectRepeatOption()
+
+        // then
+        #expect(self.spyRouter.didShowToastWithMessage == "eventDetail::gogoleEvent::notEditableField::message".localized())
+        #expect(self.spyRouter.didRouteToRepeatOptionSelectWith == nil)
+    }
+
+    @Test func viewModel_whenRuleIsMappable_selectRepeatOptionRoutes() async throws {
+        // given
+        let viewModel = self.makeViewModel(recurrence: "RRULE:FREQ=DAILY;INTERVAL=5")
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+
+        // when
+        viewModel.selectRepeatOption()
+
+        // then
+        #expect(self.spyRouter.didRouteToRepeatOptionSelectWith != nil)
+        #expect(self.spyRouter.didShowToastWithMessage == nil)
+    }
+
+    @Test func viewModel_whenNoRecurrence_selectRepeatOptionRoutes() async throws {
+        // given
+        let viewModel = self.makeViewModel(recurrence: nil)
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+
+        // when
+        viewModel.selectRepeatOption()
+
+        // then
+        #expect(self.spyRouter.didRouteToRepeatOptionSelectWith != nil)
+        #expect(self.spyRouter.didRouteToRepeatOptionSelectWith?.previousSelected == nil)
+    }
+
+    @Test func viewModel_whenMultipleRules_selectRepeatOptionShowsToast() async throws {
+        // given - 저장이 RRULE 줄을 통째 치환하므로 복수 규칙은 편집을 열면 안 된다
+        let viewModel = self.makeViewModel(
+            recurrenceLines: ["RRULE:FREQ=DAILY;INTERVAL=5", "RRULE:FREQ=WEEKLY;BYDAY=SA"]
+        )
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+
+        // when
+        viewModel.selectRepeatOption()
+
+        // then
+        #expect(self.spyRouter.didShowToastWithMessage == "eventDetail::gogoleEvent::notEditableField::message".localized())
+        #expect(self.spyRouter.didRouteToRepeatOptionSelectWith == nil)
+    }
+
+    @Test func selectRepeatOption_whenReadOnlyCalendar_doesNothing() async throws {
+        // given
+        let viewModel = self.makeViewModel(
+            recurrence: "RRULE:FREQ=DAILY;INTERVAL=5", writePermission: .readOnlyCalendar
+        )
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+
+        // when
+        viewModel.selectRepeatOption()
+
+        // then
+        #expect(self.spyRouter.didRouteToRepeatOptionSelectWith == nil)
+        #expect(self.spyRouter.didShowToastWithMessage == nil)
+    }
+}
+
+
+// MARK: - 반복 규칙 저장
+
+extension GoogleCalendarEventDetailViewModelImpleTests {
+
+    @Test func viewModel_whenRepeatChanged_sendsRecurrenceWithOtherLinesKept() async throws {
+        // given — 원본 recurrence 가 RRULE + EXDATE 두 줄
+        let viewModel = self.makeViewModel(recurrenceLines: [
+            "RRULE:FREQ=DAILY;INTERVAL=5",
+            "EXDATE;TZID=Asia/Seoul:20260101T090000"
+        ])
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+
+        // when
+        let newRepeating = EventRepeating(
+            repeatingStartTime: 1_748_400_000,
+            repeatOption: EventRepeatingOptions.EveryDay() |> \.interval .~ 3
+        )
+        viewModel.selectEventRepeatOption(didSelect: .init(text: "매 3일", repeating: newRepeating))
+        try await self.waitSaveCompleted { viewModel.save() }
+
+        // then
+        let recurrence = self.lastCalendarUsecase.didUpdateEventWith?.params.recurrence
+        #expect(recurrence?.count == 2)
+        #expect(recurrence?.last == "EXDATE;TZID=Asia/Seoul:20260101T090000")
+        #expect(recurrence?.first?.hasPrefix("RRULE:FREQ=DAILY;INTERVAL=3") == true)
+    }
+
+    @Test func viewModel_whenRepeatRemoved_sendsRecurrenceWithoutRRule() async throws {
+        // given
+        let viewModel = self.makeViewModel(recurrence: "RRULE:FREQ=DAILY;INTERVAL=5")
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+
+        // when
+        viewModel.selectEventRepeatOptionNotRepeat()
+        try await self.waitSaveCompleted { viewModel.save() }
+
+        // then
+        let recurrence = self.lastCalendarUsecase.didUpdateEventWith?.params.recurrence
+        #expect(recurrence == [])
+    }
+
+    @Test func viewModel_whenRepeatChanged_savesToMasterWithoutScopeSheet() async throws {
+        // given — 반복 인스턴스 상세(recurringEventId 존재)에서 규칙을 바꾸는 상황
+        let viewModel = self.makeViewModel(
+            recurrence: "RRULE:FREQ=DAILY;INTERVAL=5", recurringEventId: "series_id"
+        )
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+
+        // when
+        viewModel.selectEventRepeatOptionNotRepeat()
+        try await self.waitSaveCompleted { viewModel.save() }
+
+        // then
+        #expect(self.spyRouter.didShowActionSheetWith == nil)
+        #expect(self.lastCalendarUsecase.didUpdateEventWith?.eventId == "series_id")
+    }
+
+    @Test func viewModel_whenOnlyNameChanged_showsScopeSheet() async throws {
+        // given
+        let viewModel = self.makeViewModel(recurringEventId: "series_id")
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+
+        // when
+        viewModel.enter(name: "new name")
+        try await Task.sleep(for: .milliseconds(10))
+        viewModel.save()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        #expect(self.spyRouter.didShowActionSheetWith != nil)
+    }
+}
+
+
 private final class PrivateStubGoogleCalendarUsecase: StubGoogleCalendarUsecase, @unchecked Sendable {
 
     var additionalStubbing: ((GoogleCalendar.EventOrigin) -> GoogleCalendar.EventOrigin)?
@@ -1493,4 +1710,14 @@ private final class PrivateStubGoogleCalendarUsecase: StubGoogleCalendarUsecase,
     }
 }
 
-private final class SpyRouter: BaseSpyRouter, GoogleCalendarEventDetailRouting, @unchecked Sendable { }
+private final class SpyRouter: BaseSpyRouter, GoogleCalendarEventDetailRouting, @unchecked Sendable {
+
+    var didRouteToRepeatOptionSelectWith: (selectTime: Date, previousSelected: EventRepeating?)?
+    func routeToEventRepeatOptionSelect(
+        selectTime: Date,
+        previousSelected repeating: EventRepeating?,
+        listener: (any SelectEventRepeatOptionSceneListener)?
+    ) {
+        self.didRouteToRepeatOptionSelectWith = (selectTime, repeating)
+    }
+}

--- a/Presentations/EventDetailScene/Tests/SelectEventRepeatOptionViewModelTests.swift
+++ b/Presentations/EventDetailScene/Tests/SelectEventRepeatOptionViewModelTests.swift
@@ -42,14 +42,16 @@ class SelectEventRepeatOptionViewModelTests: BaseTestCase, PublisherWaitable {
     
     private func makeViewModel(
         previous: EventRepeating? = nil,
-        customSelectTime: Date? = nil
+        customSelectTime: Date? = nil,
+        rruleRepresentableOnly: Bool = false
     ) -> SelectEventRepeatOptionViewModelImple {
-        
+
         let settingUsecase = StubCalendarSettingUsecase()
         settingUsecase.selectTimeZone(self.timeZone)
         let viewModel = SelectEventRepeatOptionViewModelImple(
             selectTime: customSelectTime ?? self.someSundayStartTime,
             previousSelected: previous,
+            rruleRepresentableOnly: rruleRepresentableOnly,
             calendarSettingUsecase: settingUsecase
         )
         viewModel.router = self.spyRouter
@@ -239,6 +241,56 @@ extension SelectEventRepeatOptionViewModelTests {
         XCTAssertEqual(allItemCount, self.defaultOptionListTexts.flatMap { $0 }.count + 1)
     }
     
+    // rruleRepresentableOnly 인 경우 음력 옵션은 목록에서 빠진다
+    func testViewModel_whenRruleRepresentableOnly_excludesLunarOption() {
+        // given
+        let viewModel = self.makeViewModel(previous: nil, rruleRepresentableOnly: true)
+
+        // when
+        let options = self.waitFirstNotEmptyOptionList(viewModel)
+
+        // then
+        let lunarOptionText = "eventDetail.repeating.lunarCalendar_everyYear:title".localized()
+        XCTAssertFalse(options?.flatMap { $0 }.map { $0.text }.contains(lunarOptionText) ?? true)
+    }
+
+    // rruleRepresentableOnly 아닌 경우 음력 옵션은 목록에 그대로 노출
+    func testViewModel_whenNotRestricted_includesLunarOption() {
+        // given
+        let viewModel = self.makeViewModel(previous: nil, rruleRepresentableOnly: false)
+
+        // when
+        let options = self.waitFirstNotEmptyOptionList(viewModel)
+
+        // then
+        let lunarOptionText = "eventDetail.repeating.lunarCalendar_everyYear:title".localized()
+        XCTAssertTrue(options?.flatMap { $0 }.map { $0.text }.contains(lunarOptionText) ?? false)
+    }
+
+    // rruleRepresentableOnly 로 음력 옵션이 빠지더라도, 이전 선택값이 음력 옵션이면 목록 앞에 붙여 선택 상태로 유지
+    func testViewModel_whenPreviousOptionIsNotInSupports_showsItAsSelected() {
+        // given
+        let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ self.timeZone
+        let month = calendar.component(.month, from: self.defaultStartTime)
+        let day = calendar.component(.day, from: self.defaultStartTime)
+        let previous = EventRepeating(
+            repeatingStartTime: self.defaultStartTime.timeIntervalSince1970,
+            repeatOption: EventRepeatingOptions.LunarCalendarEveryYear(self.timeZone, month, day)
+        )
+        let viewModel = self.makeViewModel(previous: previous, rruleRepresentableOnly: true)
+        let options = self.waitFirstNotEmptyOptionList(viewModel)
+
+        // when
+        let expect = expectation(description: "이전 선택값이 목록에 없으면 선택 상태로 노출")
+        let id = self.waitFirstOutput(expect, for: viewModel.selectedOptionId)
+
+        // then
+        let lunarOptionText = "eventDetail.repeating.lunarCalendar_everyYear:title".localized()
+        let previousOptionInList = options?.flatMap { $0 }.first(where: { $0.text == lunarOptionText })
+        XCTAssertNotNil(previousOptionInList)
+        XCTAssertEqual(id, previousOptionInList?.id)
+    }
+
     // 반복 옵션 선택시에 선택된 이벤트 아이디 변경
     func testViewModel_whenSelectionIdChanged_updateSelectedId() {
         // given

--- a/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Google/GoogleCalendar+Mapping.swift
+++ b/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Google/GoogleCalendar+Mapping.swift
@@ -112,6 +112,7 @@ extension GoogleCalendar.EventEditParams {
         json["colorId"] = self.colorId
         json["start"] = self.start?.asJson()
         json["end"] = self.end?.asJson()
+        json["recurrence"] = self.recurrence
         return json
     }
 }

--- a/Repository/Tests/Event/ExternalCalendar/GoogleCalendarRepositoryImple+Tests.swift
+++ b/Repository/Tests/Event/ExternalCalendar/GoogleCalendarRepositoryImple+Tests.swift
@@ -757,6 +757,45 @@ extension GoogleCalendarRepositoryImple_Tests {
         }
     }
 
+    @Test func repository_updateEvent_sendsRecurrenceArray() async throws {
+        try await self.runTestWithOpenClose("test_google_event_update_recurrence_1") {
+            // given
+            let expect = self.expectConfirm("반복 규칙을 실은 patch 요청")
+            let repository = self.makeRepository()
+            let params = GoogleCalendar.EventEditParams()
+                |> \.recurrence .~ ["RRULE:FREQ=DAILY;COUNT=3", "EXDATE;TZID=Asia/Seoul:20260101T090000"]
+
+            // when
+            let _ = try await self.firstOutput(
+                expect, for: repository.updateEvent("c_id", "Asia/Seoul", "time_is_date", params)
+            )
+
+            // then
+            let requestedParams = try #require(self.stubRemote.didRequestedParams)
+            let recurrence = requestedParams["recurrence"] as? [String]
+            #expect(recurrence == ["RRULE:FREQ=DAILY;COUNT=3", "EXDATE;TZID=Asia/Seoul:20260101T090000"])
+        }
+    }
+
+    @Test func repository_updateEvent_whenRecurrenceIsNil_omitsKey() async throws {
+        try await self.runTestWithOpenClose("test_google_event_update_recurrence_2") {
+            // given
+            let expect = self.expectConfirm("반복을 안 건드리면 patch body 에 recurrence 키가 없다")
+            let repository = self.makeRepository()
+            let params = GoogleCalendar.EventEditParams()
+                |> \.summary .~ "updated summary"
+
+            // when
+            let _ = try await self.firstOutput(
+                expect, for: repository.updateEvent("c_id", "Asia/Seoul", "time_is_date", params)
+            )
+
+            // then
+            let requestedParams = try #require(self.stubRemote.didRequestedParams)
+            #expect(requestedParams["recurrence"] == nil)
+        }
+    }
+
     @Test func repository_updateEvent_whenResponseIsSeriesMaster_doesNotCacheAsInstanceDetail() async throws {
         try await self.runTestWithOpenClose("test_google_event_update_4") {
             // given — "전체 일정" 저장은 시리즈 마스터(recurringEventId 없음 + recurrence 있음)를 돌려준다

--- a/docs/spec/google-calendar.md
+++ b/docs/spec/google-calendar.md
@@ -6,7 +6,7 @@
 
 ## 1. 개요
 
-- 조회 + **기존 이벤트 편집·삭제** (이벤트 생성·반복 규칙 편집은 미지원 — #863)
+- 조회 + **기존 이벤트 편집·삭제** (이벤트 생성은 미지원 — #863)
 - **다중 계정** 동시 지원 (구글 계정 여러 개를 동시에 연동)
 - Google OAuth2 인증, Firebase GoogleSignIn SDK 사용
 - 연동 후 캘린더 목록/이벤트/색상 자동 동기화
@@ -346,7 +346,7 @@ activeCalendars() = 전체 캘린더 - offTagIds에 포함된 캘린더
 | 위치 | `location` | 가능 |
 | 설명 | `description` | 가능 |
 | 색상 | calendarId → 캘린더 색상 + eventColorId 오버라이드 | 가능 |
-| 반복 규칙 | `recurrence` | 불가 (탭 시 토스트) |
+| 반복 규칙 | `recurrence` | 가능 (앱 반복 옵션으로 왕복 못 시키는 규칙·복수 RRULE 줄은 잠금 → 탭 시 토스트) |
 | 참석자 목록 | `attendees[]` (이름, 이메일, 응답 상태) | 불가 (탭 시 토스트) |
 | 회의 정보 | `conferenceData.entryPoints[].uri` | 불가 (헤더 탭 시 토스트, 링크/코드는 열기·복사 그대로) |
 | 첨부파일 | `attachments[]` (title, fileUrl, mimeType) | 불가 (탭하면 Safari로 열기 — 토스트 아님) |
@@ -370,7 +370,9 @@ activeCalendars() = 전체 캘린더 - offTagIds에 포함된 캘린더
 
 ### 8.3 편집 대상 필드
 
-`summary` · `start`/`end`(종일 토글 포함) · `location` · `description` · `colorId` 만 편집한다. `recurrence`·`attendees`·`conferenceData`·`attachments` 는 `EventEditParams` 에 필드를 두지 않아 PATCH 바디에 실릴 경로 자체가 없다 — 구글 PATCH 는 부분 업데이트라 안 보낸 필드는 서버 원본이 유지되고, `RRuleParser` 가 못 읽는 `BYMONTHDAY`·EXDATE·RDATE 가 소실되지 않는다.
+`summary` · `start`/`end`(종일 토글 포함) · `location` · `description` · `colorId` · `recurrence` 를 편집한다. `attendees`·`conferenceData`·`attachments` 는 `EventEditParams` 에 필드를 두지 않아 PATCH 바디에 실릴 경로 자체가 없다 — 구글 PATCH 는 부분 업데이트라 안 보낸 필드는 서버 원본이 유지된다.
+
+`recurrence` 는 배열 전체를 보내되 RRULE 줄만 갈아끼운다(`replacingRRuleLine`) — EXDATE·RDATE 는 원본 그대로 보존된다. 규칙을 바꾼 저장은 회차가 아니라 시리즈 마스터(`recurringEventId ?? id`)를 대상으로 하고 수정 범위 선택 시트를 띄우지 않는다. 반복 옵션 선택 화면은 RRULE 로 표현 가능한 옵션만 제공한다(음력 제외).
 
 all-day 의 `end.date` 는 구글에서 배타적(exclusive)이다. 읽기가 가공 없이 담고 편집도 가공 없이 보내 왕복 항등을 유지한다 — 한쪽만 보정하면 저장할 때마다 하루씩 늘어난다.
 
@@ -653,7 +655,7 @@ flowchart TD
   2. 이벤트 상세 화면에서 RRULE을 텍스트로 파싱하여 표시
      → "매주 월, 수, 금 반복 (2026.12.31까지)"
   3. 앱의 EventRepeatingOption(EveryWeek 등)으로 변환하지 않음
-  4. → 구글 이벤트는 앱 내에서 반복 수정 불가 (읽기 전용)
+  4. → 앱 반복 옵션으로 왕복 가능한 규칙만 편집을 연다. 왕복 불가(미지원 키 등)하거나 RRULE 줄이 2개 이상이면 잠그고 원본 규칙 텍스트만 보여준다 — 저장이 RRULE 줄을 통째 치환하므로 여는 순간이 곧 파괴다
 
 RRuleParser 지원 범위:
   ✓ FREQ (DAILY/WEEKLY/MONTHLY/YEARLY)


### PR DESCRIPTION
구글 캘린더 이벤트의 반복 규칙을 상세 화면에서 추가·수정·제거할 수 있게 한다. #921 이 세운 RRULE ↔ 앱 반복 옵션 왕복 계층을 실제 쓰기 경로에 연결하는 PR 이다.

## 문제

반복 행이 읽기 전용이었고, 진입점조차 없었다.

- 규칙이 있을 때만 행이 렌더돼서 **반복 없는 이벤트에 반복을 붙일 자리가 없었다.**
- 행을 탭하면 "편집 불가" 토스트만 떴다.
- `EventEditParams` 에 `recurrence` 필드 자체가 없었다. 구글 PATCH 는 부분 업데이트라 안 보낸 필드가 서버 원본으로 유지되므로, 타입에서 빼는 것으로 "실수로 파괴할 수 없음"을 보장한 fail-safe 상태였다.

## 접근

**반복 행을 상시 표시한다.** 규칙이 없으면 "반복 없음" 플레이스홀더를 띄우고, 탭하면 기존 `SelectEventRepeatOption` 화면으로 간다. 규칙 추가·수정·제거가 한 진입점으로 모인다.

**편집 UI 는 새로 만들지 않고 기존 선택 화면을 재사용한다.** 다만 RRULE 에 음력 개념이 없어서, 외부 캘린더에서 진입할 땐 음력 옵션을 목록에서 뺀다 (`rruleRepresentableOnly`). 이름이 `excludeLunar` 가 아닌 이유는 판정 근거가 "음력이라서"가 아니라 "RRULE 로 표현 가능한가"이기 때문이다.

**앱 옵션으로 왕복시키지 못하는 규칙은 편집을 잠근다.** 잠긴 규칙도 무슨 규칙인지는 원본 RRULE 문구로 보여주고, 탭하면 편집 불가 안내만 띄운다. 저장이 곧 파괴인 영역이라 fail-closed 다.

### 원본 파괴를 막는 세 지점

- **EXDATE·RDATE 보존** — 구글 `recurrence` 는 RRULE 과 제외·추가 날짜가 섞인 배열이다. 규칙을 바꿀 때 배열을 통째로 갈지 않고 RRULE 줄만 교체한다. 유저가 특정 회차를 지운 이력이 규칙 편집에 휩쓸리지 않는다.
- **저장 범위 강제** — 규칙은 시리즈 마스터의 속성이라 "이번 일정만"이 성립하지 않는다(구글이 인스턴스 patch 의 `recurrence` 를 거부한다). 규칙이 바뀌었으면 범위 선택 없이 마스터를 대상으로 저장하고, 다른 필드만 바뀌었으면 기존 "이번 일정만 / 전체" 선택지를 그대로 둔다.
- **캐시 재조회 판정을 대상 기준으로** — 지금은 응답이 시리즈 마스터인지(`recurringEventId == nil && recurrence != nil`)로 판정한다. 반복을 **해제**하면 응답의 `recurrence` 가 nil 이라 판정이 false 로 떨어지고, 캐시에 펼쳐져 있던 인스턴스가 유령으로 남는다. 판정에 `params.recurrence` 유무를 더해 "내가 무엇을 대상으로 썼는가"로 돌렸다. #902 에서 애플·구글 삭제 경로에 고친 것과 같은 계열이다.

신규 로컬라이즈 키는 없다 — 기존 `notEditableField` 토스트와 `notRepeating::title` 을 재사용한다.
