### PR TITLE
[#910] 라이브액티비티 등록 진입점 — 이벤트 상세 (Todo·일정·공휴일)

### DIFF
--- a/Presentations/EventDetailScene/Sources/EventDetailSceneBuilderImple.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailSceneBuilderImple.swift
@@ -68,7 +68,8 @@ extension EventDetailSceneBuilderImple: EventDetailSceneBuilder {
             eventDetailDataUsecase: self.usecaseFactory.makeEventDetailDataUsecase(),
             scheduleEventUsecase: self.usecaseFactory.makeScheduleEventUsecase(),
             calendarSettingUsecase: self.usecaseFactory.makeCalendarSettingUsecase(),
-            foremostEventUsecase: self.usecaseFactory.makeForemostEventUsecase()
+            foremostEventUsecase: self.usecaseFactory.makeForemostEventUsecase(),
+            eventLiveActivityUsecase: self.usecaseFactory.eventLiveActivityUsecase
         )
         viewModel.listener = listener
         return self.makeEventDetailScene(viewModel)
@@ -89,7 +90,8 @@ extension EventDetailSceneBuilderImple: EventDetailSceneBuilder {
             todoEventUsecase: self.usecaseFactory.makeTodoEventUsecase(),
             calendarSettingUsecase: self.usecaseFactory.makeCalendarSettingUsecase(),
             foremostEventUsecase: self.usecaseFactory.makeForemostEventUsecase(),
-            ddayCandidateUsecase: self.usecaseFactory.makeDDayCandidateUsecase()
+            ddayCandidateUsecase: self.usecaseFactory.makeDDayCandidateUsecase(),
+            eventLiveActivityUsecase: self.usecaseFactory.eventLiveActivityUsecase
         )
         viewModel.listener = listener
         return self.makeEventDetailScene(viewModel)

--- a/Presentations/EventDetailScene/Sources/EventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailView.swift
@@ -1160,9 +1160,7 @@ extension EventDetailMoreAction: Identifiable {
                 ? "calendar::event::more_action:dday_candidate:unregister:item_name".localized()
                 : "calendar::event::more_action:dday_candidate:register:item_name".localized()
         case .toggleLiveActivity(let isRegistered):
-            return isRegistered
-                ? "calendar::event::more_action:live_activity:unregister:item_name".localized()
-                : "calendar::event::more_action:live_activity:register:item_name".localized()
+            return LiveActivityActionModel(isRegistered: isRegistered).itemText
         case .copy: return "calendar::event::more_action:copy:item_name".localized()
         case .addToTemplate: return "add to template".localized()
         case .share: return "calendar::event::more_action:share:item_name".localized()

--- a/Presentations/EventDetailScene/Sources/EventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailView.swift
@@ -1134,6 +1134,8 @@ extension EventDetailMoreAction: Identifiable {
             return "toggleTo:\(isForemost)"
         case .toggleDDayCandidate(let isRegistered):
             return "toggleDDayCandidate:\(isRegistered)"
+        case .toggleLiveActivity(let isRegistered):
+            return "toggleLiveActivity:\(isRegistered)"
         case .copy: return "copy"
         case .addToTemplate: return "addToTemplate"
         case .share: return "share"
@@ -1157,6 +1159,10 @@ extension EventDetailMoreAction: Identifiable {
             return isRegistered
                 ? "calendar::event::more_action:dday_candidate:unregister:item_name".localized()
                 : "calendar::event::more_action:dday_candidate:register:item_name".localized()
+        case .toggleLiveActivity(let isRegistered):
+            return isRegistered
+                ? "calendar::event::more_action:live_activity:unregister:item_name".localized()
+                : "calendar::event::more_action:live_activity:register:item_name".localized()
         case .copy: return "calendar::event::more_action:copy:item_name".localized()
         case .addToTemplate: return "add to template".localized()
         case .share: return "calendar::event::more_action:share:item_name".localized()
@@ -1170,6 +1176,7 @@ extension EventDetailMoreAction: Identifiable {
         case .remove: return "trash"
         case .toggleTo: return "exclamationmark.circle"
         case .toggleDDayCandidate: return "calendar.badge.clock"
+        case .toggleLiveActivity: return "timer"
         case .copy: return "doc.on.doc"
         case .addToTemplate: return "doc.plaintext"
         case .share: return "square.and.arrow.up"

--- a/Presentations/EventDetailScene/Sources/EventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailViewModel.swift
@@ -11,7 +11,6 @@ import Prelude
 import Optics
 import Domain
 import Extensions
-import Scenes
 
 
 struct EventDetailTypeModel: Equatable {
@@ -76,37 +75,6 @@ enum EventDetailMoreAction: Equatable {
     case toggleDDayCandidate(isRegistered: Bool)
     case toggleLiveActivity(isRegistered: Bool)
     case share
-}
-
-extension EventLiveActivityStartFailReason {
-
-    var unavailableMessage: String {
-        switch self {
-        case .eventNotFound:
-            return "calendar::event::more_action:live_activity:unavail::not_found".localized()
-        case .alreadyPassed:
-            return "calendar::event::more_action:live_activity:unavail::already_passed".localized()
-        case .tooFarFuture:
-            return "calendar::event::more_action:live_activity:unavail::too_far_future".localized()
-        }
-    }
-}
-
-extension Routing {
-
-    /// 등록 불가는 오류가 아니라 안내다 — `showError`는 "문제가 발생했습니다" 뒤에 사유를
-    /// 괄호로 덧붙여 안내문을 오류처럼 읽히게 한다.
-    func showLiveActivityUnavailable(_ error: any Error) {
-        guard let reason = error as? EventLiveActivityStartFailReason
-        else { return self.showError(error) }
-
-        let info = ConfirmDialogInfo()
-            |> \.title .~ pure("calendar::event::more_action:live_activity:title".localized())
-            |> \.message .~ pure(reason.unavailableMessage)
-            |> \.withCancel .~ false
-            |> \.confirmText .~ R.String.Common.close
-        self.showConfirm(dialog: info)
-    }
 }
 
 protocol EventDetailViewModel: Sendable, AnyObject {

--- a/Presentations/EventDetailScene/Sources/EventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailViewModel.swift
@@ -11,6 +11,7 @@ import Prelude
 import Optics
 import Domain
 import Extensions
+import Scenes
 
 
 struct EventDetailTypeModel: Equatable {
@@ -73,7 +74,39 @@ enum EventDetailMoreAction: Equatable {
     case addToTemplate  // 이후 구현 예정
     case toggleTo(isForemost: Bool)
     case toggleDDayCandidate(isRegistered: Bool)
+    case toggleLiveActivity(isRegistered: Bool)
     case share
+}
+
+extension EventLiveActivityStartFailReason {
+
+    var unavailableMessage: String {
+        switch self {
+        case .eventNotFound:
+            return "calendar::event::more_action:live_activity:unavail::not_found".localized()
+        case .alreadyPassed:
+            return "calendar::event::more_action:live_activity:unavail::already_passed".localized()
+        case .tooFarFuture:
+            return "calendar::event::more_action:live_activity:unavail::too_far_future".localized()
+        }
+    }
+}
+
+extension Routing {
+
+    /// 등록 불가는 오류가 아니라 안내다 — `showError`는 "문제가 발생했습니다" 뒤에 사유를
+    /// 괄호로 덧붙여 안내문을 오류처럼 읽히게 한다.
+    func showLiveActivityUnavailable(_ error: any Error) {
+        guard let reason = error as? EventLiveActivityStartFailReason
+        else { return self.showError(error) }
+
+        let info = ConfirmDialogInfo()
+            |> \.title .~ pure("calendar::event::more_action:live_activity:title".localized())
+            |> \.message .~ pure(reason.unavailableMessage)
+            |> \.withCancel .~ false
+            |> \.confirmText .~ R.String.Common.close
+        self.showConfirm(dialog: info)
+    }
 }
 
 protocol EventDetailViewModel: Sendable, AnyObject {

--- a/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailBuilderImple.swift
+++ b/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailBuilderImple.swift
@@ -9,6 +9,7 @@
 //
 
 import UIKit
+import Domain
 import Scenes
 import CommonPresentation
 
@@ -38,7 +39,8 @@ extension HolidayEventDetailSceneBuilerImple: HolidayEventDetailSceneBuiler {
         let viewModel = HolidayEventDetailViewModelImple(
             uuid: uuid,
             holidayUsecase: self.usecaseFactory.makeHolidayUsecase(),
-            daysIntervalCountUsecase: self.usecaseFactory.makeDaysIntervalCountUsecase()
+            daysIntervalCountUsecase: self.usecaseFactory.makeDaysIntervalCountUsecase(),
+            eventLiveActivityUsecase: self.usecaseFactory.eventLiveActivityUsecase
         )
         
         let viewController = HolidayEventDetailViewController(

--- a/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailView.swift
@@ -27,6 +27,7 @@ import CommonPresentation
     var dateText: String = ""
     var ddayText: String = ""
     var countryModel: CountryModel?
+    var liveActivityActionModel: LiveActivityActionModel?
     
     func bind(_ viewModel: any HolidayEventDetailViewModel) {
         
@@ -60,6 +61,13 @@ import CommonPresentation
                 self?.countryModel = model
             })
             .store(in: &self.cancellables)
+        
+        viewModel.liveActivityActionModel
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self] model in
+                self?.liveActivityActionModel = model
+            })
+            .store(in: &self.cancellables)
     }
 }
 
@@ -70,12 +78,14 @@ final class HolidayEventDetailViewEventHandler: Observable {
     var onAppear: () -> Void = { }
     var close: () -> Void = { }
     var hideHoliday: () -> Void = { }
+    var toggleLiveActivity: (Bool) -> Void = { _ in }
 
     func bind(_ viewModel: any HolidayEventDetailViewModel) {
 
         self.onAppear = viewModel.refresh
         self.close = viewModel.close
         self.hideHoliday = viewModel.hideHoliday
+        self.toggleLiveActivity = viewModel.toggleLiveActivity(isRegistered:)
     }
 }
 
@@ -150,6 +160,14 @@ struct HolidayEventDetailView: View {
                 .eventHandler(\.onTap, self.eventHandlers.close)
 
             Menu {
+                if let model = self.state.liveActivityActionModel {
+                    Button {
+                        self.eventHandlers.toggleLiveActivity(model.isRegistered)
+                    } label: {
+                        Label(model.itemText, systemImage: "timer")
+                    }
+                }
+
                 Button(role: .destructive) {
                     self.eventHandlers.hideHoliday()
                 } label: {

--- a/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailViewModel.swift
@@ -30,32 +30,38 @@ protocol HolidayEventDetailViewModel: AnyObject, Sendable, HolidayEventDetailSce
     func refresh()
     func close()
     func hideHoliday()
+    func toggleLiveActivity(isRegistered: Bool)
 
     // presenter
     var holidayName: AnyPublisher<String, Never> { get }
     var dateText: AnyPublisher<String, Never> { get }
     var ddayText: AnyPublisher<String, Never> { get }
     var countryModel: AnyPublisher<CountryModel, Never> { get }
+    var liveActivityActionModel: AnyPublisher<LiveActivityActionModel?, Never> { get }
 }
 
 
 // MARK: - HolidayEventDetailViewModelImple
 
-final class HolidayEventDetailViewModelImple: HolidayEventDetailViewModel, @unchecked Sendable {
+final class HolidayEventDetailViewModelImple: HolidayEventDetailViewModel, LiveActivityToggleHandling, @unchecked Sendable {
     
     private let uuid: String
     private let holidayUsecase: any HolidayUsecase
     private let daysIntervalCountUsecase: any DaysIntervalCountUsecase
+    let eventLiveActivityUsecase: any EventLiveActivityUsecase
     var router: (any HolidayEventDetailRouting)?
+    var liveActivityRouting: (any Routing)? { self.router }
     
     init(
         uuid: String,
         holidayUsecase: any HolidayUsecase,
-        daysIntervalCountUsecase: any DaysIntervalCountUsecase
+        daysIntervalCountUsecase: any DaysIntervalCountUsecase,
+        eventLiveActivityUsecase: any EventLiveActivityUsecase
     ) {
         self.uuid = uuid
         self.holidayUsecase = holidayUsecase
         self.daysIntervalCountUsecase = daysIntervalCountUsecase
+        self.eventLiveActivityUsecase = eventLiveActivityUsecase
     }
     
     
@@ -105,6 +111,11 @@ extension HolidayEventDetailViewModelImple {
             |> \.confirmed .~ pure(confirmed)
             |> \.withCancel .~ true
         self.router?.showConfirm(dialog: info)
+    }
+
+    func toggleLiveActivity(isRegistered: Bool) {
+        guard let holiday = self.subject.holiday.value else { return }
+        self.startOrStopLiveActivity(holiday.liveActivityTarget, isRegistered: isRegistered)
     }
 
     private func hideHolidayConfirmed(_ name: String) {
@@ -160,6 +171,21 @@ extension HolidayEventDetailViewModelImple {
             .eraseToAnyPublisher()
     }
     
+    var liveActivityActionModel: AnyPublisher<LiveActivityActionModel?, Never> {
+        let transform: (Holiday?, LiveActivityTarget?) -> LiveActivityActionModel? = { holiday, registeredTarget in
+            guard let holiday else { return nil }
+            return LiveActivityActionModel(
+                isRegistered: registeredTarget == holiday.liveActivityTarget
+            )
+        }
+        return Publishers.CombineLatest(
+            self.subject.holiday, self.eventLiveActivityUsecase.registeredTarget
+        )
+        .map(transform)
+        .removeDuplicates()
+        .eraseToAnyPublisher()
+    }
+    
     var countryModel: AnyPublisher<CountryModel, Never> {
         let transform: (HolidaySupportCountry) -> CountryModel = { country in
             return .init(
@@ -171,5 +197,13 @@ extension HolidayEventDetailViewModelImple {
             .map(transform)
             .removeDuplicates()
             .eraseToAnyPublisher()
+    }
+}
+
+
+private extension Holiday {
+
+    var liveActivityTarget: LiveActivityTarget {
+        return .holiday(uuid: self.uuid, dateString: self.dateString)
     }
 }

--- a/Presentations/EventDetailScene/Sources/LiveActivityToggleHandling.swift
+++ b/Presentations/EventDetailScene/Sources/LiveActivityToggleHandling.swift
@@ -1,0 +1,83 @@
+//
+//  LiveActivityToggleHandling.swift
+//  EventDetailScene
+//
+//  Created by sudo.park on 8/19/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Prelude
+import Optics
+import Domain
+import Scenes
+import Extensions
+
+
+struct LiveActivityActionModel: Equatable {
+
+    let isRegistered: Bool
+
+    var itemText: String {
+        return self.isRegistered
+            ? "calendar::event::more_action:live_activity:unregister:item_name".localized()
+            : "calendar::event::more_action:live_activity:register:item_name".localized()
+    }
+}
+
+
+protocol LiveActivityToggleHandling: AnyObject, Sendable {
+
+    var eventLiveActivityUsecase: any EventLiveActivityUsecase { get }
+    var liveActivityRouting: (any Routing)? { get }
+}
+
+extension LiveActivityToggleHandling {
+
+    func startOrStopLiveActivity(_ target: LiveActivityTarget, isRegistered: Bool) {
+        Task { [weak self] in
+            guard let self else { return }
+            guard isRegistered == false
+            else { return await self.eventLiveActivityUsecase.stopActivity() }
+
+            do {
+                try await self.eventLiveActivityUsecase.startActivity(target)
+            } catch {
+                self.liveActivityRouting?.showLiveActivityUnavailable(error)
+            }
+        }
+    }
+}
+
+
+extension Routing {
+
+    /// 등록 불가는 오류가 아니라 안내다 — `showError`는 "문제가 발생했습니다" 뒤에 사유를
+    /// 괄호로 덧붙여 안내문을 오류처럼 읽히게 한다.
+    func showLiveActivityUnavailable(_ error: any Error) {
+        guard let reason = error as? EventLiveActivityStartFailReason
+        else { return self.showError(error) }
+
+        let info = ConfirmDialogInfo()
+            |> \.title .~ pure("calendar::event::more_action:live_activity:title".localized())
+            |> \.message .~ pure(reason.unavailableMessage)
+            |> \.withCancel .~ false
+            |> \.confirmText .~ R.String.Common.close
+        self.showConfirm(dialog: info)
+    }
+}
+
+
+private extension EventLiveActivityStartFailReason {
+
+    var unavailableMessage: String {
+        switch self {
+        case .eventNotFound:
+            return "calendar::event::more_action:live_activity:unavail::not_found".localized()
+        case .alreadyPassed:
+            return "calendar::event::more_action:live_activity:unavail::already_passed".localized()
+        case .tooFarFuture:
+            return "calendar::event::more_action:live_activity:unavail::too_far_future".localized()
+        }
+    }
+}

--- a/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
@@ -25,6 +25,7 @@ final class EditScheduleEventDetailViewModelImple: EventDetailViewModel, @unchec
     private let calendarSettingUsecase: any CalendarSettingUsecase
     private let foremostEventUsecase: any ForemostEventUsecase
     private let ddayCandidateUsecase: any DDayCandidateUsecase
+    private let eventLiveActivityUsecase: any EventLiveActivityUsecase
     var router: (any EventDetailRouting)?
     weak var listener: EventDetailSceneListener?
     
@@ -37,7 +38,8 @@ final class EditScheduleEventDetailViewModelImple: EventDetailViewModel, @unchec
         todoEventUsecase: any TodoEventUsecase,
         calendarSettingUsecase: any CalendarSettingUsecase,
         foremostEventUsecase: any ForemostEventUsecase,
-        ddayCandidateUsecase: any DDayCandidateUsecase
+        ddayCandidateUsecase: any DDayCandidateUsecase,
+        eventLiveActivityUsecase: any EventLiveActivityUsecase
     ) {
         self.scheduleId = scheduleId
         self.repeatingEventTargetTime = repeatingEventTargetTime
@@ -48,6 +50,7 @@ final class EditScheduleEventDetailViewModelImple: EventDetailViewModel, @unchec
         self.calendarSettingUsecase = calendarSettingUsecase
         self.foremostEventUsecase = foremostEventUsecase
         self.ddayCandidateUsecase = ddayCandidateUsecase
+        self.eventLiveActivityUsecase = eventLiveActivityUsecase
 
         self.internalBinding()
     }
@@ -151,6 +154,9 @@ extension EditScheduleEventDetailViewModelImple: EventDetailInputListener {
 
         case .toggleDDayCandidate(let isRegistered):
             self.toggleDDayCandidateAfterConfirm(isRegistered: isRegistered)
+
+        case .toggleLiveActivity(let isRegistered):
+            self.toggleLiveActivity(isRegistered)
 
         case .copy:
             self.copyEvent()
@@ -293,6 +299,30 @@ extension EditScheduleEventDetailViewModelImple: EventDetailInputListener {
     /// 상세가 열린 회차가 곧 등록 대상이다 — 반복이면 그 회차, 아니면 원본.
     private var currentCandidate: DDayCandidate {
         return DDayCandidate(
+            scheduleId: self.scheduleId,
+            targetTime: self.repeatingEventTargetTime,
+            isRepeating: self.subject.basicData.value?.origin.isRepeatingEvent ?? false
+        )
+    }
+
+    private func toggleLiveActivity(_ isRegistered: Bool) {
+        let target = self.currentLiveActivityTarget
+        Task { [weak self] in
+            guard let self else { return }
+            guard isRegistered == false
+            else { return await self.eventLiveActivityUsecase.stopActivity() }
+
+            do {
+                try await self.eventLiveActivityUsecase.startActivity(target)
+            } catch {
+                self.router?.showLiveActivityUnavailable(error)
+            }
+        }
+    }
+
+    /// 상세가 열린 회차가 곧 등록 대상이다 — 반복이면 그 회차, 아니면 원본.
+    private var currentLiveActivityTarget: LiveActivityTarget {
+        return LiveActivityTarget(
             scheduleId: self.scheduleId,
             targetTime: self.repeatingEventTargetTime,
             isRepeating: self.subject.basicData.value?.origin.isRepeatingEvent ?? false
@@ -578,8 +608,8 @@ extension EditScheduleEventDetailViewModelImple {
         // 위젯 없이 후보만 등록하게 두면 갈 곳 없는 기능이 된다. 처리 로직은 살아 있다
         let isDDayWidgetEnabled = FeatureFlag.isEnable(.ddayWidget)
         let transform: (
-            EventDetailBasicData, (any ForemostMarkableEvent)?, [DDayCandidate]
-        ) -> [[EventDetailMoreAction]] = { basic, foremostEvent, candidates in
+            EventDetailBasicData, (any ForemostMarkableEvent)?, [DDayCandidate], LiveActivityTarget?
+        ) -> [[EventDetailMoreAction]] = { basic, foremostEvent, candidates, registeredTarget in
             let isRepeating = basic.isRepeatingEvent
             let isForemost = foremostEvent?.eventId == scheduleId
             let removeActions: [EventDetailMoreAction] = isRepeating
@@ -598,18 +628,31 @@ extension EditScheduleEventDetailViewModelImple {
                     )
                 ]
                 : []
+            let liveActivityActions: [EventDetailMoreAction] = basic.selectedTime != nil
+                ? [
+                    .toggleLiveActivity(
+                        isRegistered: registeredTarget == LiveActivityTarget(
+                            scheduleId: scheduleId,
+                            targetTime: targetTime,
+                            isRepeating: isRepeating
+                        )
+                    )
+                ]
+                : []
             let otherActions: [EventDetailMoreAction] = isRepeating
-                ? ddayActions + [.copy, .transformToTodo, .share]
-                : [.toggleTo(isForemost: !isForemost)] + ddayActions + [.copy, .transformToTodo, .share]
+                ? ddayActions + liveActivityActions + [.copy, .transformToTodo, .share]
+                : [.toggleTo(isForemost: !isForemost)] + ddayActions + liveActivityActions
+                    + [.copy, .transformToTodo, .share]
             return [removeActions, otherActions]
         }
-        return Publishers.CombineLatest3(
+        return Publishers.CombineLatest4(
             self.subject.basicData.compactMap { $0?.origin },
             self.foremostEventUsecase.foremostEvent,
             // 플래그가 꺼져 있으면 후보 목록을 조회·구독하지 않는다
             isDDayWidgetEnabled
                 ? self.ddayCandidateUsecase.candidates
-                : Just<[DDayCandidate]>([]).eraseToAnyPublisher()
+                : Just<[DDayCandidate]>([]).eraseToAnyPublisher(),
+            self.eventLiveActivityUsecase.registeredTarget
         )
         .map(transform)
         .removeDuplicates()
@@ -657,6 +700,19 @@ private extension ScheduleMakeParams {
         self.eventTagId = basic.eventTagId
         self.repeating = basic.eventRepeating?.repeating
         self.notificationOptions = basic.eventNotifications
+    }
+}
+
+
+private extension LiveActivityTarget {
+
+    /// 회차 키 규칙은 `DDayCandidate.init(scheduleId:targetTime:isRepeating:)`과 같다 —
+    /// 비반복에도 채워져 있는 `repeatingEventTargetTime`을 그대로 실으면 등록 대상이 어긋난다.
+    init(scheduleId: String, targetTime: EventTime?, isRepeating: Bool) {
+        self = .schedule(
+            id: scheduleId,
+            turnKey: isRepeating ? targetTime?.customKey : nil
+        )
     }
 }
 

--- a/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
@@ -14,7 +14,9 @@ import Extensions
 import Scenes
 
 
-final class EditScheduleEventDetailViewModelImple: EventDetailViewModel, @unchecked Sendable {
+final class EditScheduleEventDetailViewModelImple: EventDetailViewModel, LiveActivityToggleHandling, @unchecked Sendable {
+
+    var liveActivityRouting: (any Routing)? { self.router }
     
     private let scheduleId: String
     private let repeatingEventTargetTime: EventTime?
@@ -25,7 +27,7 @@ final class EditScheduleEventDetailViewModelImple: EventDetailViewModel, @unchec
     private let calendarSettingUsecase: any CalendarSettingUsecase
     private let foremostEventUsecase: any ForemostEventUsecase
     private let ddayCandidateUsecase: any DDayCandidateUsecase
-    private let eventLiveActivityUsecase: any EventLiveActivityUsecase
+    let eventLiveActivityUsecase: any EventLiveActivityUsecase
     var router: (any EventDetailRouting)?
     weak var listener: EventDetailSceneListener?
     
@@ -156,7 +158,9 @@ extension EditScheduleEventDetailViewModelImple: EventDetailInputListener {
             self.toggleDDayCandidateAfterConfirm(isRegistered: isRegistered)
 
         case .toggleLiveActivity(let isRegistered):
-            self.toggleLiveActivity(isRegistered)
+            self.startOrStopLiveActivity(
+                self.currentLiveActivityTarget, isRegistered: isRegistered
+            )
 
         case .copy:
             self.copyEvent()
@@ -303,21 +307,6 @@ extension EditScheduleEventDetailViewModelImple: EventDetailInputListener {
             targetTime: self.repeatingEventTargetTime,
             isRepeating: self.subject.basicData.value?.origin.isRepeatingEvent ?? false
         )
-    }
-
-    private func toggleLiveActivity(_ isRegistered: Bool) {
-        let target = self.currentLiveActivityTarget
-        Task { [weak self] in
-            guard let self else { return }
-            guard isRegistered == false
-            else { return await self.eventLiveActivityUsecase.stopActivity() }
-
-            do {
-                try await self.eventLiveActivityUsecase.startActivity(target)
-            } catch {
-                self.router?.showLiveActivityUnavailable(error)
-            }
-        }
     }
 
     /// 상세가 열린 회차가 곧 등록 대상이다 — 반복이면 그 회차, 아니면 원본.

--- a/Presentations/EventDetailScene/Sources/ViewModels/EditTodoEventDetailViewModelImple.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/EditTodoEventDetailViewModelImple.swift
@@ -23,6 +23,7 @@ final class EditTodoEventDetailViewModelImple: EventDetailViewModel, @unchecked 
     private let scheduleEventUsecase: any ScheduleEventUsecase
     private let calendarSettingUsecase: any CalendarSettingUsecase
     private let foremostEventUsecase: any ForemostEventUsecase
+    private let eventLiveActivityUsecase: any EventLiveActivityUsecase
     var router: (any EventDetailRouting)?
     weak var listener: EventDetailSceneListener?
     
@@ -33,7 +34,8 @@ final class EditTodoEventDetailViewModelImple: EventDetailViewModel, @unchecked 
         eventDetailDataUsecase: any EventDetailDataUsecase,
         scheduleEventUsecase: any ScheduleEventUsecase,
         calendarSettingUsecase: any CalendarSettingUsecase,
-        foremostEventUsecase: any ForemostEventUsecase
+        foremostEventUsecase: any ForemostEventUsecase,
+        eventLiveActivityUsecase: any EventLiveActivityUsecase
     ) {
         self.todoId = todoId
         self.todoUsecase = todoUsecase
@@ -42,6 +44,7 @@ final class EditTodoEventDetailViewModelImple: EventDetailViewModel, @unchecked 
         self.scheduleEventUsecase = scheduleEventUsecase
         self.calendarSettingUsecase = calendarSettingUsecase
         self.foremostEventUsecase = foremostEventUsecase
+        self.eventLiveActivityUsecase = eventLiveActivityUsecase
         
         self.internalBinding()
     }
@@ -145,6 +148,9 @@ extension EditTodoEventDetailViewModelImple: EventDetailInputListener {
             
         case .transformToSchedule:
             self.transformToScheduleAfterConfirm()
+
+        case .toggleLiveActivity(let isRegistered):
+            self.toggleLiveActivity(isRegistered)
             
         case .addToTemplate:
             // TODO:
@@ -153,6 +159,21 @@ extension EditTodoEventDetailViewModelImple: EventDetailInputListener {
             self.shareEvent()
 
         default: break
+        }
+    }
+
+    private func toggleLiveActivity(_ isRegistered: Bool) {
+        let target = LiveActivityTarget.todo(id: self.todoId)
+        Task { [weak self] in
+            guard let self else { return }
+            guard isRegistered == false
+            else { return await self.eventLiveActivityUsecase.stopActivity() }
+
+            do {
+                try await self.eventLiveActivityUsecase.startActivity(target)
+            } catch {
+                self.router?.showLiveActivityUnavailable(error)
+            }
         }
     }
 
@@ -504,17 +525,27 @@ extension EditTodoEventDetailViewModelImple {
     
     var moreActions: AnyPublisher<[[EventDetailMoreAction]], Never> {
         let todoId = self.todoId
-        let transform: (EventDetailBasicData, (any ForemostMarkableEvent)?) -> [[EventDetailMoreAction]] = { basic, foremostEvent in
+        let transform: (
+            EventDetailBasicData, (any ForemostMarkableEvent)?, LiveActivityTarget?
+        ) -> [[EventDetailMoreAction]] = { basic, foremostEvent, registeredTarget in
             let isRepeating = basic.selectedTime != nil && basic.eventRepeating != nil
             let isForemost = foremostEvent?.eventId == todoId
             let removeActions: [EventDetailMoreAction] = isRepeating
                 ? [.remove(onlyThisEvent: true), .remove(onlyThisEvent: false)]
                 : [.remove(onlyThisEvent: false)]
-            return [removeActions, [.toggleTo(isForemost: !isForemost), .copy, .transformToSchedule, .share]]
+            let liveActivityActions: [EventDetailMoreAction] = basic.selectedTime != nil
+                ? [.toggleLiveActivity(isRegistered: registeredTarget == .todo(id: todoId))]
+                : []
+            return [
+                removeActions,
+                [.toggleTo(isForemost: !isForemost)] + liveActivityActions
+                    + [.copy, .transformToSchedule, .share]
+            ]
         }
-        return Publishers.CombineLatest(
+        return Publishers.CombineLatest3(
             self.subject.basicData.compactMap{ $0?.origin },
-            self.foremostEventUsecase.foremostEvent
+            self.foremostEventUsecase.foremostEvent,
+            self.eventLiveActivityUsecase.registeredTarget
         )
         .map(transform)
         .removeDuplicates()

--- a/Presentations/EventDetailScene/Sources/ViewModels/EditTodoEventDetailViewModelImple.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/EditTodoEventDetailViewModelImple.swift
@@ -14,7 +14,9 @@ import Extensions
 import Scenes
 
 
-final class EditTodoEventDetailViewModelImple: EventDetailViewModel, @unchecked Sendable {
+final class EditTodoEventDetailViewModelImple: EventDetailViewModel, LiveActivityToggleHandling, @unchecked Sendable {
+
+    var liveActivityRouting: (any Routing)? { self.router }
     
     private let todoId: String
     private let todoUsecase: any TodoEventUsecase
@@ -23,7 +25,7 @@ final class EditTodoEventDetailViewModelImple: EventDetailViewModel, @unchecked 
     private let scheduleEventUsecase: any ScheduleEventUsecase
     private let calendarSettingUsecase: any CalendarSettingUsecase
     private let foremostEventUsecase: any ForemostEventUsecase
-    private let eventLiveActivityUsecase: any EventLiveActivityUsecase
+    let eventLiveActivityUsecase: any EventLiveActivityUsecase
     var router: (any EventDetailRouting)?
     weak var listener: EventDetailSceneListener?
     
@@ -150,7 +152,7 @@ extension EditTodoEventDetailViewModelImple: EventDetailInputListener {
             self.transformToScheduleAfterConfirm()
 
         case .toggleLiveActivity(let isRegistered):
-            self.toggleLiveActivity(isRegistered)
+            self.startOrStopLiveActivity(.todo(id: self.todoId), isRegistered: isRegistered)
             
         case .addToTemplate:
             // TODO:
@@ -159,21 +161,6 @@ extension EditTodoEventDetailViewModelImple: EventDetailInputListener {
             self.shareEvent()
 
         default: break
-        }
-    }
-
-    private func toggleLiveActivity(_ isRegistered: Bool) {
-        let target = LiveActivityTarget.todo(id: self.todoId)
-        Task { [weak self] in
-            guard let self else { return }
-            guard isRegistered == false
-            else { return await self.eventLiveActivityUsecase.stopActivity() }
-
-            do {
-                try await self.eventLiveActivityUsecase.startActivity(target)
-            } catch {
-                self.router?.showLiveActivityUnavailable(error)
-            }
         }
     }
 

--- a/Presentations/EventDetailScene/Tests/EditScheduleEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/EditScheduleEventDetailViewModelImpleTests.swift
@@ -25,6 +25,7 @@ class EditScheduleEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitabl
     private var spyEventDetailDataUsecase: StubEventDetailDataUsecase!
     private var stubForemostEventUsecase: StubForemostEventUsecase!
     private var stubDDayCandidateUsecase: PrivateStubDDayCandidateUsecase!
+    private var stubLiveActivityUsecase: StubEventLiveActivityUsecase!
     private var spyRouter: SpyEventDetailRouter!
     private var spyListener: SpyEventDetailListener!
     
@@ -32,6 +33,7 @@ class EditScheduleEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitabl
         self.cancelBag = .init()
         self.spyScheduleUsecase = .init()
         self.spyEventDetailDataUsecase = .init()
+        self.stubLiveActivityUsecase = .init()
         self.spyRouter = .init()
         self.spyListener = .init()
     }
@@ -42,6 +44,7 @@ class EditScheduleEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitabl
         self.spyEventDetailDataUsecase = nil
         self.stubForemostEventUsecase = nil
         self.stubDDayCandidateUsecase = nil
+        self.stubLiveActivityUsecase = nil
         FeatureFlag.disable(.ddayWidget)
         self.spyRouter = nil
         self.spyListener = nil
@@ -60,7 +63,9 @@ class EditScheduleEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitabl
         shouldFailToSaveDetail: Bool = false,
         shouldFailToRemoveSchedule: Bool = false,
         registeredCandidates: [DDayCandidate] = [],
-        isDDayWidgetEnabled: Bool = false
+        isDDayWidgetEnabled: Bool = false,
+        registeredLiveActivityTarget: LiveActivityTarget? = nil,
+        liveActivityStartError: (any Error)? = nil
     ) -> EditScheduleEventDetailViewModelImple {
 
         // 배포 기본값은 off — 후보 액션을 보려는 케이스만 켠다 (tearDown에서 원복)
@@ -89,6 +94,8 @@ class EditScheduleEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitabl
         todoUsecase.shouldFailMakeTodo = shouldFailToTransformToTodo
 
         self.stubDDayCandidateUsecase = .init(registeredCandidates)
+        self.stubLiveActivityUsecase.registeredTargetSubject.send(registeredLiveActivityTarget)
+        self.stubLiveActivityUsecase.stubStartError = liveActivityStartError
 
         let viewModel = EditScheduleEventDetailViewModelImple(
             scheduleId: schedule.uuid,
@@ -99,7 +106,8 @@ class EditScheduleEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitabl
             todoEventUsecase: todoUsecase,
             calendarSettingUsecase: calendarSettingUsecase,
             foremostEventUsecase: self.stubForemostEventUsecase,
-            ddayCandidateUsecase: self.stubDDayCandidateUsecase
+            ddayCandidateUsecase: self.stubDDayCandidateUsecase,
+            eventLiveActivityUsecase: self.stubLiveActivityUsecase
         )
         viewModel.router = self.spyRouter
         viewModel.listener = self.spyListener
@@ -247,14 +255,14 @@ extension EditScheduleEventDetailViewModelImpleTests {
             self.makeViewModel(customSchedule: schedule),
             expect: [
                 [.remove(onlyThisEvent: true), .remove(onlyThisEvent: false)],
-                [.copy, .transformToTodo, .share]
+                [.toggleLiveActivity(isRegistered: false), .copy, .transformToTodo, .share]
             ]
         )
         parameterizeTest(
             self.makeViewModel(customSchedule: schedule, isForemost: true),
             expect: [
                 [.remove(onlyThisEvent: true), .remove(onlyThisEvent: false)],
-                [.copy, .transformToTodo, .share]
+                [.toggleLiveActivity(isRegistered: false), .copy, .transformToTodo, .share]
             ]
         )
         let scheduleNotRepeating = schedule |> \.repeating .~ nil
@@ -262,14 +270,14 @@ extension EditScheduleEventDetailViewModelImpleTests {
             self.makeViewModel(customSchedule: scheduleNotRepeating),
             expect: [
                 [.remove(onlyThisEvent: false)],
-                [.toggleTo(isForemost: true), .copy, .transformToTodo, .share]
+                [.toggleTo(isForemost: true), .toggleLiveActivity(isRegistered: false), .copy, .transformToTodo, .share]
             ]
         )
         parameterizeTest(
             self.makeViewModel(customSchedule: scheduleNotRepeating, isForemost: true),
             expect: [
                 [.remove(onlyThisEvent: false)],
-                [.toggleTo(isForemost: false), .copy, .transformToTodo, .share]
+                [.toggleTo(isForemost: false), .toggleLiveActivity(isRegistered: false), .copy, .transformToTodo, .share]
             ]
         )
     }
@@ -671,7 +679,9 @@ extension EditScheduleEventDetailViewModelImpleTests {
         shouldFailToTransformToTodo: Bool = false,
         shouldFailToSaveDetail: Bool = false,
         shouldFailToRemoveSchedule: Bool = false,
-        registeredCandidates: [DDayCandidate] = []
+        registeredCandidates: [DDayCandidate] = [],
+        registeredLiveActivityTarget: LiveActivityTarget? = nil,
+        liveActivityStartError: (any Error)? = nil
     ) -> EditScheduleEventDetailViewModelImple {
         // given
         let expect = expectation(description: "wait prepared")
@@ -689,7 +699,9 @@ extension EditScheduleEventDetailViewModelImpleTests {
             shouldFailToTransformToTodo: shouldFailToTransformToTodo,
             shouldFailToSaveDetail: shouldFailToSaveDetail,
             shouldFailToRemoveSchedule: shouldFailToRemoveSchedule,
-            registeredCandidates: registeredCandidates
+            registeredCandidates: registeredCandidates,
+            registeredLiveActivityTarget: registeredLiveActivityTarget,
+            liveActivityStartError: liveActivityStartError
         )
 
         // when
@@ -1229,3 +1241,117 @@ private final class PrivateStubScheduleEventUsecase: StubScheduleEventUsecase, @
         }
     }
 }
+
+
+// MARK: - 라이브액티비티 등록·해제
+
+extension EditScheduleEventDetailViewModelImpleTests {
+
+    func testViewModel_whenLiveActivityRegistered_provideUnregisterAction() {
+        // given
+        let expect = expectation(description: "등록된 일정은 해제 항목으로 노출")
+        let viewModel = self.makeViewModel(
+            registeredLiveActivityTarget: .schedule(id: "dummy_schedule", turnKey: nil)
+        )
+
+        // when
+        let actions = self.waitFirstOutput(expect, for: viewModel.moreActions) {
+            viewModel.prepare()
+        }
+
+        // then
+        let contains = actions?.flatMap { $0 }.contains(.toggleLiveActivity(isRegistered: true))
+        XCTAssertEqual(contains, true)
+    }
+
+    func testViewModel_whenOtherEventRegistered_provideRegisterAction() {
+        // given
+        let expect = expectation(description: "다른 이벤트가 등록됐으면 등록 항목으로 노출")
+        let viewModel = self.makeViewModel(
+            registeredLiveActivityTarget: .schedule(id: "other_schedule", turnKey: nil)
+        )
+
+        // when
+        let actions = self.waitFirstOutput(expect, for: viewModel.moreActions) {
+            viewModel.prepare()
+        }
+
+        // then
+        let contains = actions?.flatMap { $0 }.contains(.toggleLiveActivity(isRegistered: false))
+        XCTAssertEqual(contains, true)
+    }
+
+    func testViewModel_whenToggleLiveActivityOfRepeatingSchedule_startWithTurnKey() {
+        // given
+        let expect = expectation(description: "반복 일정은 열린 회차 키로 등록")
+        let targetTime = EventTime.at(300)
+        let viewModel = self.makeViewModelWithPrepare(repeatingEventTargetTime: targetTime)
+        self.stubLiveActivityUsecase.didStartTargetCallback = { _ in expect.fulfill() }
+
+        // when
+        viewModel.handleMoreAction(.toggleLiveActivity(isRegistered: false))
+
+        // then
+        self.wait(for: [expect], timeout: self.timeout)
+        XCTAssertEqual(
+            self.stubLiveActivityUsecase.didStartTarget,
+            .schedule(id: "dummy_schedule", turnKey: targetTime.customKey)
+        )
+    }
+
+    func testViewModel_whenToggleLiveActivityOfNotRepeatingSchedule_startWithoutTurnKey() {
+        // given
+        let expect = expectation(description: "비반복 일정은 회차 키 없이 등록")
+        let viewModel = self.makeViewModelWithPrepare(
+            isNotRepeating: true, repeatingEventTargetTime: .at(300)
+        )
+        self.stubLiveActivityUsecase.didStartTargetCallback = { _ in expect.fulfill() }
+
+        // when
+        viewModel.handleMoreAction(.toggleLiveActivity(isRegistered: false))
+
+        // then
+        self.wait(for: [expect], timeout: self.timeout)
+        XCTAssertEqual(
+            self.stubLiveActivityUsecase.didStartTarget,
+            .schedule(id: "dummy_schedule", turnKey: nil)
+        )
+    }
+
+    func testViewModel_whenToggleRegisteredLiveActivity_stopActivity() {
+        // given
+        let expect = expectation(description: "등록된 상태에서 누르면 해제")
+        let viewModel = self.makeViewModelWithPrepare(
+            registeredLiveActivityTarget: .schedule(id: "dummy_schedule", turnKey: nil)
+        )
+        self.stubLiveActivityUsecase.didStopActivityCallback = { expect.fulfill() }
+
+        // when
+        viewModel.handleMoreAction(.toggleLiveActivity(isRegistered: true))
+
+        // then
+        self.wait(for: [expect], timeout: self.timeout)
+        XCTAssertNil(self.stubLiveActivityUsecase.didStartTarget)
+    }
+
+    func testViewModel_whenStartLiveActivityFail_showUnavailableMessage() {
+        // given
+        let expect = expectation(description: "등록 실패 사유 안내")
+        let viewModel = self.makeViewModelWithPrepare(
+            liveActivityStartError: EventLiveActivityStartFailReason.tooFarFuture
+        )
+        self.spyRouter.didShowConfirmWithCallback = { _ in expect.fulfill() }
+
+        // when
+        viewModel.handleMoreAction(.toggleLiveActivity(isRegistered: false))
+
+        // then
+        self.wait(for: [expect], timeout: self.timeout)
+        XCTAssertEqual(
+            self.spyRouter.didShowConfirmWith?.message,
+            "calendar::event::more_action:live_activity:unavail::too_far_future".localized()
+        )
+        XCTAssertNil(self.spyRouter.didShowError)
+    }
+}
+

--- a/Presentations/EventDetailScene/Tests/EditTodoEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/EditTodoEventDetailViewModelImpleTests.swift
@@ -24,6 +24,7 @@ class EditTodoEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitable {
     private var spyTodoUsecase: StubTodoEventUsecase!
     private var spyEventDetailDataUsecase: StubEventDetailDataUsecase!
     private var stubForemostEventUsecase: StubForemostEventUsecase!
+    private var stubLiveActivityUsecase: StubEventLiveActivityUsecase!
     private var spyRouter: SpyEventDetailRouter!
     private var spyListener: SpyEventDetailListener!
     
@@ -31,6 +32,7 @@ class EditTodoEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitable {
         self.cancelBag = .init()
         self.spyTodoUsecase = .init()
         self.spyEventDetailDataUsecase = .init()
+        self.stubLiveActivityUsecase = .init()
         self.spyRouter = .init()
         self.spyListener = .init()
     }
@@ -40,6 +42,7 @@ class EditTodoEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitable {
         self.spyTodoUsecase = nil
         self.spyEventDetailDataUsecase = nil
         self.stubForemostEventUsecase = nil
+        self.stubLiveActivityUsecase = nil
         self.spyRouter = nil
         self.spyListener = nil
     }
@@ -55,7 +58,9 @@ class EditTodoEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitable {
         withEmptyAddition: Bool = false,
         shouldFailToTransformToSchedule: Bool = false,
         shouldFailToSaveDetail: Bool = false,
-        shouldFailToRemoveTodo: Bool = false
+        shouldFailToRemoveTodo: Bool = false,
+        registeredLiveActivityTarget: LiveActivityTarget? = nil,
+        liveActivityStartError: (any Error)? = nil
     ) -> EditTodoEventDetailViewModelImple {
         
         let (todo, detail) = (customTodo ?? self.dummyRepeatingTodo, self.dummyDetail)
@@ -81,6 +86,9 @@ class EditTodoEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitable {
         
         let scheduleUsecase = StubScheduleEventUsecase()
         scheduleUsecase.shouldFailMakeEvent = shouldFailToTransformToSchedule
+
+        self.stubLiveActivityUsecase.registeredTargetSubject.send(registeredLiveActivityTarget)
+        self.stubLiveActivityUsecase.stubStartError = liveActivityStartError
         
         let viewModel = EditTodoEventDetailViewModelImple(
             todoId: todo.uuid,
@@ -89,7 +97,8 @@ class EditTodoEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitable {
             eventDetailDataUsecase: self.spyEventDetailDataUsecase,
             scheduleEventUsecase: scheduleUsecase,
             calendarSettingUsecase: calendarSettingUsecase,
-            foremostEventUsecase: self.stubForemostEventUsecase
+            foremostEventUsecase: self.stubForemostEventUsecase,
+            eventLiveActivityUsecase: self.stubLiveActivityUsecase
         )
         viewModel.router = self.spyRouter
         viewModel.listener = self.spyListener
@@ -241,14 +250,14 @@ extension EditTodoEventDetailViewModelImpleTests {
             self.makeViewModel(customTodo: todo),
             expect: [
                 [.remove(onlyThisEvent: true), .remove(onlyThisEvent: false)],
-                [.toggleTo(isForemost: true), .copy, .transformToSchedule, .share]
+                [.toggleTo(isForemost: true), .toggleLiveActivity(isRegistered: false), .copy, .transformToSchedule, .share]
             ]
         )
         parameterizeTest(
             self.makeViewModel(customTodo: todo, isForemost: true),
             expect: [
                 [.remove(onlyThisEvent: true), .remove(onlyThisEvent: false)],
-                [.toggleTo(isForemost: false), .copy, .transformToSchedule, .share]
+                [.toggleTo(isForemost: false), .toggleLiveActivity(isRegistered: false), .copy, .transformToSchedule, .share]
             ]
         )
         let todoNotRepeating = todo |> \.repeating .~ nil
@@ -256,7 +265,7 @@ extension EditTodoEventDetailViewModelImpleTests {
             self.makeViewModel(customTodo: todoNotRepeating),
             expect: [
                 [.remove(onlyThisEvent: false)],
-                [.toggleTo(isForemost: true), .copy, .transformToSchedule, .share]
+                [.toggleTo(isForemost: true), .toggleLiveActivity(isRegistered: false), .copy, .transformToSchedule, .share]
             ]
         )
     }
@@ -512,7 +521,9 @@ extension EditTodoEventDetailViewModelImpleTests {
         shouldFailEdit: Bool = false,
         shouldFailToTransformToSchedule: Bool = false,
         shouldFailToSaveDetail: Bool = false,
-        shouldFailToRemoveTodo: Bool = false
+        shouldFailToRemoveTodo: Bool = false,
+        registeredLiveActivityTarget: LiveActivityTarget? = nil,
+        liveActivityStartError: (any Error)? = nil
     ) -> EditTodoEventDetailViewModelImple {
         // given
         let expect = expectation(description: "wait prepared")
@@ -528,7 +539,9 @@ extension EditTodoEventDetailViewModelImpleTests {
             customTodo: todo, shouldFailSave: shouldFailEdit,
             shouldFailToTransformToSchedule: shouldFailToTransformToSchedule,
             shouldFailToSaveDetail: shouldFailToSaveDetail,
-            shouldFailToRemoveTodo: shouldFailToRemoveTodo
+            shouldFailToRemoveTodo: shouldFailToRemoveTodo,
+            registeredLiveActivityTarget: registeredLiveActivityTarget,
+            liveActivityStartError: liveActivityStartError
         )
         
         // when
@@ -770,5 +783,129 @@ extension EditTodoEventDetailViewModelImpleTests {
         
         // then
         self.wait(for: [expect], timeout: self.timeoutLong)
+    }
+}
+
+
+// MARK: - 라이브액티비티 등록·해제
+
+extension EditTodoEventDetailViewModelImpleTests {
+
+    func testViewModel_whenTodoHasNoTime_notProvideLiveActivityAction() {
+        // given
+        let expect = expectation(description: "시간 없는 todo 는 라이브액티비티 항목이 없다")
+        let todoWithoutTime = self.dummyRepeatingTodo |> \.time .~ nil
+        let viewModel = self.makeViewModel(customTodo: todoWithoutTime)
+
+        // when
+        let actions = self.waitFirstOutput(expect, for: viewModel.moreActions) {
+            viewModel.prepare()
+        }
+
+        // then
+        let hasLiveActivityAction = actions?.flatMap { $0 }.contains {
+            if case .toggleLiveActivity = $0 { return true } else { return false }
+        }
+        XCTAssertEqual(hasLiveActivityAction, false)
+    }
+
+    func testViewModel_whenLiveActivityRegistered_provideUnregisterAction() {
+        // given
+        let expect = expectation(description: "등록된 todo 는 해제 항목으로 노출")
+        let viewModel = self.makeViewModel(
+            registeredLiveActivityTarget: .todo(id: "dummy_todo")
+        )
+
+        // when
+        let actions = self.waitFirstOutput(expect, for: viewModel.moreActions) {
+            viewModel.prepare()
+        }
+
+        // then
+        let contains = actions?.flatMap { $0 }.contains(.toggleLiveActivity(isRegistered: true))
+        XCTAssertEqual(contains, true)
+    }
+
+    func testViewModel_whenOtherEventRegistered_provideRegisterAction() {
+        // given
+        let expect = expectation(description: "다른 이벤트가 등록됐으면 등록 항목으로 노출")
+        let viewModel = self.makeViewModel(
+            registeredLiveActivityTarget: .todo(id: "other_todo")
+        )
+
+        // when
+        let actions = self.waitFirstOutput(expect, for: viewModel.moreActions) {
+            viewModel.prepare()
+        }
+
+        // then
+        let contains = actions?.flatMap { $0 }.contains(.toggleLiveActivity(isRegistered: false))
+        XCTAssertEqual(contains, true)
+    }
+
+    func testViewModel_whenToggleLiveActivity_startActivity() {
+        // given
+        let expect = expectation(description: "등록되지 않은 상태에서 누르면 등록")
+        let viewModel = self.makeViewModelWithPrepare()
+        self.stubLiveActivityUsecase.didStartTargetCallback = { _ in expect.fulfill() }
+
+        // when
+        viewModel.handleMoreAction(.toggleLiveActivity(isRegistered: false))
+
+        // then
+        self.wait(for: [expect], timeout: self.timeout)
+        XCTAssertEqual(self.stubLiveActivityUsecase.didStartTarget, .todo(id: "dummy_todo"))
+        XCTAssertEqual(self.stubLiveActivityUsecase.didStopActivity, false)
+    }
+
+    func testViewModel_whenToggleRegisteredLiveActivity_stopActivity() {
+        // given
+        let expect = expectation(description: "등록된 상태에서 누르면 해제")
+        let viewModel = self.makeViewModelWithPrepare(
+            registeredLiveActivityTarget: .todo(id: "dummy_todo")
+        )
+        self.stubLiveActivityUsecase.didStopActivityCallback = { expect.fulfill() }
+
+        // when
+        viewModel.handleMoreAction(.toggleLiveActivity(isRegistered: true))
+
+        // then
+        self.wait(for: [expect], timeout: self.timeout)
+        XCTAssertNil(self.stubLiveActivityUsecase.didStartTarget)
+    }
+
+    func testViewModel_whenStartLiveActivityFail_showUnavailableMessage() {
+        // given
+        func parameterizeTest(
+            _ reason: EventLiveActivityStartFailReason, expectMessage: String
+        ) {
+            // given
+            let expect = expectation(description: "등록 실패 사유 안내")
+            let viewModel = self.makeViewModelWithPrepare(liveActivityStartError: reason)
+            self.spyRouter.didShowConfirmWithCallback = { _ in expect.fulfill() }
+
+            // when
+            viewModel.handleMoreAction(.toggleLiveActivity(isRegistered: false))
+
+            // then
+            self.wait(for: [expect], timeout: self.timeout)
+            let info = self.spyRouter.didShowConfirmWith
+            XCTAssertEqual(info?.message, expectMessage)
+            XCTAssertEqual(info?.withCancel, false)
+            XCTAssertNil(self.spyRouter.didShowError)
+        }
+        // when + then
+        parameterizeTest(
+            .eventNotFound,
+            expectMessage: "calendar::event::more_action:live_activity:unavail::not_found".localized()
+        )
+        parameterizeTest(
+            .alreadyPassed,
+            expectMessage: "calendar::event::more_action:live_activity:unavail::already_passed".localized()
+        )
+        parameterizeTest(
+            .tooFarFuture,
+            expectMessage: "calendar::event::more_action:live_activity:unavail::too_far_future".localized()
+        )
     }
 }

--- a/Presentations/EventDetailScene/Tests/HolidayEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/HolidayEventDetailViewModelImpleTests.swift
@@ -22,14 +22,21 @@ final class HolidayEventDetailViewModelImpleTests: PublisherWaitable {
     
     var cancelBag: Set<AnyCancellable>! = []
     private let spyRouter = SpyRouter()
+    private let stubLiveActivityUsecase = StubEventLiveActivityUsecase()
     
-    private func makeViewModel() async throws -> HolidayEventDetailViewModelImple {
+    private func makeViewModel(
+        registeredLiveActivityTarget: LiveActivityTarget? = nil,
+        liveActivityStartError: (any Error)? = nil
+    ) async throws -> HolidayEventDetailViewModelImple {
         let usecase = PrivateStubHolidayUsecase()
         try await usecase.prepare()
+        self.stubLiveActivityUsecase.registeredTargetSubject.send(registeredLiveActivityTarget)
+        self.stubLiveActivityUsecase.stubStartError = liveActivityStartError
         let viewModel = HolidayEventDetailViewModelImple(
             uuid: "some",
             holidayUsecase: usecase,
-            daysIntervalCountUsecase: StubDaysIntervalCountUsecase()
+            daysIntervalCountUsecase: StubDaysIntervalCountUsecase(),
+            eventLiveActivityUsecase: self.stubLiveActivityUsecase
         )
         viewModel.router = self.spyRouter
         return viewModel
@@ -110,7 +117,8 @@ extension HolidayEventDetailViewModelImpleTests {
         let viewModel = HolidayEventDetailViewModelImple(
             uuid: "some",
             holidayUsecase: usecase,
-            daysIntervalCountUsecase: StubDaysIntervalCountUsecase()
+            daysIntervalCountUsecase: StubDaysIntervalCountUsecase(),
+            eventLiveActivityUsecase: self.stubLiveActivityUsecase
         )
         viewModel.router = self.spyRouter
         return (viewModel, usecase)
@@ -150,6 +158,101 @@ extension HolidayEventDetailViewModelImpleTests {
         #expect(usecase.hiddenHolidayNamesSubject.value.isEmpty)
     }
 }
+
+
+// MARK: - 라이브액티비티 등록·해제
+
+extension HolidayEventDetailViewModelImpleTests {
+
+    @Test func viewModel_whenHolidayLoaded_provideLiveActivityAction() async throws {
+        // given
+        let expect = expectConfirm("공휴일이 로드되면 등록 항목 노출")
+        expect.count = 2
+        let viewModel = try await self.makeViewModel()
+
+        // when
+        let models = try await self.outputs(expect, for: viewModel.liveActivityActionModel) {
+            viewModel.refresh()
+        }
+
+        // then
+        #expect(models == [nil, LiveActivityActionModel(isRegistered: false)])
+    }
+
+    @Test func viewModel_whenHolidayLiveActivityRegistered_provideUnregisterAction() async throws {
+        // given
+        let expect = expectConfirm("등록된 공휴일은 해제 항목으로 노출")
+        expect.count = 2
+        let viewModel = try await self.makeViewModel(
+            registeredLiveActivityTarget: .holiday(uuid: "some", dateString: "2025-03-01")
+        )
+
+        // when
+        let models = try await self.outputs(expect, for: viewModel.liveActivityActionModel) {
+            viewModel.refresh()
+        }
+
+        // then
+        #expect(models == [nil, LiveActivityActionModel(isRegistered: true)])
+    }
+
+    @Test func viewModel_whenToggleLiveActivity_startActivityWithHolidayTarget() async throws {
+        // given
+        let viewModel = try await self.makeViewModel()
+        viewModel.refresh()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // when
+        viewModel.toggleLiveActivity(isRegistered: false)
+        try await Task.sleep(for: .milliseconds(100))
+
+        // then
+        #expect(
+            self.stubLiveActivityUsecase.didStartTarget
+            == .holiday(uuid: "some", dateString: "2025-03-01")
+        )
+        #expect(self.stubLiveActivityUsecase.didStopActivity == false)
+    }
+
+    @Test func viewModel_whenToggleRegisteredLiveActivity_stopActivity() async throws {
+        // given
+        let viewModel = try await self.makeViewModel(
+            registeredLiveActivityTarget: .holiday(uuid: "some", dateString: "2025-03-01")
+        )
+        viewModel.refresh()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // when
+        viewModel.toggleLiveActivity(isRegistered: true)
+        try await Task.sleep(for: .milliseconds(100))
+
+        // then
+        #expect(self.stubLiveActivityUsecase.didStopActivity == true)
+        #expect(self.stubLiveActivityUsecase.didStartTarget == nil)
+    }
+
+    @Test func viewModel_whenStartLiveActivityFail_showUnavailableMessage() async throws {
+        // given
+        let viewModel = try await self.makeViewModel(
+            liveActivityStartError: EventLiveActivityStartFailReason.tooFarFuture
+        )
+        viewModel.refresh()
+        try await Task.sleep(for: .milliseconds(100))
+
+        // when
+        viewModel.toggleLiveActivity(isRegistered: false)
+        try await Task.sleep(for: .milliseconds(100))
+
+        // then
+        #expect(
+            self.spyRouter.didShowConfirmWith?.message
+            == "calendar::event::more_action:live_activity:unavail::too_far_future".localized()
+        )
+        #expect(self.spyRouter.didShowConfirmWith?.withCancel == false)
+        #expect(self.spyRouter.didShowError == nil)
+    }
+}
+
 
 private final class PrivateStubHolidayUsecase: StubHolidayUsecase {
     

--- a/Presentations/Scenes/Sources/Factories.swift
+++ b/Presentations/Scenes/Sources/Factories.swift
@@ -37,6 +37,7 @@ public protocol EventUsecaseFactory {
     func makeDaysIntervalCountUsecase() -> any DaysIntervalCountUsecase
     var eventSyncUsecase: any EventSyncUsecase { get }
     var eventUploadService: any EventUploadService { get }
+    var eventLiveActivityUsecase: any EventLiveActivityUsecase { get }
 }
 
 public protocol SettingUsecaseFactory {

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -135,6 +135,12 @@
 "calendar::event::more_action:dday_candidate:title" = "D-day widget candidate";
 "calendar::event::more_action:dday_candidate:register:message" = "Add this event as a D-day widget candidate? It will appear at the top of the list when you edit the widget.";
 "calendar::event::more_action:dday_candidate:unregister:message" = "Remove this event from D-day widget candidates?";
+"calendar::event::more_action:live_activity:title" = "Live Activity";
+"calendar::event::more_action:live_activity:register:item_name" = "Show on Lock Screen";
+"calendar::event::more_action:live_activity:unregister:item_name" = "Remove from Lock Screen";
+"calendar::event::more_action:live_activity:unavail::not_found" = "This event is no longer available.";
+"calendar::event::more_action:live_activity:unavail::already_passed" = "This event has already started.";
+"calendar::event::more_action:live_activity:unavail::too_far_future" = "Only events starting within 8 hours can be shown.";
 "calendar::event::more_action:copy:item_name" = "Copy event";
 "calendar::event::more_action:share:item_name" = "Share";
 "event_detail::share::field::time" = "Time";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -135,6 +135,12 @@
 "calendar::event::more_action:dday_candidate:title" = "D-day 위젯 후보";
 "calendar::event::more_action:dday_candidate:register:message" = "이 일정을 D-day 위젯 후보로 추가할까요? 위젯을 편집할 때 목록 맨 위에 표시됩니다.";
 "calendar::event::more_action:dday_candidate:unregister:message" = "이 일정을 D-day 위젯 후보에서 제거할까요?";
+"calendar::event::more_action:live_activity:title" = "라이브 액티비티";
+"calendar::event::more_action:live_activity:register:item_name" = "잠금화면에 표시";
+"calendar::event::more_action:live_activity:unregister:item_name" = "잠금화면에서 제거";
+"calendar::event::more_action:live_activity:unavail::not_found" = "이벤트 정보를 찾을 수 없어요.";
+"calendar::event::more_action:live_activity:unavail::already_passed" = "이미 시작한 이벤트예요.";
+"calendar::event::more_action:live_activity:unavail::too_far_future" = "8시간 이내에 시작하는 이벤트만 표시할 수 있어요.";
 "calendar::event::more_action:copy:item_name" = "이벤트 복사";
 "calendar::event::more_action:share:item_name" = "공유";
 "event_detail::share::field::time" = "시간";

--- a/Supports/TestDoubles/Sources/Usecases/StubEventLiveActivityUsecase.swift
+++ b/Supports/TestDoubles/Sources/Usecases/StubEventLiveActivityUsecase.swift
@@ -1,0 +1,53 @@
+//
+//  StubEventLiveActivityUsecase.swift
+//  TestDoubles
+//
+//  Created by sudo.park on 8/19/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Combine
+import Domain
+
+
+open class StubEventLiveActivityUsecase: EventLiveActivityUsecase, @unchecked Sendable {
+
+    public init(registeredTarget: LiveActivityTarget? = nil) {
+        self.registeredTargetSubject = .init(registeredTarget)
+    }
+
+    public let registeredTargetSubject: CurrentValueSubject<LiveActivityTarget?, Never>
+    public var stubStartError: (any Error)?
+
+    public var didStartTarget: LiveActivityTarget?
+    public var didStartTargetCallback: ((LiveActivityTarget) -> Void)?
+    open func startActivity(_ target: LiveActivityTarget) async throws {
+        self.didStartTarget = target
+        self.didStartTargetCallback?(target)
+        if let error = self.stubStartError { throw error }
+        self.registeredTargetSubject.send(target)
+    }
+
+    public var didStopActivity: Bool = false
+    public var didStopActivityCallback: (() -> Void)?
+    open func stopActivity() async {
+        self.didStopActivity = true
+        self.didStopActivityCallback?()
+        self.registeredTargetSubject.send(nil)
+    }
+
+    public var didPrepare: Bool = false
+    open func prepare() async {
+        self.didPrepare = true
+    }
+
+    public var didHandleWillEnterForeground: Bool = false
+    open func handleWillEnterForeground() async {
+        self.didHandleWillEnterForeground = true
+    }
+
+    public var registeredTarget: AnyPublisher<LiveActivityTarget?, Never> {
+        return self.registeredTargetSubject.eraseToAnyPublisher()
+    }
+}

--- a/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
+++ b/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
@@ -28,6 +28,7 @@ struct NonLoginUsecaseFactoryImple: UsecaseFactory {
     let appUpdateCheckUsecase: any AppUpdateCheckUsecase
     let aiAgentOrchestrationUsecase: any AIAgentOrchestrationUsecase
     let billingUsecase: any BillingUsecase
+    let eventLiveActivityUsecase: any EventLiveActivityUsecase
     let imageTextRecognizeService: any ImageTextRecognizeService = ImageTextRecognizeServiceImple()
     private let applicationBase: ApplicationBase
 
@@ -49,6 +50,11 @@ struct NonLoginUsecaseFactoryImple: UsecaseFactory {
         self.billingUsecase = NotNeedBillingUsecase(sharedDataStore: applicationBase.sharedDataStore)
 
         self.aiAgentOrchestrationUsecase = NotNeedAIAgentOrchestrationUsecase()
+
+        self.eventLiveActivityUsecase = EventLiveActivityUsecaseImple(
+            controller: EventCountdownLiveActivityController(),
+            sharedDataStore: applicationBase.sharedDataStore
+        )
     }
 
     var eventNotifyService: SharedEventNotifyService {
@@ -373,6 +379,7 @@ struct LoginUsecaseFactoryImple: UsecaseFactory {
     let appUpdateCheckUsecase: any AppUpdateCheckUsecase
     let aiAgentOrchestrationUsecase: any AIAgentOrchestrationUsecase
     let billingUsecase: any BillingUsecase
+    let eventLiveActivityUsecase: any EventLiveActivityUsecase
     let imageTextRecognizeService: any ImageTextRecognizeService = ImageTextRecognizeServiceImple()
     private let applicationBase: ApplicationBase
 
@@ -483,6 +490,11 @@ struct LoginUsecaseFactoryImple: UsecaseFactory {
                 sharedDataStore: applicationBase.sharedDataStore
             )
             : NotNeedBillingUsecase(sharedDataStore: applicationBase.sharedDataStore)
+
+        self.eventLiveActivityUsecase = EventLiveActivityUsecaseImple(
+            controller: EventCountdownLiveActivityController(),
+            sharedDataStore: applicationBase.sharedDataStore
+        )
     }
 
     var eventNotifyService: SharedEventNotifyService {

--- a/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
+++ b/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
@@ -51,9 +51,15 @@ struct NonLoginUsecaseFactoryImple: UsecaseFactory {
 
         self.aiAgentOrchestrationUsecase = NotNeedAIAgentOrchestrationUsecase()
 
+        let eventDetailStorage = EventDetailDataLocalStorageImple<EventDetailDataTable>(
+            sqliteService: applicationBase.commonSqliteService
+        )
         self.eventLiveActivityUsecase = EventLiveActivityUsecaseImple(
             controller: EventCountdownLiveActivityController(),
-            sharedDataStore: applicationBase.sharedDataStore
+            sharedDataStore: applicationBase.sharedDataStore,
+            eventDetailDataUsecase: EventDetailDataLocalRepostioryImple(
+                localStorage: eventDetailStorage
+            )
         )
     }
 
@@ -493,7 +499,14 @@ struct LoginUsecaseFactoryImple: UsecaseFactory {
 
         self.eventLiveActivityUsecase = EventLiveActivityUsecaseImple(
             controller: EventCountdownLiveActivityController(),
-            sharedDataStore: applicationBase.sharedDataStore
+            sharedDataStore: applicationBase.sharedDataStore,
+            eventDetailDataUsecase: EventDetailUploadDecorateRepositoryImple(
+                remote: EventDetailRemoteImple(remoteAPI: applicationBase.remoteAPI),
+                cacheStorage: EventDetailDataLocalStorageImple<EventDetailDataTable>(
+                    sqliteService: applicationBase.commonSqliteService
+                ),
+                uploadService: uploadService
+            )
         )
     }
 

--- a/TodoCalendarApp/Sources/Main/MainBuilderImple.swift
+++ b/TodoCalendarApp/Sources/Main/MainBuilderImple.swift
@@ -18,20 +18,17 @@ import CommonPresentation
 public final class MainSceneBuilerImple {
     
     private let usecaseFactory: any UsecaseFactory
-    private let sharedDataStore: SharedDataStore
     private let viewAppearance: ViewAppearance
     private let calendarSceneBulder: any CalendarSceneBuilder
     private let settingSceneBuilder: any SettingSceneBuiler
     
     public init(
         usecaseFactory: any UsecaseFactory,
-        sharedDataStore: SharedDataStore,
         viewAppearance: ViewAppearance,
         calendarSceneBulder: any CalendarSceneBuilder,
         settingSceneBuilder: any SettingSceneBuiler
     ) {
         self.usecaseFactory = usecaseFactory
-        self.sharedDataStore = sharedDataStore
         self.viewAppearance = viewAppearance
         self.calendarSceneBulder = calendarSceneBulder
         self.settingSceneBuilder = settingSceneBuilder
@@ -55,10 +52,7 @@ extension MainSceneBuilerImple: MainSceneBuiler {
             eventSyncUsecase: self.usecaseFactory.eventSyncUsecase,
             billingUsecase: self.usecaseFactory.billingUsecase,
             aiAgentOrchestrationUsecase: self.usecaseFactory.aiAgentOrchestrationUsecase,
-            eventLiveActivityUsecase: EventLiveActivityUsecaseImple(
-                controller: EventCountdownLiveActivityController(),
-                sharedDataStore: self.sharedDataStore
-            )
+            eventLiveActivityUsecase: self.usecaseFactory.eventLiveActivityUsecase
         )
         
         let viewController = MainViewController(

--- a/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
@@ -388,7 +388,6 @@ extension ApplicationRootRouter {
         
         let builder = MainSceneBuilerImple(
             usecaseFactory: self.usecaseFactory,
-            sharedDataStore: self.applicationBase.sharedDataStore,
             viewAppearance: self.viewAppearanceStore.appearance,
             calendarSceneBulder: self.calendarSceneBulder(),
             settingSceneBuilder: self.settingSceneBuilder()

--- a/TodoCalendarApp/Sources/Root/EventLiveActivityUsecaseImple.swift
+++ b/TodoCalendarApp/Sources/Root/EventLiveActivityUsecaseImple.swift
@@ -21,13 +21,16 @@ final class EventLiveActivityUsecaseImple: EventLiveActivityUsecase, @unchecked 
 
     private let controller: any LiveActivityController
     private let sharedDataStore: SharedDataStore
+    private let eventDetailDataUsecase: any EventDetailDataUsecase
 
     init(
         controller: any LiveActivityController,
-        sharedDataStore: SharedDataStore
+        sharedDataStore: SharedDataStore,
+        eventDetailDataUsecase: any EventDetailDataUsecase
     ) {
         self.controller = controller
         self.sharedDataStore = sharedDataStore
+        self.eventDetailDataUsecase = eventDetailDataUsecase
     }
 
     private struct Subject {
@@ -54,7 +57,8 @@ extension EventLiveActivityUsecaseImple {
         else { throw EventLiveActivityStartFailReason.eventNotFound }
         try self.validateRegistration(eventDate: observed.eventDate, now: now)
 
-        let content = self.initialContent(from: observed, startDate: now)
+        let detail = await self.eventDetail(for: target)
+        let content = self.initialContent(from: observed, startDate: now, detail: detail)
         let baseline = LiveActivityBaseline(observed)
 
         let previous = self.pendingStart
@@ -66,8 +70,20 @@ extension EventLiveActivityUsecaseImple {
         try await task.value
     }
 
+    /// 원격 상세 조회는 캐시가 없고 서버가 빈 응답을 주면 값도 완료도 보내지 않고 끝난다
+    /// (`EventDetailUploadDecorateRepositoryImple`) — 타임아웃이 없으면 등록이 영영 매달린다.
+    private func eventDetail(for target: LiveActivityTarget) async -> EventDetailData? {
+        guard let id = target.eventDetailDataId else { return nil }
+        return try? await self.eventDetailDataUsecase.loadDetail(id)
+            .timeout(.seconds(Constant.detailLoadTimeout), scheduler: DispatchQueue.global())
+            .values
+            .first(where: { _ in true })
+    }
+
     private func initialContent(
-        from observed: LiveActivityObservedEvent, startDate: Date
+        from observed: LiveActivityObservedEvent,
+        startDate: Date,
+        detail: EventDetailData?
     ) -> EventCountdownActivityAttributes.State {
         return EventCountdownActivityAttributes.State(
             eventName: observed.name,
@@ -75,7 +91,8 @@ extension EventLiveActivityUsecaseImple {
             tagColorHex: observed.tagColorHex,
             eventDate: observed.eventDate,
             startDate: startDate,
-            placeName: observed.placeName
+            placeName: detail?.place?.placeName ?? observed.placeName,
+            memo: detail?.memo
         )
     }
 
@@ -546,6 +563,7 @@ extension EventLiveActivityUsecaseImple {
 
 private enum Constant {
     static let activeLimit: TimeInterval = 8 * 3600
+    static let detailLoadTimeout: TimeInterval = 1
 }
 
 private typealias Holidays = [String: [Int: [Holiday]]]
@@ -594,6 +612,14 @@ private extension LiveActivityTarget {
         switch self {
         case .googleCalendar, .appleCalendar: return true
         case .todo, .schedule, .holiday: return false
+        }
+    }
+
+    var eventDetailDataId: String? {
+        switch self {
+        case .todo(let id): return id
+        case .schedule(let id, _): return id
+        case .holiday, .googleCalendar, .appleCalendar: return nil
         }
     }
 }

--- a/TodoCalendarApp/TodoCalendarAppTests/EventLiveActivityUsecaseImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/EventLiveActivityUsecaseImpleTests.swift
@@ -12,6 +12,7 @@ import Foundation
 import Prelude
 import Optics
 import UnitTestHelpKit
+import TestDoubles
 import Extensions
 
 import Domain
@@ -27,7 +28,8 @@ final class EventLiveActivityUsecaseImpleTests: PublisherWaitable {
         stubRestoredRegistration: LiveActivityRegistration? = nil,
         stubStartError: (any Error)? = nil,
         stubEmitsNilOnEnd: Bool = false,
-        stubStartDelayNanoseconds: UInt64 = 0
+        stubStartDelayNanoseconds: UInt64 = 0,
+        eventDetailUsecase: SpyEventDetailDataUsecase = .init()
     ) -> (EventLiveActivityUsecaseImple, StubLiveActivityController, SharedDataStore) {
         let stub = StubLiveActivityController(
             stubRestoredRegistration: stubRestoredRegistration,
@@ -36,7 +38,11 @@ final class EventLiveActivityUsecaseImpleTests: PublisherWaitable {
             stubStartDelayNanoseconds: stubStartDelayNanoseconds
         )
         let store = SharedDataStore()
-        let usecase = EventLiveActivityUsecaseImple(controller: stub, sharedDataStore: store)
+        let usecase = EventLiveActivityUsecaseImple(
+            controller: stub,
+            sharedDataStore: store,
+            eventDetailDataUsecase: eventDetailUsecase
+        )
         return (usecase, stub, store)
     }
 
@@ -1232,5 +1238,146 @@ extension EventLiveActivityUsecaseImpleTests {
 
         // then
         #expect(stub.didStartWith?.1.tagColorHex == "#222222")
+    }
+}
+
+
+// MARK: - 잠금화면 부제
+
+extension EventLiveActivityUsecaseImpleTests {
+
+    private func makeDetail(
+        _ eventId: String, place: String? = nil, memo: String? = nil
+    ) -> EventDetailData {
+        return EventDetailData(eventId)
+            |> \.place .~ place.map { Place($0) }
+            |> \.memo .~ memo
+    }
+
+    @Test func usecase_startTodoActivity_fillsPlaceNameFromEventDetail() async throws {
+        // given
+        let detailUsecase = SpyEventDetailDataUsecase()
+        detailUsecase.stubDetail = self.makeDetail("t1", place: "회의실 A", memo: "준비물")
+        let (usecase, stub, store) = self.makeUsecase(eventDetailUsecase: detailUsecase)
+        let future = Date().addingTimeInterval(60)
+        self.putTodos(store, [self.makeTodo(id: "t1", eventDate: future)])
+
+        // when
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // then
+        let content = try #require(stub.didStartWith?.1)
+        #expect(detailUsecase.didLoadDetailIds == ["t1"])
+        #expect(content.placeName == "회의실 A")
+        #expect(content.memo == "준비물")
+    }
+
+    @Test func usecase_startTodoActivity_whenPlaceIsNil_fillsMemoOnly() async throws {
+        // given
+        let detailUsecase = SpyEventDetailDataUsecase()
+        detailUsecase.stubDetail = self.makeDetail("t1", memo: "준비물")
+        let (usecase, stub, store) = self.makeUsecase(eventDetailUsecase: detailUsecase)
+        let future = Date().addingTimeInterval(60)
+        self.putTodos(store, [self.makeTodo(id: "t1", eventDate: future)])
+
+        // when
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // then
+        let content = try #require(stub.didStartWith?.1)
+        #expect(content.placeName == nil)
+        #expect(content.memo == "준비물")
+    }
+
+    @Test func usecase_startScheduleActivity_fillsPlaceNameFromEventDetail() async throws {
+        // given
+        let detailUsecase = SpyEventDetailDataUsecase()
+        detailUsecase.stubDetail = self.makeDetail("s1", place: "3층 라운지")
+        let (usecase, stub, store) = self.makeUsecase(eventDetailUsecase: detailUsecase)
+        let future = Date().addingTimeInterval(60)
+        store.put(
+            MemorizedEventsContainer<ScheduleEvent>.self, key: ShareDataKeys.schedules.rawValue,
+            MemorizedEventsContainer<ScheduleEvent>().append(self.makeSchedule(id: "s1", eventDate: future))
+        )
+
+        // when
+        try await usecase.startActivity(
+            .schedule(id: "s1", turnKey: EventTime.at(future.timeIntervalSince1970).customKey)
+        )
+
+        // then
+        let content = try #require(stub.didStartWith?.1)
+        #expect(detailUsecase.didLoadDetailIds == ["s1"])
+        #expect(content.placeName == "3층 라운지")
+    }
+
+    @Test func usecase_startHolidayActivity_notLoadEventDetail() async throws {
+        // given
+        let detailUsecase = SpyEventDetailDataUsecase()
+        let (usecase, stub, store) = self.makeUsecase(eventDetailUsecase: detailUsecase)
+        let scenario = self.holidayTimeZoneScenario()
+        store.put(TimeZone.self, key: ShareDataKeys.timeZone.rawValue, scenario.timeZone)
+        store.put(
+            [String: [Int: [Holiday]]].self, key: ShareDataKeys.holidays.rawValue,
+            ["KR": [2026: [Holiday(uuid: "hz", dateString: scenario.dateString, name: "holiday")]]]
+        )
+
+        // when
+        try await usecase.startActivity(.holiday(uuid: "hz", dateString: scenario.dateString))
+
+        // then
+        #expect(detailUsecase.didLoadDetailIds.isEmpty)
+        #expect(stub.didStartWith?.1.placeName == nil)
+    }
+
+    @Test func usecase_startActivity_whenEventDetailNeverResponds_startsWithoutSubtitle() async throws {
+        // given
+        let detailUsecase = SpyEventDetailDataUsecase()
+        detailUsecase.stubNeverResponds = true
+        let (usecase, stub, store) = self.makeUsecase(eventDetailUsecase: detailUsecase)
+        let future = Date().addingTimeInterval(60)
+        self.putTodos(store, [self.makeTodo(id: "t1", eventDate: future)])
+
+        // when
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // then
+        let content = try #require(stub.didStartWith?.1)
+        #expect(content.placeName == nil)
+        #expect(content.memo == nil)
+    }
+
+    @Test func usecase_whenUpdatedAfterRegistration_keepsSubtitle() async throws {
+        // given
+        let detailUsecase = SpyEventDetailDataUsecase()
+        detailUsecase.stubDetail = self.makeDetail("t1", place: "회의실 A", memo: "준비물")
+        let (usecase, stub, store) = self.makeUsecase(eventDetailUsecase: detailUsecase)
+        let future = Date().addingTimeInterval(60)
+        self.putTodos(store, [self.makeTodo(id: "t1", name: "old", eventDate: future)])
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // when
+        self.putTodos(store, [self.makeTodo(id: "t1", name: "new", eventDate: future)])
+        try await self.waitForEffects()
+
+        // then
+        let content = try #require(stub.didUpdateWith)
+        #expect(content.eventName == "new")
+        #expect(content.placeName == "회의실 A")
+        #expect(content.memo == "준비물")
+    }
+}
+
+
+private final class SpyEventDetailDataUsecase: StubEventDetailDataUsecase, @unchecked Sendable {
+
+    var didLoadDetailIds: [String] = []
+    var stubNeverResponds: Bool = false
+
+    override func loadDetail(_ id: String) -> AnyPublisher<EventDetailData, any Error> {
+        self.didLoadDetailIds.append(id)
+        guard self.stubNeverResponds == false
+        else { return Empty(completeImmediately: false).eraseToAnyPublisher() }
+        return super.loadDetail(id)
     }
 }


### PR DESCRIPTION
## 문제

#908 이 라이브액티비티 제어 계층을 만들었지만 켤 방법이 없었다. usecase 를 메인 씬 빌더가 인라인으로 만들어 쥐고 있어서, 별개 프레임워크인 이벤트 상세 씬에서는 그 인스턴스에 닿을 길이 자체가 없었다.

또 #909 잠금화면은 부제 자리에 `placeName ?? memo` 를 그리는데, Todo·일정은 공유 상태에 장소·메모가 없어 그 자리가 늘 비어 있었다.

## 접근

**소유를 `UsecaseFactory` 로 올린다.** factory impl 이 struct 라 계정 전환마다 통째로 재생성되므로, `let` 프로퍼티로 잡으면 인스턴스 수명이 계정 세션과 정확히 일치한다 — #908 이 "인스턴스 해제 = 등록 상태 소멸" 로 노린 성질이 그대로 유지되면서 진입점과 메인 씬이 한 인스턴스를 본다.

**부제는 등록 순간에만 채운다.** 등록 시점 1회 `EventDetailDataUsecase.loadDetail` 로 장소 → 없으면 메모를 싣고, 이후 갱신 판정은 손대지 않는다. `normalizedObserved` 가 Todo·일정·공휴일을 장소 비교 대상에서 이미 빼고 있어 부제가 갱신에 지워지지 않는다. 다만 원격 경로는 캐시가 없고 서버가 빈 응답을 주면 값도 완료도 안 보내고 끝나므로 타임아웃을 걸었다 — 없으면 등록이 영영 매달린다.

**진입점 셋은 공통 흐름을 공유한다.** Todo·일정은 기존 more 메뉴에 `toggleLiveActivity` 케이스를 더하고, 별개 씬인 공휴일은 하단 ellipsis 메뉴에 항목을 붙인다. 확인 다이얼로그 없이 즉시 실행하고, 실패 3종은 각각 다른 사유 문구의 안내 알럿으로 뜬다 — `showError` 는 쓰지 않았다. "8시간 이내만 표시 가능" 이 "문제가 발생했습니다 (…)" 로 감싸이면 안내가 오류로 읽힌다.

반복 일정의 회차 키는 **반복일 때만** 싣는다. 진입점이 비반복 일정에도 셀의 시각을 그대로 넘겨 `repeatingEventTargetTime` 이 채워져 있어서, 그대로 실으면 등록 대상이 어긋난다. `DDayCandidate` 가 같은 자리에서 데인 적이 있어 같은 규칙을 따랐다.

## 스코프 밖

- Google·Apple 캘린더 상세 진입점 → #934 (#917 계열 PR 이 두 화면 하단 버튼 영역을 손대는 중이라 분리)
- en·ko 외 29개 언어 → #810 대기 목록에 등재

## 유저 검증 대기

실기기에서만 확인 가능한 항목이다 (#908 인계 코멘트의 1번을 이 PR 이 검증 가능하게 만든다):

- 8시간 이내 시작하는 Todo·일정을 상세에서 등록 → 잠금화면에 카운트다운·이벤트명·태그색이 뜨는가
- 장소가 있는 이벤트는 장소가, 없고 메모만 있으면 메모가 부제로 뜨는가
- 등록 후 상세를 닫았다 다시 열면 항목이 '잠금화면에서 제거' 로 유지되는가
- 8시간을 넘는 이벤트에서 항목을 누르면 "8시간 이내에 시작하는 이벤트만 표시할 수 있어요" 안내가 뜨는가
