### PR TITLE
[#911] 라이브액티비티 등록 진입점 — 일별 이벤트 리스트 셀

### DIFF
--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventCellViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventCellViewModel.swift
@@ -211,6 +211,8 @@ public struct TodoEventCellViewModel: EventCellViewModel {
     public var isForemost: Bool = false
     public var isAlldayEvent: Bool = false
     public var isCurrentTodo: Bool = false
+    public var isLiveActivityRegistered: Bool = false
+    public var isUncompletedTodo: Bool = false
 
     public init(_ id: String, name: String) {
         self.eventIdentifier = id
@@ -256,7 +258,11 @@ public struct TodoEventCellViewModel: EventCellViewModel {
             : [.remove(onlyThisTime: false)]
         let skipActions: [EventListMoreAction] = self.isRepeating
             ? [.skipTodo] : []
-        let basicActions: [EventListMoreAction] = [.toggleTo(isForemost: self.isForemost)] + skipActions + [.edit, .copy]
+        let liveActivityActions: [EventListMoreAction] = (self.liveActivityTarget != nil && !self.isUncompletedTodo)
+            ? [.toggleLiveActivity(isRegistered: self.isLiveActivityRegistered)]
+            : []
+        let basicActions: [EventListMoreAction] = [.toggleTo(isForemost: self.isForemost)]
+            + liveActivityActions + skipActions + [.edit, .copy]
         return .init(
             basicActions: basicActions,
             removeActions: removeActions
@@ -315,6 +321,7 @@ public struct ScheduleEventCellViewModel: EventCellViewModel {
     public let isForemost: Bool
     public var isAlldayEvent: Bool { self.eventTimeRawValue?.isAllDay ?? false }
     public var eventTimeRawValue: EventTime?
+    public var isLiveActivityRegistered: Bool = false
 
     public init(_ id: String, turn: Int? = nil, name: String, isRepeating: Bool = false) {
         self.eventIdWithoutTurn = id
@@ -354,8 +361,11 @@ public struct ScheduleEventCellViewModel: EventCellViewModel {
         let removeActions: [EventListMoreAction] = self.isRepeating
             ? [.remove(onlyThisTime: true), .remove(onlyThisTime: false)]
             : [.remove(onlyThisTime: false)]
+        let liveActivityActions: [EventListMoreAction] = self.liveActivityTarget != nil
+            ? [.toggleLiveActivity(isRegistered: self.isLiveActivityRegistered)]
+            : []
         return .init(
-            basicActions: [.toggleTo(isForemost: self.isForemost), .edit, .copy],
+            basicActions: [.toggleTo(isForemost: self.isForemost)] + liveActivityActions + [.edit, .copy],
             removeActions: removeActions
         )
     }
@@ -389,6 +399,7 @@ public struct HolidayEventCellViewModel: EventCellViewModel {
     public let isForemost: Bool = false
     public let isAlldayEvent: Bool = true
     public let dateString: String
+    public var isLiveActivityRegistered: Bool = false
 
     public init(_ holiday: HolidayCalendarEvent) {
         self.eventIdentifier = holiday.eventId
@@ -400,7 +411,12 @@ public struct HolidayEventCellViewModel: EventCellViewModel {
         self.colorSource = EventTagId.holiday
     }
 
-    public var moreActions: EventListMoreActionModel? { nil }
+    public var moreActions: EventListMoreActionModel? {
+        return .init(
+            basicActions: [.toggleLiveActivity(isRegistered: self.isLiveActivityRegistered)],
+            removeActions: []
+        )
+    }
 
     public var liveActivityTarget: LiveActivityTarget? {
         .holiday(uuid: self.eventIdentifier, dateString: self.dateString)

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventCellViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventCellViewModel.swift
@@ -143,6 +143,7 @@ public enum EventListMoreAction: Sendable, Equatable {
     
     case remove(onlyThisTime: Bool)
     case toggleTo(isForemost: Bool)
+    case toggleLiveActivity(isRegistered: Bool)
     case skipTodo
     case edit
     case copy
@@ -165,6 +166,7 @@ public protocol EventCellViewModel: Sendable {
     var isRepeating: Bool { get }
     var moreActions: EventListMoreActionModel? { get }
     var isAlldayEvent: Bool { get }
+    var liveActivityTarget: LiveActivityTarget? { get }
 
     /// 셀이 그리는 값 + 셀 액션이 소비하는 값 전부를 담는다. 이 키가 같으면 셀 목록 재방출이 생략된다.
     /// 프로토콜 밖 프로퍼티는 각 타입이 `makeCustomCompareKey`의 추가 성분으로 직접 얹어야 한다 — 빠뜨리면 그 값의 변경이 화면·동작에 안 붙는다.
@@ -172,6 +174,8 @@ public protocol EventCellViewModel: Sendable {
 }
 
 extension EventCellViewModel {
+
+    public var liveActivityTarget: LiveActivityTarget? { nil }
 
     fileprivate func makeCustomCompareKey(_ additionalComponents: [String?]) -> String {
         let baseComponents: [String?] = [
@@ -257,6 +261,11 @@ public struct TodoEventCellViewModel: EventCellViewModel {
             basicActions: basicActions,
             removeActions: removeActions
         )
+    }
+
+    public var liveActivityTarget: LiveActivityTarget? {
+        guard self.eventTimeRawValue != nil else { return nil }
+        return .todo(id: self.eventIdentifier)
     }
 
     public var customCompareKey: String {
@@ -351,6 +360,14 @@ public struct ScheduleEventCellViewModel: EventCellViewModel {
         )
     }
 
+    public var liveActivityTarget: LiveActivityTarget? {
+        guard self.eventTimeRawValue != nil else { return nil }
+        return .schedule(
+            id: self.eventIdWithoutTurn,
+            turnKey: self.isRepeating ? self.eventTimeRawValue?.customKey : nil
+        )
+    }
+
     public var customCompareKey: String {
         return self.makeCustomCompareKey([
             self.turn.map { "\($0)" },
@@ -371,10 +388,12 @@ public struct HolidayEventCellViewModel: EventCellViewModel {
     public let isRepeating: Bool = false
     public let isForemost: Bool = false
     public let isAlldayEvent: Bool = true
+    public let dateString: String
 
     public init(_ holiday: HolidayCalendarEvent) {
         self.eventIdentifier = holiday.eventId
         self.name = holiday.name
+        self.dateString = holiday.dateString
         self.periodText = .singleText(
             .init(text: R.String.calendarEventTimeAllday)
         )
@@ -382,6 +401,10 @@ public struct HolidayEventCellViewModel: EventCellViewModel {
     }
 
     public var moreActions: EventListMoreActionModel? { nil }
+
+    public var liveActivityTarget: LiveActivityTarget? {
+        .holiday(uuid: self.eventIdentifier, dateString: self.dateString)
+    }
 
     public var customCompareKey: String { self.makeCustomCompareKey([]) }
 }

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModel.swift
@@ -41,29 +41,43 @@ protocol EventListCellEventHanleViewModel: EventDetailSceneListener {
 
 
 final class EventListCellEventHanleViewModelImple: EventListCellEventHanleViewModel, @unchecked Sendable {
-    
+
     private let todoEventUsecase: any TodoEventUsecase
     private let scheduleEventUsecase: any ScheduleEventUsecase
     private let foremostEventUsecase: any ForemostEventUsecase
-    
+    private let liveActivityToggleViewModel: any LiveActivityToggleViewModel
+
     var router: (any EventListCellEventHanleRouting)?
-    
+
     init(
         todoEventUsecase: any TodoEventUsecase,
         scheduleEventUsecase: any ScheduleEventUsecase,
-        foremostEventUsecase: any ForemostEventUsecase
+        foremostEventUsecase: any ForemostEventUsecase,
+        liveActivityToggleViewModel: any LiveActivityToggleViewModel
     ) {
         self.todoEventUsecase = todoEventUsecase
         self.scheduleEventUsecase = scheduleEventUsecase
         self.foremostEventUsecase = foremostEventUsecase
+        self.liveActivityToggleViewModel = liveActivityToggleViewModel
+
+        self.internalBind()
     }
-    
+
     private struct Subject {
         let doneTodoResult = PassthroughSubject<DoneTodoResult, Never>()
+        let registeredLiveActivityTarget = CurrentValueSubject<LiveActivityTarget?, Never>(nil)
     }
     private var cancellables: Set<AnyCancellable> = []
     private var todoCompleteTaskMap: [String: Task<Void, any Error>] = [:]
     private let subject = Subject()
+
+    private func internalBind() {
+        self.liveActivityToggleViewModel.registeredTarget
+            .sink { [weak self] target in
+                self?.subject.registeredLiveActivityTarget.send(target)
+            }
+            .store(in: &self.cancellables)
+    }
 }
 
 extension EventListCellEventHanleViewModelImple {
@@ -130,7 +144,10 @@ extension EventListCellEventHanleViewModelImple {
             
         case .toggleTo(let isForemost):
             self.toggleForemostEvent(cellViewModel, isForemost)
-            
+
+        case .toggleLiveActivity(let isRegistered):
+            self.toggleLiveActivity(cellViewModel, isRegistered)
+
         case .edit:
             self.selectEvent(cellViewModel)
             
@@ -218,6 +235,32 @@ extension EventListCellEventHanleViewModelImple {
         }
     }
     
+    private func toggleLiveActivity(
+        _ cellViewModel: any EventCellViewModel,
+        _ isRegistered: Bool
+    ) {
+        guard let target = cellViewModel.liveActivityTarget else { return }
+
+        let title = "calendar::event::more_action:live_activity:title".localized()
+        let message = self.toggleLiveActivityConfirmMessage(isRegistered, target: target)
+        self.runMoreActionAfterConfirm(title, message) { [weak self] in
+            self?.liveActivityToggleViewModel.startOrStopLiveActivity(target, isCurrentlyRegistered: isRegistered)
+        }
+    }
+
+    private func toggleLiveActivityConfirmMessage(
+        _ isRegistered: Bool, target: LiveActivityTarget
+    ) -> String {
+        guard !isRegistered else {
+            return "calendar::event::more_action:live_activity:unregister:confirm".localized()
+        }
+        let currentlyRegisteredTarget = self.subject.registeredLiveActivityTarget.value
+        let isReplacingOtherTarget = currentlyRegisteredTarget != nil && currentlyRegisteredTarget != target
+        return isReplacingOtherTarget
+            ? "calendar::event::more_action:live_activity:replace:confirm".localized()
+            : "calendar::event::more_action:live_activity:register:confirm".localized()
+    }
+
     private func showUnavailToMarkRepeatingScheduleAsForemostEvent() {
         let info = ConfirmDialogInfo()
             |> \.title .~ "calendar::event::more_action::foremost_event:title".localized()

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModelBuilder.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModelBuilder.swift
@@ -33,16 +33,21 @@ final class EventListCellEventHanleViewModelBuilderImple: EventListCellEventHanl
         self.usecaseFactory = usecaseFactory
         self.eventDetailSceneBuilder = eventDetailSceneBuilder
         
+        let liveActivityToggleViewModel = LiveActivityToggleViewModelImple(
+            eventLiveActivityUsecase: self.usecaseFactory.eventLiveActivityUsecase
+        )
         let viewModel = EventListCellEventHanleViewModelImple(
             todoEventUsecase: self.usecaseFactory.makeTodoEventUsecase(),
             scheduleEventUsecase: self.usecaseFactory.makeScheduleEventUsecase(),
-            foremostEventUsecase: self.usecaseFactory.makeForemostEventUsecase()
+            foremostEventUsecase: self.usecaseFactory.makeForemostEventUsecase(),
+            liveActivityToggleViewModel: liveActivityToggleViewModel
         )
         let router = EventListCellEventHanleRouter(
             eventDetailSceneBuilder: eventDetailSceneBuilder
         )
         self.viewModel = viewModel
         viewModel.router = router
+        liveActivityToggleViewModel.router = router
         router.eventDetailListener = viewModel
         self.router = router
     }

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellView.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellView.swift
@@ -11,6 +11,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Scenes
 import Extensions
 import CommonPresentation
 
@@ -114,6 +115,8 @@ struct EventListCellView: View {
             return removeButton(onlyThisTime).asAnyView()
         case .toggleTo(let isForemost):
             return toggleForemostButton(isForemost).asAnyView()
+        case .toggleLiveActivity(let isRegistered):
+            return toggleLiveActivityButton(isRegistered).asAnyView()
         case .skipTodo:
             return skipTodoButton().asAnyView()
         case .copy:
@@ -155,6 +158,19 @@ struct EventListCellView: View {
         }
     }
     
+    private func toggleLiveActivityButton(_ isRegistered: Bool) -> some View {
+        return Button {
+            self.handleMoreAction(
+                self.cellViewModel, .toggleLiveActivity(isRegistered: isRegistered)
+            )
+        } label: {
+            HStack {
+                Text(LiveActivityActionModel(isRegistered: isRegistered).itemText)
+                Image(systemName: "timer")
+            }
+        }
+    }
+
     private func editEventButton() -> some View {
         return Button {
             self.requestShowDetail(self.cellViewModel)

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellView.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellView.swift
@@ -97,11 +97,13 @@ struct EventListCellView: View {
                 ForEach(0..<moreActions.basicActions.count, id: \.self) {
                     moreActionsView(moreActions.basicActions[$0])
                 }
-                
-                Divider()
-                
-                ForEach(0..<moreActions.removeActions.count, id: \.self) {
-                    moreActionsView(moreActions.removeActions[$0])
+
+                if !moreActions.removeActions.isEmpty {
+                    Divider()
+
+                    ForEach(0..<moreActions.removeActions.count, id: \.self) {
+                        moreActionsView(moreActions.removeActions[$0])
+                    }
                 }
             }
         }

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListBuilderImple.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListBuilderImple.swift
@@ -76,7 +76,8 @@ extension DayEventListSceneBuilerImple: DayEventListSceneBuiler {
             foremostEventUsecase: foremostEventUsecase,
             uiSettingUsecase: uiSettingUsecase,
             accountUsecase: self.accountUsecase,
-            aiAgentOrchestrationUsecase: self.usecaseFactory.aiAgentOrchestrationUsecase
+            aiAgentOrchestrationUsecase: self.usecaseFactory.aiAgentOrchestrationUsecase,
+            eventLiveActivityUsecase: self.usecaseFactory.eventLiveActivityUsecase
         )
         let router = DayEventListRouter(
             eventDetailSceneBuilder: self.eventDetailSceneBuilder,

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListViewModel.swift
@@ -94,6 +94,7 @@ final class DayEventListViewModelImple: DayEventListViewModel, @unchecked Sendab
     private let uiSettingUsecase: any UISettingUsecase
     private let accountUsecase: any AccountUsecase
     private let aiAgentOrchestrationUsecase: any AIAgentOrchestrationUsecase
+    private let eventLiveActivityUsecase: any EventLiveActivityUsecase
     var router: (any DayEventListRouting)?
     private weak var listener: (any DayEventListSceneListener)?
 
@@ -105,7 +106,8 @@ final class DayEventListViewModelImple: DayEventListViewModel, @unchecked Sendab
         foremostEventUsecase: any ForemostEventUsecase,
         uiSettingUsecase: any UISettingUsecase,
         accountUsecase: any AccountUsecase,
-        aiAgentOrchestrationUsecase: any AIAgentOrchestrationUsecase
+        aiAgentOrchestrationUsecase: any AIAgentOrchestrationUsecase,
+        eventLiveActivityUsecase: any EventLiveActivityUsecase
     ) {
         self.calendarUsecase = calendarUsecase
         self.calendarSettingUsecase = calendarSettingUsecase
@@ -115,6 +117,7 @@ final class DayEventListViewModelImple: DayEventListViewModel, @unchecked Sendab
         self.uiSettingUsecase = uiSettingUsecase
         self.accountUsecase = accountUsecase
         self.aiAgentOrchestrationUsecase = aiAgentOrchestrationUsecase
+        self.eventLiveActivityUsecase = eventLiveActivityUsecase
 
         self.internalBind()
     }
@@ -341,6 +344,11 @@ extension DayEventListViewModelImple {
             default: return nil
             }
         }
+        let applyRegistration: ((any EventCellViewModel)?, LiveActivityTarget?) -> (any EventCellViewModel)?
+        applyRegistration = { cvm, target in
+            cvm?.liveActivityRegistrationApplied(target)
+        }
+
         let foremostModel = Publishers.CombineLatest4(
             self.foremostEventUsecase.foremostEvent,
             self.calendarUsecase.currentDay.removeDuplicates(),
@@ -349,7 +357,8 @@ extension DayEventListViewModelImple {
         )
         .map(asCellViewModel)
 
-        return foremostModel
+        return Publishers.CombineLatest(foremostModel, self.eventLiveActivityUsecase.registeredTarget)
+            .map(applyRegistration)
             .removeDuplicates(by: { $0?.customCompareKey == $1?.customCompareKey })
             .eraseToAnyPublisher()
     }
@@ -364,17 +373,26 @@ extension DayEventListViewModelImple {
                 .filter { !$0.isForemost }
                 .compactMap {
                     TodoEventCellViewModel($0, in: todayRange, timeZone, is24Form, forceShowEventDateDurationText: true)
+                        .map { $0 |> \.isUncompletedTodo .~ true }
                 }
         }
-        return Publishers.CombineLatest4(
+        let applyRegistration: ([TodoEventCellViewModel], LiveActivityTarget?) -> [TodoEventCellViewModel]
+        applyRegistration = { todos, target in
+            todos.compactMap { $0.liveActivityRegistrationApplied(target) as? TodoEventCellViewModel }
+        }
+
+        let todos = Publishers.CombineLatest4(
             self.eventListUsecase.uncompletedTodos(),
             self.calendarUsecase.currentDay,
             self.calendarSettingUsecase.currentTimeZone,
             self.uiSettingUsecase.currentCalendarUISeting.map { $0.is24hourForm }.removeDuplicates()
         )
         .compactMap(asCellViewModels)
-        .removeDuplicates(by: { $0.map { $0.customCompareKey } == $1.map { $0.customCompareKey } })
-        .eraseToAnyPublisher()
+
+        return Publishers.CombineLatest(todos, self.eventLiveActivityUsecase.registeredTarget)
+            .map(applyRegistration)
+            .removeDuplicates(by: { $0.map { $0.customCompareKey } == $1.map { $0.customCompareKey } })
+            .eraseToAnyPublisher()
     }
 
     var selectedDay: AnyPublisher<SelectedDayModel, Never> {
@@ -397,6 +415,10 @@ extension DayEventListViewModelImple {
         combineEvents = { pair, pending in
             return pair.0 + pending + pair.1
         }
+        let applyRegistration: ([any EventCellViewModel], LiveActivityTarget?) -> [any EventCellViewModel]
+        applyRegistration = { cvms, target in
+            cvms.map { $0.liveActivityRegistrationApplied(target) }
+        }
 
         let cells = Publishers.CombineLatest(
             self.currentAndEventCellViewModels.receive(on: self.cvmCombineScheduler),
@@ -404,7 +426,8 @@ extension DayEventListViewModelImple {
         )
         .map(combineEvents)
 
-        return cells
+        return Publishers.CombineLatest(cells, self.eventLiveActivityUsecase.registeredTarget)
+            .map(applyRegistration)
             .removeDuplicates(by: { $0.map { $0.customCompareKey } == $1.map { $0.customCompareKey } })
             .eraseToAnyPublisher()
     }
@@ -471,6 +494,22 @@ extension DayEventListViewModelImple {
 
 
 // MARK: - private helpers
+
+private extension EventCellViewModel {
+
+    func liveActivityRegistrationApplied(_ registered: LiveActivityTarget?) -> any EventCellViewModel {
+        switch self {
+        case let todo as TodoEventCellViewModel:
+            return todo |> \.isLiveActivityRegistered .~ (registered != nil && todo.liveActivityTarget == registered)
+        case let schedule as ScheduleEventCellViewModel:
+            return schedule |> \.isLiveActivityRegistered .~ (registered != nil && schedule.liveActivityTarget == registered)
+        case let holiday as HolidayEventCellViewModel:
+            return holiday |> \.isLiveActivityRegistered .~ (registered != nil && holiday.liveActivityTarget == registered)
+        default:
+            return self
+        }
+    }
+}
 
 private extension EventTime {
 

--- a/Presentations/CalendarScenes/Tests/Common/EventCellViewModelTests.swift
+++ b/Presentations/CalendarScenes/Tests/Common/EventCellViewModelTests.swift
@@ -128,4 +128,40 @@ extension EventCellViewModelTests {
         // when + then
         #expect(cell.liveActivityTarget == .holiday(uuid: "holiday", dateString: "2023-02-03"))
     }
+
+    @Test("시간 있는 todo의 moreActions는 라이브액티비티 토글을 담고 등록 여부를 반영한다 — 시간 없으면 안 담는다")
+    func todoCell_moreActionsContainsLiveActivityToggle_whenTimeExists() {
+        // given
+        let cellWithTime = self.makeTodoCell(rawTime: .at(100))
+        let registeredCellWithTime = cellWithTime |> \.isLiveActivityRegistered .~ true
+        let cellWithoutTime = self.makeTodoCell(rawTime: nil)
+
+        // when + then
+        #expect(cellWithTime.moreActions?.basicActions.contains(.toggleLiveActivity(isRegistered: false)) == true)
+        #expect(registeredCellWithTime.moreActions?.basicActions.contains(.toggleLiveActivity(isRegistered: true)) == true)
+        #expect(cellWithoutTime.moreActions?.basicActions.contains(where: { if case .toggleLiveActivity = $0 { return true } else { return false } }) == false)
+    }
+
+    @Test("holiday의 moreActions는 라이브액티비티 토글 하나만 담는다")
+    func holidayCell_moreActionsHasOnlyLiveActivityToggle() {
+        // given
+        let holiday = HolidayCalendarEvent(
+            .init(uuid: "holiday", dateString: "2023-02-03", name: "dummy"), in: self.timeZone
+        )!
+        let cell = HolidayEventCellViewModel(holiday)
+
+        // when + then
+        #expect(cell.moreActions?.basicActions == [.toggleLiveActivity(isRegistered: false)])
+        #expect(cell.moreActions?.removeActions == [])
+    }
+
+    @Test("시간 있는 todo 셀이라도 isUncompletedTodo면 moreActions는 라이브액티비티 토글을 안 담는다")
+    func todoCell_moreActionsExcludesLiveActivityToggle_whenUncompletedTodo() {
+        // given
+        let uncompletedCell = self.makeTodoCell(rawTime: .at(100))
+            |> \.isUncompletedTodo .~ true
+
+        // when + then
+        #expect(uncompletedCell.moreActions?.basicActions.contains(where: { if case .toggleLiveActivity = $0 { return true } else { return false } }) == false)
+    }
 }

--- a/Presentations/CalendarScenes/Tests/Common/EventCellViewModelTests.swift
+++ b/Presentations/CalendarScenes/Tests/Common/EventCellViewModelTests.swift
@@ -88,3 +88,44 @@ extension EventCellViewModelTests {
         #expect(cell?.customCompareKey != accountChangedCell?.customCompareKey)
     }
 }
+
+extension EventCellViewModelTests {
+
+    @Test("시간 있는 todo 셀의 라이브액티비티 타겟은 .todo다 — 시간 없으면 nil")
+    func todoCell_liveActivityTarget_dependsOnEventTime() {
+        // given
+        let cellWithTime = self.makeTodoCell(rawTime: .at(100))
+        let cellWithoutTime = self.makeTodoCell(rawTime: nil)
+
+        // when + then
+        #expect(cellWithTime.liveActivityTarget == .todo(id: "todo"))
+        #expect(cellWithoutTime.liveActivityTarget == nil)
+    }
+
+    @Test("schedule 셀의 라이브액티비티 타겟은 반복일 때만 회차 키를 싣는다 — 시간 없으면 nil")
+    func scheduleCell_liveActivityTargetTurnKey_dependsOnRepeating() {
+        // given
+        let repeatingCell = ScheduleEventCellViewModel("schedule", turn: 1, name: "name", isRepeating: true)
+            |> \.eventTimeRawValue .~ .at(100)
+        let nonRepeatingCell = ScheduleEventCellViewModel("schedule", turn: 1, name: "name", isRepeating: false)
+            |> \.eventTimeRawValue .~ .at(100)
+        let noTimeCell = self.makeScheduleCell(rawTime: nil)
+
+        // when + then
+        #expect(repeatingCell.liveActivityTarget == .schedule(id: "schedule", turnKey: EventTime.at(100).customKey))
+        #expect(nonRepeatingCell.liveActivityTarget == .schedule(id: "schedule", turnKey: nil))
+        #expect(noTimeCell.liveActivityTarget == nil)
+    }
+
+    @Test("holiday 셀의 라이브액티비티 타겟은 uuid와 dateString을 싣는다")
+    func holidayCell_liveActivityTarget() {
+        // given
+        let holiday = HolidayCalendarEvent(
+            .init(uuid: "holiday", dateString: "2023-02-03", name: "dummy"), in: self.timeZone
+        )!
+        let cell = HolidayEventCellViewModel(holiday)
+
+        // when + then
+        #expect(cell.liveActivityTarget == .holiday(uuid: "holiday", dateString: "2023-02-03"))
+    }
+}

--- a/Presentations/CalendarScenes/Tests/Common/EventListCellEventHanleViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Common/EventListCellEventHanleViewModelImpleTests.swift
@@ -24,8 +24,9 @@ class EventListCellEventHanleViewModelImpleTests: BaseTestCase, PublisherWaitabl
     private var spyTodoUsecase: PrivateStubTodoEventUsecase!
     private var spySchedleUsecase: PrivateScheduleEventUsecase!
     private var spyForemostUsecase: PrivateForemostEventUsecase!
+    private var stubLiveActivityUsecase: StubEventLiveActivityUsecase!
     private var spyRouter: SpyEventListCellEventHanleRouter!
-    
+
     override func setUpWithError() throws {
         self.cancelBag = .init()
         self.spyTodoUsecase = .init()
@@ -33,27 +34,37 @@ class EventListCellEventHanleViewModelImpleTests: BaseTestCase, PublisherWaitabl
         self.spyForemostUsecase = .init()
         self.spyRouter = .init()
     }
-    
+
     override func tearDownWithError() throws {
         self.cancelBag = nil
         self.spyTodoUsecase = nil
         self.spySchedleUsecase = nil
         self.spyForemostUsecase = nil
+        self.stubLiveActivityUsecase = nil
         self.spyRouter = nil
     }
-    
+
     private func makeViewModel(
-        shouldFailDoneTodo: Bool = false
+        shouldFailDoneTodo: Bool = false,
+        registeredLiveActivityTarget: LiveActivityTarget? = nil,
+        liveActivityStartError: (any Error)? = nil
     ) -> EventListCellEventHanleViewModelImple {
-        
+
         self.spyTodoUsecase.shouldFailCompleteTodo = shouldFailDoneTodo
-        
+        self.stubLiveActivityUsecase = .init(registeredTarget: registeredLiveActivityTarget)
+        self.stubLiveActivityUsecase.stubStartError = liveActivityStartError
+
+        let liveActivityToggleViewModel = LiveActivityToggleViewModelImple(
+            eventLiveActivityUsecase: self.stubLiveActivityUsecase
+        )
         let viewModel = EventListCellEventHanleViewModelImple(
             todoEventUsecase: self.spyTodoUsecase,
             scheduleEventUsecase: self.spySchedleUsecase,
-            foremostEventUsecase: self.spyForemostUsecase
+            foremostEventUsecase: self.spyForemostUsecase,
+            liveActivityToggleViewModel: liveActivityToggleViewModel
         )
         viewModel.router = self.spyRouter
+        liveActivityToggleViewModel.router = self.spyRouter
         return viewModel
     }
 }
@@ -380,6 +391,114 @@ extension EventListCellEventHanleViewModelImpleTests {
         XCTAssertEqual(names, ["origin", "skipped"])
     }
     
+    func testViewModel_whenToggleLiveActivityToRegister_afterConfirm_startActivity() {
+        // given
+        let expect = expectation(description: "미등록 상태에서 토글하면 확인 후 등록")
+        let viewModel = self.makeViewModel()
+        self.stubLiveActivityUsecase.didStartTargetCallback = { _ in expect.fulfill() }
+        let cellViewModel = TodoEventCellViewModel("todo", name: "name")
+            |> \.eventTimeRawValue .~ .at(100)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .toggleLiveActivity(isRegistered: false))
+        self.wait(for: [expect], timeout: self.timeout)
+
+        // then
+        XCTAssertEqual(self.stubLiveActivityUsecase.didStartTarget, cellViewModel.liveActivityTarget)
+        XCTAssertEqual(
+            self.spyRouter.didShowConfirmWith?.message,
+            "calendar::event::more_action:live_activity:register:confirm".localized()
+        )
+    }
+
+    func testViewModel_whenToggleLiveActivityToRegister_whileOtherTargetRegistered_showReplaceConfirm() {
+        // given
+        let expect = expectation(description: "다른 이벤트가 등록된 상태에서 등록을 누르면 교체 확인 문구가 뜬다")
+        let viewModel = self.makeViewModel(registeredLiveActivityTarget: .todo(id: "other-todo"))
+        self.stubLiveActivityUsecase.didStartTargetCallback = { _ in expect.fulfill() }
+        let cellViewModel = TodoEventCellViewModel("todo", name: "name")
+            |> \.eventTimeRawValue .~ .at(100)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .toggleLiveActivity(isRegistered: false))
+        self.wait(for: [expect], timeout: self.timeout)
+
+        // then
+        XCTAssertEqual(
+            self.spyRouter.didShowConfirmWith?.message,
+            "calendar::event::more_action:live_activity:replace:confirm".localized()
+        )
+    }
+
+    func testViewModel_whenToggleLiveActivityToUnregister_afterConfirm_stopActivity() {
+        // given
+        let expect = expectation(description: "등록 상태에서 토글하면 확인 후 해제")
+        let viewModel = self.makeViewModel()
+        self.stubLiveActivityUsecase.didStopActivityCallback = { expect.fulfill() }
+        let cellViewModel = TodoEventCellViewModel("todo", name: "name")
+            |> \.eventTimeRawValue .~ .at(100)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .toggleLiveActivity(isRegistered: true))
+        self.wait(for: [expect], timeout: self.timeout)
+
+        // then
+        XCTAssertEqual(self.stubLiveActivityUsecase.didStopActivity, true)
+        XCTAssertNil(self.stubLiveActivityUsecase.didStartTarget)
+        XCTAssertEqual(
+            self.spyRouter.didShowConfirmWith?.message,
+            "calendar::event::more_action:live_activity:unregister:confirm".localized()
+        )
+    }
+
+    func testViewModel_whenStartLiveActivityFails_showUnavailableConfirm() {
+        // given
+        let expect = expectation(description: "등록 실패시 안내 다이얼로그 표시")
+        expect.expectedFulfillmentCount = 2
+        let viewModel = self.makeViewModel(
+            liveActivityStartError: EventLiveActivityStartFailReason.tooFarFuture
+        )
+        self.spyRouter.didShowConfirmWithCallback = { _ in expect.fulfill() }
+        let cellViewModel = TodoEventCellViewModel("todo", name: "name")
+            |> \.eventTimeRawValue .~ .at(100)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .toggleLiveActivity(isRegistered: false))
+        self.wait(for: [expect], timeout: self.timeout)
+
+        // then
+        XCTAssertEqual(self.spyRouter.didShowConfirmWith?.withCancel, false)
+    }
+
+    func testViewModel_whenCancelToggleLiveActivityConfirm_doesNothing() {
+        // given
+        let viewModel = self.makeViewModel()
+        self.spyRouter.shouldConfirmNotCancel = false
+        let cellViewModel = TodoEventCellViewModel("todo", name: "name")
+            |> \.eventTimeRawValue .~ .at(100)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .toggleLiveActivity(isRegistered: false))
+
+        // then
+        XCTAssertNotNil(self.spyRouter.didShowConfirmWith)
+        XCTAssertNil(self.stubLiveActivityUsecase.didStartTarget)
+        XCTAssertEqual(self.stubLiveActivityUsecase.didStopActivity, false)
+    }
+
+    func testViewModel_whenCellHasNoLiveActivityTarget_toggleLiveActivityDoesNothing() {
+        // given
+        let viewModel = self.makeViewModel()
+        let cellViewModel = TodoEventCellViewModel("todo", name: "name")
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .toggleLiveActivity(isRegistered: false))
+
+        // then
+        XCTAssertNil(self.spyRouter.didShowConfirmWith)
+        XCTAssertNil(self.stubLiveActivityUsecase.didStartTarget)
+    }
+
     func testViewModel_handleEditGoogleCalendarEventDetail() {
         // given
         let viewModel = self.makeViewModel()

--- a/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
@@ -27,6 +27,7 @@ class DayEventListViewModelImpleTests: BaseTestCase, PublisherWaitable {
     private var stubForemostEventUsecase: StubForemostEventUsecase!
     private var stubTagUsecase: StubEventTagUsecase!
     private var stubUISettingUsecase: StubUISettingUsecase!
+    private var stubLiveActivityUsecase: StubEventLiveActivityUsecase!
     private var spyRouter: SpyRouter!
     private var spyListener: SpyListener!
 
@@ -48,6 +49,7 @@ class DayEventListViewModelImpleTests: BaseTestCase, PublisherWaitable {
         self.stubForemostEventUsecase = nil
         self.stubTagUsecase = nil
         self.stubUISettingUsecase = nil
+        self.stubLiveActivityUsecase = nil
         self.spyRouter = nil
         self.spyListener = nil
         self.stubOrchestrationUsecase = nil
@@ -63,7 +65,8 @@ class DayEventListViewModelImpleTests: BaseTestCase, PublisherWaitable {
         shouldFailDoneTodo: Bool = false,
         shouldFailMakeTodo: Bool = false,
         isSignedIn: Bool = true,
-        isCreditExhausted: Bool = false
+        isCreditExhausted: Bool = false,
+        registeredLiveActivityTarget: LiveActivityTarget? = nil
     ) -> DayEventListViewModelImple {
         let currentTodos: [TodoEvent] = [
             .init(uuid: "current-todo-1", name: "current-todo-1") |> \.creatTimeStamp .~ 100,
@@ -100,6 +103,7 @@ class DayEventListViewModelImpleTests: BaseTestCase, PublisherWaitable {
         )
         
         self.stubOrchestrationUsecase.stubIsCreditExhausted = isCreditExhausted
+        self.stubLiveActivityUsecase = StubEventLiveActivityUsecase(registeredTarget: registeredLiveActivityTarget)
         let account: AccountInfo? = isSignedIn ? AccountInfo("uid") : nil
         let viewModel = DayEventListViewModelImple(
             calendarUsecase: StubCalendarUsecase(),
@@ -109,7 +113,8 @@ class DayEventListViewModelImpleTests: BaseTestCase, PublisherWaitable {
             foremostEventUsecase: self.stubForemostEventUsecase,
             uiSettingUsecase: self.stubUISettingUsecase,
             accountUsecase: StubAccountUsecase(account),
-            aiAgentOrchestrationUsecase: self.stubOrchestrationUsecase
+            aiAgentOrchestrationUsecase: self.stubOrchestrationUsecase,
+            eventLiveActivityUsecase: self.stubLiveActivityUsecase
         )
         viewModel.router = self.spyRouter
         viewModel.attachListener(self.spyListener)
@@ -569,33 +574,19 @@ extension DayEventListViewModelImpleTests {
         
         // then
         XCTAssertEqual(repeating?.moreActions, .init(
-            basicActions: [.toggleTo(isForemost: false), .edit, .copy],
+            basicActions: [.toggleTo(isForemost: false), .toggleLiveActivity(isRegistered: false), .edit, .copy],
             removeActions: [.remove(onlyThisTime: true), .remove(onlyThisTime: false)]
         ))
         XCTAssertEqual(notRepeating?.moreActions, .init(
-            basicActions: [.toggleTo(isForemost: false), .edit, .copy],
+            basicActions: [.toggleTo(isForemost: false), .toggleLiveActivity(isRegistered: false), .edit, .copy],
             removeActions: [.remove(onlyThisTime: false)]
         ))
         XCTAssertEqual(foremostEvent?.moreActions, .init(
-            basicActions: [.toggleTo(isForemost: true), .edit, .copy],
+            basicActions: [.toggleTo(isForemost: true), .toggleLiveActivity(isRegistered: false), .edit, .copy],
             removeActions: [.remove(onlyThisTime: false)]
         ))
     }
-    
-    func testHolidayCellViewModel_notProvideMoreAction() {
-        // given
-        let kst = TimeZone(abbreviation: "KST")!
-        let holiday = Holiday(uuid: "id", dateString: "2020-03-01", name: "삼일절")
-        
-        // when
-        let cellViewModel = HolidayEventCellViewModel(
-            .init(holiday, in: kst)!
-        )
-        
-        // then
-        XCTAssertEqual(cellViewModel.moreActions, nil)
-    }
-    
+
     func testGoogleCalendarEventCellViewModel_provideMoreActionWhenHtmlLinkExists() {
         // given
         func parameterizeTest(_ link: String?) {
@@ -757,14 +748,16 @@ extension DayEventListViewModelImpleTests {
     
     private func makeViewModelWithInitialListLoaded(
         shouldFailDoneTodo: Bool = false,
-        shouldFailMakeTodo: Bool = false
+        shouldFailMakeTodo: Bool = false,
+        registeredLiveActivityTarget: LiveActivityTarget? = nil
     ) -> DayEventListViewModelImple {
         // given
         let expect = expectation(description: "wait first cells loaded")
         expect.assertForOverFulfill = false
         let viewModel = self.makeViewModel(
             shouldFailDoneTodo: shouldFailDoneTodo,
-            shouldFailMakeTodo: shouldFailMakeTodo
+            shouldFailMakeTodo: shouldFailMakeTodo,
+            registeredLiveActivityTarget: registeredLiveActivityTarget
         )
         
         // when
@@ -819,6 +812,172 @@ extension DayEventListViewModelImpleTests {
             removeActionsPerEmit.last,
             [.remove(onlyThisTime: true), .remove(onlyThisTime: false)]
         )
+    }
+}
+
+// MARK: - live activity registration mark
+
+extension DayEventListViewModelImpleTests {
+
+    private func isLiveActivityRegisteredCell(_ cvm: any EventCellViewModel) -> Bool {
+        switch cvm {
+        case let todo as TodoEventCellViewModel: return todo.isLiveActivityRegistered
+        case let schedule as ScheduleEventCellViewModel: return schedule.isLiveActivityRegistered
+        case let holiday as HolidayEventCellViewModel: return holiday.isLiveActivityRegistered
+        default: return false
+        }
+    }
+
+    func testViewModel_whenLiveActivityRegistered_cellViewModelsMarkMatchingCell() {
+        // given
+        let expect = expectation(description: "라이브액티비티 등록된 타겟과 일치하는 셀만 표시가 켜진다")
+        let viewModel = self.makeViewModelWithInitialListLoaded(
+            registeredLiveActivityTarget: .todo(id: "todo-with-time")
+        )
+
+        // when
+        let cvms = self.waitFirstOutput(expect, for: viewModel.cellViewModels, timeout: 0.1)
+
+        // then
+        let registeredIds = cvms?
+            .filter { self.isLiveActivityRegisteredCell($0) }
+            .map { $0.eventIdentifier }
+        XCTAssertEqual(registeredIds, ["todo-with-time"])
+    }
+
+    func testViewModel_whenLiveActivityUnregistered_cellViewModelsClearMark() {
+        // given
+        let expect = expectation(description: "라이브액티비티 등록 해제되면 모든 셀의 표시가 사라진다")
+        let viewModel = self.makeViewModelWithInitialListLoaded(
+            registeredLiveActivityTarget: .todo(id: "todo-with-time")
+        )
+        let clearedState = viewModel.cellViewModels.first(where: { cvms in
+            cvms.contains(where: { $0.eventIdentifier == "todo-with-time" })
+                && !cvms.contains(where: { self.isLiveActivityRegisteredCell($0) })
+        })
+
+        // when
+        let cleared = self.waitFirstOutput(expect, for: clearedState, timeout: 2.0) {
+            self.stubLiveActivityUsecase.registeredTargetSubject.send(nil)
+        }
+
+        // then
+        XCTAssertNotNil(cleared)
+    }
+
+    func testViewModel_uncompletedTodoModels_excludeLiveActivityToggleFromMoreActions() {
+        // given
+        let expect = expectation(description: "미완료 todo 셀은 전부 isUncompletedTodo이고 라이브액티비티 토글이 없다")
+        let timedTodo1 = TodoEvent.dummy(1) |> \.time .~ .at(100)
+        let timedTodo2 = TodoEvent.dummy(2) |> \.time .~ .at(200)
+        self.stubTodoUsecase.stubUncompletedTodoLists = [[timedTodo1, timedTodo2]]
+        let viewModel = self.makeViewModel()
+
+        // when
+        let uncompleteds = self.waitFirstOutput(expect, for: viewModel.uncompletedTodoEventModels, timeout: 0.1) {
+            viewModel.refreshUncompletedTodoEvents()
+        }
+
+        // then
+        XCTAssertEqual(uncompleteds?.allSatisfy { $0.isUncompletedTodo }, true)
+        let hasLiveActivityToggle = uncompleteds?.contains { cvm in
+            cvm.moreActions?.basicActions.contains { if case .toggleLiveActivity = $0 { return true } else { return false } } == true
+        }
+        XCTAssertEqual(hasLiveActivityToggle, false)
+    }
+
+    func testViewModel_whenLiveActivityRegistered_uncompletedTodoModelsMarkMatchingCell() {
+        // given
+        let expect = expectation(description: "미완료 todo 셀 목록에도 라이브액티비티 등록 표시가 실린다")
+        let timedTodo1 = TodoEvent.dummy(1) |> \.time .~ .at(100)
+        let timedTodo2 = TodoEvent.dummy(2) |> \.time .~ .at(200)
+        self.stubTodoUsecase.stubUncompletedTodoLists = [[timedTodo1, timedTodo2]]
+        let viewModel = self.makeViewModel(registeredLiveActivityTarget: .todo(id: "id:1"))
+
+        // when
+        let uncompleteds = self.waitFirstOutput(expect, for: viewModel.uncompletedTodoEventModels, timeout: 0.1) {
+            viewModel.refreshUncompletedTodoEvents()
+        }
+
+        // then
+        let flags = uncompleteds?.reduce(into: [String: Bool]()) { acc, cvm in
+            acc[cvm.eventIdentifier] = cvm.isLiveActivityRegistered
+        }
+        XCTAssertEqual(flags?["id:1"], true)
+        XCTAssertEqual(flags?["id:2"], false)
+    }
+
+    func testViewModel_whenLiveActivityRegistered_foremostEventModelMarksCell() {
+        // given
+        let expect = expectation(description: "가장 중요 이벤트 셀에도 라이브액티비티 등록 표시가 실린다")
+        let viewModel = self.makeViewModelWithInitialListLoaded(
+            registeredLiveActivityTarget: .schedule(id: "schedule", turnKey: nil)
+        )
+
+        // when
+        let foremost = self.waitFirstOutput(
+            expect, for: viewModel.foremostEventModel.compactMap { $0 }, timeout: 0.1
+        ) {
+            Task {
+                try await self.stubForemostEventUsecase.update(foremost: .init("schedule", false))
+            }
+        }
+
+        // then
+        let scheduleCell = foremost as? ScheduleEventCellViewModel
+        XCTAssertEqual(scheduleCell?.isLiveActivityRegistered, true)
+    }
+
+    func testViewModel_whenLiveActivityRegisteredForHoliday_holidayCellMarked() {
+        // given
+        let expect = expectation(description: "등록된 타겟과 일치하는 공휴일 셀만 표시가 켜진다")
+        let viewModel = self.makeViewModelWithInitialListLoaded(
+            registeredLiveActivityTarget: .holiday(uuid: "2023-09-30-holiday", dateString: "2023-09-30")
+        )
+
+        // when
+        let cvms = self.waitFirstOutput(expect, for: viewModel.cellViewModels, timeout: 0.1)
+
+        // then
+        let registeredIds = cvms?
+            .filter { self.isLiveActivityRegisteredCell($0) }
+            .map { $0.eventIdentifier }
+        XCTAssertEqual(registeredIds, ["2023-09-30-holiday"])
+    }
+
+    func testViewModel_whenLiveActivityRegisteredForSpecificRepeatingTurn_onlyThatTurnCellMarked() {
+        // given
+        let expect = expectation(description: "반복 일정의 특정 회차 키가 일치하는 셀만 표시가 켜지고 같은 날 뜬 다른 회차는 켜지지 않는다")
+        let timeZone = TimeZone(abbreviation: "KST")!
+        let dummyRepeating = EventRepeating(repeatingStartTime: 0, repeatOption: EventRepeatingOptions.EveryDay())
+        let turn1Time: EventTime = .period(
+            self.todayRange.lowerBound - (3600 * 24) ..< self.todayRange.lowerBound + (3600 * 30)
+        )
+        let turn2Time: EventTime = .period(
+            self.todayRange.lowerBound + (3600 * 6) ..< self.todayRange.upperBound + (3600 * 24)
+        )
+        let periodSchedule = ScheduleEvent(
+            uuid: "repeating-period-schedule", name: "repeating-period-schedule", time: turn1Time
+        )
+        |> \.repeating .~ dummyRepeating
+        |> \.eventTagId .~ .custom("some")
+        |> \.nextRepeatingTimes .~ [.init(time: turn2Time, turn: 2)]
+        let twoTurnEvents = ScheduleCalendarEvent.events(from: periodSchedule, in: timeZone)
+        let viewModel = self.makeViewModel(
+            registeredLiveActivityTarget: .schedule(id: "repeating-period-schedule", turnKey: turn2Time.customKey)
+        )
+
+        // when
+        let source = viewModel.cellViewModels.drop(while: { $0.count != twoTurnEvents.count + 2 })
+        let cvms = self.waitFirstOutput(expect, for: source, timeout: 0.1) {
+            viewModel.selectedDayChanaged(self.dummyCurrentDay, and: twoTurnEvents)
+        }
+
+        // then
+        let registeredIds = cvms?
+            .filter { self.isLiveActivityRegisteredCell($0) }
+            .map { $0.eventIdentifier }
+        XCTAssertEqual(registeredIds, ["repeating-period-schedule-2"])
     }
 }
 

--- a/Presentations/EventDetailScene/Sources/EventDetailSceneBuilderImple.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailSceneBuilderImple.swift
@@ -61,6 +61,9 @@ extension EventDetailSceneBuilderImple: EventDetailSceneBuilder {
         _ todoId: String,
         listener: EventDetailSceneListener?
     ) -> any EventDetailScene {
+        let liveActivityToggleViewModel = LiveActivityToggleViewModelImple(
+            eventLiveActivityUsecase: self.usecaseFactory.eventLiveActivityUsecase
+        )
         let viewModel = EditTodoEventDetailViewModelImple(
             todoId: todoId,
             todoUsecase: self.usecaseFactory.makeTodoEventUsecase(),
@@ -69,10 +72,10 @@ extension EventDetailSceneBuilderImple: EventDetailSceneBuilder {
             scheduleEventUsecase: self.usecaseFactory.makeScheduleEventUsecase(),
             calendarSettingUsecase: self.usecaseFactory.makeCalendarSettingUsecase(),
             foremostEventUsecase: self.usecaseFactory.makeForemostEventUsecase(),
-            eventLiveActivityUsecase: self.usecaseFactory.eventLiveActivityUsecase
+            liveActivityToggleViewModel: liveActivityToggleViewModel
         )
         viewModel.listener = listener
-        return self.makeEventDetailScene(viewModel)
+        return self.makeEventDetailScene(viewModel, liveActivityToggleViewModel: liveActivityToggleViewModel)
     }
     
     @MainActor
@@ -81,6 +84,9 @@ extension EventDetailSceneBuilderImple: EventDetailSceneBuilder {
         _ repeatingEventTargetTime: EventTime?,
         listener: EventDetailSceneListener?
     ) -> any EventDetailScene {
+        let liveActivityToggleViewModel = LiveActivityToggleViewModelImple(
+            eventLiveActivityUsecase: self.usecaseFactory.eventLiveActivityUsecase
+        )
         let viewModel = EditScheduleEventDetailViewModelImple(
             scheduleId: scheduleId,
             repeatingEventTargetTime: repeatingEventTargetTime,
@@ -91,15 +97,16 @@ extension EventDetailSceneBuilderImple: EventDetailSceneBuilder {
             calendarSettingUsecase: self.usecaseFactory.makeCalendarSettingUsecase(),
             foremostEventUsecase: self.usecaseFactory.makeForemostEventUsecase(),
             ddayCandidateUsecase: self.usecaseFactory.makeDDayCandidateUsecase(),
-            eventLiveActivityUsecase: self.usecaseFactory.eventLiveActivityUsecase
+            liveActivityToggleViewModel: liveActivityToggleViewModel
         )
         viewModel.listener = listener
-        return self.makeEventDetailScene(viewModel)
+        return self.makeEventDetailScene(viewModel, liveActivityToggleViewModel: liveActivityToggleViewModel)
     }
 
     @MainActor
     private func makeEventDetailScene(
-        _ viewModel: any EventDetailViewModel
+        _ viewModel: any EventDetailViewModel,
+        liveActivityToggleViewModel: LiveActivityToggleViewModelImple? = nil
     ) -> any EventDetailScene {
         
         let inputViewModel = EventDetailInputViewModelImple(
@@ -151,6 +158,7 @@ extension EventDetailSceneBuilderImple: EventDetailSceneBuilder {
         router.inputViewModel = inputViewModel
         router.scene = viewController
         viewModel.router = router
+        liveActivityToggleViewModel?.router = router
         inputViewModel.routing = router
         viewModel.attachInput()
         viewController.router = router

--- a/Presentations/EventDetailScene/Sources/EventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailView.swift
@@ -13,6 +13,7 @@ import Combine
 import Domain
 import Extensions
 import CommonPresentation
+import Scenes
 
 
 // MARK: - EventDetailViewState

--- a/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailBuilderImple.swift
+++ b/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailBuilderImple.swift
@@ -36,11 +36,14 @@ extension HolidayEventDetailSceneBuilerImple: HolidayEventDetailSceneBuiler {
     @MainActor
     public func makeHolidayEventDetailScene(uuid: String) -> any HolidayEventDetailScene {
         
+        let liveActivityToggleViewModel = LiveActivityToggleViewModelImple(
+            eventLiveActivityUsecase: self.usecaseFactory.eventLiveActivityUsecase
+        )
         let viewModel = HolidayEventDetailViewModelImple(
             uuid: uuid,
             holidayUsecase: self.usecaseFactory.makeHolidayUsecase(),
             daysIntervalCountUsecase: self.usecaseFactory.makeDaysIntervalCountUsecase(),
-            eventLiveActivityUsecase: self.usecaseFactory.eventLiveActivityUsecase
+            liveActivityToggleViewModel: liveActivityToggleViewModel
         )
         
         let viewController = HolidayEventDetailViewController(
@@ -52,6 +55,7 @@ extension HolidayEventDetailSceneBuilerImple: HolidayEventDetailSceneBuiler {
         )
         router.scene = viewController
         viewModel.router = router
+        liveActivityToggleViewModel.router = router
         
         return viewController
     }

--- a/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailView.swift
@@ -14,6 +14,7 @@ import Combine
 import Domain
 import Extensions
 import CommonPresentation
+import Scenes
 
 
 // MARK: - HolidayEventDetailViewState

--- a/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailViewModel.swift
@@ -43,25 +43,24 @@ protocol HolidayEventDetailViewModel: AnyObject, Sendable, HolidayEventDetailSce
 
 // MARK: - HolidayEventDetailViewModelImple
 
-final class HolidayEventDetailViewModelImple: HolidayEventDetailViewModel, LiveActivityToggleHandling, @unchecked Sendable {
+final class HolidayEventDetailViewModelImple: HolidayEventDetailViewModel, @unchecked Sendable {
     
     private let uuid: String
     private let holidayUsecase: any HolidayUsecase
     private let daysIntervalCountUsecase: any DaysIntervalCountUsecase
-    let eventLiveActivityUsecase: any EventLiveActivityUsecase
+    private let liveActivityToggleViewModel: any LiveActivityToggleViewModel
     var router: (any HolidayEventDetailRouting)?
-    var liveActivityRouting: (any Routing)? { self.router }
     
     init(
         uuid: String,
         holidayUsecase: any HolidayUsecase,
         daysIntervalCountUsecase: any DaysIntervalCountUsecase,
-        eventLiveActivityUsecase: any EventLiveActivityUsecase
+        liveActivityToggleViewModel: any LiveActivityToggleViewModel
     ) {
         self.uuid = uuid
         self.holidayUsecase = holidayUsecase
         self.daysIntervalCountUsecase = daysIntervalCountUsecase
-        self.eventLiveActivityUsecase = eventLiveActivityUsecase
+        self.liveActivityToggleViewModel = liveActivityToggleViewModel
     }
     
     
@@ -115,7 +114,7 @@ extension HolidayEventDetailViewModelImple {
 
     func toggleLiveActivity(isRegistered: Bool) {
         guard let holiday = self.subject.holiday.value else { return }
-        self.startOrStopLiveActivity(holiday.liveActivityTarget, isRegistered: isRegistered)
+        self.liveActivityToggleViewModel.startOrStopLiveActivity(holiday.liveActivityTarget, isCurrentlyRegistered: isRegistered)
     }
 
     private func hideHolidayConfirmed(_ name: String) {
@@ -179,7 +178,7 @@ extension HolidayEventDetailViewModelImple {
             )
         }
         return Publishers.CombineLatest(
-            self.subject.holiday, self.eventLiveActivityUsecase.registeredTarget
+            self.subject.holiday, self.liveActivityToggleViewModel.registeredTarget
         )
         .map(transform)
         .removeDuplicates()

--- a/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
@@ -14,10 +14,8 @@ import Extensions
 import Scenes
 
 
-final class EditScheduleEventDetailViewModelImple: EventDetailViewModel, LiveActivityToggleHandling, @unchecked Sendable {
+final class EditScheduleEventDetailViewModelImple: EventDetailViewModel, @unchecked Sendable {
 
-    var liveActivityRouting: (any Routing)? { self.router }
-    
     private let scheduleId: String
     private let repeatingEventTargetTime: EventTime?
     private let scheduleUsecase: any ScheduleEventUsecase
@@ -27,7 +25,7 @@ final class EditScheduleEventDetailViewModelImple: EventDetailViewModel, LiveAct
     private let calendarSettingUsecase: any CalendarSettingUsecase
     private let foremostEventUsecase: any ForemostEventUsecase
     private let ddayCandidateUsecase: any DDayCandidateUsecase
-    let eventLiveActivityUsecase: any EventLiveActivityUsecase
+    private let liveActivityToggleViewModel: any LiveActivityToggleViewModel
     var router: (any EventDetailRouting)?
     weak var listener: EventDetailSceneListener?
     
@@ -41,7 +39,7 @@ final class EditScheduleEventDetailViewModelImple: EventDetailViewModel, LiveAct
         calendarSettingUsecase: any CalendarSettingUsecase,
         foremostEventUsecase: any ForemostEventUsecase,
         ddayCandidateUsecase: any DDayCandidateUsecase,
-        eventLiveActivityUsecase: any EventLiveActivityUsecase
+        liveActivityToggleViewModel: any LiveActivityToggleViewModel
     ) {
         self.scheduleId = scheduleId
         self.repeatingEventTargetTime = repeatingEventTargetTime
@@ -52,7 +50,7 @@ final class EditScheduleEventDetailViewModelImple: EventDetailViewModel, LiveAct
         self.calendarSettingUsecase = calendarSettingUsecase
         self.foremostEventUsecase = foremostEventUsecase
         self.ddayCandidateUsecase = ddayCandidateUsecase
-        self.eventLiveActivityUsecase = eventLiveActivityUsecase
+        self.liveActivityToggleViewModel = liveActivityToggleViewModel
 
         self.internalBinding()
     }
@@ -158,8 +156,8 @@ extension EditScheduleEventDetailViewModelImple: EventDetailInputListener {
             self.toggleDDayCandidateAfterConfirm(isRegistered: isRegistered)
 
         case .toggleLiveActivity(let isRegistered):
-            self.startOrStopLiveActivity(
-                self.currentLiveActivityTarget, isRegistered: isRegistered
+            self.liveActivityToggleViewModel.startOrStopLiveActivity(
+                self.currentLiveActivityTarget, isCurrentlyRegistered: isRegistered
             )
 
         case .copy:
@@ -641,7 +639,7 @@ extension EditScheduleEventDetailViewModelImple {
             isDDayWidgetEnabled
                 ? self.ddayCandidateUsecase.candidates
                 : Just<[DDayCandidate]>([]).eraseToAnyPublisher(),
-            self.eventLiveActivityUsecase.registeredTarget
+            self.liveActivityToggleViewModel.registeredTarget
         )
         .map(transform)
         .removeDuplicates()

--- a/Presentations/EventDetailScene/Sources/ViewModels/EditTodoEventDetailViewModelImple.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/EditTodoEventDetailViewModelImple.swift
@@ -14,10 +14,8 @@ import Extensions
 import Scenes
 
 
-final class EditTodoEventDetailViewModelImple: EventDetailViewModel, LiveActivityToggleHandling, @unchecked Sendable {
+final class EditTodoEventDetailViewModelImple: EventDetailViewModel, @unchecked Sendable {
 
-    var liveActivityRouting: (any Routing)? { self.router }
-    
     private let todoId: String
     private let todoUsecase: any TodoEventUsecase
     private let eventTagUsecase: any EventTagUsecase
@@ -25,7 +23,7 @@ final class EditTodoEventDetailViewModelImple: EventDetailViewModel, LiveActivit
     private let scheduleEventUsecase: any ScheduleEventUsecase
     private let calendarSettingUsecase: any CalendarSettingUsecase
     private let foremostEventUsecase: any ForemostEventUsecase
-    let eventLiveActivityUsecase: any EventLiveActivityUsecase
+    private let liveActivityToggleViewModel: any LiveActivityToggleViewModel
     var router: (any EventDetailRouting)?
     weak var listener: EventDetailSceneListener?
     
@@ -37,7 +35,7 @@ final class EditTodoEventDetailViewModelImple: EventDetailViewModel, LiveActivit
         scheduleEventUsecase: any ScheduleEventUsecase,
         calendarSettingUsecase: any CalendarSettingUsecase,
         foremostEventUsecase: any ForemostEventUsecase,
-        eventLiveActivityUsecase: any EventLiveActivityUsecase
+        liveActivityToggleViewModel: any LiveActivityToggleViewModel
     ) {
         self.todoId = todoId
         self.todoUsecase = todoUsecase
@@ -46,7 +44,7 @@ final class EditTodoEventDetailViewModelImple: EventDetailViewModel, LiveActivit
         self.scheduleEventUsecase = scheduleEventUsecase
         self.calendarSettingUsecase = calendarSettingUsecase
         self.foremostEventUsecase = foremostEventUsecase
-        self.eventLiveActivityUsecase = eventLiveActivityUsecase
+        self.liveActivityToggleViewModel = liveActivityToggleViewModel
         
         self.internalBinding()
     }
@@ -152,7 +150,7 @@ extension EditTodoEventDetailViewModelImple: EventDetailInputListener {
             self.transformToScheduleAfterConfirm()
 
         case .toggleLiveActivity(let isRegistered):
-            self.startOrStopLiveActivity(.todo(id: self.todoId), isRegistered: isRegistered)
+            self.liveActivityToggleViewModel.startOrStopLiveActivity(.todo(id: self.todoId), isCurrentlyRegistered: isRegistered)
             
         case .addToTemplate:
             // TODO:
@@ -532,7 +530,7 @@ extension EditTodoEventDetailViewModelImple {
         return Publishers.CombineLatest3(
             self.subject.basicData.compactMap{ $0?.origin },
             self.foremostEventUsecase.foremostEvent,
-            self.eventLiveActivityUsecase.registeredTarget
+            self.liveActivityToggleViewModel.registeredTarget
         )
         .map(transform)
         .removeDuplicates()

--- a/Presentations/EventDetailScene/Tests/EditScheduleEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/EditScheduleEventDetailViewModelImpleTests.swift
@@ -97,6 +97,9 @@ class EditScheduleEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitabl
         self.stubLiveActivityUsecase.registeredTargetSubject.send(registeredLiveActivityTarget)
         self.stubLiveActivityUsecase.stubStartError = liveActivityStartError
 
+        let liveActivityToggleViewModel = LiveActivityToggleViewModelImple(
+            eventLiveActivityUsecase: self.stubLiveActivityUsecase
+        )
         let viewModel = EditScheduleEventDetailViewModelImple(
             scheduleId: schedule.uuid,
             repeatingEventTargetTime: repeatingEventTargetTime,
@@ -107,9 +110,10 @@ class EditScheduleEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitabl
             calendarSettingUsecase: calendarSettingUsecase,
             foremostEventUsecase: self.stubForemostEventUsecase,
             ddayCandidateUsecase: self.stubDDayCandidateUsecase,
-            eventLiveActivityUsecase: self.stubLiveActivityUsecase
+            liveActivityToggleViewModel: liveActivityToggleViewModel
         )
         viewModel.router = self.spyRouter
+        liveActivityToggleViewModel.router = self.spyRouter
         viewModel.listener = self.spyListener
         viewModel.attachInput()
         return viewModel

--- a/Presentations/EventDetailScene/Tests/EditTodoEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/EditTodoEventDetailViewModelImpleTests.swift
@@ -90,6 +90,9 @@ class EditTodoEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitable {
         self.stubLiveActivityUsecase.registeredTargetSubject.send(registeredLiveActivityTarget)
         self.stubLiveActivityUsecase.stubStartError = liveActivityStartError
         
+        let liveActivityToggleViewModel = LiveActivityToggleViewModelImple(
+            eventLiveActivityUsecase: self.stubLiveActivityUsecase
+        )
         let viewModel = EditTodoEventDetailViewModelImple(
             todoId: todo.uuid,
             todoUsecase: self.spyTodoUsecase,
@@ -98,9 +101,10 @@ class EditTodoEventDetailViewModelImpleTests: BaseTestCase, PublisherWaitable {
             scheduleEventUsecase: scheduleUsecase,
             calendarSettingUsecase: calendarSettingUsecase,
             foremostEventUsecase: self.stubForemostEventUsecase,
-            eventLiveActivityUsecase: self.stubLiveActivityUsecase
+            liveActivityToggleViewModel: liveActivityToggleViewModel
         )
         viewModel.router = self.spyRouter
+        liveActivityToggleViewModel.router = self.spyRouter
         viewModel.listener = self.spyListener
         viewModel.attachInput()
         return viewModel

--- a/Presentations/EventDetailScene/Tests/HolidayEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/HolidayEventDetailViewModelImpleTests.swift
@@ -14,6 +14,7 @@ import Domain
 import Extensions
 import UnitTestHelpKit
 import TestDoubles
+import Scenes
 
 @testable import EventDetailScene
 
@@ -32,13 +33,17 @@ final class HolidayEventDetailViewModelImpleTests: PublisherWaitable {
         try await usecase.prepare()
         self.stubLiveActivityUsecase.registeredTargetSubject.send(registeredLiveActivityTarget)
         self.stubLiveActivityUsecase.stubStartError = liveActivityStartError
+        let liveActivityToggleViewModel = LiveActivityToggleViewModelImple(
+            eventLiveActivityUsecase: self.stubLiveActivityUsecase
+        )
         let viewModel = HolidayEventDetailViewModelImple(
             uuid: "some",
             holidayUsecase: usecase,
             daysIntervalCountUsecase: StubDaysIntervalCountUsecase(),
-            eventLiveActivityUsecase: self.stubLiveActivityUsecase
+            liveActivityToggleViewModel: liveActivityToggleViewModel
         )
         viewModel.router = self.spyRouter
+        liveActivityToggleViewModel.router = self.spyRouter
         return viewModel
     }
 }
@@ -114,13 +119,17 @@ extension HolidayEventDetailViewModelImpleTests {
     private func makeViewModelWithUsecase() async throws -> (HolidayEventDetailViewModelImple, PrivateStubHolidayUsecase) {
         let usecase = PrivateStubHolidayUsecase()
         try await usecase.prepare()
+        let liveActivityToggleViewModel = LiveActivityToggleViewModelImple(
+            eventLiveActivityUsecase: self.stubLiveActivityUsecase
+        )
         let viewModel = HolidayEventDetailViewModelImple(
             uuid: "some",
             holidayUsecase: usecase,
             daysIntervalCountUsecase: StubDaysIntervalCountUsecase(),
-            eventLiveActivityUsecase: self.stubLiveActivityUsecase
+            liveActivityToggleViewModel: liveActivityToggleViewModel
         )
         viewModel.router = self.spyRouter
+        liveActivityToggleViewModel.router = self.spyRouter
         return (viewModel, usecase)
     }
 

--- a/Presentations/Scenes/Sources/LiveActivityToggleViewModel.swift
+++ b/Presentations/Scenes/Sources/LiveActivityToggleViewModel.swift
@@ -1,51 +1,66 @@
 //
-//  LiveActivityToggleHandling.swift
-//  EventDetailScene
+//  LiveActivityToggleViewModel.swift
+//  Scenes
 //
 //  Created by sudo.park on 8/19/26.
 //  Copyright © 2026 com.sudo.park. All rights reserved.
 //
 
 import Foundation
+import Combine
 import Prelude
 import Optics
 import Domain
-import Scenes
 import Extensions
 
 
-struct LiveActivityActionModel: Equatable {
+public struct LiveActivityActionModel: Equatable, Sendable {
 
-    let isRegistered: Bool
+    public let isRegistered: Bool
 
-    var itemText: String {
+    public var itemText: String {
         return self.isRegistered
             ? "calendar::event::more_action:live_activity:unregister:item_name".localized()
             : "calendar::event::more_action:live_activity:register:item_name".localized()
     }
+
+    public init(isRegistered: Bool) {
+        self.isRegistered = isRegistered
+    }
 }
 
 
-protocol LiveActivityToggleHandling: AnyObject, Sendable {
+public protocol LiveActivityToggleViewModel: AnyObject, Sendable {
 
-    var eventLiveActivityUsecase: any EventLiveActivityUsecase { get }
-    var liveActivityRouting: (any Routing)? { get }
+    func startOrStopLiveActivity(_ target: LiveActivityTarget, isCurrentlyRegistered: Bool)
+    var registeredTarget: AnyPublisher<LiveActivityTarget?, Never> { get }
 }
 
-extension LiveActivityToggleHandling {
+public final class LiveActivityToggleViewModelImple: LiveActivityToggleViewModel, @unchecked Sendable {
 
-    func startOrStopLiveActivity(_ target: LiveActivityTarget, isRegistered: Bool) {
+    private let eventLiveActivityUsecase: any EventLiveActivityUsecase
+    public weak var router: (any Routing)?
+
+    public init(eventLiveActivityUsecase: any EventLiveActivityUsecase) {
+        self.eventLiveActivityUsecase = eventLiveActivityUsecase
+    }
+
+    public func startOrStopLiveActivity(_ target: LiveActivityTarget, isCurrentlyRegistered: Bool) {
         Task { [weak self] in
             guard let self else { return }
-            guard isRegistered == false
+            guard isCurrentlyRegistered == false
             else { return await self.eventLiveActivityUsecase.stopActivity() }
 
             do {
                 try await self.eventLiveActivityUsecase.startActivity(target)
             } catch {
-                self.liveActivityRouting?.showLiveActivityUnavailable(error)
+                self.router?.showLiveActivityUnavailable(error)
             }
         }
+    }
+
+    public var registeredTarget: AnyPublisher<LiveActivityTarget?, Never> {
+        return self.eventLiveActivityUsecase.registeredTarget
     }
 }
 
@@ -54,7 +69,7 @@ extension Routing {
 
     /// 등록 불가는 오류가 아니라 안내다 — `showError`는 "문제가 발생했습니다" 뒤에 사유를
     /// 괄호로 덧붙여 안내문을 오류처럼 읽히게 한다.
-    func showLiveActivityUnavailable(_ error: any Error) {
+    public func showLiveActivityUnavailable(_ error: any Error) {
         guard let reason = error as? EventLiveActivityStartFailReason
         else { return self.showError(error) }
 

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -142,6 +142,8 @@
 "calendar::event::more_action:live_activity:unavail::not_found" = "This event is no longer available.";
 "calendar::event::more_action:live_activity:unavail::already_passed" = "This event has already started.";
 "calendar::event::more_action:live_activity:unavail::too_far_future" = "Only events starting within 8 hours can be shown.";
+"calendar::event::more_action:live_activity:register:confirm" = "Do you want to show this event on the Lock Screen?";
+"calendar::event::more_action:live_activity:unregister:confirm" = "Do you want to remove this event from the Lock Screen?";
 "calendar::event::more_action:copy:item_name" = "Copy event";
 "calendar::event::more_action:share:item_name" = "Share";
 "event_detail::share::field::time" = "Time";

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -144,6 +144,7 @@
 "calendar::event::more_action:live_activity:unavail::too_far_future" = "Only events starting within 8 hours can be shown.";
 "calendar::event::more_action:live_activity:register:confirm" = "Do you want to show this event on the Lock Screen?";
 "calendar::event::more_action:live_activity:unregister:confirm" = "Do you want to remove this event from the Lock Screen?";
+"calendar::event::more_action:live_activity:replace:confirm" = "Another event is showing on the Lock Screen. Replace it with this one?";
 "calendar::event::more_action:copy:item_name" = "Copy event";
 "calendar::event::more_action:share:item_name" = "Share";
 "event_detail::share::field::time" = "Time";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -142,6 +142,8 @@
 "calendar::event::more_action:live_activity:unavail::not_found" = "이벤트 정보를 찾을 수 없어요.";
 "calendar::event::more_action:live_activity:unavail::already_passed" = "이미 시작한 이벤트예요.";
 "calendar::event::more_action:live_activity:unavail::too_far_future" = "8시간 이내에 시작하는 이벤트만 표시할 수 있어요.";
+"calendar::event::more_action:live_activity:register:confirm" = "이 이벤트를 잠금화면에 표시할까요?";
+"calendar::event::more_action:live_activity:unregister:confirm" = "이 이벤트를 잠금화면에서 제거할까요?";
 "calendar::event::more_action:copy:item_name" = "이벤트 복사";
 "calendar::event::more_action:share:item_name" = "공유";
 "event_detail::share::field::time" = "시간";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -144,6 +144,7 @@
 "calendar::event::more_action:live_activity:unavail::too_far_future" = "8시간 이내에 시작하는 이벤트만 표시할 수 있어요.";
 "calendar::event::more_action:live_activity:register:confirm" = "이 이벤트를 잠금화면에 표시할까요?";
 "calendar::event::more_action:live_activity:unregister:confirm" = "이 이벤트를 잠금화면에서 제거할까요?";
+"calendar::event::more_action:live_activity:replace:confirm" = "다른 이벤트가 잠금화면에 표시 중이에요. 이 이벤트로 바꿀까요?";
 "calendar::event::more_action:copy:item_name" = "이벤트 복사";
 "calendar::event::more_action:share:item_name" = "공유";
 "event_detail::share::field::time" = "시간";


### PR DESCRIPTION
캘린더 일별 이벤트 리스트의 셀 액션에서 라이브액티비티를 바로 등록·해제한다. 이벤트 상세를 거치지 않는 두 번째 진입 경로.

## 접근

#910이 상세 화면에 만든 토글 흐름(`LiveActivityToggleHandling`)을 두 Presentation 모듈의 공통 상위인 `Scenes`로 올려 `EventDetailScene`·`CalendarScenes`가 공유한다. 셀 VM은 자기 필드만으로 `liveActivityTarget`을 계산하고, 등록 여부는 `DayEventListViewModelImple`이 `eventLiveActivityUsecase.registeredTarget`과 셀 목록을 합성해 실어준다. 메뉴 항목 결정은 기존과 동일하게 `EventCellViewModel.moreActions` 한 곳에 모았다.

상세 화면과 달리 리스트 셀은 **확인 다이얼로그를 한 번 거친다** — 셀의 삭제·중요 이벤트 토글과 동선을 맞췄다.

- `LiveActivityToggleHandling` — `EventDetailScene` → `Scenes` 이동. 파라미터 레이블을 `isCurrentlyRegistered:`로 바꿔 "지금 등록돼 있나"라는 계약을 이름에 박았다 (기존 `isRegistered:`는 "등록하려면 true"로 읽혀 부호를 뒤집기 쉬웠다)
- `EventListMoreAction.toggleLiveActivity(isRegistered:)` — 셀 메뉴 액션 신설. `EventListCellView.toggleLiveActivityButton`이 렌더하고 `EventListCellEventHanleViewModelImple.toggleLiveActivity`가 확인 후 토글
- `EventCellViewModel.liveActivityTarget` — 프로토콜 요구 + 기본 구현 `nil`. Todo·Schedule은 시간이 있을 때만, Schedule은 반복일 때만 회차 키를 싣는다(상세 화면의 `LiveActivityTarget.init(scheduleId:targetTime:isRepeating:)`과 같은 규칙 — 어긋나면 상세에서 등록한 걸 리스트가 인식 못 한다). Holiday는 `uuid`+`dateString`
- `HolidayEventCellViewModel.moreActions` — `nil`이던 것이 라이브액티비티 토글 하나만 담는다. 공휴일은 삭제·복사·중요 이벤트가 성립하지 않는다
- `DayEventListViewModelImple` — `cellViewModels`·`uncompletedTodoEventModels`·`foremostEventModel` 세 publisher가 각각 `registeredTarget`을 `removeDuplicates` 앞에서 합성해 등록 표시를 싣는다. `EventListCellView`가 쓰이는 세 자리 전부가 이 VM에서 나온다

## 확인 문구를 세 갈래로 가른다

라이브액티비티는 동시 1개만 등록되고, 새로 등록하면 기존 것이 조용히 종료된다. 등록 방향이면서 **다른 이벤트가 이미 표시 중일 때**는 교체 문구를 써서 그 사실을 알린다 — A가 다른 날 이벤트면 화면 어디에도 A가 없어 사라진 걸 알 방법이 없었다.

`EventListCellEventHanleViewModelImple.internalBind` — `registeredTarget`을 미러링해 `toggleLiveActivityConfirmMessage`가 등록/해제/교체를 가른다.

## 기한 지난 할일은 항목을 싣지 않는다

`UncompletedTodoView`의 셀은 미완료 판정(`upperBoundWithFixed <= now`)상 전부 과거 시각이라, 등록 조건(`eventDate > now`)에 예외 없이 걸린다. 확인 다이얼로그까지 거친 뒤 100% `alreadyPassed` 안내로 끝나는 동선이라 `TodoEventCellViewModel.isUncompletedTodo`로 그 섹션만 항목을 뺐다.

## 남은 과제

- 구글·애플 캘린더 셀의 진입점은 #934 소관 (#925·#926 머지에 블록). `moreActions`를 `nil`인 채로 뒀다
- `EventListCellView`도 `isUncompletedTodo` 생성자 파라미터를 따로 받아 이름 색에 쓴다. 같은 사실의 출처가 둘이지만 통합하려면 `EventCellViewModel` 프로토콜 요구로 올려야 해 이번엔 두 곳을 유지했다

Closes #911
