### PR TITLE
[#908] LiveActivity ActivityKit 제어 계층 — 시작·갱신·종료·복원

### DIFF
--- a/Domain/Sources/Models/Events/EventLiveActivity.swift
+++ b/Domain/Sources/Models/Events/EventLiveActivity.swift
@@ -1,0 +1,25 @@
+//
+//  EventLiveActivity.swift
+//  Domain
+//
+//  Created by sudo.park on 8/17/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+
+public enum LiveActivityTarget: Sendable, Hashable {
+    case todo(id: String)
+    case schedule(id: String, turnKey: String?)
+    case holiday(uuid: String, dateString: String)
+    case googleCalendar(accountId: String, calendarId: String, eventId: String)
+    case appleCalendar(calendarId: String, eventId: String)
+}
+
+
+public enum EventLiveActivityStartFailReason: Error, Equatable {
+    case eventNotFound
+    case alreadyPassed
+    case tooFarFuture
+}

--- a/Domain/Sources/Usecases/Events/EventLiveActivityUsecase.swift
+++ b/Domain/Sources/Usecases/Events/EventLiveActivityUsecase.swift
@@ -1,0 +1,21 @@
+//
+//  EventLiveActivityUsecase.swift
+//  Domain
+//
+//  Created by sudo.park on 8/17/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+
+public protocol EventLiveActivityUsecase: Sendable {
+
+    func startActivity(_ target: LiveActivityTarget) async throws
+    func stopActivity() async
+    func prepare() async
+    func handleWillEnterForeground() async
+
+    var registeredTarget: AnyPublisher<LiveActivityTarget?, Never> { get }
+}

--- a/TodoCalendarApp/Sources/Main/MainBuilderImple.swift
+++ b/TodoCalendarApp/Sources/Main/MainBuilderImple.swift
@@ -8,6 +8,7 @@
 //
 
 import UIKit
+import Domain
 import Scenes
 import CommonPresentation
 
@@ -17,17 +18,20 @@ import CommonPresentation
 public final class MainSceneBuilerImple {
     
     private let usecaseFactory: any UsecaseFactory
+    private let sharedDataStore: SharedDataStore
     private let viewAppearance: ViewAppearance
     private let calendarSceneBulder: any CalendarSceneBuilder
     private let settingSceneBuilder: any SettingSceneBuiler
     
     public init(
         usecaseFactory: any UsecaseFactory,
+        sharedDataStore: SharedDataStore,
         viewAppearance: ViewAppearance,
         calendarSceneBulder: any CalendarSceneBuilder,
         settingSceneBuilder: any SettingSceneBuiler
     ) {
         self.usecaseFactory = usecaseFactory
+        self.sharedDataStore = sharedDataStore
         self.viewAppearance = viewAppearance
         self.calendarSceneBulder = calendarSceneBulder
         self.settingSceneBuilder = settingSceneBuilder
@@ -50,7 +54,11 @@ extension MainSceneBuilerImple: MainSceneBuiler {
             appleCalendarUsecase: self.usecaseFactory.makeAppleCalendarUsecase(),
             eventSyncUsecase: self.usecaseFactory.eventSyncUsecase,
             billingUsecase: self.usecaseFactory.billingUsecase,
-            aiAgentOrchestrationUsecase: self.usecaseFactory.aiAgentOrchestrationUsecase
+            aiAgentOrchestrationUsecase: self.usecaseFactory.aiAgentOrchestrationUsecase,
+            eventLiveActivityUsecase: EventLiveActivityUsecaseImple(
+                controller: EventCountdownLiveActivityController(),
+                sharedDataStore: self.sharedDataStore
+            )
         )
         
         let viewController = MainViewController(

--- a/TodoCalendarApp/Sources/Main/MainViewModel.swift
+++ b/TodoCalendarApp/Sources/Main/MainViewModel.swift
@@ -62,6 +62,7 @@ final class MainViewModelImple: MainViewModel, @unchecked Sendable {
     private let eventSyncUsecase: any EventSyncUsecase
     private let billingUsecase: any BillingUsecase
     private let aiAgentOrchestrationUsecase: any AIAgentOrchestrationUsecase
+    private let eventLiveActivityUsecase: any EventLiveActivityUsecase
     var router: (any MainRouting)?
 
     init(
@@ -74,7 +75,8 @@ final class MainViewModelImple: MainViewModel, @unchecked Sendable {
         appleCalendarUsecase: any AppleCalendarUsecase,
         eventSyncUsecase: any EventSyncUsecase,
         billingUsecase: any BillingUsecase,
-        aiAgentOrchestrationUsecase: any AIAgentOrchestrationUsecase
+        aiAgentOrchestrationUsecase: any AIAgentOrchestrationUsecase,
+        eventLiveActivityUsecase: any EventLiveActivityUsecase
     ) {
         self.uiSettingUsecase = uiSettingUsecase
         self.temporaryUserDataMigrationUsecase = temporaryUserDataMigrationUsecase
@@ -86,6 +88,7 @@ final class MainViewModelImple: MainViewModel, @unchecked Sendable {
         self.eventSyncUsecase = eventSyncUsecase
         self.billingUsecase = billingUsecase
         self.aiAgentOrchestrationUsecase = aiAgentOrchestrationUsecase
+        self.eventLiveActivityUsecase = eventLiveActivityUsecase
 
         self.internalBinding()
     }
@@ -132,6 +135,7 @@ final class MainViewModelImple: MainViewModel, @unchecked Sendable {
                 self?.billingUsecase.recoverUnfinishedTransactions()
                 self?.aiAgentOrchestrationUsecase.refreshProcessingJobIfNeeded()
                 self?.aiAgentOrchestrationUsecase.loadUsage()
+                self?.handleWillEnterForeground()
             })
             .store(in: &self.cancellables)
     }
@@ -156,6 +160,15 @@ extension MainViewModelImple {
         self.appleCalendarUsecase.prepare()
         self.billingUsecase.startObservingTransactions()
         self.billingUsecase.recoverUnfinishedTransactions()
+        Task { [weak self] in
+            await self?.eventLiveActivityUsecase.prepare()
+        }
+    }
+
+    private func handleWillEnterForeground() {
+        Task { [weak self] in
+            await self?.eventLiveActivityUsecase.handleWillEnterForeground()
+        }
     }
     
     private func refreshViewAppearanceSettings() {

--- a/TodoCalendarApp/Sources/Root/ApplicationPrepareUsecase.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationPrepareUsecase.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+@preconcurrency import ActivityKit
 import Domain
 import CommonPresentation
 import Extensions
@@ -106,6 +107,7 @@ extension ApplicationPrepareUsecaseImple {
     }
     
     func prepareSignedIn(_ auth: Auth) async {
+        await self.endLiveActivities()
         self.sharedDataStore.clearAll {
             $0 != ShareDataKeys.accountInfo.rawValue
             && $0 != ShareDataKeys.externalCalendarAccounts.rawValue
@@ -121,6 +123,7 @@ extension ApplicationPrepareUsecaseImple {
     }
     
     func prepareSignedOut() async {
+        await self.endLiveActivities()
         self.sharedDataStore.clearAll {
             $0 != ShareDataKeys.externalCalendarAccounts.rawValue
         }
@@ -131,6 +134,13 @@ extension ApplicationPrepareUsecaseImple {
             try? await self.prepareDatabase(for: nil)
         } catch let error {
             logger.log(level: .critical, "signOut -> close db failed..: \(error)")
+        }
+    }
+    
+    /// 라이브액티비티는 계정 스코프다 — 안 끄면 전환된 계정 잠금화면에 이전 계정 이벤트가 남는다.
+    private func endLiveActivities() async {
+        for activity in Activity<EventCountdownActivityAttributes>.activities {
+            await activity.end(nil, dismissalPolicy: .immediate)
         }
     }
     

--- a/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
@@ -388,6 +388,7 @@ extension ApplicationRootRouter {
         
         let builder = MainSceneBuilerImple(
             usecaseFactory: self.usecaseFactory,
+            sharedDataStore: self.applicationBase.sharedDataStore,
             viewAppearance: self.viewAppearanceStore.appearance,
             calendarSceneBulder: self.calendarSceneBulder(),
             settingSceneBuilder: self.settingSceneBuilder()

--- a/TodoCalendarApp/Sources/Root/EventCountdownLiveActivityController.swift
+++ b/TodoCalendarApp/Sources/Root/EventCountdownLiveActivityController.swift
@@ -1,0 +1,168 @@
+//
+//  EventCountdownLiveActivityController.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 8/17/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Combine
+@preconcurrency import ActivityKit
+import Domain
+
+
+final class EventCountdownLiveActivityController: LiveActivityController, @unchecked Sendable {
+
+    private let targetUpdatesSubject = CurrentValueSubject<LiveActivityTarget?, Never>(nil)
+    private var isObserving = false
+}
+
+
+// MARK: - LiveActivityController
+
+extension EventCountdownLiveActivityController {
+
+    func startObserving() {
+        guard self.isObserving == false else { return }
+        self.isObserving = true
+        self.watchExistingActivities()
+        self.watchNewActivities()
+    }
+
+    /// 등록 요청 직전에 살아있는 액티비티를 전부 종료해 "동시 1개"를 진실 원천(`Activity.activities`)
+    /// 에서 강제한다 — usecase의 자체 장부가 겹친 호출로 어긋나도 여기서 막힌다.
+    func startActivity(
+        _ target: LiveActivityTarget, _ content: EventCountdownActivityAttributes.State
+    ) async throws {
+        await self.endAllAliveActivities()
+
+        let attributes = EventCountdownActivityAttributes(target: target.asEventTarget)
+        let activityContent = ActivityContent(state: content, staleDate: content.eventDate)
+        let activity = try Activity<EventCountdownActivityAttributes>.request(
+            attributes: attributes, content: activityContent, pushType: nil
+        )
+        self.watchDismissal(of: activity)
+    }
+
+    func updateActivity(_ content: EventCountdownActivityAttributes.State) async {
+        guard let activity = self.aliveActivity()
+        else { return }
+        let activityContent = ActivityContent(state: content, staleDate: content.eventDate)
+        await activity.update(activityContent)
+    }
+
+    func endActivity() async {
+        guard let activity = self.aliveActivity()
+        else { return }
+        await activity.end(nil, dismissalPolicy: .immediate)
+    }
+
+    func currentActivity() async -> LiveActivityRegistration? {
+        return self.currentRegistration()
+    }
+
+    var activityTargetUpdates: AnyPublisher<LiveActivityTarget?, Never> {
+        return self.targetUpdatesSubject.eraseToAnyPublisher()
+    }
+}
+
+
+// MARK: - 액티비티 등록 상태 감시
+
+extension EventCountdownLiveActivityController {
+
+    /// `.ended`·`.dismissed`도 dismiss 전까진 `activities`에 남는다.
+    private func aliveActivities() -> [Activity<EventCountdownActivityAttributes>] {
+        return Activity<EventCountdownActivityAttributes>.activities.filter {
+            $0.activityState != .ended && $0.activityState != .dismissed
+        }
+    }
+
+    private func aliveActivity() -> Activity<EventCountdownActivityAttributes>? {
+        return self.aliveActivities().first
+    }
+
+    private func currentTarget() -> LiveActivityTarget? {
+        return self.aliveActivity()?.attributes.target.asDomainTarget
+    }
+
+    private func currentRegistration() -> LiveActivityRegistration? {
+        guard let activity = self.aliveActivity()
+        else { return nil }
+        return LiveActivityRegistration(
+            target: activity.attributes.target.asDomainTarget,
+            content: activity.content.state
+        )
+    }
+
+    private func endAllAliveActivities() async {
+        for activity in self.aliveActivities() {
+            await activity.end(nil, dismissalPolicy: .immediate)
+        }
+    }
+
+    private func watchExistingActivities() {
+        Activity<EventCountdownActivityAttributes>.activities.forEach { self.watchDismissal(of: $0) }
+    }
+
+    /// `Activity.activityUpdates`는 새로 생성되는 액티비티만 흘려보낸다.
+    private func watchNewActivities() {
+        Task { [weak self] in
+            for await activity in Activity<EventCountdownActivityAttributes>.activityUpdates {
+                guard let self else { return }
+                self.targetUpdatesSubject.send(self.currentTarget())
+                self.watchDismissal(of: activity)
+            }
+        }
+    }
+
+    private func watchDismissal(of activity: Activity<EventCountdownActivityAttributes>) {
+        Task { [weak self] in
+            for await state in activity.activityStateUpdates {
+                guard let self else { return }
+                guard state == .dismissed || state == .ended else { continue }
+                self.targetUpdatesSubject.send(self.currentTarget())
+            }
+        }
+    }
+}
+
+
+// MARK: - LiveActivityTarget ↔ LiveActivityEventTarget
+
+extension LiveActivityTarget {
+
+    var asEventTarget: LiveActivityEventTarget {
+        switch self {
+        case .todo(let id):
+            return .todo(id: id)
+        case .schedule(let id, let turnKey):
+            return .schedule(id: id, turnKey: turnKey)
+        case .holiday(let uuid, let dateString):
+            return .holiday(uuid: uuid, dateString: dateString)
+        case .googleCalendar(let accountId, let calendarId, let eventId):
+            return .googleCalendar(accountId: accountId, calendarId: calendarId, eventId: eventId)
+        case .appleCalendar(let calendarId, let eventId):
+            return .appleCalendar(calendarId: calendarId, eventId: eventId)
+        }
+    }
+}
+
+extension LiveActivityEventTarget {
+
+    var asDomainTarget: LiveActivityTarget {
+        switch self {
+        case .todo(let id):
+            return .todo(id: id)
+        case .schedule(let id, let turnKey):
+            return .schedule(id: id, turnKey: turnKey)
+        case .holiday(let uuid, let dateString):
+            return .holiday(uuid: uuid, dateString: dateString)
+        case .googleCalendar(let accountId, let calendarId, let eventId):
+            return .googleCalendar(accountId: accountId, calendarId: calendarId, eventId: eventId)
+        case .appleCalendar(let calendarId, let eventId):
+            return .appleCalendar(calendarId: calendarId, eventId: eventId)
+        }
+    }
+}

--- a/TodoCalendarApp/Sources/Root/EventLiveActivityUsecaseImple.swift
+++ b/TodoCalendarApp/Sources/Root/EventLiveActivityUsecaseImple.swift
@@ -1,0 +1,599 @@
+//
+//  EventLiveActivityUsecaseImple.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 8/18/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Combine
+import CombineExt
+import Prelude
+import Optics
+import Domain
+import Extensions
+
+
+/// 실제 액티비티 상태의 진실은 `controller.activityTargetUpdates`다 — 유저 스와이프 해제·
+/// 시스템 8시간 상한 종료가 그 스트림으로만 감지되므로 `registeredTarget`도 그 값을 따라간다.
+final class EventLiveActivityUsecaseImple: EventLiveActivityUsecase, @unchecked Sendable {
+
+    private let controller: any LiveActivityController
+    private let sharedDataStore: SharedDataStore
+
+    init(
+        controller: any LiveActivityController,
+        sharedDataStore: SharedDataStore
+    ) {
+        self.controller = controller
+        self.sharedDataStore = sharedDataStore
+    }
+
+    private struct Subject {
+        let registeredTarget = CurrentValueSubject<LiveActivityTarget?, Never>(nil)
+        let isReplacing = CurrentValueSubject<Bool, Never>(false)
+    }
+
+    private let subject = Subject()
+    private var watchCancellable: AnyCancellable?
+    private var externalUpdatesCancellable: AnyCancellable?
+    private var pendingStart: Task<Void, any Error>?
+}
+
+
+// MARK: - command
+
+extension EventLiveActivityUsecaseImple {
+
+    /// 겹친 호출은 앞선 호출의 등록·교체가 끝난 뒤에 실행되도록 태스크로 직렬화한다 —
+    /// 그래야 `subject.registeredTarget.value` 존재 여부로 하는 교체 판정이 유효하다.
+    func startActivity(_ target: LiveActivityTarget) async throws {
+        let now = Date()
+        guard let observed = self.currentObservedEvent(for: target)
+        else { throw EventLiveActivityStartFailReason.eventNotFound }
+        try self.validateRegistration(eventDate: observed.eventDate, now: now)
+
+        let content = self.initialContent(from: observed, startDate: now)
+        let baseline = LiveActivityBaseline(observed)
+
+        let previous = self.pendingStart
+        let task = Task { [weak self] in
+            _ = try? await previous?.value
+            try await self?.performStartActivity(target, content, baseline: baseline)
+        }
+        self.pendingStart = task
+        try await task.value
+    }
+
+    private func initialContent(
+        from observed: LiveActivityObservedEvent, startDate: Date
+    ) -> EventCountdownActivityAttributes.State {
+        return EventCountdownActivityAttributes.State(
+            eventName: observed.name,
+            eventTimeText: observed.eventTimeText,
+            tagColorHex: observed.tagColorHex,
+            eventDate: observed.eventDate,
+            startDate: startDate,
+            placeName: observed.placeName
+        )
+    }
+
+    private func validateRegistration(eventDate: Date, now: Date) throws {
+        guard eventDate > now else { throw EventLiveActivityStartFailReason.alreadyPassed }
+        guard eventDate <= now.addingTimeInterval(Constant.activeLimit)
+        else { throw EventLiveActivityStartFailReason.tooFarFuture }
+    }
+
+    private func performStartActivity(
+        _ target: LiveActivityTarget,
+        _ content: EventCountdownActivityAttributes.State,
+        baseline: LiveActivityBaseline
+    ) async throws {
+        self.subject.isReplacing.send(true)
+        defer { self.subject.isReplacing.send(false) }
+
+        if self.subject.registeredTarget.value != nil {
+            await self.endCurrentActivity()
+        }
+
+        try await self.controller.startActivity(target, content)
+
+        self.subject.registeredTarget.send(target)
+        self.startWatching(target, seedContent: content, seedBaseline: baseline)
+    }
+
+    func stopActivity() async {
+        guard self.subject.registeredTarget.value != nil else { return }
+        await self.endCurrentActivity()
+    }
+
+    func prepare() async {
+        self.controller.startObserving()
+        self.bindExternalActivityUpdates()
+
+        guard let registration = await self.controller.currentActivity()
+        else {
+            self.subject.registeredTarget.send(nil)
+            return
+        }
+        guard await self.endIfExpired(registration) == false else { return }
+
+        self.subject.registeredTarget.send(registration.target)
+        self.startWatching(registration.target, seedContent: registration.content, seedBaseline: nil)
+    }
+
+    func handleWillEnterForeground() async {
+        guard self.subject.registeredTarget.value != nil else { return }
+
+        guard let registration = await self.controller.currentActivity()
+        else {
+            self.clearRegistration()
+            return
+        }
+        _ = await self.endIfExpired(registration)
+    }
+
+    private func endIfExpired(_ registration: LiveActivityRegistration) async -> Bool {
+        guard registration.content.eventDate <= Date() else { return false }
+        await self.endCurrentActivity()
+        return true
+    }
+
+    private func endCurrentActivity() async {
+        await self.controller.endActivity()
+        self.clearRegistration()
+    }
+
+    private func clearRegistration() {
+        self.watchCancellable = nil
+        self.subject.registeredTarget.send(nil)
+    }
+
+    /// 교체 흐름(종료 → 시작) 도중 도착한 controller의 stale nil은 무시한다 — 안 그러면
+    /// 방금 끝낸 이전 액티비티의 뒤늦은 nil이 막 등록한 새 대상을 지운다.
+    private func bindExternalActivityUpdates() {
+        guard self.externalUpdatesCancellable == nil else { return }
+        self.externalUpdatesCancellable = self.controller.activityTargetUpdates
+            .dropFirst()
+            .withLatestFrom(self.subject.isReplacing) { (aliveTarget: $0, isReplacing: $1) }
+            .filter { $0.aliveTarget == nil && !$0.isReplacing }
+            .sink { [weak self] _ in self?.clearRegistration() }
+    }
+}
+
+
+// MARK: - query
+
+extension EventLiveActivityUsecaseImple {
+
+    var registeredTarget: AnyPublisher<LiveActivityTarget?, Never> {
+        return self.subject.registeredTarget.eraseToAnyPublisher()
+    }
+}
+
+
+// MARK: - 공유 상태 감시
+
+extension EventLiveActivityUsecaseImple {
+
+    /// 등록 경로는 조회 시점 관찰값을 기준선으로 넘긴다 — 첫 배달을 기다리면 그 사이 변화가
+    /// 기준선에 흡수돼 파기 판정이 사라진다. 복원 경로는 넘길 값이 없어 nil(첫 관찰값 채택)이다.
+    private func startWatching(
+        _ target: LiveActivityTarget,
+        seedContent: EventCountdownActivityAttributes.State,
+        seedBaseline: LiveActivityBaseline?
+    ) {
+        let initialState = LiveActivityWatchState(
+            hasBaseline: seedBaseline != nil,
+            baseline: seedBaseline ?? .init(),
+            displayedContent: seedContent
+        )
+
+        self.watchCancellable = self.observedEventStream(for: target)
+            .scan((initialState, LiveActivityJudgement.keep)) { [weak self] previous, observedRaw in
+                guard let self else { return (previous.0, .keep) }
+                return self.advanceWatchState(previous.0, target: target, observedRaw: observedRaw)
+            }
+            .sink { [weak self] result in
+                self?.apply(result.1, for: target)
+            }
+    }
+
+    /// 컨트롤러는 대상을 안 받고 살아있는 액티비티에 적용한다 — 판정 이후 교체가 끼어들면
+    /// 옛 판정이 새 대상에 적용되므로, 실행 직전에 등록 대상이 그대로인지 확인한다.
+    private func apply(_ judgement: LiveActivityJudgement, for target: LiveActivityTarget) {
+        switch judgement {
+        case .keep:
+            break
+        case .update(let content):
+            Task { [weak self] in
+                guard let self, self.subject.registeredTarget.value == target else { return }
+                await self.controller.updateActivity(content)
+            }
+        case .end:
+            Task { [weak self] in
+                guard let self, self.subject.registeredTarget.value == target else { return }
+                await self.endCurrentActivity()
+            }
+        }
+    }
+
+    /// 변화 신호와 조회를 나눠, 스트림 경로와 등록 시점의 단발 조회가 같은
+    /// `currentObservedEvent(for:)`를 쓰게 한다.
+    private func observedEventStream(
+        for target: LiveActivityTarget
+    ) -> AnyPublisher<LiveActivityObservedEvent?, Never> {
+        return self.sourceChanges(for: target)
+            .map { [weak self] _ in self?.currentObservedEvent(for: target) }
+            .eraseToAnyPublisher()
+    }
+
+    private func sourceChanges(for target: LiveActivityTarget) -> AnyPublisher<Void, Never> {
+        let store = self.sharedDataStore
+        let eventChanges: AnyPublisher<Void, Never>
+        switch target {
+        case .todo:
+            eventChanges = store
+                .observe([String: TodoEvent].self, key: ShareDataKeys.todos.rawValue)
+                .map { _ in }.eraseToAnyPublisher()
+        case .schedule:
+            eventChanges = store
+                .observe(MemorizedEventsContainer<ScheduleEvent>.self, key: ShareDataKeys.schedules.rawValue)
+                .map { _ in }.eraseToAnyPublisher()
+        case .holiday:
+            eventChanges = store
+                .observe(Holidays.self, key: ShareDataKeys.holidays.rawValue)
+                .map { _ in }.eraseToAnyPublisher()
+        case .googleCalendar:
+            eventChanges = store
+                .observe([String: GoogleCalendar.Event].self, key: ShareDataKeys.googleCalendarEvents.rawValue)
+                .map { _ in }.eraseToAnyPublisher()
+        case .appleCalendar:
+            eventChanges = store
+                .observe([String: AppleCalendar.Event].self, key: ShareDataKeys.appleCalendarEvents.rawValue)
+                .map { _ in }.eraseToAnyPublisher()
+        }
+
+        return Publishers.CombineLatest(eventChanges, self.displayFormatChanges)
+            .map { _ in }
+            .eraseToAnyPublisher()
+    }
+
+    /// 시각 문구·공휴일 기준 시각 해석에 쓰는 설정 — 바뀌면 재판정이 돌아야 한다.
+    private var displayFormatChanges: AnyPublisher<Void, Never> {
+        return Publishers.CombineLatest(
+            self.sharedDataStore.observe(TimeZone.self, key: ShareDataKeys.timeZone.rawValue),
+            self.sharedDataStore.observe(
+                CalendarAppearanceSettings.self, key: ShareDataKeys.calendarAppearance.rawValue
+            )
+        )
+        .map { _ in }
+        .eraseToAnyPublisher()
+    }
+}
+
+
+// MARK: - 공유 상태 → 관찰 결과
+
+extension EventLiveActivityUsecaseImple {
+
+    private func currentObservedEvent(for target: LiveActivityTarget) -> LiveActivityObservedEvent? {
+        let settings = self.currentDisplayFormatSettings()
+        switch target {
+        case .todo(let id):
+            guard let todo = self.value([String: TodoEvent].self, .todos)?[id] else { return nil }
+            return self.observedEvent(fromTodo: todo, settings: settings)
+
+        case .schedule(let id, let turnKey):
+            guard let schedule = self
+                .value(MemorizedEventsContainer<ScheduleEvent>.self, .schedules)?.evnet(id)
+            else { return nil }
+            return self.observedEvent(fromSchedule: schedule, turnKey: turnKey, settings: settings)
+
+        case .holiday(let uuid, _):
+            guard let holiday = self.value(Holidays.self, .holidays)?
+                .values.flatMap({ $0.values.flatMap { $0 } })
+                .first(where: { $0.uuid == uuid })
+            else { return nil }
+            return self.observedEvent(fromHoliday: holiday, settings: settings)
+
+        case .googleCalendar(let accountId, let calendarId, let eventId):
+            guard let event = self
+                .value([String: GoogleCalendar.Event].self, .googleCalendarEvents)?[eventId]
+            else { return nil }
+            return self.observedEvent(
+                fromGoogle: event, accountId: accountId, calendarId: calendarId, settings: settings
+            )
+
+        case .appleCalendar(let calendarId, let eventId):
+            guard let event = self
+                .value([String: AppleCalendar.Event].self, .appleCalendarEvents)?[eventId]
+            else { return nil }
+            return self.observedEvent(fromApple: event, calendarId: calendarId, settings: settings)
+        }
+    }
+
+    private func value<V>(_ type: V.Type, _ key: ShareDataKeys) -> V? {
+        return self.sharedDataStore.value(type, key: key.rawValue)
+    }
+
+    private func currentDisplayFormatSettings() -> DisplayFormatSettings {
+        return (
+            timeZone: self.value(TimeZone.self, .timeZone) ?? .current,
+            is24hourForm: self.value(CalendarAppearanceSettings.self, .calendarAppearance)?
+                .is24hourForm ?? false
+        )
+    }
+
+    private func observedEvent(
+        fromTodo todo: TodoEvent, settings: DisplayFormatSettings
+    ) -> LiveActivityObservedEvent? {
+        guard let time = todo.time else { return nil }
+        let eventDate = Date(timeIntervalSince1970: time.lowerBoundWithFixed)
+        return LiveActivityObservedEvent(
+            name: todo.name,
+            eventDate: eventDate,
+            eventTimeText: self.timeText(for: eventDate, settings: settings),
+            tagColorHex: self.tagColorHex(for: todo.eventTagId),
+            placeName: nil,
+            repeatingTurn: todo.repeatingTurn,
+            scheduleOriginTimeKey: nil,
+            isTurnExcluded: false
+        )
+    }
+
+    private func observedEvent(
+        fromSchedule schedule: ScheduleEvent, turnKey: String?, settings: DisplayFormatSettings
+    ) -> LiveActivityObservedEvent {
+        let turnLowerBound = turnKey.flatMap { EventTime.lowerBound(fromCustomKey: $0) }
+        let eventDate = Date(
+            timeIntervalSince1970: turnLowerBound ?? schedule.time.lowerBoundWithFixed
+        )
+        return LiveActivityObservedEvent(
+            name: schedule.name,
+            eventDate: eventDate,
+            eventTimeText: self.timeText(for: eventDate, settings: settings),
+            tagColorHex: self.tagColorHex(for: schedule.eventTagId),
+            placeName: nil,
+            repeatingTurn: nil,
+            scheduleOriginTimeKey: schedule.time.customKey,
+            isTurnExcluded: turnKey.map { schedule.repeatingTimeToExcludes.contains($0) } ?? false
+        )
+    }
+
+    private func observedEvent(
+        fromHoliday holiday: Holiday, settings: DisplayFormatSettings
+    ) -> LiveActivityObservedEvent? {
+        guard let date = holiday.date(at: settings.timeZone) else { return nil }
+        return LiveActivityObservedEvent(
+            name: holiday.name,
+            eventDate: date,
+            eventTimeText: self.timeText(for: date, settings: settings),
+            tagColorHex: self.defaultTagColors().holiday,
+            placeName: nil,
+            repeatingTurn: nil,
+            scheduleOriginTimeKey: nil,
+            isTurnExcluded: false
+        )
+    }
+
+    private func observedEvent(
+        fromGoogle event: GoogleCalendar.Event,
+        accountId: String,
+        calendarId: String,
+        settings: DisplayFormatSettings
+    ) -> LiveActivityObservedEvent {
+        let eventDate = Date(timeIntervalSince1970: event.eventTime.lowerBoundWithFixed)
+        let calendarTags = self.value([String: [GoogleCalendar.Tag]].self, .googleCalendarTags)
+        let colorHex = calendarTags?[accountId]?.first { $0.id == calendarId }?.colorHex
+        return LiveActivityObservedEvent(
+            name: event.name,
+            eventDate: eventDate,
+            eventTimeText: self.timeText(for: eventDate, settings: settings),
+            tagColorHex: colorHex ?? self.defaultTagColors().default,
+            placeName: event.location,
+            repeatingTurn: nil,
+            scheduleOriginTimeKey: nil,
+            isTurnExcluded: false
+        )
+    }
+
+    private func observedEvent(
+        fromApple event: AppleCalendar.Event, calendarId: String, settings: DisplayFormatSettings
+    ) -> LiveActivityObservedEvent {
+        let eventDate = Date(timeIntervalSince1970: event.eventTime.lowerBoundWithFixed)
+        let colorHex = self.value([AppleCalendar.Tag].self, .appleCalendarTags)?
+            .first { $0.id == calendarId }?.colorHex
+        return LiveActivityObservedEvent(
+            name: event.name,
+            eventDate: eventDate,
+            eventTimeText: self.timeText(for: eventDate, settings: settings),
+            tagColorHex: colorHex ?? self.defaultTagColors().default,
+            placeName: event.location,
+            repeatingTurn: nil,
+            scheduleOriginTimeKey: nil,
+            isTurnExcluded: false
+        )
+    }
+
+    private func timeText(for date: Date, settings: DisplayFormatSettings) -> String {
+        let formatter = DateFormatter()
+        formatter.timeZone = settings.timeZone
+        formatter.dateFormat = settings.is24hourForm
+            ? "date_form::24on_H:mm".localized()
+            : "date_form::a_h:mm".localized()
+        return formatter.string(from: date)
+    }
+
+    private func defaultTagColors() -> DefaultEventTagColorSetting {
+        return self.value(DefaultEventTagColorSetting.self, .defaultEventTagColor) ?? .default
+    }
+
+    private func tagColorHex(for tagId: EventTagId?) -> String {
+        let defaults = self.defaultTagColors()
+        switch tagId {
+        case .holiday:
+            return defaults.holiday
+        case .custom, .externalCalendar:
+            let tags = self.value([EventTagId: any EventTag].self, .tags)
+            return tagId.flatMap { tags?[$0]?.colorHex } ?? defaults.default
+        case .default, .none:
+            return defaults.default
+        }
+    }
+}
+
+
+// MARK: - 판정
+
+extension EventLiveActivityUsecaseImple {
+
+    private func advanceWatchState(
+        _ state: LiveActivityWatchState,
+        target: LiveActivityTarget,
+        observedRaw: LiveActivityObservedEvent?
+    ) -> (LiveActivityWatchState, LiveActivityJudgement) {
+        let observed = self.normalizedObserved(
+            observedRaw, target: target, fallbackPlaceName: state.displayedContent.placeName
+        )
+
+        guard state.hasBaseline else {
+            return (self.seededState(state, observed: observed), .keep)
+        }
+
+        let judgement = self.judge(
+            observed: observed,
+            baseline: state.baseline,
+            displayedContent: state.displayedContent,
+            now: Date()
+        )
+        return (self.advancedState(state, observed: observed, judgement: judgement), judgement)
+    }
+
+    private func seededState(
+        _ state: LiveActivityWatchState, observed: LiveActivityObservedEvent?
+    ) -> LiveActivityWatchState {
+        return state
+            |> \.hasBaseline .~ true
+            |> \.baseline .~ LiveActivityBaseline(observed)
+    }
+
+    private func advancedState(
+        _ state: LiveActivityWatchState,
+        observed: LiveActivityObservedEvent?,
+        judgement: LiveActivityJudgement
+    ) -> LiveActivityWatchState {
+        let newContent: EventCountdownActivityAttributes.State
+        if case .update(let content) = judgement {
+            newContent = content
+        } else {
+            newContent = state.displayedContent
+        }
+        return state
+            |> \.baseline.wasFound .~ (observed != nil)
+            |> \.displayedContent .~ newContent
+    }
+
+    /// 판정 규칙 표(PR 본문 § 판정 규칙) 8행과 1:1로 대응한다.
+    private func judge(
+        observed: LiveActivityObservedEvent?,
+        baseline: LiveActivityBaseline,
+        displayedContent: EventCountdownActivityAttributes.State,
+        now: Date
+    ) -> LiveActivityJudgement {
+        guard let observed else {
+            return baseline.wasFound ? .end : .keep                                   // 규칙 1, 2
+        }
+        guard observed.repeatingTurn == baseline.repeatingTurn else { return .end }   // 규칙 3
+        guard !observed.isTurnExcluded else { return .end }                           // 규칙 4
+        guard observed.scheduleOriginTimeKey == baseline.scheduleOriginTimeKey
+        else { return .end }                                                          // 규칙 5
+        guard observed.eventDate > now,
+              observed.eventDate <= now.addingTimeInterval(Constant.activeLimit)
+        else { return .end }                                                          // 규칙 6
+        guard observed.name == displayedContent.eventName,
+              observed.eventDate == displayedContent.eventDate,
+              observed.placeName == displayedContent.placeName
+        else {
+            return .update(self.updatedContent(displayedContent, observed: observed)) // 규칙 7
+        }
+        return .keep                                                                  // 규칙 8
+    }
+
+    private func updatedContent(
+        _ base: EventCountdownActivityAttributes.State, observed: LiveActivityObservedEvent
+    ) -> EventCountdownActivityAttributes.State {
+        return base
+            |> \.eventName .~ observed.name
+            |> \.eventTimeText .~ observed.eventTimeText
+            |> \.eventDate .~ observed.eventDate
+            |> \.placeName .~ observed.placeName
+    }
+
+    /// Todo·Schedule·공휴일은 공유 상태에 장소 정보가 없다 — 규칙 7의 장소 비교 대상에서
+    /// 제외하기 위해 현재 표시 중인 값을 그대로 흘려보낸다.
+    private func normalizedObserved(
+        _ observed: LiveActivityObservedEvent?, target: LiveActivityTarget, fallbackPlaceName: String?
+    ) -> LiveActivityObservedEvent? {
+        guard let observed, !target.supportsLocation else { return observed }
+        return observed |> \.placeName .~ fallbackPlaceName
+    }
+}
+
+
+// MARK: - 내부 타입
+
+private enum Constant {
+    static let activeLimit: TimeInterval = 8 * 3600
+}
+
+private typealias Holidays = [String: [Int: [Holiday]]]
+private typealias DisplayFormatSettings = (timeZone: TimeZone, is24hourForm: Bool)
+
+private struct LiveActivityObservedEvent {
+    var name: String
+    var eventDate: Date
+    var eventTimeText: String
+    var tagColorHex: String
+    var placeName: String?
+    var repeatingTurn: Int?
+    var scheduleOriginTimeKey: String?
+    var isTurnExcluded: Bool
+}
+
+private struct LiveActivityBaseline {
+    var repeatingTurn: Int?
+    var scheduleOriginTimeKey: String?
+    var wasFound: Bool = false
+
+    init(_ observed: LiveActivityObservedEvent?) {
+        self.repeatingTurn = observed?.repeatingTurn
+        self.scheduleOriginTimeKey = observed?.scheduleOriginTimeKey
+        self.wasFound = observed != nil
+    }
+
+    init() { }
+}
+
+private struct LiveActivityWatchState {
+    var hasBaseline: Bool = false
+    var baseline: LiveActivityBaseline = .init()
+    var displayedContent: EventCountdownActivityAttributes.State
+}
+
+private enum LiveActivityJudgement {
+    case keep
+    case update(EventCountdownActivityAttributes.State)
+    case end
+}
+
+private extension LiveActivityTarget {
+
+    var supportsLocation: Bool {
+        switch self {
+        case .googleCalendar, .appleCalendar: return true
+        case .todo, .schedule, .holiday: return false
+        }
+    }
+}

--- a/TodoCalendarApp/Sources/Root/LiveActivityController.swift
+++ b/TodoCalendarApp/Sources/Root/LiveActivityController.swift
@@ -1,0 +1,31 @@
+//
+//  LiveActivityController.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 8/17/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Combine
+import Domain
+
+
+struct LiveActivityRegistration: Equatable {
+    let target: LiveActivityTarget
+    let content: EventCountdownActivityAttributes.State
+}
+
+
+protocol LiveActivityController: Sendable {
+    /// ActivityKit 상태 관찰 시작 — 의존성 조립 시점이 아니라 앱이 준비된 뒤에 붙인다.
+    func startObserving()
+    func startActivity(
+        _ target: LiveActivityTarget, _ content: EventCountdownActivityAttributes.State
+    ) async throws
+    func updateActivity(_ content: EventCountdownActivityAttributes.State) async
+    func endActivity() async
+    func currentActivity() async -> LiveActivityRegistration?
+
+    var activityTargetUpdates: AnyPublisher<LiveActivityTarget?, Never> { get }
+}

--- a/TodoCalendarApp/TodoCalendarAppTests/ApplicationRootViewModelImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/ApplicationRootViewModelImpleTests.swift
@@ -31,7 +31,7 @@ final class ApplicationRootViewModelImpleTests {
             externalCalendarServiceUsecase: StubExternalCalendarIntegrationUsecase([]),
             userNotificationUsecase: StubUserNotificationUsecase(),
             backgroundEventSyncUsecase: StubBackgroundEventSyncUsecase(),
-            appUpdateCheckUsecase: self.spyAppUpdateCheckUsecase
+            appUpdateCheckUsecase: self.spyAppUpdateCheckUsecase,
         )
     }
 }
@@ -99,7 +99,6 @@ extension ApplicationRootViewModelImpleTests {
 }
 
 
-// MARK: - doubles
 
 private final class FakeAccountUsecase: StubAccountUsecase, @unchecked Sendable {
 
@@ -177,3 +176,4 @@ private final class SpyAppUpdateCheckUsecase: AppUpdateCheckUsecase, @unchecked 
         return Empty().eraseToAnyPublisher()
     }
 }
+

--- a/TodoCalendarApp/TodoCalendarAppTests/EventLiveActivityUsecaseImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/EventLiveActivityUsecaseImpleTests.swift
@@ -1,0 +1,1236 @@
+//
+//  EventLiveActivityUsecaseImpleTests.swift
+//  TodoCalendarAppTests
+//
+//  Created by sudo.park on 8/17/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Combine
+import Foundation
+import Prelude
+import Optics
+import UnitTestHelpKit
+import Extensions
+
+import Domain
+
+@testable import TodoCalendarApp
+
+
+final class EventLiveActivityUsecaseImpleTests: PublisherWaitable {
+
+    var cancelBag: Set<AnyCancellable>! = .init()
+
+    private func makeUsecase(
+        stubRestoredRegistration: LiveActivityRegistration? = nil,
+        stubStartError: (any Error)? = nil,
+        stubEmitsNilOnEnd: Bool = false,
+        stubStartDelayNanoseconds: UInt64 = 0
+    ) -> (EventLiveActivityUsecaseImple, StubLiveActivityController, SharedDataStore) {
+        let stub = StubLiveActivityController(
+            stubRestoredRegistration: stubRestoredRegistration,
+            stubStartError: stubStartError,
+            stubEmitsNilOnEnd: stubEmitsNilOnEnd,
+            stubStartDelayNanoseconds: stubStartDelayNanoseconds
+        )
+        let store = SharedDataStore()
+        let usecase = EventLiveActivityUsecaseImple(controller: stub, sharedDataStore: store)
+        return (usecase, stub, store)
+    }
+
+    /// `eventDate`는 store 왕복(`EventTime.at` → `Date(timeIntervalSince1970:)`)을 거친 값과
+    /// 비트 단위로 같아야 판정 비교(`==`)가 안정적이다 — 여기서도 동일 왕복을 미리 거친다.
+    private func content(
+        name: String = "event",
+        eventDate: Date,
+        startDate: Date? = nil,
+        place: String? = nil
+    ) -> EventCountdownActivityAttributes.State {
+        let canonicalEventDate = Date(timeIntervalSince1970: eventDate.timeIntervalSince1970)
+        return EventCountdownActivityAttributes.State(
+            eventName: name,
+            eventTimeText: "text",
+            tagColorHex: "#000000",
+            eventDate: canonicalEventDate,
+            startDate: startDate ?? canonicalEventDate,
+            placeName: place
+        )
+    }
+
+    private func makeTodo(
+        id: String, name: String = "todo", eventDate: Date, turn: Int? = nil
+    ) -> TodoEvent {
+        return TodoEvent(uuid: id, name: name)
+            |> \.time .~ .at(eventDate.timeIntervalSince1970)
+            |> \.repeatingTurn .~ turn
+    }
+
+    private func makeSchedule(
+        id: String, name: String = "schedule", eventDate: Date, excludes: Set<String> = []
+    ) -> ScheduleEvent {
+        return ScheduleEvent(uuid: id, name: name, time: .at(eventDate.timeIntervalSince1970))
+            |> \.repeatingTimeToExcludes .~ excludes
+    }
+
+    private func makeGoogleEvent(
+        id: String, calendarId: String = "cal", accountId: String = "acc",
+        name: String = "google", eventDate: Date, location: String? = nil
+    ) -> GoogleCalendar.Event {
+        return GoogleCalendar.Event(
+            id, calendarId, accountId: accountId, name: name, colorId: nil,
+            location: location, time: .at(eventDate.timeIntervalSince1970)
+        )
+    }
+
+    private func makeAppleEvent(
+        id: String, calendarId: String = "cal", name: String = "apple",
+        eventDate: Date, location: String? = nil
+    ) -> AppleCalendar.Event {
+        return AppleCalendar.Event(
+            eventId: id, originalEventId: id, calendarId: calendarId,
+            name: name, eventTime: .at(eventDate.timeIntervalSince1970)
+        )
+        |> \.location .~ location
+    }
+
+    private func putTodos(_ store: SharedDataStore, _ todos: [TodoEvent]) {
+        store.put(
+            [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+            todos.reduce(into: [:]) { $0[$1.uuid] = $1 }
+        )
+    }
+
+    private func expectedTimeText(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.timeZone = .current
+        formatter.dateFormat = "date_form::a_h:mm".localized()
+        return formatter.string(from: date)
+    }
+
+    private func waitForEffects() async throws {
+        try await Task.sleep(for: .milliseconds(100))
+    }
+
+    /// 실행 시각과 무관하게 항상 `(now, now+8h)` 안에 들어오는 공휴일 시나리오를 만든다 —
+    /// `dateString`(일 단위)이 정확히 `now + aheadHours`를 자정으로 갖도록 커스텀 오프셋
+    /// 타임존을 역산한다. `resolvedDate`는 그 타임존으로 `Holiday.date(at:)`를 호출한
+    /// 결과 그 자체라 프로덕션과 같은 계산으로 비교값을 얻는다.
+    private func holidayTimeZoneScenario(
+        aheadHours: Double = 3
+    ) -> (dateString: String, timeZone: TimeZone, resolvedDate: Date) {
+        let target = Date().addingTimeInterval(aheadHours * 3600)
+        var utcCalendar = Calendar(identifier: .gregorian)
+        utcCalendar.timeZone = TimeZone(identifier: "UTC")!
+
+        let dayStart = utcCalendar.startOfDay(for: target)
+        var offsetSeconds = Int(dayStart.timeIntervalSince(target))
+        var dayForString = dayStart
+        if offsetSeconds < -18 * 3600 {
+            offsetSeconds += 24 * 3600
+            dayForString = utcCalendar.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart
+        }
+
+        let timeZone = TimeZone(secondsFromGMT: offsetSeconds) ?? .current
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = utcCalendar.timeZone
+        let dateString = formatter.string(from: dayForString)
+        let holiday = Holiday(uuid: "hz", dateString: dateString, name: "holiday")
+        let resolvedDate = holiday.date(at: timeZone) ?? target
+        return (dateString, timeZone, resolvedDate)
+    }
+}
+
+
+// MARK: - 등록 판정
+
+extension EventLiveActivityUsecaseImpleTests {
+
+    @Test func usecase_whenEventDateIsPast_throwsAlreadyPassed() async throws {
+        // given
+        let (usecase, _, store) = self.makeUsecase()
+        let past = Date().addingTimeInterval(-10)
+        self.putTodos(store, [self.makeTodo(id: "t1", eventDate: past)])
+
+        // when
+        var caught: EventLiveActivityStartFailReason?
+        do {
+            try await usecase.startActivity(.todo(id: "t1"))
+        } catch let error as EventLiveActivityStartFailReason {
+            caught = error
+        }
+
+        // then
+        #expect(caught == .alreadyPassed)
+    }
+
+    @Test func usecase_whenEventDateIsBeyond8Hours_throwsTooFarFuture() async throws {
+        // given
+        let (usecase, _, store) = self.makeUsecase()
+        let farFuture = Date().addingTimeInterval(8 * 3600 + 1)
+        self.putTodos(store, [self.makeTodo(id: "t1", eventDate: farFuture)])
+
+        // when
+        var caught: EventLiveActivityStartFailReason?
+        do {
+            try await usecase.startActivity(.todo(id: "t1"))
+        } catch let error as EventLiveActivityStartFailReason {
+            caught = error
+        }
+
+        // then
+        #expect(caught == .tooFarFuture)
+    }
+
+    @Test func usecase_whenEventDateIsExactly8Hours_startsActivity() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let exactly8h = Date().addingTimeInterval(8 * 3600)
+        self.putTodos(store, [self.makeTodo(id: "t1", eventDate: exactly8h)])
+
+        // when
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // then
+        #expect(stub.didStartWith?.0 == .todo(id: "t1"))
+    }
+
+    @Test func usecase_whenStartFails_doesNotChangeRegisteredTarget() async throws {
+        // given
+        let (usecase, _, store) = self.makeUsecase(stubStartError: TestError())
+        let future = Date().addingTimeInterval(60)
+        self.putTodos(store, [self.makeTodo(id: "t1", eventDate: future)])
+
+        // when
+        _ = try? await usecase.startActivity(.todo(id: "t1"))
+
+        // then
+        let expect = self.expectConfirm("registeredTarget stays nil")
+        let target = try await self.firstOutput(expect, for: usecase.registeredTarget)
+        #expect(target == .some(nil))
+    }
+}
+
+
+// MARK: - 교체·종료
+
+extension EventLiveActivityUsecaseImpleTests {
+
+    @Test func usecase_whenStartingWhileAnotherIsActive_endsPreviousThenStarts() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        self.putTodos(store, [
+            self.makeTodo(id: "t1", eventDate: future), self.makeTodo(id: "t2", eventDate: future)
+        ])
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // when
+        try await usecase.startActivity(.todo(id: "t2"))
+
+        // then
+        #expect(stub.didEnd == true)
+        #expect(stub.didStartWith?.0 == .todo(id: "t2"))
+        let expect = self.expectConfirm("registered target replaced")
+        let target = try await self.firstOutput(expect, for: usecase.registeredTarget)
+        #expect(target == .todo(id: "t2"))
+    }
+
+    @Test func usecase_stopActivity_endsAndClearsRegisteredTarget() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        self.putTodos(store, [self.makeTodo(id: "t1", eventDate: future)])
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // when
+        await usecase.stopActivity()
+
+        // then
+        #expect(stub.didEnd == true)
+        let expect = self.expectConfirm("registered target cleared")
+        let target = try await self.firstOutput(expect, for: usecase.registeredTarget)
+        #expect(target == .some(nil))
+    }
+
+    /// F3 회귀 — 이전 액티비티 종료가 시스템에 자신의 종료를 nil로 알리는 것과 새 등록이
+    /// 겹칠 때, 그 stale nil이 별도의 `clearRegistration()` 호출을 더 일으키면 안 된다.
+    @Test func usecase_whenReplacingActivity_ignoresStaleNilFromController() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase(stubEmitsNilOnEnd: true)
+        let future = Date().addingTimeInterval(60)
+        self.putTodos(store, [
+            self.makeTodo(id: "t1", eventDate: future), self.makeTodo(id: "t2", eventDate: future)
+        ])
+        await usecase.prepare()
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // when
+        let expect = self.expectConfirm("교체 중 stale nil은 추가 방출을 만들지 않는다")
+        expect.count = 3
+        let targets = try await self.outputs(expect, for: usecase.registeredTarget) {
+            try await usecase.startActivity(.todo(id: "t2"))
+        }
+
+        // then
+        #expect(stub.didEnd == true)
+        #expect(targets == [.todo(id: "t1"), nil, .todo(id: "t2")])
+    }
+
+    /// I-3 회귀 — 첫 `startActivity`가 컨트롤러 호출 중(지연)일 때 두 번째 `startActivity`가
+    /// 겹쳐 들어오면, 직렬화가 없으면 둘 다 `registeredTargetSubject.value`를 nil로 관찰해
+    /// 교체 종료(`endActivity`)를 건너뛴 채 각자 등록만 한다 — 가드를 되돌리면 `didEnd`가
+    /// `false`로 빨개진다.
+    @Test func usecase_whenStartActivityCallsOverlap_serializesReplacement() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase(stubStartDelayNanoseconds: 50_000_000)
+        let future = Date().addingTimeInterval(60)
+        self.putTodos(store, [
+            self.makeTodo(id: "t1", eventDate: future), self.makeTodo(id: "t2", eventDate: future)
+        ])
+
+        // when
+        async let first: () = try usecase.startActivity(.todo(id: "t1"))
+        try await Task.sleep(nanoseconds: 5_000_000)
+        async let second: () = try usecase.startActivity(.todo(id: "t2"))
+        _ = try await (first, second)
+
+        // then
+        #expect(stub.didEnd == true)
+        #expect(stub.didStartWith?.0 == .todo(id: "t2"))
+        let expect = self.expectConfirm("겹친 시작 후 최신 대상만 남는다")
+        let target = try await self.firstOutput(expect, for: usecase.registeredTarget)
+        #expect(target == .todo(id: "t2"))
+    }
+}
+
+
+// MARK: - 판정 규칙 1, 2 — 존재 여부
+
+extension EventLiveActivityUsecaseImpleTests {
+
+    /// 등록은 공유 상태에 대상이 있어야 성립하므로, "한 번도 못 찾음"은 복원 경로에서만
+    /// 생긴다 — 콜드런치 직후 캐시가 비어 있어도 살아있는 액티비티를 끄면 안 된다.
+    @Test func usecase_afterRestore_whenTargetNeverAppearedInStore_keepsActivity() async throws {
+        // given
+        let future = Date().addingTimeInterval(60)
+        let registration = LiveActivityRegistration(
+            target: .todo(id: "missing"), content: self.content(eventDate: future)
+        )
+        let (usecase, stub, store) = self.makeUsecase(stubRestoredRegistration: registration)
+        await usecase.prepare()
+
+        // when
+        store.put([String: TodoEvent].self, key: ShareDataKeys.todos.rawValue, [:])
+        try await self.waitForEffects()
+
+        // then
+        #expect(stub.didEnd == false)
+    }
+
+    @Test func usecase_whenTargetDisappearsFromStore_endsActivity() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        store.put(
+            [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+            ["t1": self.makeTodo(id: "t1", eventDate: future)]
+        )
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // when
+        let expect = self.expectConfirm("대상 삭제 시 종료")
+        expect.count = 2
+        let targets = try await self.outputs(expect, for: usecase.registeredTarget) {
+            store.put([String: TodoEvent].self, key: ShareDataKeys.todos.rawValue, [:])
+        }
+
+        // then
+        #expect(targets.last == .some(nil))
+        #expect(stub.didEnd == true)
+    }
+}
+
+
+// MARK: - 판정 규칙 3, 4, 5 — 반복 회차·시리즈 변화
+
+extension EventLiveActivityUsecaseImpleTests {
+
+    @Test func usecase_whenTodoRepeatingTurnChanges_endsActivity() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        store.put(
+            [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+            ["t1": self.makeTodo(id: "t1", eventDate: future, turn: nil)]
+        )
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // when
+        let expect = self.expectConfirm("반복 turn 변화 시 종료")
+        expect.count = 2
+        let targets = try await self.outputs(expect, for: usecase.registeredTarget) {
+            store.put(
+                [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+                ["t1": self.makeTodo(id: "t1", eventDate: future.addingTimeInterval(3600), turn: 2)]
+            )
+        }
+
+        // then
+        #expect(targets.last == .some(nil))
+        #expect(stub.didEnd == true)
+    }
+
+    @Test func usecase_whenScheduleTurnKeyIsExcluded_endsActivity() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        let turnKey = EventTime.at(future.timeIntervalSince1970).customKey
+        store.put(
+            MemorizedEventsContainer<ScheduleEvent>.self, key: ShareDataKeys.schedules.rawValue,
+            MemorizedEventsContainer<ScheduleEvent>().append(self.makeSchedule(id: "s1", eventDate: future))
+        )
+        try await usecase.startActivity(.schedule(id: "s1", turnKey: turnKey))
+
+        // when
+        let expect = self.expectConfirm("회차 제외 시 종료")
+        expect.count = 2
+        let targets = try await self.outputs(expect, for: usecase.registeredTarget) {
+            store.put(
+                MemorizedEventsContainer<ScheduleEvent>.self, key: ShareDataKeys.schedules.rawValue,
+                MemorizedEventsContainer<ScheduleEvent>()
+                    .append(self.makeSchedule(id: "s1", eventDate: future, excludes: [turnKey]))
+            )
+        }
+
+        // then
+        #expect(targets.last == .some(nil))
+        #expect(stub.didEnd == true)
+    }
+
+    @Test func usecase_whenScheduleOriginTimeChanges_endsActivity() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        store.put(
+            MemorizedEventsContainer<ScheduleEvent>.self, key: ShareDataKeys.schedules.rawValue,
+            MemorizedEventsContainer<ScheduleEvent>().append(self.makeSchedule(id: "s1", eventDate: future))
+        )
+        try await usecase.startActivity(.schedule(id: "s1", turnKey: nil))
+
+        // when
+        let expect = self.expectConfirm("시리즈 시각 변경 시 종료")
+        expect.count = 2
+        let targets = try await self.outputs(expect, for: usecase.registeredTarget) {
+            store.put(
+                MemorizedEventsContainer<ScheduleEvent>.self, key: ShareDataKeys.schedules.rawValue,
+                MemorizedEventsContainer<ScheduleEvent>()
+                    .append(self.makeSchedule(id: "s1", eventDate: future.addingTimeInterval(1800)))
+            )
+        }
+
+        // then
+        #expect(targets.last == .some(nil))
+        #expect(stub.didEnd == true)
+    }
+}
+
+
+// MARK: - 판정 규칙 6 — 등록 조건 파기
+
+extension EventLiveActivityUsecaseImpleTests {
+
+    @Test func usecase_whenUpdatedEventDateIsPast_endsActivity() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        store.put(
+            [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+            ["t1": self.makeTodo(id: "t1", eventDate: future)]
+        )
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // when
+        let expect = self.expectConfirm("과거로 변경되면 종료")
+        expect.count = 2
+        let past = Date().addingTimeInterval(-60)
+        let targets = try await self.outputs(expect, for: usecase.registeredTarget) {
+            store.put(
+                [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+                ["t1": self.makeTodo(id: "t1", eventDate: past)]
+            )
+        }
+
+        // then
+        #expect(targets.last == .some(nil))
+        #expect(stub.didEnd == true)
+    }
+
+    @Test func usecase_whenUpdatedEventDateExceeds8Hours_endsActivity() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        store.put(
+            [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+            ["t1": self.makeTodo(id: "t1", eventDate: future)]
+        )
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // when
+        let expect = self.expectConfirm("8시간 초과로 변경되면 종료")
+        expect.count = 2
+        let farFuture = Date().addingTimeInterval(9 * 3600)
+        let targets = try await self.outputs(expect, for: usecase.registeredTarget) {
+            store.put(
+                [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+                ["t1": self.makeTodo(id: "t1", eventDate: farFuture)]
+            )
+        }
+
+        // then
+        #expect(targets.last == .some(nil))
+        #expect(stub.didEnd == true)
+    }
+}
+
+
+// MARK: - 판정 규칙 7, 8 — 표시 내용 갱신
+
+extension EventLiveActivityUsecaseImpleTests {
+
+    @Test func usecase_whenEventNameChanges_updatesActivityContent() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        store.put(
+            [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+            ["t1": self.makeTodo(id: "t1", name: "old", eventDate: future)]
+        )
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // when
+        store.put(
+            [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+            ["t1": self.makeTodo(id: "t1", name: "new", eventDate: future)]
+        )
+        try await self.waitForEffects()
+
+        // then
+        #expect(stub.didUpdateWith?.eventName == "new")
+    }
+
+    @Test func usecase_whenUpdatedEventDateStillWithin8Hours_updatesActivityContent() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        store.put(
+            [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+            ["t1": self.makeTodo(id: "t1", eventDate: future)]
+        )
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // when
+        let nextTime = future.addingTimeInterval(3600)
+        store.put(
+            [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+            ["t1": self.makeTodo(id: "t1", eventDate: nextTime)]
+        )
+        try await self.waitForEffects()
+
+        // then
+        #expect(stub.didUpdateWith?.eventDate == Date(timeIntervalSince1970: nextTime.timeIntervalSince1970))
+    }
+
+    /// I-1 회귀 — `eventDate`가 바뀌어 규칙 7이 갱신을 낼 때 `eventTimeText`도 새 시각
+    /// 기준으로 재계산돼야 한다. 옛 문자열을 그대로 흘리면 이 단언이 빨개진다.
+    @Test func usecase_whenUpdatedEventDateStillWithin8Hours_recomputesEventTimeText() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        store.put(
+            [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+            ["t1": self.makeTodo(id: "t1", eventDate: future)]
+        )
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // when
+        let nextTime = future.addingTimeInterval(3600)
+        store.put(
+            [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+            ["t1": self.makeTodo(id: "t1", eventDate: nextTime)]
+        )
+        try await self.waitForEffects()
+
+        // then
+        let expectedText = self.expectedTimeText(
+            for: Date(timeIntervalSince1970: nextTime.timeIntervalSince1970)
+        )
+        #expect(stub.didUpdateWith?.eventTimeText == expectedText)
+    }
+
+    @Test func usecase_whenGoogleEventLocationChanges_updatesActivityContent() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        store.put(
+            [String: GoogleCalendar.Event].self, key: ShareDataKeys.googleCalendarEvents.rawValue,
+            ["g1": self.makeGoogleEvent(id: "g1", eventDate: future, location: "old place")]
+        )
+        try await usecase.startActivity(.googleCalendar(accountId: "acc", calendarId: "cal", eventId: "g1"))
+
+        // when
+        store.put(
+            [String: GoogleCalendar.Event].self, key: ShareDataKeys.googleCalendarEvents.rawValue,
+            ["g1": self.makeGoogleEvent(id: "g1", eventDate: future, location: "new place")]
+        )
+        try await self.waitForEffects()
+
+        // then
+        #expect(stub.didUpdateWith?.placeName == "new place")
+    }
+
+    @Test func usecase_whenNothingChanges_doesNotUpdateActivity() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        let todo = self.makeTodo(id: "t1", name: "same", eventDate: future)
+        store.put([String: TodoEvent].self, key: ShareDataKeys.todos.rawValue, ["t1": todo])
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // when
+        store.put([String: TodoEvent].self, key: ShareDataKeys.todos.rawValue, ["t1": todo])
+        try await self.waitForEffects()
+
+        // then
+        #expect(stub.didUpdateWith == nil)
+        #expect(stub.didEnd == false)
+    }
+
+    @Test func usecase_whenUpdatingContent_keepsOriginalStartDate() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        store.put(
+            [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+            ["t1": self.makeTodo(id: "t1", eventDate: future)]
+        )
+        try await usecase.startActivity(.todo(id: "t1"))
+        let startDate = try #require(stub.didStartWith?.1.startDate)
+
+        // when
+        store.put(
+            [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+            ["t1": self.makeTodo(id: "t1", name: "changed", eventDate: future)]
+        )
+        try await self.waitForEffects()
+
+        // then
+        #expect(stub.didUpdateWith?.startDate == startDate)
+    }
+}
+
+
+// MARK: - 복원·만료
+
+extension EventLiveActivityUsecaseImpleTests {
+
+    @Test func usecase_prepare_restoresRegisteredTargetFromController() async throws {
+        // given
+        let registration = LiveActivityRegistration(
+            target: .todo(id: "t1"), content: self.content(eventDate: Date().addingTimeInterval(60))
+        )
+        let (usecase, _, _) = self.makeUsecase(stubRestoredRegistration: registration)
+
+        // when
+        await usecase.prepare()
+
+        // then
+        let expect = self.expectConfirm("restored target reflected")
+        let target = try await self.firstOutput(expect, for: usecase.registeredTarget)
+        #expect(target == .todo(id: "t1"))
+    }
+
+    /// 컨트롤러의 ActivityKit 관찰은 의존성 조립 시점이 아니라 `prepare()`에서 붙는다 —
+    /// init에서 붙이면 앱이 준비되기 전에 async sequence가 돌기 시작한다.
+    @Test func usecase_prepare_startsControllerObserving() async throws {
+        // given
+        let (usecase, stub, _) = self.makeUsecase()
+        #expect(stub.didStartObserving == false)
+
+        // when
+        await usecase.prepare()
+
+        // then
+        #expect(stub.didStartObserving == true)
+    }
+
+    @Test func usecase_prepare_whenNoActivityExists_leavesRegisteredTargetNil() async throws {
+        // given
+        let (usecase, _, _) = self.makeUsecase(stubRestoredRegistration: nil)
+
+        // when
+        await usecase.prepare()
+
+        // then
+        let expect = self.expectConfirm("no target to restore")
+        let target = try await self.firstOutput(expect, for: usecase.registeredTarget)
+        #expect(target == .some(nil))
+    }
+
+    /// M-2 회귀 — 콜드런치 시점에 복원 대상의 표시 시각이 이미 지났으면 감시를 시작하지
+    /// 않고 즉시 종료한다. `willEnterForeground`는 콜드런치엔 안 오므로 여기서 안 끊으면
+    /// 만료된 액티비티가 유저가 백그라운드→포그라운드를 왕복할 때까지 남는다.
+    @Test func usecase_prepare_whenRestoredActivityAlreadyExpired_endsImmediately() async throws {
+        // given
+        let past = Date().addingTimeInterval(-60)
+        let registration = LiveActivityRegistration(
+            target: .todo(id: "t1"), content: self.content(eventDate: past)
+        )
+        let (usecase, stub, _) = self.makeUsecase(stubRestoredRegistration: registration)
+
+        // when
+        await usecase.prepare()
+
+        // then
+        #expect(stub.didEnd == true)
+        let expect = self.expectConfirm("만료된 복원 대상 즉시 종료")
+        let target = try await self.firstOutput(expect, for: usecase.registeredTarget)
+        #expect(target == .some(nil))
+    }
+
+    /// F1 회귀 — 복원 seed는 controller가 돌려준 실제 content여야 한다. 자리표시자로
+    /// 시작했다면 `tagColorHex`·`startDate`가 빈 값/`.distantPast`로 새어나온다. `eventTimeText`는
+    /// I-1 이후 갱신마다 관찰된 시각 기준으로 재계산되므로 seed 값이 아니라 재계산값과 비교한다.
+    @Test func usecase_prepare_restoresDisplayedContentFromController() async throws {
+        // given
+        let future = Date().addingTimeInterval(60)
+        let restoredContent = EventCountdownActivityAttributes.State(
+            eventName: "restored", eventTimeText: "restored-text", tagColorHex: "#ABCDEF",
+            eventDate: future, startDate: future.addingTimeInterval(-1800)
+        )
+        let registration = LiveActivityRegistration(target: .todo(id: "t1"), content: restoredContent)
+        let (usecase, stub, store) = self.makeUsecase(stubRestoredRegistration: registration)
+        await usecase.prepare()
+        try await self.waitForEffects()
+
+        // when
+        store.put(
+            [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+            ["t1": self.makeTodo(id: "t1", name: "changed", eventDate: future)]
+        )
+        try await self.waitForEffects()
+
+        // then
+        let expectedTimeText = self.expectedTimeText(
+            for: Date(timeIntervalSince1970: future.timeIntervalSince1970)
+        )
+        #expect(stub.didUpdateWith?.eventTimeText == expectedTimeText)
+        #expect(stub.didUpdateWith?.tagColorHex == "#ABCDEF")
+        #expect(stub.didUpdateWith?.startDate == restoredContent.startDate)
+    }
+
+    @Test func usecase_afterRestore_usesFirstObservedValueAsBaseline() async throws {
+        // given
+        let future = Date().addingTimeInterval(60)
+        let registration = LiveActivityRegistration(
+            target: .todo(id: "t1"), content: self.content(eventDate: future)
+        )
+        let (usecase, stub, store) = self.makeUsecase(stubRestoredRegistration: registration)
+        store.put(
+            [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+            ["t1": self.makeTodo(id: "t1", eventDate: future, turn: 3)]
+        )
+
+        // when
+        await usecase.prepare()
+        try await self.waitForEffects()
+
+        // then
+        #expect(stub.didEnd == false)
+        #expect(stub.didUpdateWith == nil)
+    }
+
+    @Test func usecase_handleWillEnterForeground_whenEventDatePassed_endsActivity() async throws {
+        // given
+        let past = Date().addingTimeInterval(-60)
+        let registration = LiveActivityRegistration(
+            target: .todo(id: "t1"), content: self.content(eventDate: past)
+        )
+        let (usecase, stub, _) = self.makeUsecase(stubRestoredRegistration: registration)
+        await usecase.prepare()
+        try await self.waitForEffects()
+
+        // when
+        await usecase.handleWillEnterForeground()
+
+        // then
+        #expect(stub.didEnd == true)
+        let expect = self.expectConfirm("만료된 액티비티 종료")
+        let target = try await self.firstOutput(expect, for: usecase.registeredTarget)
+        #expect(target == .some(nil))
+    }
+
+    @Test func usecase_handleWillEnterForeground_whenEventDateStillFuture_keepsActivity() async throws {
+        // given
+        let future = Date().addingTimeInterval(60)
+        let registration = LiveActivityRegistration(
+            target: .todo(id: "t1"), content: self.content(eventDate: future)
+        )
+        let (usecase, stub, _) = self.makeUsecase(stubRestoredRegistration: registration)
+        await usecase.prepare()
+        try await self.waitForEffects()
+
+        // when
+        await usecase.handleWillEnterForeground()
+
+        // then
+        #expect(stub.didEnd == false)
+    }
+
+    /// F1 회귀 — 복원 직후 공유 상태가 아직 안 채워진 상태(콜드스타트 직후 주 사용 동선)에서
+    /// 포그라운드 진입해도, 자리표시자가 없으니 살아있는 액티비티를 잘못 종료하지 않는다.
+    @Test func usecase_afterRestore_whenStoreHasNoEntry_handleWillEnterForegroundKeepsActivity() async throws {
+        // given
+        let future = Date().addingTimeInterval(60)
+        let registration = LiveActivityRegistration(
+            target: .todo(id: "t1"), content: self.content(eventDate: future)
+        )
+        let (usecase, stub, _) = self.makeUsecase(stubRestoredRegistration: registration)
+
+        // when
+        await usecase.prepare()
+        try await self.waitForEffects()
+        await usecase.handleWillEnterForeground()
+
+        // then
+        #expect(stub.didEnd == false)
+    }
+
+    /// F3 회귀 — 앱 서스펜드 중 잠금화면 해제는 async sequence로 배달 보장이 없다. 포그라운드
+    /// 복귀 시 `controller.currentActivity()`로 재조정해 stale 등록을 정리한다.
+    @Test func usecase_handleWillEnterForeground_whenActivityGoneWhileSuspended_clearsRegisteredTarget() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase(stubRestoredRegistration: nil)
+        let future = Date().addingTimeInterval(60)
+        self.putTodos(store, [self.makeTodo(id: "t1", eventDate: future)])
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // when
+        await usecase.handleWillEnterForeground()
+
+        // then
+        #expect(stub.didEnd == false)
+        let expect = self.expectConfirm("재조정으로 등록 해제")
+        let target = try await self.firstOutput(expect, for: usecase.registeredTarget)
+        #expect(target == .some(nil))
+    }
+
+    @Test func usecase_handleWillEnterForeground_whenActivityStillAlive_keepsRegisteredTarget() async throws {
+        // given
+        let future = Date().addingTimeInterval(60)
+        let stillAlive = LiveActivityRegistration(
+            target: .todo(id: "t1"), content: self.content(eventDate: future)
+        )
+        let (usecase, stub, store) = self.makeUsecase(stubRestoredRegistration: stillAlive)
+        self.putTodos(store, [self.makeTodo(id: "t1", eventDate: future)])
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // when
+        await usecase.handleWillEnterForeground()
+
+        // then
+        #expect(stub.didCheckCurrentActivity == true)
+        #expect(stub.didEnd == false)
+        let expect = self.expectConfirm("재조정이 멀쩡한 등록을 유지한다")
+        let target = try await self.firstOutput(expect, for: usecase.registeredTarget)
+        #expect(target == .todo(id: "t1"))
+    }
+
+    @Test func usecase_whenSystemDismissesActivity_clearsRegisteredTarget() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        self.putTodos(store, [self.makeTodo(id: "t1", eventDate: future)])
+        await usecase.prepare()
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // when
+        let expect = self.expectConfirm("시스템 해제 시 등록 해제")
+        expect.count = 2
+        let targets = try await self.outputs(expect, for: usecase.registeredTarget) {
+            stub.activityTargetUpdatesSubject.send(nil)
+        }
+
+        // then
+        #expect(targets.last == .some(nil))
+    }
+
+    @Test func usecase_afterSystemDismissal_doesNotUpdateActivityOnStoreChange() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        self.putTodos(store, [self.makeTodo(id: "t1", name: "old", eventDate: future)])
+        await usecase.prepare()
+        try await usecase.startActivity(.todo(id: "t1"))
+        let expect = self.expectConfirm("시스템 해제 대기")
+        expect.count = 2
+        _ = try await self.outputs(expect, for: usecase.registeredTarget) {
+            stub.activityTargetUpdatesSubject.send(nil)
+        }
+
+        // when
+        store.put(
+            [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+            ["t1": self.makeTodo(id: "t1", name: "new", eventDate: future)]
+        )
+        try await self.waitForEffects()
+
+        // then
+        #expect(stub.didUpdateWith == nil)
+    }
+}
+
+
+// MARK: - 5종 대상 구독 배선
+
+extension EventLiveActivityUsecaseImpleTests {
+
+    enum TargetKindCase: String, CaseIterable, Sendable {
+        case todo, schedule, holiday, google, apple
+    }
+
+    private func target(for kind: TargetKindCase, holidayDateString: String) -> LiveActivityTarget {
+        switch kind {
+        case .todo: return .todo(id: "id1")
+        case .schedule: return .schedule(id: "id1", turnKey: nil)
+        case .holiday: return .holiday(uuid: "id1", dateString: holidayDateString)
+        case .google: return .googleCalendar(accountId: "a1", calendarId: "c1", eventId: "id1")
+        case .apple: return .appleCalendar(calendarId: "c1", eventId: "id1")
+        }
+    }
+
+    private func seedStore(
+        _ store: SharedDataStore, kind: TargetKindCase, eventDate: Date, holidayDateString: String
+    ) {
+        switch kind {
+        case .todo:
+            store.put(
+                [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
+                ["id1": self.makeTodo(id: "id1", eventDate: eventDate)]
+            )
+        case .schedule:
+            store.put(
+                MemorizedEventsContainer<ScheduleEvent>.self, key: ShareDataKeys.schedules.rawValue,
+                MemorizedEventsContainer<ScheduleEvent>()
+                    .append(self.makeSchedule(id: "id1", eventDate: eventDate))
+            )
+        case .holiday:
+            store.put(
+                [String: [Int: [Holiday]]].self, key: ShareDataKeys.holidays.rawValue,
+                ["KR": [2026: [Holiday(uuid: "id1", dateString: holidayDateString, name: "holiday")]]]
+            )
+        case .google:
+            store.put(
+                [String: GoogleCalendar.Event].self, key: ShareDataKeys.googleCalendarEvents.rawValue,
+                ["id1": self.makeGoogleEvent(id: "id1", eventDate: eventDate)]
+            )
+        case .apple:
+            store.put(
+                [String: AppleCalendar.Event].self, key: ShareDataKeys.appleCalendarEvents.rawValue,
+                ["id1": self.makeAppleEvent(id: "id1", eventDate: eventDate)]
+            )
+        }
+    }
+
+    private func clearStore(_ store: SharedDataStore, kind: TargetKindCase) {
+        switch kind {
+        case .todo:
+            store.put([String: TodoEvent].self, key: ShareDataKeys.todos.rawValue, [:])
+        case .schedule:
+            store.put(
+                MemorizedEventsContainer<ScheduleEvent>.self, key: ShareDataKeys.schedules.rawValue,
+                .init()
+            )
+        case .holiday:
+            store.put([String: [Int: [Holiday]]].self, key: ShareDataKeys.holidays.rawValue, [:])
+        case .google:
+            store.put([String: GoogleCalendar.Event].self, key: ShareDataKeys.googleCalendarEvents.rawValue, [:])
+        case .apple:
+            store.put([String: AppleCalendar.Event].self, key: ShareDataKeys.appleCalendarEvents.rawValue, [:])
+        }
+    }
+
+    @Test(
+        "5종 대상 각각 공유 상태 구독이 붙는다",
+        arguments: TargetKindCase.allCases
+    )
+    func usecase_observesStore_forEachTargetKind(_ kind: TargetKindCase) async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        let scenario = self.holidayTimeZoneScenario()
+        store.put(TimeZone.self, key: ShareDataKeys.timeZone.rawValue, scenario.timeZone)
+        let liveTarget = self.target(for: kind, holidayDateString: scenario.dateString)
+        self.seedStore(
+            store, kind: kind, eventDate: future, holidayDateString: scenario.dateString
+        )
+        try await usecase.startActivity(liveTarget)
+
+        // when
+        let expect = self.expectConfirm("\(kind.rawValue) 대상 삭제 시 종료")
+        expect.count = 2
+        let targets = try await self.outputs(expect, for: usecase.registeredTarget) {
+            self.clearStore(store, kind: kind)
+        }
+
+        // then
+        #expect(targets.last == .some(nil))
+        #expect(stub.didEnd == true)
+    }
+}
+
+
+// MARK: - 공휴일 타임존 해석
+
+extension EventLiveActivityUsecaseImpleTests {
+
+    /// I-2 회귀 — 공휴일 기준 시각은 공유 상태의 타임존(`ShareDataKeys.timeZone`)으로
+    /// 해석해야 한다. `Holiday.date(at:)`를 `.current`로 되돌리면 이 단언이 빨개진다.
+    @Test func usecase_holidayTarget_resolvesEventDateUsingSharedTimeZone() async throws {
+        // given
+        let scenario = self.holidayTimeZoneScenario()
+        let (usecase, stub, store) = self.makeUsecase()
+        store.put(TimeZone.self, key: ShareDataKeys.timeZone.rawValue, scenario.timeZone)
+        store.put(
+            [String: [Int: [Holiday]]].self, key: ShareDataKeys.holidays.rawValue,
+            ["KR": [2026: [Holiday(uuid: "hz", dateString: scenario.dateString, name: "old")]]]
+        )
+        try await usecase.startActivity(.holiday(uuid: "hz", dateString: scenario.dateString))
+
+        // when
+        store.put(
+            [String: [Int: [Holiday]]].self, key: ShareDataKeys.holidays.rawValue,
+            ["KR": [2026: [Holiday(uuid: "hz", dateString: scenario.dateString, name: "new")]]]
+        )
+        try await self.waitForEffects()
+
+        // then
+        #expect(stub.didEnd == false)
+        #expect(stub.didUpdateWith?.eventName == "new")
+        #expect(stub.didUpdateWith?.eventDate == scenario.resolvedDate)
+    }
+}
+
+
+// MARK: - 등록 시 표시 내용 구성
+
+extension EventLiveActivityUsecaseImpleTests {
+
+    @Test func usecase_whenTargetIsNotInSharedState_throwsEventNotFound() async throws {
+        // given
+        let (usecase, _, _) = self.makeUsecase()
+
+        // when
+        var caught: EventLiveActivityStartFailReason?
+        do {
+            try await usecase.startActivity(.todo(id: "missing"))
+        } catch let error as EventLiveActivityStartFailReason {
+            caught = error
+        }
+
+        // then
+        #expect(caught == .eventNotFound)
+    }
+
+    @Test func usecase_startActivity_buildsContentFromSharedState() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        store.put(
+            [String: GoogleCalendar.Event].self, key: ShareDataKeys.googleCalendarEvents.rawValue,
+            ["g1": self.makeGoogleEvent(id: "g1", name: "meeting", eventDate: future, location: "3F")]
+        )
+
+        // when
+        try await usecase.startActivity(
+            .googleCalendar(accountId: "acc", calendarId: "cal", eventId: "g1")
+        )
+
+        // then
+        let canonical = Date(timeIntervalSince1970: future.timeIntervalSince1970)
+        let content = try #require(stub.didStartWith?.1)
+        #expect(content.eventName == "meeting")
+        #expect(content.placeName == "3F")
+        #expect(content.eventDate == canonical)
+        #expect(content.eventTimeText == self.expectedTimeText(for: canonical))
+    }
+
+    @Test func usecase_startActivity_resolvesTagColorFromSharedTags() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        let tag = CustomEventTag(uuid: "tag1", name: "work", colorHex: "#123456")
+        store.put(
+            [EventTagId: any EventTag].self, key: ShareDataKeys.tags.rawValue, [tag.tagId: tag]
+        )
+        self.putTodos(store, [
+            self.makeTodo(id: "t1", eventDate: future) |> \.eventTagId .~ EventTagId.custom("tag1")
+        ])
+
+        // when
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // then
+        #expect(stub.didStartWith?.1.tagColorHex == "#123456")
+    }
+
+    @Test func usecase_startActivity_holidayTarget_usesHolidayDefaultColor() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let scenario = self.holidayTimeZoneScenario()
+        store.put(TimeZone.self, key: ShareDataKeys.timeZone.rawValue, scenario.timeZone)
+        store.put(
+            DefaultEventTagColorSetting.self, key: ShareDataKeys.defaultEventTagColor.rawValue,
+            DefaultEventTagColorSetting(holiday: "#111111", default: "#222222")
+        )
+        store.put(
+            [String: [Int: [Holiday]]].self, key: ShareDataKeys.holidays.rawValue,
+            ["KR": [2026: [Holiday(uuid: "hz", dateString: scenario.dateString, name: "holiday")]]]
+        )
+
+        // when
+        try await usecase.startActivity(.holiday(uuid: "hz", dateString: scenario.dateString))
+
+        // then
+        #expect(stub.didStartWith?.1.tagColorHex == "#111111")
+    }
+
+    /// 남은시간 링의 분모 시작점은 등록 시점이어야 한다 — 이벤트 시각을 넣으면 링이 처음부터 꽉 찬다.
+    @Test func usecase_startActivity_setsStartDateToRegistrationTime() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        self.putTodos(store, [self.makeTodo(id: "t1", eventDate: future)])
+        let before = Date()
+
+        // when
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // then
+        let startDate = try #require(stub.didStartWith?.1.startDate)
+        #expect(startDate >= before)
+        #expect(startDate <= Date())
+    }
+}
+
+
+// MARK: - 외부 캘린더 태그색 해석
+
+extension EventLiveActivityUsecaseImpleTests {
+
+    private func makeGoogleTag(id: String, colorHex: String) -> GoogleCalendar.Tag {
+        return GoogleCalendar.Tag(id: id, name: "cal")
+            |> \.backgroundColorHex .~ colorHex
+    }
+
+    @Test func usecase_startActivity_googleTarget_usesMatchingCalendarTagColor() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        store.put(
+            [String: GoogleCalendar.Event].self, key: ShareDataKeys.googleCalendarEvents.rawValue,
+            ["g1": self.makeGoogleEvent(id: "g1", eventDate: future)]
+        )
+        store.put(
+            [String: [GoogleCalendar.Tag]].self, key: ShareDataKeys.googleCalendarTags.rawValue,
+            ["acc": [
+                self.makeGoogleTag(id: "other", colorHex: "#000000"),
+                self.makeGoogleTag(id: "cal", colorHex: "#AAA111")
+            ]]
+        )
+
+        // when
+        try await usecase.startActivity(
+            .googleCalendar(accountId: "acc", calendarId: "cal", eventId: "g1")
+        )
+
+        // then
+        #expect(stub.didStartWith?.1.tagColorHex == "#AAA111")
+    }
+
+    /// 계정이 다르면 같은 calendarId여도 매칭되면 안 된다 — 다계정에서 색이 섞인다.
+    @Test func usecase_startActivity_googleTarget_whenAccountNotMatched_usesDefaultColor() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        store.put(
+            DefaultEventTagColorSetting.self, key: ShareDataKeys.defaultEventTagColor.rawValue,
+            DefaultEventTagColorSetting(holiday: "#111111", default: "#222222")
+        )
+        store.put(
+            [String: GoogleCalendar.Event].self, key: ShareDataKeys.googleCalendarEvents.rawValue,
+            ["g1": self.makeGoogleEvent(id: "g1", eventDate: future)]
+        )
+        store.put(
+            [String: [GoogleCalendar.Tag]].self, key: ShareDataKeys.googleCalendarTags.rawValue,
+            ["other-account": [self.makeGoogleTag(id: "cal", colorHex: "#AAA111")]]
+        )
+
+        // when
+        try await usecase.startActivity(
+            .googleCalendar(accountId: "acc", calendarId: "cal", eventId: "g1")
+        )
+
+        // then
+        #expect(stub.didStartWith?.1.tagColorHex == "#222222")
+    }
+
+    @Test func usecase_startActivity_appleTarget_usesMatchingCalendarTagColor() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        store.put(
+            [String: AppleCalendar.Event].self, key: ShareDataKeys.appleCalendarEvents.rawValue,
+            ["a1": self.makeAppleEvent(id: "a1", eventDate: future)]
+        )
+        store.put(
+            [AppleCalendar.Tag].self, key: ShareDataKeys.appleCalendarTags.rawValue,
+            [
+                AppleCalendar.Tag(id: "other", name: "other", colorHex: "#000000"),
+                AppleCalendar.Tag(id: "cal", name: "cal", colorHex: "#BBB222")
+            ]
+        )
+
+        // when
+        try await usecase.startActivity(.appleCalendar(calendarId: "cal", eventId: "a1"))
+
+        // then
+        #expect(stub.didStartWith?.1.tagColorHex == "#BBB222")
+    }
+
+    @Test func usecase_startActivity_appleTarget_whenCalendarTagMissing_usesDefaultColor() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        store.put(
+            DefaultEventTagColorSetting.self, key: ShareDataKeys.defaultEventTagColor.rawValue,
+            DefaultEventTagColorSetting(holiday: "#111111", default: "#222222")
+        )
+        store.put(
+            [String: AppleCalendar.Event].self, key: ShareDataKeys.appleCalendarEvents.rawValue,
+            ["a1": self.makeAppleEvent(id: "a1", eventDate: future)]
+        )
+        store.put(
+            [AppleCalendar.Tag].self, key: ShareDataKeys.appleCalendarTags.rawValue,
+            [AppleCalendar.Tag(id: "other", name: "other", colorHex: "#000000")]
+        )
+
+        // when
+        try await usecase.startActivity(.appleCalendar(calendarId: "cal", eventId: "a1"))
+
+        // then
+        #expect(stub.didStartWith?.1.tagColorHex == "#222222")
+    }
+}

