### PR TITLE
[#938] 캘린더 목록에서 구글·애플 이벤트 롱탭 삭제

### DIFF
--- a/Domain/Sources/Models/Events/ExternalCalendar/GoogleCalendarEvent.swift
+++ b/Domain/Sources/Models/Events/ExternalCalendar/GoogleCalendarEvent.swift
@@ -280,6 +280,7 @@ extension GoogleCalendar {
         
         public var nextRepeatingTimes: [RepeatingTimes] = []
         public var repeatingTimeToExcludes: Set<String> = []
+        public var recurringEventId: String?
 
         // 구글 반복 인스턴스의 id 는 "{마스터id}_{원래시작시각}" 이다 — 시각이 바뀌면 id 도 바뀌므로 낡은 항목 판별에 쓴다
         public func isInstance(of recurringEventId: String) -> Bool {
@@ -326,7 +327,8 @@ extension GoogleCalendar {
             self.status = origin.status
             
             self.location = origin.location
-            
+            self.recurringEventId = origin.recurringEventId
+
             switch (start, end) {
             case (.period(let st), .period(let et)):
                 self.eventTime = .period(

--- a/Domain/Tests/Models/Events/ExternalCalendar/GoogleCalendarEventTests.swift
+++ b/Domain/Tests/Models/Events/ExternalCalendar/GoogleCalendarEventTests.swift
@@ -1,0 +1,56 @@
+//
+//  GoogleCalendarEventTests.swift
+//  DomainTests
+//
+//  Created by sudo.park on 8/19/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Prelude
+import Optics
+
+@testable import Domain
+
+
+@Suite("GoogleCalendarEventTests")
+struct GoogleCalendarEventTests {
+
+    private func makeOrigin(recurringEventId: String?) -> GoogleCalendar.EventOrigin {
+        var origin = GoogleCalendar.EventOrigin(id: "event1", summary: "event")
+        origin.start = .init() |> \.dateTime .~ "2023-03-05T00:00:00+09:00"
+        origin.end = .init() |> \.dateTime .~ "2023-03-06T00:00:00+09:00"
+        origin.recurringEventId = recurringEventId
+        return origin
+    }
+}
+
+extension GoogleCalendarEventTests {
+
+    @Test func event_whenOriginHasRecurringEventId_carriesIt() throws {
+        // given
+        let origin = self.makeOrigin(recurringEventId: "master-1")
+
+        // when
+        let event = try #require(
+            GoogleCalendar.Event(origin, "calendar", accountId: "account", nil)
+        )
+
+        // then
+        #expect(event.recurringEventId == "master-1")
+    }
+
+    @Test func event_whenOriginHasNoRecurringEventId_isNil() throws {
+        // given
+        let origin = self.makeOrigin(recurringEventId: nil)
+
+        // when
+        let event = try #require(
+            GoogleCalendar.Event(origin, "calendar", accountId: "account", nil)
+        )
+
+        // then
+        #expect(event.recurringEventId == nil)
+    }
+}

--- a/Presentations/CalendarScenes/Sources/Common/CalendarEvents/CalendarEvent.swift
+++ b/Presentations/CalendarScenes/Sources/Common/CalendarEvents/CalendarEvent.swift
@@ -228,9 +228,11 @@ public struct GoogleCalendarEvent: CalendarEvent {
     public let htmlLink: String?
     public let isForemost: Bool
     public let isRepeating: Bool
+    public let recurringEventId: String?
+    public let isWritable: Bool
     public var locationText: String?
-    
-    public init(_ event: GoogleCalendar.Event, in timeZone: TimeZone) {
+
+    public init(_ event: GoogleCalendar.Event, in timeZone: TimeZone, isWritable: Bool = false) {
         self.eventId = event.eventId
         self.calendarId = event.calendarId
         self.accountId = event.accountId
@@ -245,7 +247,7 @@ public struct GoogleCalendarEvent: CalendarEvent {
             self.eventTimeOnCalendar = .period(
                 range.shiftting(secondsFromGMT, to: timeZone)
             )
-            
+
         default:
             self.eventTimeOnCalendar = EventTimeOnCalendar(event.eventTime, timeZone: timeZone)
         }
@@ -253,16 +255,18 @@ public struct GoogleCalendarEvent: CalendarEvent {
         self.colorId = event.colorId
         self.htmlLink = event.htmlLink
         self.isForemost = false
-        self.isRepeating = false
+        self.recurringEventId = event.recurringEventId
+        self.isRepeating = event.recurringEventId != nil
+        self.isWritable = isWritable
         self.locationText = event.location
     }
-    
+
     public var colorSource: any EventTagColorSource {
         GoogleCalendarEventColorSource(calendarId: calendarId, colorId: colorId)
     }
 
     public var compareKey: String {
-        return "\(String(describing: Self.self))-\(eventId)-\(accountId)-\(name)-\(eventTime?.hashValue ?? -1)-\(eventTimeOnCalendar?.hashValue ?? -1)-\(eventTagId.hashValue)-\(self.isForemost)-\(self.colorId ?? "nil")-\(self.htmlLink ?? "nil")-\(self.locationText ?? "nil")"
+        return "\(String(describing: Self.self))-\(eventId)-\(accountId)-\(name)-\(eventTime?.hashValue ?? -1)-\(eventTimeOnCalendar?.hashValue ?? -1)-\(eventTagId.hashValue)-\(self.isForemost)-\(self.colorId ?? "nil")-\(self.htmlLink ?? "nil")-\(self.locationText ?? "nil")-\(self.isRepeating)-\(self.recurringEventId ?? "nil")-\(self.isWritable)"
     }
 }
 
@@ -276,9 +280,10 @@ public struct AppleCalendarEvent: CalendarEvent {
     public let eventTagId: EventTagId
     public let isForemost: Bool = false
     public let isRepeating: Bool
+    public let isWritable: Bool
     public var locationText: String?
 
-    public init(_ event: AppleCalendar.Event, in timeZone: TimeZone) {
+    public init(_ event: AppleCalendar.Event, in timeZone: TimeZone, isWritable: Bool = false) {
         self.eventId = event.eventId
         self.calendarId = event.calendarId
         self.name = event.name
@@ -286,11 +291,16 @@ public struct AppleCalendarEvent: CalendarEvent {
         self.eventTimeOnCalendar = EventTimeOnCalendar(event.eventTime, timeZone: timeZone)
         self.eventTagId = event.eventTagId
         self.isRepeating = event.isRepeating
+        self.isWritable = isWritable
         self.locationText = event.location
     }
 
     public var colorSource: any EventTagColorSource {
         AppleCalendarEventColorSource(calendarId: calendarId)
+    }
+
+    public var compareKey: String {
+        return "\(String(describing: Self.self))-\(eventId)-\(name)-\(eventTime?.hashValue ?? -1)-\(eventTimeOnCalendar?.hashValue ?? -1)-\(eventTagId.hashValue)-\(self.isForemost)-\(self.locationText ?? "nil")-\(self.isRepeating)-\(self.isWritable)"
     }
 }
 

--- a/Presentations/CalendarScenes/Sources/Common/CalendarEvents/CalendarEventListhUsecase.swift
+++ b/Presentations/CalendarScenes/Sources/Common/CalendarEvents/CalendarEventListhUsecase.swift
@@ -34,6 +34,11 @@ protocol CalendarEventListhUsecase: Sendable {
 }
 
 
+private struct WritableCalendarIds: Equatable {
+    var google: [String: Set<String>] = [:]
+    var apple: Set<String> = []
+}
+
 final class CalendarEventListhUsecaseImple: CalendarEventListhUsecase, @unchecked Sendable {
 
     private let todoUsecase: any TodoEventUsecase
@@ -71,6 +76,7 @@ final class CalendarEventListhUsecaseImple: CalendarEventListhUsecase, @unchecke
         let foremostEvent = CurrentValueSubject<(any ForemostMarkableEvent)?, Never>(nil)
         let timeZone = CurrentValueSubject<TimeZone?, Never>(nil)
         let offTagIds = CurrentValueSubject<Set<EventTagId>, Never>([])
+        let writableCalendarIds = CurrentValueSubject<WritableCalendarIds, Never>(.init())
     }
     private let subject = Subject()
     private var cancellables: Set<AnyCancellable> = []
@@ -94,6 +100,24 @@ final class CalendarEventListhUsecaseImple: CalendarEventListhUsecase, @unchecke
                 self?.subject.offTagIds.send(ids)
             })
             .store(in: &self.cancellables)
+
+        Publishers.CombineLatest(
+            self.googleCalendarUsecase.calendarTags,
+            self.appleCalendarUsecase.calendarTags
+        )
+        .map { googleTags, appleTags -> WritableCalendarIds in
+            let google = googleTags
+                .filter { $0.isWritable }
+                .reduce(into: [String: Set<String>]()) { acc, tag in
+                    acc[tag.ownerId, default: []].insert(tag.id)
+                }
+            let apple = Set(appleTags.filter { $0.isWritable == true }.map { $0.id })
+            return WritableCalendarIds(google: google, apple: apple)
+        }
+        .sink(receiveValue: { [weak self] ids in
+            self?.subject.writableCalendarIds.send(ids)
+        })
+        .store(in: &self.cancellables)
     }
 }
 
@@ -116,8 +140,8 @@ extension CalendarEventListhUsecaseImple {
             return event.map { ForemostEventId(event: $0) }
         }
         let transform: (
-            CalendarEventTuple, ForemostEventId?, TimeZone
-        ) -> [any CalendarEvent] = { events, foremostId, timeZone in
+            CalendarEventTuple, ForemostEventId?, TimeZone, WritableCalendarIds
+        ) -> [any CalendarEvent] = { events, foremostId, timeZone, writableIds in
             let (todos, schedules, googles, apples) = events
             let todoEvents = todos.compactMap {
                 TodoCalendarEvent($0, in: timeZone, isForemost: foremostId?.eventId == $0.uuid)
@@ -125,15 +149,20 @@ extension CalendarEventListhUsecaseImple {
             let scheduleEvents = schedules.flatMap {
                 ScheduleCalendarEvent.events(from: $0, in: timeZone, foremostId: foremostId?.eventId)
             }
-            let googleEvents = googles.map { GoogleCalendarEvent($0, in: timeZone) }
-            let appleEvents = apples.map { AppleCalendarEvent($0, in: timeZone) }
+            let googleEvents = googles.map {
+                GoogleCalendarEvent($0, in: timeZone, isWritable: writableIds.google[$0.accountId]?.contains($0.calendarId) == true)
+            }
+            let appleEvents = apples.map {
+                AppleCalendarEvent($0, in: timeZone, isWritable: writableIds.apple.contains($0.calendarId))
+            }
             return todoEvents + scheduleEvents + googleEvents + appleEvents
         }
 
-        return Publishers.CombineLatest3(
+        return Publishers.CombineLatest4(
             tuplePublisher,
             foremost,
-            self.subject.timeZone.compactMap { $0 }
+            self.subject.timeZone.compactMap { $0 },
+            self.subject.writableCalendarIds
         )
         .map(transform)
         .removeDuplicates(by: { $0.map { $0.compareKey } == $1.map { $0.compareKey } })

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventCellViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventCellViewModel.swift
@@ -139,9 +139,15 @@ public enum EventPeriodText: Equatable, Sendable {
 
 // MARK: - EventEditAction
 
+public enum EventListRemoveScope: Sendable, Equatable {
+    case onlyThisTime
+    case thisAndFuture
+    case all
+}
+
 public enum EventListMoreAction: Sendable, Equatable {
-    
-    case remove(onlyThisTime: Bool)
+
+    case remove(scope: EventListRemoveScope)
     case toggleTo(isForemost: Bool)
     case skipTodo
     case edit
@@ -247,8 +253,8 @@ public struct TodoEventCellViewModel: EventCellViewModel {
     
     public var moreActions: EventListMoreActionModel? {
         let removeActions: [EventListMoreAction] = self.isRepeating
-            ? [.remove(onlyThisTime: true), .remove(onlyThisTime: false)]
-            : [.remove(onlyThisTime: false)]
+            ? [.remove(scope: .onlyThisTime), .remove(scope: .all)]
+            : [.remove(scope: .all)]
         let skipActions: [EventListMoreAction] = self.isRepeating
             ? [.skipTodo] : []
         let basicActions: [EventListMoreAction] = [.toggleTo(isForemost: self.isForemost)] + skipActions + [.edit, .copy]
@@ -342,8 +348,8 @@ public struct ScheduleEventCellViewModel: EventCellViewModel {
     
     public var moreActions: EventListMoreActionModel? {
         let removeActions: [EventListMoreAction] = self.isRepeating
-            ? [.remove(onlyThisTime: true), .remove(onlyThisTime: false)]
-            : [.remove(onlyThisTime: false)]
+            ? [.remove(scope: .onlyThisTime), .remove(scope: .all)]
+            : [.remove(scope: .all)]
         return .init(
             basicActions: [.toggleTo(isForemost: self.isForemost), .edit, .copy],
             removeActions: removeActions

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventCellViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventCellViewModel.swift
@@ -404,6 +404,7 @@ public struct AppleCalendarEventCellViewModel: EventCellViewModel {
     public let isRepeating: Bool
     public var isForemost: Bool = false
     public let calendarId: String
+    public let isWritable: Bool
     public var isAlldayEvent: Bool = false
 
     public init?(
@@ -421,13 +422,20 @@ public struct AppleCalendarEventCellViewModel: EventCellViewModel {
         self.periodText = EventPeriodText(schedule: time, in: todayRange, timeZone: timeZone, is24hourForm: is24hourForm)
         self.periodDescription = event.eventTime?.durationText(timeZone, forceShowEventDateDurationText: forceShowEventDateDurationText)
         self.calendarId = event.calendarId
+        self.isWritable = event.isWritable
         self.isAlldayEvent = event.eventTime?.isAllDay ?? false
     }
 
-    public var moreActions: EventListMoreActionModel? { nil }
+    public var moreActions: EventListMoreActionModel? {
+        guard self.isWritable else { return nil }
+        let removeActions: [EventListMoreAction] = self.isRepeating
+            ? [.remove(scope: .onlyThisTime), .remove(scope: .thisAndFuture)]
+            : [.remove(scope: .all)]
+        return .init(basicActions: [], removeActions: removeActions)
+    }
 
     public var customCompareKey: String {
-        return self.makeCustomCompareKey([self.calendarId])
+        return self.makeCustomCompareKey([self.calendarId, "\(self.isWritable)"])
     }
 }
 
@@ -440,10 +448,12 @@ public struct GoogleCalendarEventCellViewModel: EventCellViewModel {
     public let name: String
     public var periodText: EventPeriodText?
     public var periodDescription: String?
-    public let isRepeating: Bool = false
+    public let isRepeating: Bool
     public var isForemost: Bool = false
     public let calendarId: String
     public let accountId: String
+    public let recurringEventId: String?
+    public let isWritable: Bool
     public var isAlldayEvent: Bool = false
 
     public init?(
@@ -459,16 +469,27 @@ public struct GoogleCalendarEventCellViewModel: EventCellViewModel {
         self.name = event.name
         self.periodText = EventPeriodText(schedule: time, in: todayRange, timeZone: timeZone, is24hourForm: is24hourForm)
         self.periodDescription = event.eventTime?.durationText(timeZone, forceShowEventDateDurationText: forceShowEventDateDurationText)
+        self.isRepeating = event.isRepeating
         self.isForemost = event.isForemost
         self.calendarId = event.calendarId
         self.accountId = event.accountId
+        self.recurringEventId = event.recurringEventId
+        self.isWritable = event.isWritable
         self.isAlldayEvent = event.eventTime?.isAllDay ?? false
     }
 
-    public var moreActions: EventListMoreActionModel? { nil }
+    public var moreActions: EventListMoreActionModel? {
+        guard self.isWritable else { return nil }
+        let removeActions: [EventListMoreAction] = self.isRepeating
+            ? [.remove(scope: .onlyThisTime), .remove(scope: .all)]
+            : [.remove(scope: .all)]
+        return .init(basicActions: [], removeActions: removeActions)
+    }
 
     public var customCompareKey: String {
-        return self.makeCustomCompareKey([self.calendarId, self.accountId])
+        return self.makeCustomCompareKey([
+            self.calendarId, self.accountId, self.recurringEventId, "\(self.isWritable)"
+        ])
     }
 }
 

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModel.swift
@@ -125,8 +125,8 @@ extension EventListCellEventHanleViewModelImple {
     ) {
         
         switch action {
-        case .remove(let onlyThisTime):
-            self.removeEvent(cellViewModel, onlyThisTime)
+        case .remove(let scope):
+            self.removeEvent(cellViewModel, scope)
             
         case .toggleTo(let isForemost):
             self.toggleForemostEvent(cellViewModel, isForemost)
@@ -145,27 +145,42 @@ extension EventListCellEventHanleViewModelImple {
 
     private func removeEvent(
         _ cellViewModel: any EventCellViewModel,
-        _ onlyThisTime: Bool
+        _ scope: EventListRemoveScope
     ) {
 
         let title = R.String.calendarEventMoreActionRemoveTitle
-        let message = onlyThisTime
-            ? R.String.calendarEventMoreActionRemoveOnlyThistimeMessage
-            : R.String.calendarEventMoreActionRemoveMessage
+        let message = self.removeConfirmMessage(scope)
         self.runMoreActionAfterConfirm(title, message) { [weak self] in
             guard let self = self else { return }
             Task { [weak self] in
                 do {
                     switch cellViewModel {
                     case let todo as TodoEventCellViewModel:
-                        try await self?.todoEventUsecase.removeTodo(
-                            todo.eventIdentifier, onlyThisTime: onlyThisTime
-                        )
+                        switch scope {
+                        case .onlyThisTime:
+                            try await self?.todoEventUsecase.removeTodo(
+                                todo.eventIdentifier, onlyThisTime: true
+                            )
+                        case .all:
+                            try await self?.todoEventUsecase.removeTodo(
+                                todo.eventIdentifier, onlyThisTime: false
+                            )
+                        case .thisAndFuture:
+                            break
+                        }
                     case let schedule as ScheduleEventCellViewModel:
-                        let time = onlyThisTime ? schedule.eventTimeRawValue : nil
-                        try await self?.scheduleEventUsecase.removeScheduleEvent(
-                            schedule.eventIdWithoutTurn, onlyThisTime: time
-                        )
+                        switch scope {
+                        case .onlyThisTime:
+                            try await self?.scheduleEventUsecase.removeScheduleEvent(
+                                schedule.eventIdWithoutTurn, onlyThisTime: schedule.eventTimeRawValue
+                            )
+                        case .all:
+                            try await self?.scheduleEventUsecase.removeScheduleEvent(
+                                schedule.eventIdWithoutTurn, onlyThisTime: nil
+                            )
+                        case .thisAndFuture:
+                            break
+                        }
                     default: break
                     }
                 } catch {
@@ -173,6 +188,17 @@ extension EventListCellEventHanleViewModelImple {
                 }
             }
             .store(in: &self.cancellables)
+        }
+    }
+
+    private func removeConfirmMessage(_ scope: EventListRemoveScope) -> String {
+        switch scope {
+        case .onlyThisTime:
+            return R.String.calendarEventMoreActionRemoveOnlyThistimeMessage
+        case .thisAndFuture:
+            return "calendar::event::more_action::remove_this_and_future:message".localized()
+        case .all:
+            return R.String.calendarEventMoreActionRemoveMessage
         }
     }
     

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModel.swift
@@ -45,17 +45,26 @@ final class EventListCellEventHanleViewModelImple: EventListCellEventHanleViewMo
     private let todoEventUsecase: any TodoEventUsecase
     private let scheduleEventUsecase: any ScheduleEventUsecase
     private let foremostEventUsecase: any ForemostEventUsecase
+    private let googleCalendarUsecase: any GoogleCalendarUsecase
+    private let appleCalendarUsecase: any AppleCalendarUsecase
+    private let externalCalendarIntegrationUsecase: any ExternalCalendarIntegrationUsecase
 
     var router: (any EventListCellEventHanleRouting)?
 
     init(
         todoEventUsecase: any TodoEventUsecase,
         scheduleEventUsecase: any ScheduleEventUsecase,
-        foremostEventUsecase: any ForemostEventUsecase
+        foremostEventUsecase: any ForemostEventUsecase,
+        googleCalendarUsecase: any GoogleCalendarUsecase,
+        appleCalendarUsecase: any AppleCalendarUsecase,
+        externalCalendarIntegrationUsecase: any ExternalCalendarIntegrationUsecase
     ) {
         self.todoEventUsecase = todoEventUsecase
         self.scheduleEventUsecase = scheduleEventUsecase
         self.foremostEventUsecase = foremostEventUsecase
+        self.googleCalendarUsecase = googleCalendarUsecase
+        self.appleCalendarUsecase = appleCalendarUsecase
+        self.externalCalendarIntegrationUsecase = externalCalendarIntegrationUsecase
     }
     
     private struct Subject {
@@ -147,47 +156,152 @@ extension EventListCellEventHanleViewModelImple {
         _ cellViewModel: any EventCellViewModel,
         _ scope: EventListRemoveScope
     ) {
+        guard let google = cellViewModel as? GoogleCalendarEventCellViewModel else {
+            self.confirmAndRemoveEvent(cellViewModel, scope)
+            return
+        }
+        self.googleCalendarUsecase
+            .eventWritePermission(accountId: google.accountId, calendarId: google.calendarId)
+            .first()
+            .sink { [weak self] permission in
+                switch permission {
+                case .writable:
+                    self?.confirmAndRemoveEvent(google, scope)
+                case .needReauthentication:
+                    self?.confirmReauthenticateThenRemove(google, scope)
+                case .readOnlyCalendar:
+                    break
+                }
+            }
+            .store(in: &self.cancellables)
+    }
 
+    private func confirmReauthenticateThenRemove(
+        _ google: GoogleCalendarEventCellViewModel,
+        _ scope: EventListRemoveScope
+    ) {
+        let info = ConfirmDialogInfo()
+            |> \.title .~ pure("eventDetail::gogoleEvent::reauthenticate::title".localized())
+            |> \.message .~ pure("eventDetail::gogoleEvent::reauthenticate::message".localized())
+            |> \.confirmed .~ pure({ [weak self] in self?.reauthenticateThenRemove(google, scope) })
+            |> \.withCancel .~ true
+        self.router?.showConfirm(dialog: info)
+    }
+
+    private func reauthenticateThenRemove(
+        _ google: GoogleCalendarEventCellViewModel,
+        _ scope: EventListRemoveScope
+    ) {
+        let service = self.googleCalendarUsecase.googleService
+        let accountId = google.accountId
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                _ = try await self.externalCalendarIntegrationUsecase.reauthenticate(
+                    external: service, accountId: accountId
+                )
+                self.confirmAndRemoveEvent(google, scope)
+            } catch {
+                self.router?.showError(error)
+            }
+        }
+        .store(in: &self.cancellables)
+    }
+
+    private func confirmAndRemoveEvent(
+        _ cellViewModel: any EventCellViewModel,
+        _ scope: EventListRemoveScope
+    ) {
         let title = R.String.calendarEventMoreActionRemoveTitle
         let message = self.removeConfirmMessage(scope)
         self.runMoreActionAfterConfirm(title, message) { [weak self] in
             guard let self = self else { return }
             Task { [weak self] in
                 do {
-                    switch cellViewModel {
-                    case let todo as TodoEventCellViewModel:
-                        switch scope {
-                        case .onlyThisTime:
-                            try await self?.todoEventUsecase.removeTodo(
-                                todo.eventIdentifier, onlyThisTime: true
-                            )
-                        case .all:
-                            try await self?.todoEventUsecase.removeTodo(
-                                todo.eventIdentifier, onlyThisTime: false
-                            )
-                        case .thisAndFuture:
-                            break
-                        }
-                    case let schedule as ScheduleEventCellViewModel:
-                        switch scope {
-                        case .onlyThisTime:
-                            try await self?.scheduleEventUsecase.removeScheduleEvent(
-                                schedule.eventIdWithoutTurn, onlyThisTime: schedule.eventTimeRawValue
-                            )
-                        case .all:
-                            try await self?.scheduleEventUsecase.removeScheduleEvent(
-                                schedule.eventIdWithoutTurn, onlyThisTime: nil
-                            )
-                        case .thisAndFuture:
-                            break
-                        }
-                    default: break
-                    }
+                    try await self?.executeRemove(cellViewModel, scope)
                 } catch {
                     self?.router?.showError(error)
                 }
             }
             .store(in: &self.cancellables)
+        }
+    }
+
+    private func executeRemove(
+        _ cellViewModel: any EventCellViewModel,
+        _ scope: EventListRemoveScope
+    ) async throws {
+        switch cellViewModel {
+        case let todo as TodoEventCellViewModel:
+            switch scope {
+            case .onlyThisTime:
+                try await self.todoEventUsecase.removeTodo(
+                    todo.eventIdentifier, onlyThisTime: true
+                )
+            case .all:
+                try await self.todoEventUsecase.removeTodo(
+                    todo.eventIdentifier, onlyThisTime: false
+                )
+            case .thisAndFuture:
+                break
+            }
+        case let schedule as ScheduleEventCellViewModel:
+            switch scope {
+            case .onlyThisTime:
+                try await self.scheduleEventUsecase.removeScheduleEvent(
+                    schedule.eventIdWithoutTurn, onlyThisTime: schedule.eventTimeRawValue
+                )
+            case .all:
+                try await self.scheduleEventUsecase.removeScheduleEvent(
+                    schedule.eventIdWithoutTurn, onlyThisTime: nil
+                )
+            case .thisAndFuture:
+                break
+            }
+        case let google as GoogleCalendarEventCellViewModel:
+            try await self.removeGoogleEvent(google, scope)
+        case let apple as AppleCalendarEventCellViewModel:
+            try await self.removeAppleEvent(apple, scope)
+        default: break
+        }
+    }
+
+    private func removeGoogleEvent(
+        _ google: GoogleCalendarEventCellViewModel,
+        _ scope: EventListRemoveScope
+    ) async throws {
+        switch scope {
+        case .onlyThisTime:
+            try await self.googleCalendarUsecase.removeEvent(
+                google.calendarId, google.eventIdentifier, accountId: google.accountId, scope: .thisEventOnly
+            )
+        case .all:
+            // 셀의 eventIdentifier 는 펼쳐진 인스턴스 id — 시리즈를 지우려면 마스터 id 가 필요하다
+            if let masterId = google.recurringEventId {
+                try await self.googleCalendarUsecase.removeEvent(
+                    google.calendarId, masterId, accountId: google.accountId, scope: .allEvents
+                )
+            } else {
+                try await self.googleCalendarUsecase.removeEvent(
+                    google.calendarId, google.eventIdentifier, accountId: google.accountId, scope: .thisEventOnly
+                )
+            }
+        case .thisAndFuture:
+            break
+        }
+    }
+
+    private func removeAppleEvent(
+        _ apple: AppleCalendarEventCellViewModel,
+        _ scope: EventListRemoveScope
+    ) async throws {
+        switch scope {
+        case .onlyThisTime:
+            try await self.appleCalendarUsecase.removeEvent(apple.eventIdentifier, scope: .thisEventOnly)
+        case .thisAndFuture:
+            try await self.appleCalendarUsecase.removeEvent(apple.eventIdentifier, scope: .thisAndFuture)
+        case .all:
+            try await self.appleCalendarUsecase.removeEvent(apple.eventIdentifier, scope: .thisEventOnly)
         }
     }
 

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModelBuilder.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModelBuilder.swift
@@ -36,7 +36,10 @@ final class EventListCellEventHanleViewModelBuilderImple: EventListCellEventHanl
         let viewModel = EventListCellEventHanleViewModelImple(
             todoEventUsecase: self.usecaseFactory.makeTodoEventUsecase(),
             scheduleEventUsecase: self.usecaseFactory.makeScheduleEventUsecase(),
-            foremostEventUsecase: self.usecaseFactory.makeForemostEventUsecase()
+            foremostEventUsecase: self.usecaseFactory.makeForemostEventUsecase(),
+            googleCalendarUsecase: self.usecaseFactory.makeGoogleCalendarUsecase(),
+            appleCalendarUsecase: self.usecaseFactory.makeAppleCalendarUsecase(),
+            externalCalendarIntegrationUsecase: self.usecaseFactory.externalCalenarIntegrationUsecase
         )
         let router = EventListCellEventHanleRouter(
             eventDetailSceneBuilder: eventDetailSceneBuilder

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellView.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellView.swift
@@ -96,22 +96,24 @@ struct EventListCellView: View {
                 ForEach(0..<moreActions.basicActions.count, id: \.self) {
                     moreActionsView(moreActions.basicActions[$0])
                 }
-                
-                Divider()
-                
+
+                if !moreActions.basicActions.isEmpty {
+                    Divider()
+                }
+
                 ForEach(0..<moreActions.removeActions.count, id: \.self) {
                     moreActionsView(moreActions.removeActions[$0])
                 }
             }
         }
     }
-    
+
     private func moreActionsView(_ action: EventListMoreAction) -> some View {
         switch action {
         case .edit:
             return editEventButton().asAnyView()
-        case .remove(let onlyThisTime):
-            return removeButton(onlyThisTime).asAnyView()
+        case .remove(let scope):
+            return removeButton(scope).asAnyView()
         case .toggleTo(let isForemost):
             return toggleForemostButton(isForemost).asAnyView()
         case .skipTodo:
@@ -120,20 +122,28 @@ struct EventListCellView: View {
             return copyButton().asAnyView()
         }
     }
-    
-    private func removeButton(_ onlyThisTime: Bool) -> some View {
+
+    private func removeButton(_ scope: EventListRemoveScope) -> some View {
         return Button(role: .destructive) {
             self.handleMoreAction(
-                self.cellViewModel, .remove(onlyThisTime: onlyThisTime)
+                self.cellViewModel, .remove(scope: scope)
             )
         } label: {
             HStack {
-                Text(onlyThisTime
-                     ? R.String.calendarEventMoreActionRemoveOnlyThistimeItemName
-                     : R.String.calendarEventMoreActionRemoveItemName
-                )
+                Text(self.removeItemName(scope))
                 Image(systemName: "trash")
             }
+        }
+    }
+
+    private func removeItemName(_ scope: EventListRemoveScope) -> String {
+        switch scope {
+        case .onlyThisTime:
+            return R.String.calendarEventMoreActionRemoveOnlyThistimeItemName
+        case .thisAndFuture:
+            return "calendar::event::more_action:remove_this_and_future:item_name".localized()
+        case .all:
+            return R.String.calendarEventMoreActionRemoveItemName
         }
     }
     

--- a/Presentations/CalendarScenes/Tests/Common/CalendarEventListhUsecaseImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Common/CalendarEventListhUsecaseImpleTests.swift
@@ -27,7 +27,10 @@ final class CalendarEventListhUsecaseImpleTests: PublisherWaitable {
     
     private func makeUsecase(
         appleEvents: [AppleCalendar.Event] = [],
-        offTagIds: [EventTagId] = []
+        offTagIds: [EventTagId] = [],
+        googleEvents: [GoogleCalendar.Event]? = nil,
+        googleCalendarTags: [GoogleCalendar.Tag]? = nil,
+        appleCalendarTags: [AppleCalendar.Tag]? = nil
     ) async throws -> CalendarEventListhUsecaseImple {
         let todos = (0..<3).map { int in
             return TodoEvent(uuid: "todo:\(int)", name: "todo")
@@ -38,7 +41,7 @@ final class CalendarEventListhUsecaseImpleTests: PublisherWaitable {
             return ScheduleEvent(uuid: "sc:\(int)", name: "sc", time: .at(0))
                 |> \.eventTagId .~ .default
         }
-        let googles = (0..<4).map { int in
+        let defaultGoogles = (0..<4).map { int in
             return GoogleCalendar.Event(
                 "g:\(int)", "google", accountId: "stub@gmail.com", name: "g", colorId: "color", time: .at(0)
             )
@@ -64,10 +67,17 @@ final class CalendarEventListhUsecaseImpleTests: PublisherWaitable {
         scheduleUsecase.stubScheduleEventsInRange = schedules
 
         let googleUsecase = StubGoogleCalendarUsecase()
-        googleUsecase.stubEvents = googles
+        googleUsecase.stubEvents = googleEvents ?? defaultGoogles
+        if let googleCalendarTags {
+            googleUsecase.stubCalendarTags = googleCalendarTags
+            googleUsecase.refreshGoogleCalendarEventTags()
+        }
 
         let appleUsecase = StubAppleCalendarUsecase()
         appleUsecase.stubEvents = appleEvents
+        if let appleCalendarTags {
+            appleUsecase.sendCalendarTags(appleCalendarTags)
+        }
 
         let calendarSettingUsecase = StubCalendarSettingUsecase()
         calendarSettingUsecase.prepare()
@@ -205,6 +215,136 @@ extension CalendarEventListhUsecaseImpleTests {
             [],
             withoutGoogles
         ])
+    }
+}
+
+
+// MARK: - 쓰기 가능한 외부 캘린더 이벤트 판정
+
+extension CalendarEventListhUsecaseImpleTests {
+
+    @Test func calendarEvents_googleEventIsWritable_whenCalendarAccessRoleIsWritable() async throws {
+        // given
+        let expect = expectConfirm("쓰기 가능한 캘린더의 구글 이벤트만 isWritable == true")
+        let writableEvent = GoogleCalendar.Event(
+            "g:writable", "cal:writable", accountId: "stub@gmail.com", name: "writable", colorId: "color", time: .at(0)
+        )
+        |> \.eventTagId .~ .externalCalendar(serviceId: GoogleCalendarService.id, id: "cal:writable")
+        let readonlyEvent = GoogleCalendar.Event(
+            "g:readonly", "cal:readonly", accountId: "stub@gmail.com", name: "readonly", colorId: "color", time: .at(0)
+        )
+        |> \.eventTagId .~ .externalCalendar(serviceId: GoogleCalendarService.id, id: "cal:readonly")
+        let tags = [
+            GoogleCalendar.Tag(id: "cal:writable", name: "writable")
+                |> \.accessRole .~ .owner
+                |> \.ownerId .~ "stub@gmail.com",
+            GoogleCalendar.Tag(id: "cal:readonly", name: "readonly")
+                |> \.accessRole .~ .reader
+                |> \.ownerId .~ "stub@gmail.com"
+        ]
+        let usecase = try await self.makeUsecase(
+            googleEvents: [writableEvent, readonlyEvent], googleCalendarTags: tags, appleCalendarTags: []
+        )
+
+        // when
+        let eventSource = usecase.calendarEvents(in: 0..<10)
+        let events = try await self.firstOutput(expect, for: eventSource)
+
+        // then
+        let googleEvents = events?.compactMap { $0 as? GoogleCalendarEvent } ?? []
+        let isWritableByEventId = Dictionary(uniqueKeysWithValues: googleEvents.map { ($0.eventId, $0.isWritable) })
+        #expect(isWritableByEventId["g:writable"] == true)
+        #expect(isWritableByEventId["g:readonly"] == false)
+    }
+
+    @Test func calendarEvents_googleEventIsWritable_perAccount_whenSameCalendarIdSharedAcrossAccounts() async throws {
+        // given
+        let expect = expectConfirm("같은 calendarId 라도 계정별로 쓰기 가능 여부가 갈린다")
+        let ownerAccountEvent = GoogleCalendar.Event(
+            "g:owner", "shared-cal", accountId: "owner@gmail.com", name: "owner-side", colorId: "color", time: .at(0)
+        )
+        |> \.eventTagId .~ .externalCalendar(serviceId: GoogleCalendarService.id, id: "shared-cal")
+        let readerAccountEvent = GoogleCalendar.Event(
+            "g:reader", "shared-cal", accountId: "reader@gmail.com", name: "reader-side", colorId: "color", time: .at(0)
+        )
+        |> \.eventTagId .~ .externalCalendar(serviceId: GoogleCalendarService.id, id: "shared-cal")
+        let tags = [
+            GoogleCalendar.Tag(id: "shared-cal", name: "shared-cal")
+                |> \.accessRole .~ .owner
+                |> \.ownerId .~ "owner@gmail.com",
+            GoogleCalendar.Tag(id: "shared-cal", name: "shared-cal")
+                |> \.accessRole .~ .reader
+                |> \.ownerId .~ "reader@gmail.com"
+        ]
+        let usecase = try await self.makeUsecase(
+            googleEvents: [ownerAccountEvent, readerAccountEvent], googleCalendarTags: tags, appleCalendarTags: []
+        )
+
+        // when
+        let eventSource = usecase.calendarEvents(in: 0..<10)
+        let events = try await self.firstOutput(expect, for: eventSource)
+
+        // then
+        let googleEvents = events?.compactMap { $0 as? GoogleCalendarEvent } ?? []
+        let isWritableByEventId = Dictionary(uniqueKeysWithValues: googleEvents.map { ($0.eventId, $0.isWritable) })
+        #expect(isWritableByEventId["g:owner"] == true)
+        #expect(isWritableByEventId["g:reader"] == false)
+    }
+
+    @Test func calendarEvents_appleEventIsWritable_whenCalendarTagIsWritable() async throws {
+        // given
+        let expect = expectConfirm("쓰기 가능한 캘린더의 애플 이벤트만 isWritable == true, 미확인(nil) 태그는 fail-closed")
+        let writableEvent = AppleCalendar.Event(
+            eventId: "a:writable", originalEventId: "a:writable", calendarId: "cal:writable", name: "writable", eventTime: .at(0)
+        )
+        let readonlyEvent = AppleCalendar.Event(
+            eventId: "a:readonly", originalEventId: "a:readonly", calendarId: "cal:readonly", name: "readonly", eventTime: .at(0)
+        )
+        let unresolvedEvent = AppleCalendar.Event(
+            eventId: "a:unresolved", originalEventId: "a:unresolved", calendarId: "cal:unresolved", name: "unresolved", eventTime: .at(0)
+        )
+        let tags = [
+            AppleCalendar.Tag(id: "cal:writable", name: "writable", colorHex: "hex") |> \.isWritable .~ true,
+            AppleCalendar.Tag(id: "cal:readonly", name: "readonly", colorHex: "hex") |> \.isWritable .~ false,
+            AppleCalendar.Tag(id: "cal:unresolved", name: "unresolved", colorHex: "hex")
+        ]
+        let usecase = try await self.makeUsecase(
+            appleEvents: [writableEvent, readonlyEvent, unresolvedEvent], googleCalendarTags: [], appleCalendarTags: tags
+        )
+
+        // when
+        let eventSource = usecase.calendarEvents(in: 0..<10)
+        let events = try await self.firstOutput(expect, for: eventSource)
+
+        // then
+        let appleEvents = events?.compactMap { $0 as? AppleCalendarEvent } ?? []
+        let isWritableByEventId = Dictionary(uniqueKeysWithValues: appleEvents.map { ($0.eventId, $0.isWritable) })
+        #expect(isWritableByEventId["a:writable"] == true)
+        #expect(isWritableByEventId["a:readonly"] == false)
+        #expect(isWritableByEventId["a:unresolved"] == false)
+    }
+
+    @Test func calendarEvents_externalEventIsNotWritable_whenCalendarTagsNotLoaded() async throws {
+        // given
+        let expect = expectConfirm("캘린더 태그가 로드되지 않아도 이벤트 목록은 방출되고, 외부 이벤트는 전부 isWritable == false")
+        let appleEvents = (0..<2).map { int in
+            AppleCalendar.Event(
+                eventId: "a:\(int)", originalEventId: "a:\(int)", calendarId: "apple-cal", name: "apple-event", eventTime: .at(0)
+            )
+        }
+        let usecase = try await self.makeUsecase(appleEvents: appleEvents)
+
+        // when
+        let eventSource = usecase.calendarEvents(in: 0..<10)
+        let events = try await self.firstOutput(expect, for: eventSource)
+
+        // then
+        let googleEvents = events?.compactMap { $0 as? GoogleCalendarEvent } ?? []
+        let appleCalendarEvents = events?.compactMap { $0 as? AppleCalendarEvent } ?? []
+        #expect(!googleEvents.isEmpty)
+        #expect(!appleCalendarEvents.isEmpty)
+        #expect(googleEvents.allSatisfy { $0.isWritable == false })
+        #expect(appleCalendarEvents.allSatisfy { $0.isWritable == false })
     }
 }
 

--- a/Presentations/CalendarScenes/Tests/Common/CalendarEventTests.swift
+++ b/Presentations/CalendarScenes/Tests/Common/CalendarEventTests.swift
@@ -19,17 +19,23 @@ class CalendarEventTests {
 
     private func makeGoogleEvent(
         calendarId: String = "calendar",
-        accountId: String = "account"
+        accountId: String = "account",
+        isWritable: Bool = false,
+        recurringEventId: String? = nil
     ) -> GoogleCalendarEvent {
-        let raw = GoogleCalendar.Event(
+        var raw = GoogleCalendar.Event(
             "google", calendarId,
             accountId: accountId, name: "name", colorId: "color",
             time: .at(100)
         )
-        return GoogleCalendarEvent(raw, in: self.timeZone)
+        raw.recurringEventId = recurringEventId
+        return GoogleCalendarEvent(raw, in: self.timeZone, isWritable: isWritable)
     }
 
-    private func makeAppleEvent(calendarId: String = "calendar") -> AppleCalendarEvent {
+    private func makeAppleEvent(
+        calendarId: String = "calendar",
+        isWritable: Bool = false
+    ) -> AppleCalendarEvent {
         let raw = AppleCalendar.Event(
             eventId: "apple",
             originalEventId: "apple",
@@ -37,7 +43,7 @@ class CalendarEventTests {
             name: "name",
             eventTime: .at(100)
         )
-        return AppleCalendarEvent(raw, in: self.timeZone)
+        return AppleCalendarEvent(raw, in: self.timeZone, isWritable: isWritable)
     }
 }
 
@@ -82,5 +88,41 @@ extension CalendarEventTests {
 
         // when + then
         #expect(event.compareKey != calendarChangedEvent.compareKey)
+    }
+
+    @Test("google 이벤트는 원본에 recurringEventId가 있으면 반복 이벤트다")
+    func googleEvent_isRepeating_whenHasRecurringEventId() {
+        // given
+        let repeatingEvent = self.makeGoogleEvent(recurringEventId: "master-1")
+        let notRepeatingEvent = self.makeGoogleEvent(recurringEventId: nil)
+
+        // when + then
+        #expect(repeatingEvent.isRepeating == true)
+        #expect(notRepeatingEvent.isRepeating == false)
+    }
+
+    @Test("외부 캘린더 이벤트는 쓰기 가능 여부가 달라지면 compare key도 달라진다")
+    func externalEvent_compareKeyIsDifferent_whenIsWritableChanged() {
+        // given
+        let (google, writableGoogle) = (
+            self.makeGoogleEvent(isWritable: false), self.makeGoogleEvent(isWritable: true)
+        )
+        let (apple, writableApple) = (
+            self.makeAppleEvent(isWritable: false), self.makeAppleEvent(isWritable: true)
+        )
+
+        // when + then
+        #expect(google.compareKey != writableGoogle.compareKey)
+        #expect(apple.compareKey != writableApple.compareKey)
+    }
+
+    @Test("google 이벤트는 recurringEventId가 달라지면 compare key도 달라진다")
+    func googleEvent_compareKeyIsDifferent_whenRecurringEventIdChanged() {
+        // given
+        let event = self.makeGoogleEvent(recurringEventId: nil)
+        let recurringEvent = self.makeGoogleEvent(recurringEventId: "master-1")
+
+        // when + then
+        #expect(event.compareKey != recurringEvent.compareKey)
     }
 }

--- a/Presentations/CalendarScenes/Tests/Common/EventCellViewModelTests.swift
+++ b/Presentations/CalendarScenes/Tests/Common/EventCellViewModelTests.swift
@@ -30,14 +30,30 @@ class EventCellViewModelTests {
             |> \.eventTimeRawValue .~ rawTime
     }
 
-    private func makeGoogleCell(accountId: String) -> GoogleCalendarEventCellViewModel? {
+    private func makeGoogleCell(
+        accountId: String = "account",
+        recurringEventId: String? = nil,
+        isWritable: Bool = false
+    ) -> GoogleCalendarEventCellViewModel? {
         let raw = GoogleCalendar.Event(
             "google", "calendar",
             accountId: accountId, name: "name", colorId: "color",
             time: .at(100)
         )
-        let event = GoogleCalendarEvent(raw, in: self.timeZone)
+        |> \.recurringEventId .~ recurringEventId
+        let event = GoogleCalendarEvent(raw, in: self.timeZone, isWritable: isWritable)
         return GoogleCalendarEventCellViewModel(
+            event, in: self.todayRange, self.timeZone, true
+        )
+    }
+
+    private func makeAppleCell(isWritable: Bool) -> AppleCalendarEventCellViewModel? {
+        let raw = AppleCalendar.Event(
+            eventId: "apple", originalEventId: "apple", calendarId: "calendar",
+            name: "name", eventTime: .at(100)
+        )
+        let event = AppleCalendarEvent(raw, in: self.timeZone, isWritable: isWritable)
+        return AppleCalendarEventCellViewModel(
             event, in: self.todayRange, self.timeZone, true
         )
     }
@@ -86,5 +102,35 @@ extension EventCellViewModelTests {
 
         // when + then
         #expect(cell?.customCompareKey != accountChangedCell?.customCompareKey)
+    }
+
+    @Test("google 셀은 둘 다 반복 이벤트라도 시리즈 마스터 id가 다르면 compare key가 달라진다")
+    func googleCell_compareKeyIsDifferent_whenRecurringEventIdChanged() {
+        // given
+        let cell = self.makeGoogleCell(recurringEventId: "master-1")
+        let recurringEventIdChangedCell = self.makeGoogleCell(recurringEventId: "master-2")
+
+        // when + then
+        #expect(cell?.customCompareKey != recurringEventIdChangedCell?.customCompareKey)
+    }
+
+    @Test("google 셀은 표시에 안 쓰이는 isWritable이 달라져도 compare key가 달라진다")
+    func googleCell_compareKeyIsDifferent_whenIsWritableChanged() {
+        // given
+        let cell = self.makeGoogleCell(isWritable: false)
+        let writableChangedCell = self.makeGoogleCell(isWritable: true)
+
+        // when + then
+        #expect(cell?.customCompareKey != writableChangedCell?.customCompareKey)
+    }
+
+    @Test("apple 셀은 표시에 안 쓰이는 isWritable이 달라져도 compare key가 달라진다")
+    func appleCell_compareKeyIsDifferent_whenIsWritableChanged() {
+        // given
+        let cell = self.makeAppleCell(isWritable: false)
+        let writableChangedCell = self.makeAppleCell(isWritable: true)
+
+        // when + then
+        #expect(cell?.customCompareKey != writableChangedCell?.customCompareKey)
     }
 }

--- a/Presentations/CalendarScenes/Tests/Common/EventListCellEventHanleViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Common/EventListCellEventHanleViewModelImpleTests.swift
@@ -195,7 +195,8 @@ extension EventListCellEventHanleViewModelImpleTests {
             _ cellViewModel: TodoEventCellViewModel,
             _ action: EventListMoreAction,
             expectRemovedId: String,
-            and expectOnlyThisTime: Bool
+            and expectOnlyThisTime: Bool,
+            expectConfirmMessage: String
         ) {
             // given
             let expect = expectation(description: description)
@@ -213,22 +214,24 @@ extension EventListCellEventHanleViewModelImpleTests {
             // then
             XCTAssertEqual(recordParams?.0, expectRemovedId)
             XCTAssertEqual(recordParams?.1, expectOnlyThisTime)
-            XCTAssertEqual(self.spyRouter.didShowConfirmWith != nil, true)
+            XCTAssertEqual(self.spyRouter.didShowConfirmWith?.message, expectConfirmMessage)
         }
         // when + then
         let dummy = TodoEventCellViewModel("todo", name: "some")
         parameterizeTest(
             "todo event 삭제",
-            dummy, .remove(onlyThisTime: false),
-            expectRemovedId: "todo", and: false
+            dummy, .remove(scope: .all),
+            expectRemovedId: "todo", and: false,
+            expectConfirmMessage: R.String.calendarEventMoreActionRemoveMessage
         )
         parameterizeTest(
             "반복중인 todo event 이번 회차만 삭제",
-            dummy, .remove(onlyThisTime: true),
-            expectRemovedId: "todo", and: true
+            dummy, .remove(scope: .onlyThisTime),
+            expectRemovedId: "todo", and: true,
+            expectConfirmMessage: R.String.calendarEventMoreActionRemoveOnlyThistimeMessage
         )
     }
-    
+
     func testViewModel_removeScheduleEvent() {
         // given
         func parameterizeTest(
@@ -236,7 +239,8 @@ extension EventListCellEventHanleViewModelImpleTests {
             _ cellViewModel: ScheduleEventCellViewModel,
             _ action: EventListMoreAction,
             expectRemovedId: String,
-            and expectOnlyThisTime: EventTime?
+            and expectOnlyThisTime: EventTime?,
+            expectConfirmMessage: String
         ) {
             // given
             let expect = expectation(description: description)
@@ -254,20 +258,22 @@ extension EventListCellEventHanleViewModelImpleTests {
             // then
             XCTAssertEqual(recordParams?.0, expectRemovedId)
             XCTAssertEqual(recordParams?.1, expectOnlyThisTime)
-            XCTAssertEqual(self.spyRouter.didShowConfirmWith != nil, true)
+            XCTAssertEqual(self.spyRouter.didShowConfirmWith?.message, expectConfirmMessage)
         }
         // when + then
         let dummy = ScheduleEventCellViewModel("schedule", name: "name")
             |> \.eventTimeRawValue .~ .at(100)
         parameterizeTest(
             "schedule event 삭제",
-            dummy, .remove(onlyThisTime: false),
-            expectRemovedId: "schedule", and: nil
+            dummy, .remove(scope: .all),
+            expectRemovedId: "schedule", and: nil,
+            expectConfirmMessage: R.String.calendarEventMoreActionRemoveMessage
         )
         parameterizeTest(
             "반복중인 schedule event 이번 회차만 삭제",
-            dummy, .remove(onlyThisTime: true),
-            expectRemovedId: "schedule", and: .at(100)
+            dummy, .remove(scope: .onlyThisTime),
+            expectRemovedId: "schedule", and: .at(100),
+            expectConfirmMessage: R.String.calendarEventMoreActionRemoveOnlyThistimeMessage
         )
     }
     

--- a/Presentations/CalendarScenes/Tests/Common/EventListCellEventHanleViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Common/EventListCellEventHanleViewModelImpleTests.swift
@@ -24,6 +24,9 @@ class EventListCellEventHanleViewModelImpleTests: BaseTestCase, PublisherWaitabl
     private var spyTodoUsecase: PrivateStubTodoEventUsecase!
     private var spySchedleUsecase: PrivateScheduleEventUsecase!
     private var spyForemostUsecase: PrivateForemostEventUsecase!
+    private var spyGoogleUsecase: PrivateGoogleCalendarUsecase!
+    private var spyAppleUsecase: PrivateAppleCalendarUsecase!
+    private var stubIntegrationUsecase: StubExternalCalendarIntegrationUsecase!
     private var spyRouter: SpyEventListCellEventHanleRouter!
 
     override func setUpWithError() throws {
@@ -31,6 +34,9 @@ class EventListCellEventHanleViewModelImpleTests: BaseTestCase, PublisherWaitabl
         self.spyTodoUsecase = .init()
         self.spySchedleUsecase = .init()
         self.spyForemostUsecase = .init()
+        self.spyGoogleUsecase = .init()
+        self.spyAppleUsecase = .init()
+        self.stubIntegrationUsecase = .init([])
         self.spyRouter = .init()
     }
 
@@ -39,19 +45,33 @@ class EventListCellEventHanleViewModelImpleTests: BaseTestCase, PublisherWaitabl
         self.spyTodoUsecase = nil
         self.spySchedleUsecase = nil
         self.spyForemostUsecase = nil
+        self.spyGoogleUsecase = nil
+        self.spyAppleUsecase = nil
+        self.stubIntegrationUsecase = nil
         self.spyRouter = nil
     }
 
     private func makeViewModel(
-        shouldFailDoneTodo: Bool = false
+        shouldFailDoneTodo: Bool = false,
+        googleWritePermission: GoogleCalendar.EventWritePermission = .writable,
+        appleShouldFailWrite: Bool = false,
+        googleShouldFailWrite: Bool = false,
+        shouldFailReauthenticate: Bool = false
     ) -> EventListCellEventHanleViewModelImple {
 
         self.spyTodoUsecase.shouldFailCompleteTodo = shouldFailDoneTodo
+        self.spyGoogleUsecase.stubWritePermission = googleWritePermission
+        self.spyAppleUsecase.shouldFailWrite = appleShouldFailWrite
+        self.spyGoogleUsecase.shouldFailWrite = googleShouldFailWrite
+        self.stubIntegrationUsecase.shouldFailReauthenticate = shouldFailReauthenticate
 
         let viewModel = EventListCellEventHanleViewModelImple(
             todoEventUsecase: self.spyTodoUsecase,
             scheduleEventUsecase: self.spySchedleUsecase,
-            foremostEventUsecase: self.spyForemostUsecase
+            foremostEventUsecase: self.spyForemostUsecase,
+            googleCalendarUsecase: self.spyGoogleUsecase,
+            appleCalendarUsecase: self.spyAppleUsecase,
+            externalCalendarIntegrationUsecase: self.stubIntegrationUsecase
         )
         viewModel.router = self.spyRouter
         return viewModel
@@ -140,10 +160,93 @@ extension EventListCellEventHanleViewModelImpleTests {
 }
 
 
+// MARK: - 외부 캘린더 셀 more actions
+
+extension EventListCellEventHanleViewModelImpleTests {
+
+    func testGoogleCell_moreActionsIsNil_whenCalendarIsNotWritable() {
+        // given
+        let model = GoogleCalendarEventCellViewModel.dummy(isWritable: false)
+
+        // when
+        let actions = model.moreActions
+
+        // then
+        XCTAssertNil(actions)
+    }
+
+    func testGoogleCell_removeActions_whenNotRepeating() {
+        // given
+        let model = GoogleCalendarEventCellViewModel.dummy(isWritable: true, recurringEventId: nil)
+
+        // when
+        let actions = model.moreActions
+
+        // then
+        XCTAssertEqual(actions?.removeActions, [.remove(scope: .all)])
+    }
+
+    func testGoogleCell_removeActions_whenRepeating() {
+        // given
+        let model = GoogleCalendarEventCellViewModel.dummy(isWritable: true, recurringEventId: "master-1")
+
+        // when
+        let actions = model.moreActions
+
+        // then
+        XCTAssertEqual(actions?.removeActions, [.remove(scope: .onlyThisTime), .remove(scope: .all)])
+    }
+
+    func testGoogleCell_basicActionsIsEmpty() {
+        // given
+        let model = GoogleCalendarEventCellViewModel.dummy(isWritable: true)
+
+        // when
+        let actions = model.moreActions
+
+        // then
+        XCTAssertEqual(actions?.basicActions, [])
+    }
+
+    func testAppleCell_moreActionsIsNil_whenCalendarIsNotWritable() {
+        // given
+        let model = AppleCalendarEventCellViewModel.dummy(isWritable: false)
+
+        // when
+        let actions = model.moreActions
+
+        // then
+        XCTAssertNil(actions)
+    }
+
+    func testAppleCell_removeActions_whenRepeating() {
+        // given
+        let model = AppleCalendarEventCellViewModel.dummy(isWritable: true, isRepeating: true)
+
+        // when
+        let actions = model.moreActions
+
+        // then
+        XCTAssertEqual(actions?.removeActions, [.remove(scope: .onlyThisTime), .remove(scope: .thisAndFuture)])
+    }
+
+    func testAppleCell_removeActions_whenNotRepeating() {
+        // given
+        let model = AppleCalendarEventCellViewModel.dummy(isWritable: true, isRepeating: false)
+
+        // when
+        let actions = model.moreActions
+
+        // then
+        XCTAssertEqual(actions?.removeActions, [.remove(scope: .all)])
+    }
+}
+
+
 // MARK: - test handle done todo
 
 extension EventListCellEventHanleViewModelImpleTests {
-    
+
     func testViewModel_doneTodo() {
         // given
         func parameterizeTest(shouldFail: Bool) {
@@ -385,11 +488,216 @@ extension EventListCellEventHanleViewModelImpleTests {
         let names = todos.map { $0.name }
         XCTAssertEqual(names, ["origin", "skipped"])
     }
-    
+
+}
+
+
+// MARK: - 외부 캘린더 이벤트 삭제
+
+extension EventListCellEventHanleViewModelImpleTests {
+
+    func testViewModel_whenRemoveGoogleEventOnlyThisTime_removeInstanceWithThisEventOnlyScope() {
+        // given
+        let expect = expectation(description: "구글 이벤트 이번 회차만 삭제")
+        self.spyGoogleUsecase.didRemoveEventWithCallback = { expect.fulfill() }
+        let viewModel = self.makeViewModel(googleWritePermission: .writable)
+        let cellViewModel = GoogleCalendarEventCellViewModel.dummy(isWritable: true, recurringEventId: "master-1")
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .remove(scope: .onlyThisTime))
+        self.wait(for: [expect], timeout: self.timeout)
+
+        // then
+        XCTAssertEqual(self.spyGoogleUsecase.didRemoveEventWith?.eventId, "google")
+        XCTAssertEqual(self.spyGoogleUsecase.didRemoveEventWith?.scope, .thisEventOnly)
+    }
+
+    func testViewModel_whenRemoveRepeatingGoogleEventWithAllScope_removeMasterWithAllEventsScope() {
+        // given
+        let expect = expectation(description: "구글 반복 이벤트 전체 삭제 — 시리즈 마스터 id 사용")
+        self.spyGoogleUsecase.didRemoveEventWithCallback = { expect.fulfill() }
+        let viewModel = self.makeViewModel(googleWritePermission: .writable)
+        let cellViewModel = GoogleCalendarEventCellViewModel.dummy(isWritable: true, recurringEventId: "master-1")
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .remove(scope: .all))
+        self.wait(for: [expect], timeout: self.timeout)
+
+        // then
+        XCTAssertEqual(self.spyGoogleUsecase.didRemoveEventWith?.eventId, "master-1")
+        XCTAssertEqual(self.spyGoogleUsecase.didRemoveEventWith?.scope, .allEvents)
+    }
+
+    func testViewModel_whenRemoveNotRepeatingGoogleEvent_removeItselfWithThisEventOnlyScope() {
+        // given
+        let expect = expectation(description: "구글 비반복 이벤트 전체 삭제 — 인스턴스 id 사용")
+        self.spyGoogleUsecase.didRemoveEventWithCallback = { expect.fulfill() }
+        let viewModel = self.makeViewModel(googleWritePermission: .writable)
+        let cellViewModel = GoogleCalendarEventCellViewModel.dummy(isWritable: true, recurringEventId: nil)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .remove(scope: .all))
+        self.wait(for: [expect], timeout: self.timeout)
+
+        // then
+        XCTAssertEqual(self.spyGoogleUsecase.didRemoveEventWith?.eventId, "google")
+        XCTAssertEqual(self.spyGoogleUsecase.didRemoveEventWith?.scope, .thisEventOnly)
+    }
+
+    func testViewModel_whenRemoveGoogleEventAndNeedReauthentication_reauthenticateThenRemove() {
+        // given
+        let expect = expectation(description: "재인증 이후 삭제 실행")
+        self.spyGoogleUsecase.didRemoveEventWithCallback = { expect.fulfill() }
+        let viewModel = self.makeViewModel(googleWritePermission: .needReauthentication)
+        let cellViewModel = GoogleCalendarEventCellViewModel.dummy(isWritable: true, recurringEventId: nil)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .remove(scope: .all))
+        self.wait(for: [expect], timeout: self.timeout)
+
+        // then
+        XCTAssertEqual(self.stubIntegrationUsecase.didReauthenticateWith?.accountId, "stub@gmail.com")
+        XCTAssertEqual(self.spyGoogleUsecase.didRemoveEventWith?.eventId, "google")
+    }
+
+    func testViewModel_whenRemoveGoogleEventAndReauthenticateFailed_showError() {
+        // given
+        let expect = expectation(description: "재인증 자체가 실패하면 에러 노출, 삭제는 시도 안 함")
+        self.spyRouter.didShowErrorCallback = { _ in expect.fulfill() }
+        let viewModel = self.makeViewModel(
+            googleWritePermission: .needReauthentication, shouldFailReauthenticate: true
+        )
+        let cellViewModel = GoogleCalendarEventCellViewModel.dummy(isWritable: true, recurringEventId: nil)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .remove(scope: .all))
+        self.wait(for: [expect], timeout: self.timeout)
+
+        // then
+        XCTAssertNotNil(self.spyRouter.didShowError)
+        XCTAssertNil(self.spyGoogleUsecase.didRemoveEventWith)
+    }
+
+    func testViewModel_whenCancelReauthenticateConfirm_neitherReauthenticateNorRemove() {
+        // given
+        let notCalled = expectation(description: "재인증 확인 다이얼로그를 거절하면 재인증도 삭제도 시도 안 함")
+        notCalled.isInverted = true
+        self.spyGoogleUsecase.didRemoveEventWithCallback = { notCalled.fulfill() }
+        let viewModel = self.makeViewModel(googleWritePermission: .needReauthentication)
+        self.spyRouter.shouldConfirmNotCancel = false
+        let cellViewModel = GoogleCalendarEventCellViewModel.dummy(isWritable: true, recurringEventId: nil)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .remove(scope: .all))
+        self.wait(for: [notCalled], timeout: 0.3)
+
+        // then
+        XCTAssertNil(self.stubIntegrationUsecase.didReauthenticateWith)
+        XCTAssertNil(self.spyGoogleUsecase.didRemoveEventWith)
+    }
+
+    func testViewModel_whenRemoveGoogleEventFailed_showError() {
+        // given
+        let expect = expectation(description: "구글 삭제 자체가 실패하면 에러 노출")
+        self.spyRouter.didShowErrorCallback = { _ in expect.fulfill() }
+        let viewModel = self.makeViewModel(googleWritePermission: .writable, googleShouldFailWrite: true)
+        let cellViewModel = GoogleCalendarEventCellViewModel.dummy(isWritable: true, recurringEventId: nil)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .remove(scope: .all))
+        self.wait(for: [expect], timeout: self.timeout)
+
+        // then
+        XCTAssertNotNil(self.spyRouter.didShowError)
+    }
+
+    func testViewModel_whenRemoveGoogleEventOnReadOnlyCalendar_notRemove() {
+        // given
+        let notCalled = expectation(description: "읽기 전용 캘린더에서는 삭제도 확인 다이얼로그도 시도하지 않음")
+        notCalled.isInverted = true
+        self.spyGoogleUsecase.didRemoveEventWithCallback = { notCalled.fulfill() }
+        let viewModel = self.makeViewModel(googleWritePermission: .readOnlyCalendar)
+        let cellViewModel = GoogleCalendarEventCellViewModel.dummy(isWritable: true, recurringEventId: nil)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .remove(scope: .all))
+        self.wait(for: [notCalled], timeout: 0.3)
+
+        // then
+        XCTAssertNil(self.spyGoogleUsecase.didRemoveEventWith)
+        XCTAssertNil(self.spyRouter.didShowConfirmWith)
+    }
+
+    func testViewModel_whenRemoveAppleEventOnlyThisTime_removeWithThisEventOnlyScope() {
+        // given
+        let expect = expectation(description: "애플 이벤트 이번만 삭제")
+        self.spyAppleUsecase.didRemoveEventWithCallback = { expect.fulfill() }
+        let viewModel = self.makeViewModel()
+        let cellViewModel = AppleCalendarEventCellViewModel.dummy(isWritable: true, isRepeating: true)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .remove(scope: .onlyThisTime))
+        self.wait(for: [expect], timeout: self.timeout)
+
+        // then
+        XCTAssertEqual(self.spyAppleUsecase.didRemoveEventWith?.eventId, "apple-event")
+        XCTAssertEqual(self.spyAppleUsecase.didRemoveEventWith?.scope, .thisEventOnly)
+    }
+
+    func testViewModel_whenRemoveAppleEventThisAndFuture_removeWithThisAndFutureScope() {
+        // given
+        let expect = expectation(description: "애플 이벤트 이후 모든 이벤트 삭제")
+        self.spyAppleUsecase.didRemoveEventWithCallback = { expect.fulfill() }
+        let viewModel = self.makeViewModel()
+        let cellViewModel = AppleCalendarEventCellViewModel.dummy(isWritable: true, isRepeating: true)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .remove(scope: .thisAndFuture))
+        self.wait(for: [expect], timeout: self.timeout)
+
+        // then
+        XCTAssertEqual(self.spyAppleUsecase.didRemoveEventWith?.eventId, "apple-event")
+        XCTAssertEqual(self.spyAppleUsecase.didRemoveEventWith?.scope, .thisAndFuture)
+        XCTAssertEqual(
+            self.spyRouter.didShowConfirmWith?.message,
+            "calendar::event::more_action::remove_this_and_future:message".localized()
+        )
+    }
+
+    func testViewModel_whenRemoveNotRepeatingAppleEventWithAllScope_removeWithThisEventOnlyScope() {
+        // given
+        let expect = expectation(description: "애플 비반복 이벤트를 all scope로 삭제해도 thisEventOnly로 변환")
+        self.spyAppleUsecase.didRemoveEventWithCallback = { expect.fulfill() }
+        let viewModel = self.makeViewModel()
+        let cellViewModel = AppleCalendarEventCellViewModel.dummy(isWritable: true, isRepeating: false)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .remove(scope: .all))
+        self.wait(for: [expect], timeout: self.timeout)
+
+        // then
+        XCTAssertEqual(self.spyAppleUsecase.didRemoveEventWith?.eventId, "apple-event")
+        XCTAssertEqual(self.spyAppleUsecase.didRemoveEventWith?.scope, .thisEventOnly)
+    }
+
+    func testViewModel_whenRemoveExternalEventFailed_showError() {
+        // given
+        let expect = expectation(description: "삭제 실패시 에러 노출")
+        self.spyRouter.didShowErrorCallback = { _ in expect.fulfill() }
+        let viewModel = self.makeViewModel(appleShouldFailWrite: true)
+        let cellViewModel = AppleCalendarEventCellViewModel.dummy(isWritable: true, isRepeating: false)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .remove(scope: .all))
+        self.wait(for: [expect], timeout: self.timeout)
+
+        // then
+        XCTAssertNotNil(self.spyRouter.didShowError)
+    }
 }
 
 extension EventListCellEventHanleViewModelImpleTests {
-    
+
     func testViewModel_makeTodoWithParams() {
         // given
         let viewModel = self.makeViewModel()
@@ -552,6 +860,32 @@ private final class PrivateForemostEventUsecase: StubForemostEventUsecase {
     }
 }
 
+private final class PrivateGoogleCalendarUsecase: StubGoogleCalendarUsecase {
+
+    var didRemoveEventWithCallback: (() -> Void)?
+    override func removeEvent(
+        _ calendarId: String,
+        _ eventId: String,
+        accountId: String,
+        scope: GoogleCalendar.EventRemoveScope
+    ) async throws {
+        try await super.removeEvent(calendarId, eventId, accountId: accountId, scope: scope)
+        self.didRemoveEventWithCallback?()
+    }
+}
+
+private final class PrivateAppleCalendarUsecase: StubAppleCalendarUsecase {
+
+    var didRemoveEventWithCallback: (() -> Void)?
+    override func removeEvent(
+        _ eventId: String,
+        scope: AppleCalendar.EventEditScope
+    ) async throws {
+        try await super.removeEvent(eventId, scope: scope)
+        self.didRemoveEventWithCallback?()
+    }
+}
+
 private extension DoneTodoResult {
     
     var isSuccess: Bool {
@@ -567,14 +901,19 @@ private extension DoneTodoResult {
 
 extension GoogleCalendarEventCellViewModel {
 
-    static func dummy(_ link: String? = "link") -> GoogleCalendarEventCellViewModel {
+    static func dummy(
+        _ link: String? = "link",
+        isWritable: Bool = false,
+        recurringEventId: String? = nil
+    ) -> GoogleCalendarEventCellViewModel {
         let google = GoogleCalendar.Event(
             "google", "calendar", accountId: "stub@gmail.com",
             name: "name",
             colorId: "id", htmlLink: link,
             time: .at(1)
         )
-        let googleEvent = GoogleCalendarEvent(google, in: TimeZone.current)
+        |> \.recurringEventId .~ recurringEventId
+        let googleEvent = GoogleCalendarEvent(google, in: TimeZone.current, isWritable: isWritable)
         return GoogleCalendarEventCellViewModel(
             googleEvent, in: 0..<10, TimeZone.current, true
         )!
@@ -583,7 +922,10 @@ extension GoogleCalendarEventCellViewModel {
 
 extension AppleCalendarEventCellViewModel {
 
-    static func dummy() -> AppleCalendarEventCellViewModel {
+    static func dummy(
+        isWritable: Bool = false,
+        isRepeating: Bool = false
+    ) -> AppleCalendarEventCellViewModel {
         let appleEvent = AppleCalendar.Event(
             eventId: "apple-event",
             originalEventId: "apple-event",
@@ -591,7 +933,8 @@ extension AppleCalendarEventCellViewModel {
             name: "Apple Event",
             eventTime: .at(1)
         )
-        let calendarEvent = AppleCalendarEvent(appleEvent, in: TimeZone.current)
+        |> \.isRepeating .~ isRepeating
+        let calendarEvent = AppleCalendarEvent(appleEvent, in: TimeZone.current, isWritable: isWritable)
         return AppleCalendarEventCellViewModel(
             calendarEvent, in: 0..<10, TimeZone.current, true
         )!

--- a/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
@@ -535,25 +535,25 @@ extension DayEventListViewModelImpleTests {
             todoNotRepeating.moreActions,
             .init(
                 basicActions: [.toggleTo(isForemost: false), .edit, .copy],
-                removeActions: [.remove(onlyThisTime: false)]
+                removeActions: [.remove(scope: .all)]
             )
         )
         XCTAssertEqual(
             todoWithRepeating.moreActions,
             .init(
                 basicActions: [.toggleTo(isForemost: false), .skipTodo, .edit, .copy],
-                removeActions: [.remove(onlyThisTime: true), .remove(onlyThisTime: false)]
+                removeActions: [.remove(scope: .onlyThisTime), .remove(scope: .all)]
             )
         )
         XCTAssertEqual(
             todoAsForemost.moreActions,
             .init(
                 basicActions: [.toggleTo(isForemost: true), .edit, .copy],
-                removeActions: [.remove(onlyThisTime: false)]
+                removeActions: [.remove(scope: .all)]
             )
         )
     }
-    
+
     func testScheduleEventCellViewModel_provideMoreAction() {
         // given
         let kst = TimeZone(abbreviation: "KST")!
@@ -570,15 +570,15 @@ extension DayEventListViewModelImpleTests {
         // then
         XCTAssertEqual(repeating?.moreActions, .init(
             basicActions: [.toggleTo(isForemost: false), .edit, .copy],
-            removeActions: [.remove(onlyThisTime: true), .remove(onlyThisTime: false)]
+            removeActions: [.remove(scope: .onlyThisTime), .remove(scope: .all)]
         ))
         XCTAssertEqual(notRepeating?.moreActions, .init(
             basicActions: [.toggleTo(isForemost: false), .edit, .copy],
-            removeActions: [.remove(onlyThisTime: false)]
+            removeActions: [.remove(scope: .all)]
         ))
         XCTAssertEqual(foremostEvent?.moreActions, .init(
             basicActions: [.toggleTo(isForemost: true), .edit, .copy],
-            removeActions: [.remove(onlyThisTime: false)]
+            removeActions: [.remove(scope: .all)]
         ))
     }
     
@@ -810,10 +810,10 @@ extension DayEventListViewModelImpleTests {
         let removeActionsPerEmit = cvmLists.map { cvms in
             cvms.first(where: { $0.eventIdentifier == "not-repeating-schedule" })?.moreActions?.removeActions
         }
-        XCTAssertEqual(removeActionsPerEmit.first, [.remove(onlyThisTime: false)])
+        XCTAssertEqual(removeActionsPerEmit.first, [.remove(scope: .all)])
         XCTAssertEqual(
             removeActionsPerEmit.last,
-            [.remove(onlyThisTime: true), .remove(onlyThisTime: false)]
+            [.remove(scope: .onlyThisTime), .remove(scope: .all)]
         )
     }
 }

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -125,11 +125,13 @@
 "calendar::event::more_action::foremost_event:title" = "Foremost event";
 "calendar::event::more_action::remove_only_thistime:message" = "Do you want to delete only this event from all repeating events?";
 "calendar::event::more_action::remove:message" = "Do you want to remove this event?";
+"calendar::event::more_action::remove_this_and_future:message" = "Do you want to delete this and all future events in the repeating series?";
 "calendar::event::more_action::mark_as_foremost" = "Do you want to mark this event as your most important event?";
 "calendar::event::more_action::unmark_as_foremost" = "Do you want to unmark this event as your most important event?";
 "calendar::event::more_action::mark_as_foremost::unavail" = "A repeating schedule event cannot be marked as the most important event.";
 "calendar::event::more_action:remove_only_thistime:item_name" = "Remove only this event";
 "calendar::event::more_action:remove:item_name" = "Remove event";
+"calendar::event::more_action:remove_this_and_future:item_name" = "Remove this and all future events";
 "calendar::event::more_action:foremost:mark:item_name" = "Mark as foremost";
 "calendar::event::more_action:foremost:unmark:item_name" = "Unmark as foremost";
 "calendar::event::more_action:dday_candidate:register:item_name" = "Add to D-day widget";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -125,11 +125,13 @@
 "calendar::event::more_action::foremost_event:title" = "제일 중요한 이벤트";
 "calendar::event::more_action::remove_only_thistime:message" = "전체 반복 이벤트 중 이번 이벤트만을 삭제하기 원합니까?";
 "calendar::event::more_action::remove:message" = "이벤트를 삭제하시겠습니까?";
+"calendar::event::more_action::remove_this_and_future:message" = "이번 및 향후 반복 이벤트를 모두 삭제하시겠습니까?";
 "calendar::event::more_action::mark_as_foremost" = "제일 중요한 이벤트로 등록할까요?";
 "calendar::event::more_action::unmark_as_foremost" = "제일 중요한 이벤트를 해제할까요?";
 "calendar::event::more_action::mark_as_foremost::unavail" = "반복되는 일정 이벤트는 가장 중요한 이벤트로 등록할 수 없습니다.";
 "calendar::event::more_action:remove_only_thistime:item_name" = "이번만 삭제";
 "calendar::event::more_action:remove:item_name" = "이벤트 삭제";
+"calendar::event::more_action:remove_this_and_future:item_name" = "이번 및 향후 이벤트 삭제";
 "calendar::event::more_action:foremost:mark:item_name" = "제일 중요 이벤트 등록";
 "calendar::event::more_action:foremost:unmark:item_name" = "제일 중요 이벤트 해제";
 "calendar::event::more_action:dday_candidate:register:item_name" = "D-day 위젯 후보로 추가";

--- a/Supports/TestDoubles/Sources/Usecases/StubGoogleCalendarUsecase.swift
+++ b/Supports/TestDoubles/Sources/Usecases/StubGoogleCalendarUsecase.swift
@@ -89,6 +89,8 @@ open class StubGoogleCalendarUsecase: GoogleCalendarUsecase, @unchecked Sendable
         return Just(self.stubWritePermission).eraseToAnyPublisher()
     }
 
+    public var shouldFailWrite: Bool = false
+
     public var didUpdateEventWith: (calendarId: String, eventId: String, accountId: String, params: GoogleCalendar.EventEditParams)?
     public var stubUpdatedEventOrigin: GoogleCalendar.EventOrigin?
     open func updateEvent(
@@ -99,6 +101,9 @@ open class StubGoogleCalendarUsecase: GoogleCalendarUsecase, @unchecked Sendable
         params: GoogleCalendar.EventEditParams
     ) async throws -> GoogleCalendar.EventOrigin {
         self.didUpdateEventWith = (calendarId, eventId, accountId, params)
+        if shouldFailWrite {
+            throw RuntimeError("failed to update google calendar event")
+        }
         guard let origin = self.stubUpdatedEventOrigin
         else {
             throw RuntimeError("stubUpdatedEventOrigin not set")
@@ -114,5 +119,8 @@ open class StubGoogleCalendarUsecase: GoogleCalendarUsecase, @unchecked Sendable
         scope: GoogleCalendar.EventRemoveScope
     ) async throws {
         self.didRemoveEventWith = (calendarId, eventId, accountId, scope)
+        if shouldFailWrite {
+            throw RuntimeError("failed to remove google calendar event")
+        }
     }
 }


### PR DESCRIPTION
캘린더 화면 이벤트 목록에서 쓰기 가능한 구글·애플 캘린더 이벤트를 롱탭하면 삭제 메뉴가 뜨고, 반복 이벤트는 삭제 범위를 골라 지울 수 있다.

closes #938 · 상위 #853 (꼭지 7)

## 문제

삭제 실행 경로(`GoogleCalendarUsecase.removeEvent`·`AppleCalendarUsecase.removeEvent`)는 이미 있었지만 목록 셀에서 부를 방법이 없었다. 걸림돌이 둘이었다.

- **셀이 판단할 재료가 없다.** 삭제 노출 판정은 캘린더 단위 쓰기 권한인데, `moreActions` 가 동기 계산 프로퍼티라 usecase 를 부를 수 없다. 구글 이벤트는 `isRepeating` 이 `false` 로 하드코딩돼 있어 반복 여부도 몰랐고, 반복 시리즈를 지울 때 필요한 마스터 id 도 화면까지 안 올라왔다.
- **삭제 액션이 두 갈래뿐이다.** `EventListMoreAction.remove(onlyThisTime: Bool)` 로는 애플의 `이후 모두`(EventKit `futureEvents`)를 표현할 수 없다.

## 접근

재료를 아래에서 실어 올리고, 액션 표현을 넓힌 뒤, 핸들러에 외부 캘린더 분기를 더했다.

- **재료** — `GoogleCalendar.Event` 가 origin 에서 `recurringEventId` 를 싣고, 그 유무가 곧 반복 여부가 된다(목록을 `singleEvents=true` 로 조회해 캐시 이벤트는 항상 펼쳐진 인스턴스다). 쓰기 가능 여부는 구글·애플 usecase 를 이미 들고 있는 `CalendarEventListhUsecaseImple` 이 캘린더 태그와 조인해 채운다. 태그 스트림을 이벤트 스트림에 직접 물리면 태그가 늦게 오는 동안 목록 전체가 멈추므로, 빈 집합으로 시드한 `CurrentValueSubject` 를 거친다 — 태그 미로드 시 fail-closed 이면서 목록은 계속 흐른다.
- **표현** — `remove` 페이로드를 `EventListRemoveScope { onlyThisTime, thisAndFuture, all }` 로 넓혔다. 앱 Todo·Schedule 의 노출·동작은 그대로다.
- **실행** — 구글은 `.all` + 반복일 때만 시리즈 마스터 id 로 `.allEvents` 를 부른다. 셀 id 는 펼쳐진 인스턴스 id(`{마스터}_{시각}`) 라 그걸로는 시리즈가 안 지워진다. 애플은 두 scope 모두 occurrence id 를 그대로 넘기고 usecase 가 회차를 판별한다.

## 노출 규칙

| 셀 | 쓰기 불가 | 비반복 | 반복 |
|---|---|---|---|
| 구글 | 메뉴 없음 | `이벤트 삭제` | `이번만 삭제` / `이벤트 삭제`(시리즈 전체) |
| 애플 | 메뉴 없음 | `이벤트 삭제` | `이번만 삭제` / `이번 및 향후 이벤트 삭제` |

애플은 EventKit 이 `thisEvent`/`futureEvents` 만 지원해 '전체 삭제'가 존재하지 않는다. 목록 셀엔 삭제만 노출한다 — 편집·복사·최상위 지정은 상세 화면 소관이다. 위젯 셀에는 여전히 메뉴가 없다(`isWritable` 기본값 `false` 로 흡수).

구글 계정이 `needReauthentication` 이어도 메뉴는 뜬다. 삭제를 누르면 상세 화면과 같은 순서로 재인증 확인 → 재인증 → 삭제 확인으로 이어간다. `readOnlyCalendar` 면 아무것도 하지 않는다.

## 리뷰에서 잡힌 것

쓰기 가능 판정에 **계정 축이 빠져 있었다.** `GoogleCalendarUsecase.calendarTags` 가 `[accountId: [Tag]]` 를 flatten 해 계정 정보를 잃는 반면, 삭제 직전 게이트인 `eventWritePermission` 은 계정별로 판정한다. 같은 공유 캘린더를 계정 A=writer · B=reader 로 구독하면 B 이벤트에도 메뉴가 떠서 눌러도 무음으로 아무 일이 안 일어나는 fail-open 이었다. 쓰기 가능 집합을 계정별 dict 로 바꾸고 회귀 테스트를 붙였다.

## 남은 과제

신규 문구 2키는 en·ko 만 채웠다(#810 대기 목록 등재 완료). 전 언어 번역 전엔 `R.String` 접근자가 생성되지 않아 리터럴 `.localized()` 를 쓰고 있고, #810 처리 시점에 접근자로 교체한다.
