### PR TITLE
[#901] 전체 sync 진행 상태 노출로 로딩 표시 복구

### DIFF
--- a/Domain/Sources/Models/Events/EventSync.swift
+++ b/Domain/Sources/Models/Events/EventSync.swift
@@ -61,3 +61,12 @@ public struct EventSyncResponse<T: Sendable>: Sendable {
     
     public init() { }
 }
+
+
+// MARK: - sync status
+
+public enum EventSyncStatus: Equatable, Sendable {
+    case idle
+    case incrementalSyncing
+    case fullSyncing
+}

--- a/Domain/Sources/Usecases/Events/EventSyncUsecase.swift
+++ b/Domain/Sources/Usecases/Events/EventSyncUsecase.swift
@@ -19,13 +19,20 @@ public protocol EventSyncUsecase: Sendable, AnyObject {
     func cancelSync()
     func forceSync()
     
-    var isSyncInProgress: AnyPublisher<Bool, Never> { get }
+    var syncStatus: AnyPublisher<EventSyncStatus, Never> { get }
     func loadLatestSyncDataTimestamp() async throws -> TimeInterval?
 }
 
 extension EventSyncUsecase {
-    
+
     public func sync() { self.sync(nil) }
+
+    public var isSyncInProgress: AnyPublisher<Bool, Never> {
+        return self.syncStatus
+            .map { $0 != .idle }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
 }
 
 
@@ -49,7 +56,7 @@ public final class EventSyncUsecaseImple: EventSyncUsecase, @unchecked Sendable 
         static let pageSize: Int = 30
     }
     private struct Subject {
-        let isSyncing = CurrentValueSubject<Bool, Never>(false)
+        let syncStatus = CurrentValueSubject<EventSyncStatus, Never>(.idle)
     }
     private let subject = Subject()
     private var syncTask: Task<Void, any Error>?
@@ -72,7 +79,7 @@ extension EventSyncUsecaseImple {
     public func cancelSync() {
         self.syncTask?.cancel()
         self.syncTask = nil
-        self.subject.isSyncing.send(false)
+        self.subject.syncStatus.send(.idle)
     }
     
     public func forceSync() {
@@ -87,7 +94,7 @@ extension EventSyncUsecaseImple {
     }
     
     private func runSyncTask() async throws {
-        self.subject.isSyncing.send(true)
+        self.subject.syncStatus.send(.incrementalSyncing)
 
         try await self.eventSyncMediator.waitUntilEventSyncAvailable()
 
@@ -103,11 +110,14 @@ extension EventSyncUsecaseImple {
         }
 
         logger.log(level: .debug, "event sync process end")
-        self.subject.isSyncing.send(false)
+        self.subject.syncStatus.send(.idle)
     }
-    
+
     private func runSync(_ dataType: SyncDataType) async throws {
         let checkIsNeed = try await self.syncRepository.checkIsNeedSync(for: dataType)
+        if checkIsNeed.result == .migrationNeeds {
+            self.subject.syncStatus.send(.fullSyncing)
+        }
         switch (checkIsNeed.result, dataType) {
         case (.noNeedToSync, _): break
         case (.migrationNeeds, .eventTag):
@@ -158,12 +168,12 @@ extension EventSyncUsecaseImple {
 
 extension EventSyncUsecaseImple {
     
-    public var isSyncInProgress: AnyPublisher<Bool, Never> {
-        return self.subject.isSyncing
+    public var syncStatus: AnyPublisher<EventSyncStatus, Never> {
+        return self.subject.syncStatus
             .removeDuplicates()
             .eraseToAnyPublisher()
     }
-    
+
     public func loadLatestSyncDataTimestamp() async throws -> TimeInterval? {
         return try await self.syncRepository.loadLatestSyncDataTimestamp()
     }
@@ -184,8 +194,8 @@ public final class NotNeedEventSyncUsecase: EventSyncUsecase, Sendable {
     
     public func forceSync() { }
     
-    public var isSyncInProgress: AnyPublisher<Bool, Never> {
-        return Just(false).eraseToAnyPublisher()
+    public var syncStatus: AnyPublisher<EventSyncStatus, Never> {
+        return Just(.idle).eraseToAnyPublisher()
     }
     
     public func loadLatestSyncDataTimestamp() async throws -> TimeInterval? {

--- a/Domain/Tests/Usecases/EventSyncUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/EventSyncUsecaseImpleTests.swift
@@ -113,7 +113,37 @@ extension EventSyncUsecaseImpleTests {
         // then
         #expect(syncs == [false, true, false])
     }
-    
+
+    @Test func usecase_whenMigrationNeeds_syncStatusIsFullSyncing() async throws {
+        // given
+        let expect = expectConfirm("migration 이 필요하면 전체 sync 상태로 알림")
+        expect.count = 4
+        let usecase = self.makeUsecase(checkResult: .migrationNeeds)
+
+        // when
+        let statuses = try await self.outputs(expect, for: usecase.syncStatus) {
+            usecase.sync()
+        }
+
+        // then
+        #expect(statuses == [.idle, .incrementalSyncing, .fullSyncing, .idle])
+    }
+
+    @Test func usecase_whenNeedToSync_syncStatusIsIncrementalSyncing() async throws {
+        // given
+        let expect = expectConfirm("증분 sync 는 전체 sync 상태로 올라가지 않음")
+        expect.count = 3
+        let usecase = self.makeUsecase(checkResult: .needToSync)
+
+        // when
+        let statuses = try await self.outputs(expect, for: usecase.syncStatus) {
+            usecase.sync()
+        }
+
+        // then
+        #expect(statuses == [.idle, .incrementalSyncing, .idle])
+    }
+
     @Test func usecase_whenEventUploading_waitSync() async throws {
         // given
         let expect = expectConfirm("event uploading 중에는 sync 동작 대기")

--- a/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
@@ -1565,13 +1565,13 @@ private extension CalendarViewModelImpleTests {
     }
     
     private class PrivateStubEventSyncUsecase: StubEventSyncUsecase, @unchecked Sendable {
-        
-        private let isSyncing = CurrentValueSubject<Bool, Never>(false)
+
+        private let isSyncing = CurrentValueSubject<EventSyncStatus, Never>(.idle)
         func updateIsSync(_ isSync: Bool) {
-            self.isSyncing.send(isSync)
+            self.isSyncing.send(isSync ? .incrementalSyncing : .idle)
         }
-        
-        override var isSyncInProgress: AnyPublisher<Bool, Never> {
+
+        override var syncStatus: AnyPublisher<EventSyncStatus, Never> {
             return isSyncing.removeDuplicates()
                 .eraseToAnyPublisher()
         }

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -112,6 +112,7 @@
 
 "calendar::foremostevent:title" = "Foremost Event";
 "calendar::uncompletedTodos:title" = "Uncompleted To-do";
+"calendar::eventSync::loadingAllEvents::message" = "Fetching all your events…";
 "calendar::event_time::todo" = "Todo";
 "calendar::event_time::allday" = "All day";
 "calendar::event_time::allday::with" = "%@ all day";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -112,6 +112,7 @@
 
 "calendar::foremostevent:title" = "제일 중요한 이벤트";
 "calendar::uncompletedTodos:title" = "완료되지 않은 할일";
+"calendar::eventSync::loadingAllEvents::message" = "모든 이벤트를 불러오는 중…";
 "calendar::event_time::todo" = "할일";
 "calendar::event_time::allday" = "하루종일";
 "calendar::event_time::allday::with" = "%@ 하루종일";

--- a/Supports/TestDoubles/Sources/Usecases/StubEventSyncUsecase.swift
+++ b/Supports/TestDoubles/Sources/Usecases/StubEventSyncUsecase.swift
@@ -17,25 +17,26 @@ open class StubEventSyncUsecase: EventSyncUsecase, @unchecked Sendable {
     
     public var didSyncRequested: Bool = false
     public var didSyncRequestedCount: Int = 0
-    private let isSyncSubject = CurrentValueSubject<Bool, Never>(false)
-    
+    private let isSyncSubject = CurrentValueSubject<EventSyncStatus, Never>(.idle)
+    public var stubStatusWhileSyncing: EventSyncStatus = .incrementalSyncing
+
     open func sync(_ completed: (@Sendable () -> Void)?) {
-        self.isSyncSubject.send(true)
+        self.isSyncSubject.send(self.stubStatusWhileSyncing)
         self.didSyncRequested = true
         self.didSyncRequestedCount += 1
-        self.isSyncSubject.send(false)
+        self.isSyncSubject.send(.idle)
         completed?()
     }
-    
+
     open func forceSync() {
         self.sync(nil)
     }
-    
+
     open func cancelSync() {
-        self.isSyncSubject.send(false)
+        self.isSyncSubject.send(.idle)
     }
-    
-    open var isSyncInProgress: AnyPublisher<Bool, Never> {
+
+    open var syncStatus: AnyPublisher<EventSyncStatus, Never> {
         return self.isSyncSubject
             .removeDuplicates()
             .eraseToAnyPublisher()

--- a/TodoCalendarApp/Sources/Main/CompositeLoadingBarView.swift
+++ b/TodoCalendarApp/Sources/Main/CompositeLoadingBarView.swift
@@ -16,7 +16,8 @@ final class CompositeLoadingBarView: UIView {
     private enum Constant {
         static let animationDuration: CGFloat = 2.0
         static let animationStartDebouncing: CGFloat = 1.0
-        static let animtionTimeout: TimeInterval = 10.0
+        // 전체 sync(마이그레이션 대기 + 3 dataType 페이징) 소요 상한을 덮는 안전장치 값
+        static let animtionTimeout: TimeInterval = 180.0
     }
     private let barLayer = CALayer()
     private var isLoadingCount = 0

--- a/TodoCalendarApp/Sources/Main/MainViewController.swift
+++ b/TodoCalendarApp/Sources/Main/MainViewController.swift
@@ -23,6 +23,7 @@ final class MainViewController: UIViewController, MainScene {
     private let headerAreaStackView = UIStackView()
     private let headerView = HeaderView()
     private let calendarContainerView = UIView()
+    private let loadingAllEventsLabel = UILabel()
     private let compositeLoadingBarView = CompositeLoadingBarView()
     
     private let viewModel: any MainViewModel
@@ -112,7 +113,14 @@ extension MainViewController {
                 self?.compositeLoadingBarView.updateIsLoading(isLoading)
             })
             .store(in: &self.cancellables)
-        
+
+        self.viewModel.isLoadingAllEvents
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self] isLoading in
+                self?.loadingAllEventsLabel.isHidden = !isLoading
+            })
+            .store(in: &self.cancellables)
+
         self.headerView.returnTodayView.addTapGestureRecognizerPublisher()
             .sink(receiveValue: { [weak self] in
                 self?.viewModel.returnToToday()
@@ -184,7 +192,12 @@ extension MainViewController {
             $0.heightAnchor.constraint(equalToConstant: 44)
         }
         headerView.setupLayout()
-        
+
+        headerAreaStackView.addArrangedSubview(loadingAllEventsLabel)
+        loadingAllEventsLabel.text = "calendar::eventSync::loadingAllEvents::message".localized()
+        loadingAllEventsLabel.textAlignment = .center
+        loadingAllEventsLabel.isHidden = true
+
         headerAreaStackView.addArrangedSubview(compositeLoadingBarView)
         compositeLoadingBarView.autoLayout.active {
             $0.heightAnchor.constraint(equalToConstant: 3.2)
@@ -204,6 +217,8 @@ extension MainViewController {
     ) {
         self.view.backgroundColor = colorSet.dayBackground
         self.headerView.setupStyling(fontSet, colorSet)
+        self.loadingAllEventsLabel.font = fontSet.subNormal
+        self.loadingAllEventsLabel.textColor = colorSet.text2
         self.compositeLoadingBarView.setupStyling(fontSet, colorSet)
     }
 }

--- a/TodoCalendarApp/Sources/Main/MainViewModel.swift
+++ b/TodoCalendarApp/Sources/Main/MainViewModel.swift
@@ -45,6 +45,7 @@ protocol MainViewModel: AnyObject, Sendable, MainSceneInteractor {
     var isShowReturnToToday: AnyPublisher<Bool, Never> { get }
     var temporaryUserDataMigrationStatus: AnyPublisher<TemporaryUserDataMigrationStatus?, Never> { get }
     var isLoadingCalendarEvents: AnyPublisher<Bool, Never> { get }
+    var isLoadingAllEvents: AnyPublisher<Bool, Never> { get }
 }
 
 
@@ -288,6 +289,13 @@ extension MainViewModelImple {
     
     var isLoadingCalendarEvents: AnyPublisher<Bool, Never> {
         return self.eventSyncUsecase.isSyncInProgress
+            .eraseToAnyPublisher()
+    }
+
+    var isLoadingAllEvents: AnyPublisher<Bool, Never> {
+        return self.eventSyncUsecase.syncStatus
+            .map { $0 == .fullSyncing }
+            .removeDuplicates()
             .eraseToAnyPublisher()
     }
 }

--- a/TodoCalendarApp/TodoCalendarAppTests/MainViewModelImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/MainViewModelImpleTests.swift
@@ -66,9 +66,11 @@ class MainViewModelImpleTests: BaseTestCase, PublisherWaitable {
     }
 
     private func makeViewModel(
-        shouldFailMigration: Bool = false
+        shouldFailMigration: Bool = false,
+        fullSyncing: Bool = false
     ) -> MainViewModelImple {
         self.stubMigrationUsecase.shouldFail = shouldFailMigration
+        self.stubSyncUsecase.stubStatusWhileSyncing = fullSyncing ? .fullSyncing : .incrementalSyncing
         let expect = expectation(description: "wait until attached")
         let viewModel = MainViewModelImple(
             uiSettingUsecase: self.spyUISettingUsecase,
@@ -384,10 +386,40 @@ extension MainViewModelImpleTests {
         // then
         XCTAssertEqual(isLoadings, [false, true, false])
     }
+
+    func testViewModel_whenFullSyncing_notifyLoadingAllEvents() {
+        // given
+        let expect = expectation(description: "전체 sync 중임을 알림")
+        expect.expectedFulfillmentCount = 3
+        let viewModel = self.makeViewModel(fullSyncing: true)
+
+        // when
+        let isLoadings = self.waitOutputs(expect, for: viewModel.isLoadingAllEvents) {
+            self.stubSyncUsecase.sync()
+        }
+
+        // then
+        XCTAssertEqual(isLoadings, [false, true, false])
+    }
+
+    func testViewModel_whenIncrementalSyncing_notNotifyLoadingAllEvents() {
+        // given
+        let expect = expectation(description: "증분 sync 중에는 전체 sync 안내를 하지 않음")
+        expect.expectedFulfillmentCount = 1
+        let viewModel = self.makeViewModel()
+
+        // when
+        let isLoadings = self.waitOutputs(expect, for: viewModel.isLoadingAllEvents) {
+            self.stubSyncUsecase.sync()
+        }
+
+        // then
+        XCTAssertEqual(isLoadings, [false])
+    }
 }
 
 extension MainViewModelImpleTests {
-    
+
     func testViewModel_jumpDay() {
         // given
         let viewModel = self.makeViewModel()


### PR DESCRIPTION
로그인 직후 sync API로 전체 이벤트를 땡겨오는 동안 캘린더 화면에 로딩 상태가 안 뜨던 문제를 잡는다.

## 문제

두 겹이었다.

로딩바는 `CompositeLoadingBarView`가 10초 타임아웃으로 강제 종료한다. 전체 sync는 3개 dataType을 30개씩 페이징하느라 10초를 훨씬 넘고, 그 앞단 `EventSyncMediator.waitUntilEventSyncAvailable()`이 마이그레이션 종료까지 대기하느라 10초를 대기에만 써버린다. 정작 다운로드가 시작될 땐 바가 이미 죽어 있다.

그리고 도메인이 "지금 도는 sync가 전체인지 증분인지"를 노출하지 않았다. `migrationNeeds` 판정은 `EventSyncUsecaseImple.runSync(_:)`의 switch 안에만 있어서, UI가 전체 sync에 더 적극적으로 반응할 근거가 없었다.

## 접근

`EventSyncUsecase`의 진행 상태를 `Bool`에서 `EventSyncStatus`(`idle`/`incrementalSyncing`/`fullSyncing`) enum으로 승격했다. `checkIsNeedSync`가 `migrationNeeds`를 주면 그 sync 런이 끝날 때까지 `.fullSyncing`을 유지한다 — dataType 셋 중 하나만 migration이어도 강등하지 않고, 런 경계에서 리셋된다.

기존 `isSyncInProgress` 소비처(`EventSettingViewModel`, `CalendarViewModel.syncEnd`, `MainViewModel.isLoadingCalendarEvents`)는 프로토콜 extension 기본 구현으로 흡수해 무변경으로 통과한다.

앱 레이어는 그 상태를 받아 헤더와 로딩바 사이에 안내 라벨을 띄운다. 전체 sync면 라벨 + 로딩바, 증분 sync면 기존대로 로딩바만. 캘린더 조작은 sync 중에도 그대로 되고, 전체 화면 오버레이는 두지 않았다.

로딩바 타임아웃은 usecase가 종료 신호를 못 보내고 죽는 경우의 안전장치라 제거하지 않고 180초로 올렸다.

## 참고

- 신규 문구 `calendar::eventSync::loadingAllEvents::message`는 en/ko만 추가. 나머지 29개 언어는 #810 대기 목록에 등록.
- 로컬에서 TodoCalendarApp 스킴은 실제 케이스 29/29 통과 후 "Selected tests" 구성이 0개를 실행해 `run-all-tests.sh`가 FAILED로 찍는다. 이 브랜치 이전 커밋에서도 동일 재현되는 기존 문제다.

Closes #901