--- a/TodoCalendarApp/TodoCalendarAppTests/MainViewModelImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/MainViewModelImpleTests.swift
@@ -29,6 +29,7 @@ class MainViewModelImpleTests: BaseTestCase, PublisherWaitable {
     private var stubSyncUsecase: StubEventSyncUsecase!
     private var spyBillingUsecase: SpyBillingUsecase!
     private var stubAIOrchestrationUsecase: StubAIAgentOrchestrationUsecase!
+    private var spyEventLiveActivityUsecase: SpyEventLiveActivityUsecase!
     var cancelBag: Set<AnyCancellable>!
 
     override func setUpWithError() throws {
@@ -43,6 +44,7 @@ class MainViewModelImpleTests: BaseTestCase, PublisherWaitable {
         self.stubSyncUsecase = .init()
         self.spyBillingUsecase = .init()
         self.stubAIOrchestrationUsecase = .init()
+        self.spyEventLiveActivityUsecase = .init()
         self.cancelBag = .init()
         self.timeout = 0.01
     }
@@ -59,6 +61,7 @@ class MainViewModelImpleTests: BaseTestCase, PublisherWaitable {
         self.stubSyncUsecase = nil
         self.spyBillingUsecase = nil
         self.stubAIOrchestrationUsecase = nil
+        self.spyEventLiveActivityUsecase = nil
         self.cancelBag = nil
     }
 
@@ -77,7 +80,8 @@ class MainViewModelImpleTests: BaseTestCase, PublisherWaitable {
             appleCalendarUsecase: self.spyAppleCalendarUsecase,
             eventSyncUsecase: self.stubSyncUsecase,
             billingUsecase: self.spyBillingUsecase,
-            aiAgentOrchestrationUsecase: self.stubAIOrchestrationUsecase
+            aiAgentOrchestrationUsecase: self.stubAIOrchestrationUsecase,
+            eventLiveActivityUsecase: self.spyEventLiveActivityUsecase
         )
         viewModel.router = self.spyRouter
         self.spyRouter.didCalendarAttached = {
@@ -102,7 +106,8 @@ extension MainViewModelImpleTests {
             appleCalendarUsecase: self.spyAppleCalendarUsecase,
             eventSyncUsecase: self.stubSyncUsecase,
             billingUsecase: self.spyBillingUsecase,
-            aiAgentOrchestrationUsecase: self.stubAIOrchestrationUsecase
+            aiAgentOrchestrationUsecase: self.stubAIOrchestrationUsecase,
+            eventLiveActivityUsecase: self.spyEventLiveActivityUsecase
         )
         viewModel.router = self.spyRouter
         return viewModel
@@ -464,6 +469,35 @@ extension MainViewModelImpleTests {
         }
     }
 
+    final class SpyEventLiveActivityUsecase: EventLiveActivityUsecase, @unchecked Sendable {
+
+        var didPrepare: Bool = false
+        var didHandleWillEnterForeground: Bool = false
+        var didStop: Bool = false
+        var whenDidPrepare: (() -> Void)?
+        var whenDidHandleWillEnterForeground: (() -> Void)?
+
+        func startActivity(_ target: LiveActivityTarget) async throws { }
+
+        func stopActivity() async {
+            self.didStop = true
+        }
+
+        func prepare() async {
+            self.didPrepare = true
+            self.whenDidPrepare?()
+        }
+
+        func handleWillEnterForeground() async {
+            self.didHandleWillEnterForeground = true
+            self.whenDidHandleWillEnterForeground?()
+        }
+
+        var registeredTarget: AnyPublisher<LiveActivityTarget?, Never> {
+            return Empty().eraseToAnyPublisher()
+        }
+    }
+
     private final class SpyBillingUsecase: BillingUsecase, @unchecked Sendable {
 
         var didRecoverUnfinishedTimes: Int = 0
@@ -557,5 +591,42 @@ extension MainViewModelImpleTests {
         // then
         XCTAssertNil(self.stubAIOrchestrationUsecase.didLoadUsage)
         withExtendedLifetime(viewModel) { }
+    }
+}
+
+
+// MARK: - 라이브액티비티
+
+extension MainViewModelImpleTests {
+
+    func testViewModel_whenPrepare_prepareLiveActivity() {
+        // given
+        let expect = expectation(description: "prepare 시 라이브액티비티 복원이 걸린다")
+        let viewModel = self.makeViewModelWithoutPrepare()
+        self.spyEventLiveActivityUsecase.whenDidPrepare = { expect.fulfill() }
+
+        // when
+        viewModel.prepare()
+
+        // then
+        self.wait(for: [expect], timeout: 0.1)
+        XCTAssertEqual(self.spyEventLiveActivityUsecase.didPrepare, true)
+    }
+
+    func testViewModel_whenWillEnterForeground_reconcileLiveActivity() {
+        // given
+        let expect = expectation(description: "포그라운드 복귀 시 등록 상태를 재조정한다")
+        let viewModel = self.makeViewModelWithoutPrepare()
+        viewModel.prepare()
+        self.spyEventLiveActivityUsecase.whenDidHandleWillEnterForeground = { expect.fulfill() }
+
+        // when
+        NotificationCenter.default.post(
+            name: UIApplication.willEnterForegroundNotification, object: nil
+        )
+
+        // then
+        self.wait(for: [expect], timeout: 0.1)
+        XCTAssertEqual(self.spyEventLiveActivityUsecase.didHandleWillEnterForeground, true)
     }
 }

--- a/TodoCalendarApp/TodoCalendarAppTests/StubLiveActivityController.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/StubLiveActivityController.swift
@@ -1,0 +1,82 @@
+//
+//  StubLiveActivityController.swift
+//  TodoCalendarAppTests
+//
+//  Created by sudo.park on 8/17/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+import Domain
+
+@testable import TodoCalendarApp
+
+
+final class StubLiveActivityController: LiveActivityController, @unchecked Sendable {
+
+    private let stubRestoredRegistration: LiveActivityRegistration?
+    private let stubStartError: (any Error)?
+    /// 실제 ActivityKit이 `end()` 직후 `activityStateUpdates`로 종료를 알리는 것을 흉내낸다 —
+    /// 교체 흐름 중 도착하는 stale nil 레이스(F3) 재현용.
+    private let stubEmitsNilOnEnd: Bool
+    /// 겹친 `startActivity` 호출을 재현하려고 `Activity.request`의 지연을 흉내낸다 (I-3 회귀).
+    private let stubStartDelayNanoseconds: UInt64
+    let activityTargetUpdatesSubject: CurrentValueSubject<LiveActivityTarget?, Never>
+
+    var didStartWith: (LiveActivityTarget, EventCountdownActivityAttributes.State)?
+    var didUpdateWith: EventCountdownActivityAttributes.State?
+    var didEnd: Bool = false
+    var didCheckCurrentActivity: Bool = false
+    var didStartObserving: Bool = false
+
+    init(
+        stubRestoredRegistration: LiveActivityRegistration? = nil,
+        stubStartError: (any Error)? = nil,
+        stubEmitsNilOnEnd: Bool = false,
+        stubStartDelayNanoseconds: UInt64 = 0
+    ) {
+        self.stubRestoredRegistration = stubRestoredRegistration
+        self.stubStartError = stubStartError
+        self.stubEmitsNilOnEnd = stubEmitsNilOnEnd
+        self.stubStartDelayNanoseconds = stubStartDelayNanoseconds
+        self.activityTargetUpdatesSubject = .init(nil)
+    }
+
+    func startObserving() {
+        self.didStartObserving = true
+    }
+
+    func startActivity(
+        _ target: LiveActivityTarget, _ content: EventCountdownActivityAttributes.State
+    ) async throws {
+        if self.stubStartDelayNanoseconds > 0 {
+            try? await Task.sleep(nanoseconds: self.stubStartDelayNanoseconds)
+        }
+        self.didStartWith = (target, content)
+        if let stubStartError {
+            throw stubStartError
+        }
+    }
+
+    func updateActivity(_ content: EventCountdownActivityAttributes.State) async {
+        self.didUpdateWith = content
+    }
+
+    func endActivity() async {
+        self.didEnd = true
+        if self.stubEmitsNilOnEnd {
+            self.activityTargetUpdatesSubject.send(nil)
+        }
+    }
+
+    func currentActivity() async -> LiveActivityRegistration? {
+        self.didCheckCurrentActivity = true
+        return self.stubRestoredRegistration
+    }
+
+    var activityTargetUpdates: AnyPublisher<LiveActivityTarget?, Never> {
+        return self.activityTargetUpdatesSubject.eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
라이브액티비티를 실제로 띄우고 끄는 제어 계층을 만든다(#323). #909가 화면을 만들었지만 아무도 시작하지 않았고, 이 PR로 시작·갱신·종료·복원이 돌게 된다. 다만 등록을 트리거할 UI는 #910·#911 소관이라 이 PR만으로는 여전히 화면에 뜨지 않는다.

## 접근

**액티비티는 앱·위젯 한정 스펙이라 무게중심을 앱 타겟에 둔다.** Domain이 갖는 건 `EventLiveActivityUsecase` 프로토콜과 `LiveActivityTarget`뿐 — 다른 화면·usecase가 등록·해제를 걸려면 어쩔 수 없이 뚫어야 하는 만큼이다. 판정하는 `EventLiveActivityUsecaseImple`도, `Activity.request`/`update`/`end`를 부르는 `EventCountdownLiveActivityController`도 앱 타겟에 있다.

**표시 내용은 Domain에 한 벌 더 만들지 않고 구현체가 만든다.** `startActivity`는 대상만 받고, 이름·시각·장소·태그색은 구현체가 공유 상태에서 뽑아 `EventCountdownActivityAttributes.State`를 직접 조립한다. ActivityKit이 요구하는 `Codable`은 앱 타겟 타입이 지고, Domain은 그 요건을 모른다. 덕분에 도메인 모델 ↔ 액티비티 상태 매핑이 통째로 없다.

**그래도 판정은 전부 유닛테스트로 덮인다.** ActivityKit은 주입 지점이 없어 그대로 뒀으면 한 줄도 못 덮었을 영역인데, `LiveActivityController` 프로토콜로 갈라놔서 판정 규칙 여덟 줄과 등록 시 내용 구성이 40 케이스로 덮인다.

**등록 조건 파기는 조회가 아니라 관찰로 잡는다.** 이벤트가 지워졌는지·시각이 바뀌었는지 확인하려고 따로 조회하지 않고, 이미 도는 갱신이 채우는 `SharedDataStore`를 구독해서 방출될 때마다 판정한다. 대상 종류에 맞는 키 하나만 구독하므로 Todo 액티비티가 구글 캐시 갱신에 재평가되지 않는다.

**등록 상태의 진실은 `Activity.activities`다.** 별도 장부를 두면 유저의 스와이프 해제·8시간 상한 종료와 어긋난다(#323). 그래서 컨트롤러가 `activityTargetUpdates`로 실제 상태를 흘리고 usecase가 그걸 따라간다.

## 메커니즘

**레이어와 진실 원천** — Domain은 등록·해제 인터페이스만, 판정·표시 내용 구성·ActivityKit 호출은 앱 타겟, 등록 상태의 진실은 `Activity.activities`에서 역류한다.

```mermaid
flowchart LR
    subgraph SC["Presentations/Scenes"]
        UI["등록 진입점<br/>이벤트 상세 · 일별 리스트<br/>(#910 · #911)"]
    end

    subgraph DM["Domain"]
        API{{"EventLiveActivityUsecase<br/>프로토콜 · LiveActivityTarget"}}
        SDS[("SharedDataStore<br/>todos · schedules · holidays<br/>google · apple · 태그 · 표시 설정")]
    end

    subgraph AP["TodoCalendarApp"]
        MAIN["MainViewModelImple<br/>복원 · 포그라운드 재조정"]
        UC["EventLiveActivityUsecaseImple<br/>등록 판정 · 감시 · 파기"]
        CTRL{{"LiveActivityController<br/>프로토콜"}}
        IMPL["EventCountdownLiveActivityController"]
    end

    AK[["ActivityKit<br/>Activity.activities"]]

    UI -->|"startActivity(target) · stopActivity"| API
    MAIN -->|"prepare · handleWillEnterForeground"| API
    API -.- UC
    SDS -->|"방출마다 재판정"| UC
    UC -->|"State 조립 후 start · update · end"| CTRL
    CTRL -.- IMPL
    IMPL -->|"request · update · end"| AK
    AK -->|"activityUpdates<br/>activityStateUpdates"| IMPL
    IMPL -->|"activityTargetUpdates"| UC
    UC -->|"registeredTarget"| UI
```

역방향 화살표 둘이 핵심이다. 유저가 잠금화면에서 스와이프로 지우거나 시스템이 8시간 상한으로 끝내면 앱은 그 사실을 `Activity.activities` 쪽에서만 알 수 있다 — 그래서 usecase는 자기 장부를 진실로 삼지 않고 `activityTargetUpdates`를 따라간다.

**감시 루프** — 등록된 대상 1건에 대해 공유 상태가 방출될 때마다 도는 판정.

```mermaid
flowchart TD
    A["공유 상태 방출<br/>+ 타임존 · 24시간 표기"] --> B["대상별 스트림<br/>todo · schedule · holiday<br/>google · apple 중 하나만 구독"]
    B --> C["관찰 결과<br/>이름 · 시각 · 장소 · 회차 · 원본시각키"]
    C --> D{"기준선 있나"}
    D -->|"없음 — 복원 경로"| E["첫 관찰값을 기준선으로 채택"]
    D -->|있음| F["판정 — 규칙 1~8"]
    F -->|end| G["endActivity · 등록 해제"]
    F -->|update| H["updateActivity"]
    F -->|keep| I["아무것도 안 함"]
```

대상 종류에 맞는 키 하나만 구독하므로 Todo 액티비티가 구글 캐시 갱신에 재평가되지 않는다.

## 판정 규칙

등록된 대상 1건에 대해 공유 상태가 방출될 때마다 위에서부터 첫 매치를 채택한다.

| # | 조건 | 판정 |
|---|---|---|
| 1 | 못 찾음 + 이전에도 못 찾음 | 유지 |
| 2 | 못 찾음 + 이전엔 찾음 | 종료 — 삭제 |
| 3 | Todo이고 `repeatingTurn`이 기준선과 다름 | 종료 — 회차 종료 |
| 4 | Schedule이고 `repeatingTimeToExcludes`에 등록 `turnKey` 포함 | 종료 |
| 5 | Schedule이고 원본 `time.customKey`가 기준선과 다름 | 종료 |
| 6 | 시각이 과거이거나 `now + 8시간` 초과 | 종료 |
| 7 | 이름·시각·장소 중 하나라도 다름 | 갱신 |
| 8 | 그 외 | 유지 |

**규칙 1이 fail-open인 게 핵심이다.** 앱 재시작 직후나 화면이 그 기간을 안 본 상태에선 살아있는 이벤트도 캐시에 없다. "없음"을 삭제로 읽으면 멀쩡한 액티비티가 꺼진다. 있다가 사라진 전이만 삭제로 본다 — 네 갈래 refresh 경로(`TodoEventUsecase.swift:224`·`MemorizedEventsContainer.swift:141`·`AppleCalendarUsecase.swift:176`·`GoogleCalendarUsecase.swift:266`)가 전부 "그 기간에 캐시돼 있었는데 응답엔 없는 것"만 지우기 때문에 이 구분이 성립한다.

**반복 Todo 완료는 `repeatingTurn`으로 잡는다.** 완료하면 dict에서 사라지는 게 아니라 같은 uuid가 시각·회차만 전진한 채 남는다(`TodoEventUsecase.swift:130` → `TodoLocalRepositoryImple.swift:67`). 삭제로 안 보이므로 회차 비교가 아니면 액티비티가 조용히 다음 회차로 굴러간다.

## 커밋

1. **도메인 타입·제어 계약** — Domain에 `LiveActivityTarget`(5종)·실패 사유, 앱 타겟에 `LiveActivityController`
2. **표시 내용 구성·파기 판정** — 등록 시 공유 상태에서 content 조립, 위 규칙 표, 포그라운드 재조정 (프로토콜은 Domain, 구현체는 앱 타겟)
3. **ActivityKit 구현** — 시작·갱신·종료·복원과 Domain↔앱 타입 매핑
4. **메인 화면이 인스턴스를 소유** — 씬 빌더가 usecase를 만들어 주입하고, 메인 뷰모델이 복원·포그라운드 재조정을 건다. 계정 전환 시엔 참조 없이 액티비티를 끊는다

## 설계 판단

**복원은 대상만이 아니라 표시 내용까지 가져온다.** `tagColorHex`·`startDate`는 등록 시점에만 정해지는 값이라 공유 상태 어디에도 없다 — 대상만 복원하면 복원된 액티비티가 영영 갱신 못 되거나, 갱신하면 빈 값을 밀어넣는다. 유일한 출처가 살아있는 액티비티 자신(`activity.content.state`)이라 `currentActivity() -> LiveActivityRegistration?`로 받는다.

**기준선은 등록 시점 관찰값으로 박는다.** 관찰 스트림의 첫 배달을 기다려 기준선을 잡으면, 등록과 첫 배달 사이에 일어난 변화(회차 전진·시리즈 시각 변경)가 기준선에 그대로 흡수돼 파기 판정이 사라진다. 등록 경로는 content를 만들려고 이미 공유 상태를 읽으므로 그 값을 기준선으로 같이 넘긴다. 복원 경로는 넘길 기준선이 없어(`ContentState`에 회차가 없다) 첫 관찰값을 쓴다.

**`Activity.activities`에서 종료 상태를 걸러낸다.** `.activities`는 아직 잠금화면에서 dismiss 안 된 `.ended` 항목을 포함한다. 안 거르면 8시간 상한으로 죽은 액티비티를 콜드 런치 때 살아있는 등록으로 복원한다. 단 `.active`만 남기면 안 된다 — `staleDate`를 지난 액티비티는 `.stale`이고, 그게 #909가 만료 표시를 그리는 구간이다. 종료 상태 둘만 제외한다.

**컨트롤러는 `Sources/Root/`에 둔다.** `Sources/LiveActivity/`는 `extensionSources` 글롭(`Project+Templates.swift:336`)이 위젯·인텐트·Share 세 확장에 각각 컴파일시키는 폴더다. ActivityKit 제어 코드가 확장에 섞이면 안 된다.

**usecase 인스턴스는 메인 화면이 소유한다.** 앱 전역 싱글턴으로 두지 않고 `MainSceneBuilerImple.makeMainScene()`이 만들어 주입한다 — 메인 씬은 계정 전환마다 재생성되므로 수명이 계정 세션에 묶인다. 팩토리에 `make…()`를 남기지 않은 건, 남기면 다른 Scene이 호출해 각자 다른 인스턴스를 들고 등록 상태가 갈라지기 때문이다(#910·#911은 메인 씬 인터랙터를 경유해야 한다). ActivityKit 상태 관찰도 컨트롤러 `init`이 아니라 `startObserving()` 명시 호출로 바꿔, 의존성 조립 중에 async sequence가 도는 일이 없다.

**포그라운드 진입에서 등록 상태를 재조정한다.** 앱이 서스펜드된 동안 유저가 잠금화면에서 액티비티를 지운 걸 async sequence가 재개 시 배달한다는 보장이 없다. 재조정이 없으면 등록 상태가 stale non-nil로 남아 죽은 액티비티에 계속 갱신을 시도한다.

**계정 전환 종료는 usecase 참조 없이 건다.** usecase는 계정을 모른다 — 인스턴스가 씬과 함께 사라지면 등록 상태도 같이 사라질 뿐이다. 다만 `Activity.activities`엔 이전 계정 액티비티가 남고, 새 씬의 `prepare()`는 콜드런치와 계정 전환을 구분할 수 없어 그대로 복원해버린다. 그래서 `ApplicationPrepareUsecaseImple`이 로그인·로그아웃 진입에서 살아있는 액티비티를 직접 끊는다 — `handleDidEnterBackground`가 `WidgetCenter.shared.reloadAllTimelines()`를 부르는 것과 같은 결이라 의존성이 늘지 않는다.

**시각 문구는 Domain에서 한 곳으로 모은다.** 시각이 바뀌면 `eventDate`만 갱신되고 잠금화면 문구는 옛 시각에 머물러서, "오후 3:00" 옆에서 타이머가 4시를 향해 도는 모순이 났다. 문구를 만드는 자리가 등록 콜사이트(#910)와 갱신 경로 둘로 갈리는 게 원인이라, `EventLiveActivityTimeTextFormatter`로 모아 양쪽이 같은 함수를 쓰게 했다. Domain에서 이벤트 시각 문구를 만드는 건 알림 경로(`EventTime.notificationTimeInfo(timeOption:)`)에 이미 있는 관례다.

**타임존·24시간 표기는 공유 상태에서 한 스트림으로 받는다.** 공휴일의 기준 시각(그날 00:00)과 시각 문구가 둘 다 이 설정에 걸린다. 디바이스 타임존(`.current`)을 쓰면 앱 타임존을 다르게 설정한 유저에게서 자정 기준이 13~14시간 어긋나 규칙 6이 걸리고 방금 켠 액티비티가 즉시 꺼진다 — 선례인 `DaysIntervalCountUsecase`도 유저 선택 타임존을 쓴다.

**"동시 1개"는 usecase 장부가 아니라 진실 원천에서 강제한다.** `startActivity`를 겹쳐 호출하면 앞선 호출이 `endActivity()`에서 대기하는 사이 등록이 이미 nil이라 뒤 호출이 종료를 건너뛰고, 액티비티가 둘 생긴다. `.first`만 집히니 나머지는 8시간 상한까지 고아로 남는다. 그래서 컨트롤러가 `request` 직전에 살아있는 액티비티를 전부 종료하고, usecase 진입도 직렬화했다.

**8시간 경계 TC는 뮤테이션 감도가 없다.** 벽시계로는 정확히 8시간 지점에 착지할 수 없어(테스트의 `Date()`가 프로덕션의 것보다 항상 앞선다) `<=`↔`<` 뒤집기를 못 잡는다. 시계를 주입하면 잡히지만 Domain에 그 선례가 없고, 그 차이는 마이크로초 폭이라 관찰 가능한 결과가 없다. 상수 오류·부등호 방향 뒤집기 같은 실질적 뮤테이션은 현행 경계 쌍이 잡는다.

## 남은 과제

**#910·#911에 넘기는 제약**

- **usecase는 메인 씬이 소유하므로 팩토리로 못 받는다.** 등록 진입점은 메인 씬 인터랙터를 경유해야 한다.
- **등록은 대상이 공유 상태에 있어야 성립한다.** 없으면 `eventNotFound`로 거절한다. 이벤트 상세·일별 리스트 둘 다 화면이 이미 그 이벤트를 캐시에 올린 뒤라 성립하지만, 진입점에서 실패 사유 3종(`eventNotFound`·`alreadyPassed`·`tooFarFuture`)을 각각 안내해야 한다.
- **Todo·Schedule은 장소·메모를 못 싣는다.** 공유 상태엔 둘 다 없어(`EventDetailData`는 별도 조회) 구현체가 만들 수 없다. Google·Apple은 `location`이 공유 상태에 있어 문제없다.
- **`memo`는 아직 안 채운다.** 공유 상태엔 이벤트 메모가 없어(`EventDetailData`는 별도 조회) 구현체가 만들 수 없다. #909의 잠금화면은 `placeName ?? memo`를 부제로 쓰므로, Todo·Schedule 부제를 살리려면 #910이 메모 출처를 붙여야 한다.

**의도적으로 안 고친 것**

- 교체 중 신규 시작이 실패하면 이전 액티비티가 복구되지 않는다. 최종 상태는 일관되고(액티비티 없음 + 등록 nil + 에러 전파), 복구하려면 실패 가능한 `request`를 한 번 더 때려야 해서 오히려 상태가 갈라진다. "종료 후 시작" 순서를 유지한 결과다.
- 규칙 7은 이름·시각·장소만 비교한다. 이벤트는 그대로인데 24시간 표기만 토글하거나 태그 색만 바꾸면, 다음 실질 갱신이 올 때까지 잠금화면이 옛 값으로 남는다. 설정 변경만으로 액티비티를 갱신하는 건 이 이슈 스코프 밖이다.

## 검증

`Domain`(306)·`TodoCalendarApp`(59)·`TodoCalendarAppWidget`(75) 세 스킴 통과. `EventLiveActivityUsecaseImpleTests` 41 케이스가 판정 규칙 8행·등록 시 내용 구성(태그색·장소·시각 문구·등록 시점 startDate)·실패 사유 3종·복원·포그라운드 재조정·외부 해제·겹친 등록 직렬화를 덮고, `MainViewModelImpleTests` 2 케이스가 수명주기 배선을 덮는다.

컨트롤러는 유닛테스트가 없다 — `Activity`가 주입 지점 없는 시스템 타입이고, 형제인 `BackgroundEventSyncUsecaseImple`(`BGTaskScheduler.shared` 직접 호출)도 같은 이유로 없다.

**유저 검증 대기**: 실기기 라이브액티비티 등록(트리거 UI가 #910이라 그 머지 후 가능), 8시간 상한 도달 시 시스템 자동 종료.

Closes #908
