### PR TITLE
[#912] 라이브액티비티 액션 인텐트 — 종료·Todo 완료

### DIFF
--- a/Presentations/Scenes/Sources/LiveActivityToggleViewModel.swift
+++ b/Presentations/Scenes/Sources/LiveActivityToggleViewModel.swift
@@ -53,6 +53,9 @@ public final class LiveActivityToggleViewModelImple: LiveActivityToggleViewModel
 
             do {
                 try await self.eventLiveActivityUsecase.startActivity(target)
+                self.router?.showToast(
+                    "calendar::event::more_action:live_activity:register:success".localized()
+                )
             } catch {
                 self.router?.showLiveActivityUnavailable(error)
             }

--- a/Presentations/Scenes/Tests/LiveActivityToggleViewModelImpleTests.swift
+++ b/Presentations/Scenes/Tests/LiveActivityToggleViewModelImpleTests.swift
@@ -1,0 +1,76 @@
+//
+//  LiveActivityToggleViewModelImpleTests.swift
+//  ScenesTests
+//
+//  Created by sudo.park on 8/19/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Domain
+import Extensions
+import TestDoubles
+
+@testable import Scenes
+
+
+struct LiveActivityToggleViewModelImpleTests {
+
+    private let spyRouter = BaseSpyRouter()
+    private let stubUsecase = StubEventLiveActivityUsecase()
+
+    private func makeViewModel() -> LiveActivityToggleViewModelImple {
+        let viewModel = LiveActivityToggleViewModelImple(
+            eventLiveActivityUsecase: self.stubUsecase
+        )
+        viewModel.router = self.spyRouter
+        return viewModel
+    }
+
+    @Test func viewModel_whenRegisterSucceed_showToastToCheckLockScreen() async throws {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        viewModel.startOrStopLiveActivity(.todo(id: "todo-1"), isCurrentlyRegistered: false)
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        #expect(self.stubUsecase.didStartTarget == .todo(id: "todo-1"))
+        #expect(
+            self.spyRouter.didShowToastWithMessage
+                == "calendar::event::more_action:live_activity:register:success".localized()
+        )
+    }
+
+    @Test func viewModel_whenRegisterFail_notShowToastAndGuideUnavailable() async throws {
+        // given
+        self.stubUsecase.stubStartError = EventLiveActivityStartFailReason.alreadyPassed
+        let viewModel = self.makeViewModel()
+
+        // when
+        viewModel.startOrStopLiveActivity(.todo(id: "todo-1"), isCurrentlyRegistered: false)
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        #expect(self.spyRouter.didShowToastWithMessage == nil)
+        #expect(
+            self.spyRouter.didShowConfirmWith?.message
+                == "calendar::event::more_action:live_activity:unavail::already_passed".localized()
+        )
+    }
+
+    @Test func viewModel_whenUnregister_notShowToast() async throws {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        viewModel.startOrStopLiveActivity(.todo(id: "todo-1"), isCurrentlyRegistered: true)
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        #expect(self.stubUsecase.didStopActivity == true)
+        #expect(self.spyRouter.didShowToastWithMessage == nil)
+    }
+}

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -145,6 +145,7 @@
 "calendar::event::more_action:live_activity:register:confirm" = "Do you want to show this event on the Lock Screen?";
 "calendar::event::more_action:live_activity:unregister:confirm" = "Do you want to remove this event from the Lock Screen?";
 "calendar::event::more_action:live_activity:replace:confirm" = "Another event is showing on the Lock Screen. Replace it with this one?";
+"calendar::event::more_action:live_activity:register:success" = "Now showing on the Lock Screen. Lock your device to see it.";
 "calendar::event::more_action:copy:item_name" = "Copy event";
 "calendar::event::more_action:share:item_name" = "Share";
 "event_detail::share::field::time" = "Time";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -145,6 +145,7 @@
 "calendar::event::more_action:live_activity:register:confirm" = "이 이벤트를 잠금화면에 표시할까요?";
 "calendar::event::more_action:live_activity:unregister:confirm" = "이 이벤트를 잠금화면에서 제거할까요?";
 "calendar::event::more_action:live_activity:replace:confirm" = "다른 이벤트가 잠금화면에 표시 중이에요. 이 이벤트로 바꿀까요?";
+"calendar::event::more_action:live_activity:register:success" = "잠금화면에 표시했어요. 기기를 잠그고 확인해보세요.";
 "calendar::event::more_action:copy:item_name" = "이벤트 복사";
 "calendar::event::more_action:share:item_name" = "공유";
 "event_detail::share::field::time" = "시간";

--- a/TodoCalendarApp/AppExtensions/Base/AppExtensionBase.swift
+++ b/TodoCalendarApp/AppExtensions/Base/AppExtensionBase.swift
@@ -68,7 +68,10 @@ final class AppExtensionBase {
         if AppEnvironment.isTestBuild {
             return DummyFirebaseAuthService()
         } else {
-            FirebaseApp.configure()
+            // 앱 프로세스에서는 AppDelegate가 먼저 configure 한다 — 두 번 부르면 예외가 난다.
+            if FirebaseApp.app() == nil {
+                FirebaseApp.configure()
+            }
             let service = FirebaseAuthServiceImple(
                 appGroupId: AppEnvironment.groupID,
                 useEmulator: AppEnvironment.useEmulator
@@ -129,7 +132,7 @@ final class AppExtensionBase {
 
 // MARK: - dummy
 
-class DummyFirebaseAuthService: FirebaseAuthService {
+private class DummyFirebaseAuthService: FirebaseAuthService {
     
     func setup() throws {
         

--- a/TodoCalendarApp/AppExtensions/Base/TodoEventRepositoryFactory.swift
+++ b/TodoCalendarApp/AppExtensions/Base/TodoEventRepositoryFactory.swift
@@ -1,0 +1,49 @@
+//
+//  TodoEventRepositoryFactory.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 8/19/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Domain
+import Repository
+
+
+// MARK: - TodoEventRepositoryFactory
+
+struct TodoEventRepositoryFactory {
+
+    private let base: AppExtensionBase
+    init(base: AppExtensionBase) {
+        self.base = base
+    }
+
+    func makeRepository() -> any TodoEventRepository {
+        let auth = self.base.authStore.loadCurrentAuth()
+
+        if let auth {
+            let localStorage = TodoLocalStorageImple(
+                sqliteService: base.writableSqliteService
+            )
+
+            let remote = base.remoteAPI
+            let credential = APICredential(auth: auth)
+            remote.setup(credential: credential)
+            return TodoRemoteRepositoryImple(
+                remote: TodoRemoteImple(remote: base.remoteAPI),
+                cacheStorage: localStorage
+            )
+        } else {
+            let localStorage = TodoLocalStorageImple(
+                sqliteService: base.commonSqliteService
+            )
+
+            return TodoLocalRepositoryImple(
+                localStorage: localStorage,
+                environmentStorage: base.userDefaultEnvironmentStorage
+            )
+        }
+    }
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Base+Factory/WidgetUsecaseFactory.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Base+Factory/WidgetUsecaseFactory.swift
@@ -57,7 +57,7 @@ extension WidgetUsecaseFactory {
     }
     
     func makeTodoToggleRepository() -> any TodoEventRepository {
-        return self.makeTodoRepositoryByUser()
+        return TodoEventRepositoryFactory(base: self.base).makeRepository()
     }
     
     func makeHolidaysFetchUsecase(
@@ -142,32 +142,5 @@ extension WidgetUsecaseFactory {
             eventDetailRepository: eventDetailRepository,
             cached: FetchCacheStores.shared.events
         )
-    }
-    
-    private func makeTodoRepositoryByUser() -> any TodoEventRepository {
-        let auth = self.base.authStore.loadCurrentAuth()
-        
-        if let auth {
-            let localStorage = TodoLocalStorageImple(
-                sqliteService: base.writableSqliteService
-            )
-            
-            let remote = base.remoteAPI
-            let credential = APICredential(auth: auth)
-            remote.setup(credential: credential)
-            return TodoRemoteRepositoryImple(
-                remote: TodoRemoteImple(remote: base.remoteAPI),
-                cacheStorage: localStorage
-            )
-        } else {
-            let localStorage = TodoLocalStorageImple(
-                sqliteService: base.commonSqliteService
-            )
-            
-            return TodoLocalRepositoryImple(
-                localStorage: localStorage,
-                environmentStorage: base.userDefaultEnvironmentStorage
-            )
-        }
     }
 }

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownActivityViewModel.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownActivityViewModel.swift
@@ -20,7 +20,7 @@ struct EventCountdownActivityViewModel {
     let subtitle: String?
     let tagColor: Color
     let usesDarkGlyph: Bool
-    let showsCompleteButton: Bool
+    let todoId: String?
 
     init(_ attributes: EventCountdownActivityAttributes, _ state: EventCountdownActivityAttributes.State) {
         self.eventName = state.eventName
@@ -28,7 +28,13 @@ struct EventCountdownActivityViewModel {
         self.eventDate = state.eventDate
         self.startDate = state.startDate
         self.subtitle = state.placeName?.nonEmptyTrimmed ?? state.memo?.nonEmptyTrimmed
-        self.showsCompleteButton = attributes.target.isTodo
+
+        switch attributes.target {
+        case .todo(let id):
+            self.todoId = id
+        case .schedule, .holiday, .googleCalendar, .appleCalendar:
+            self.todoId = nil
+        }
 
         let uiColor = UIColor.from(hex: state.tagColorHex) ?? .gray
         self.tagColor = uiColor.asColor

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLockScreenView.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLockScreenView.swift
@@ -100,10 +100,14 @@ struct EventCountdownActionButtonRow: View {
     var body: some View {
         HStack(spacing: 8) {
             if let todoId = model.todoId {
-                Button(intent: CompleteTodoAndEndLiveActivityIntent(todoId: todoId)) {
+                Toggle(
+                    isOn: false,
+                    intent: CompleteTodoAndEndLiveActivityIntent(todoId: todoId)
+                ) {
                     Text("common.done".localized())
                         .frame(maxWidth: .infinity)
                 }
+                .toggleStyle(.button)
             }
 
             Button(intent: EndLiveActivityIntent()) {

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLockScreenView.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLockScreenView.swift
@@ -99,19 +99,17 @@ struct EventCountdownActionButtonRow: View {
 
     var body: some View {
         HStack(spacing: 8) {
-            if model.showsCompleteButton {
-                Button(action: { }) {
+            if let todoId = model.todoId {
+                Button(intent: CompleteTodoAndEndLiveActivityIntent(todoId: todoId)) {
                     Text("common.done".localized())
                         .frame(maxWidth: .infinity)
                 }
-                .disabled(true)
             }
 
-            Button(action: { }) {
+            Button(intent: EndLiveActivityIntent()) {
                 Text("liveActivity::action::end".localized())
                     .frame(maxWidth: .infinity)
             }
-            .disabled(true)
         }
         .buttonStyle(.bordered)
     }

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/LiveActivities/EventCountdownActivityViewModelTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/LiveActivities/EventCountdownActivityViewModelTests.swift
@@ -62,24 +62,30 @@ struct EventCountdownActivityViewModelTests {
         #expect(viewModel.usesDarkGlyph == false)
     }
 
+    @Test("todoId when todo target", arguments: ["t1", "t123"])
+    func viewModel_whenTodoTarget_exposesTodoId(_ todoId: String) {
+        // given
+        let viewModel = makeViewModel(target: .todo(id: todoId), colorHex: "#EEEEEE")
+
+        // when + then
+        #expect(viewModel.todoId == todoId)
+    }
+
     @Test(
-        "complete button",
+        "todoId when non-todo target",
         arguments: [
-            (LiveActivityEventTarget.todo(id: "t1"), true),
-            (LiveActivityEventTarget.schedule(id: "s1", turnKey: "1755400800..<1755404400"), false),
-            (LiveActivityEventTarget.holiday(uuid: "h1", dateString: "2026-08-17"), false),
-            (LiveActivityEventTarget.googleCalendar(accountId: "a1", calendarId: "c1", eventId: "e1"), false),
-            (LiveActivityEventTarget.appleCalendar(calendarId: "c1", eventId: "e1"), false)
+            LiveActivityEventTarget.schedule(id: "s1", turnKey: "1755400800..<1755404400"),
+            LiveActivityEventTarget.holiday(uuid: "h1", dateString: "2026-08-17"),
+            LiveActivityEventTarget.googleCalendar(accountId: "a1", calendarId: "c1", eventId: "e1"),
+            LiveActivityEventTarget.appleCalendar(calendarId: "c1", eventId: "e1")
         ]
     )
-    func viewModel_showsCompleteButton_onlyForTodoTarget(
-        _ target: LiveActivityEventTarget, _ expected: Bool
-    ) {
+    func viewModel_whenNotTodoTarget_hasNoTodoId(_ target: LiveActivityEventTarget) {
         // given
         let viewModel = makeViewModel(target: target, colorHex: "#EEEEEE")
 
         // when + then
-        #expect(viewModel.showsCompleteButton == expected)
+        #expect(viewModel.todoId == nil)
     }
 
     @Test

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/LiveActivities/EventCountdownTodoCompletionTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/LiveActivities/EventCountdownTodoCompletionTests.swift
@@ -1,0 +1,92 @@
+//
+//  EventCountdownTodoCompletionTests.swift
+//  TodoCalendarAppWidgetTests
+//
+//  Created by sudo.park on 8/19/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Domain
+import TestDoubles
+
+@testable import TodoCalendarAppWidget
+
+
+struct EventCountdownTodoCompletionTests {
+
+    private func makeCompletion(
+        repository: SpyTodoEventRepository, activityEnding: SpyEventCountdownActivityEnding
+    ) -> EventCountdownTodoCompletion {
+        return EventCountdownTodoCompletion(
+            todoRepository: repository, activityEnding: activityEnding
+        )
+    }
+
+    @Test func completeTodo_whenSucceed_completesWithGivenIdAndEndsActivity() async {
+        // given
+        let repository = SpyTodoEventRepository()
+        let activityEnding = SpyEventCountdownActivityEnding()
+        let completion = self.makeCompletion(repository: repository, activityEnding: activityEnding)
+
+        // when
+        let didComplete = await completion.completeTodoAndEndActivity("todo-1")
+
+        // then
+        #expect(didComplete == true)
+        #expect(repository.didCompleteTodoId == "todo-1")
+        #expect(activityEnding.didEndCallCount == 1)
+    }
+
+    @Test func completeTodo_whenFail_doesNotEndActivity() async {
+        // given
+        let repository = SpyTodoEventRepository()
+        repository.shouldFailComplete = true
+        let activityEnding = SpyEventCountdownActivityEnding()
+        let completion = self.makeCompletion(repository: repository, activityEnding: activityEnding)
+
+        // when
+        let didComplete = await completion.completeTodoAndEndActivity("todo-1")
+
+        // then
+        #expect(didComplete == false)
+        #expect(activityEnding.didEndCallCount == 0)
+    }
+
+    @Test func completeTodo_whenFail_stillRequestsCompletion() async {
+        // given
+        let repository = SpyTodoEventRepository()
+        repository.shouldFailComplete = true
+        let activityEnding = SpyEventCountdownActivityEnding()
+        let completion = self.makeCompletion(repository: repository, activityEnding: activityEnding)
+
+        // when
+        _ = await completion.completeTodoAndEndActivity("todo-1")
+
+        // then
+        #expect(repository.didCompleteTodoId == "todo-1")
+    }
+}
+
+
+// MARK: - doubles
+
+final class SpyEventCountdownActivityEnding: EventCountdownActivityEnding, @unchecked Sendable {
+
+    private(set) var didEndCallCount: Int = 0
+
+    func endActivities() async {
+        self.didEndCallCount += 1
+    }
+}
+
+final class SpyTodoEventRepository: StubTodoEventRepository, @unchecked Sendable {
+
+    private(set) var didCompleteTodoId: String?
+
+    override func completeTodo(_ eventId: String) async throws -> CompleteTodoResult {
+        self.didCompleteTodoId = eventId
+        return try await super.completeTodo(eventId)
+    }
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/LiveActivities/LiveActivityEventTargetTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/LiveActivities/LiveActivityEventTargetTests.swift
@@ -36,22 +36,4 @@ struct LiveActivityEventTargetTests {
         // then
         #expect(restored == target)
     }
-
-    @Test(
-        "isTodo",
-        arguments: [
-            (LiveActivityEventTarget.todo(id: "t1"), true),
-            (LiveActivityEventTarget.schedule(id: "s1", turnKey: "1755400800..<1755404400"), false),
-            (LiveActivityEventTarget.holiday(uuid: "h1", dateString: "2026-08-17"), false),
-            (LiveActivityEventTarget.googleCalendar(accountId: "a1", calendarId: "c1", eventId: "e1"), false),
-            (LiveActivityEventTarget.appleCalendar(calendarId: "c1", eventId: "e1"), false)
-        ]
-    )
-    func target_isTodo_onlyForTodoCase(_ target: LiveActivityEventTarget, _ expected: Bool) {
-        // given + when
-        let isTodo = target.isTodo
-
-        // then
-        #expect(isTodo == expected)
-    }
 }

--- a/TodoCalendarApp/Sources/Factories/ApplicationBase.swift
+++ b/TodoCalendarApp/Sources/Factories/ApplicationBase.swift
@@ -273,7 +273,7 @@ struct DeviceInfoFetchServiceImple: DeviceInfoFetchService {
 
 // MARK: - dummy
 
-class DummyFirebaseAuthService: FirebaseAuthService {
+private class DummyFirebaseAuthService: FirebaseAuthService {
     
     func setup() throws { }
     

--- a/TodoCalendarApp/Sources/LiveActivity/EventCountdownActivityActions.swift
+++ b/TodoCalendarApp/Sources/LiveActivity/EventCountdownActivityActions.swift
@@ -1,0 +1,52 @@
+//
+//  EventCountdownActivityActions.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 8/19/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import ActivityKit
+import Domain
+
+
+protocol EventCountdownActivityEnding: Sendable {
+    func endActivities() async
+}
+
+struct EventCountdownActivityEndingImple: EventCountdownActivityEnding {
+
+    init() { }
+
+    /// 이미 끝난 액티비티에 `end`를 다시 부르는 건 no-op이라 `activityState` 필터를 두지 않는다
+    func endActivities() async {
+        for activity in Activity<EventCountdownActivityAttributes>.activities {
+            await activity.end(nil, dismissalPolicy: .immediate)
+        }
+    }
+}
+
+struct EventCountdownTodoCompletion: Sendable {
+
+    private let todoRepository: any TodoEventRepository
+    private let activityEnding: any EventCountdownActivityEnding
+
+    init(
+        todoRepository: any TodoEventRepository,
+        activityEnding: any EventCountdownActivityEnding
+    ) {
+        self.todoRepository = todoRepository
+        self.activityEnding = activityEnding
+    }
+
+    func completeTodoAndEndActivity(_ todoId: String) async -> Bool {
+        do {
+            _ = try await self.todoRepository.completeTodo(todoId)
+        } catch {
+            return false
+        }
+        await self.activityEnding.endActivities()
+        return true
+    }
+}

--- a/TodoCalendarApp/Sources/LiveActivity/EventCountdownLiveActivityIntents.swift
+++ b/TodoCalendarApp/Sources/LiveActivity/EventCountdownLiveActivityIntents.swift
@@ -1,0 +1,55 @@
+//
+//  EventCountdownLiveActivityIntents.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 8/19/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import WidgetKit
+import AppIntents
+import Domain
+import Repository
+
+
+struct EndLiveActivityIntent: LiveActivityIntent {
+
+    static let title: LocalizedStringResource = "Live activity dismissal"
+
+    init() { }
+
+    func perform() async throws -> some IntentResult {
+        await EventCountdownActivityEndingImple().endActivities()
+        return .result()
+    }
+}
+
+
+struct CompleteTodoAndEndLiveActivityIntent: LiveActivityIntent {
+
+    static let title: LocalizedStringResource = "To-do completion and live activity dismissal"
+
+    @Parameter(title: "to-do id")
+    var todoId: String
+
+    init() { }
+
+    init(todoId: String) {
+        self.todoId = todoId
+    }
+
+    func perform() async throws -> some IntentResult {
+        let base = AppExtensionBase()
+        let repository = TodoEventRepositoryFactory(base: base).makeRepository()
+        let completion = EventCountdownTodoCompletion(
+            todoRepository: repository, activityEnding: EventCountdownActivityEndingImple()
+        )
+        let didComplete = await completion.completeTodoAndEndActivity(self.todoId)
+        guard didComplete else { return .result() }
+
+        base.userDefaultEnvironmentStorage.update(EnvironmentKeys.needCheckResetWidgetCache.rawValue, true)
+        WidgetCenter.shared.reloadAllTimelines()
+        return .result()
+    }
+}

--- a/TodoCalendarApp/Sources/LiveActivity/LiveActivityEventTarget.swift
+++ b/TodoCalendarApp/Sources/LiveActivity/LiveActivityEventTarget.swift
@@ -17,9 +17,4 @@ enum LiveActivityEventTarget: Codable, Hashable, Sendable {
     case holiday(uuid: String, dateString: String)
     case googleCalendar(accountId: String, calendarId: String, eventId: String)
     case appleCalendar(calendarId: String, eventId: String)
-
-    var isTodo: Bool {
-        if case .todo = self { return true }
-        return false
-    }
 }

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -277,6 +277,7 @@ extension Project {
             ]),
             sources: [
                 "Sources/**",
+                "AppExtensions/Base/**",
                 .glob("Intents/TodoCalendarWidgetIntents.intentdefinition", codeGen: .public)
             ],
             resources: ["Resources/**"],


### PR DESCRIPTION
잠금화면·다이나믹아일랜드 액티비티의 "완료"·"종료" 버튼은 자리만 잡혀 있고 `.disabled(true)`로 죽어 있었다. 이 PR이 둘을 실제로 동작하게 한다 — 앱이 완전히 종료된 상태에서 눌러도.

## 문제

액티비티 종료·갱신은 **앱 프로세스에서만** 가능한데 버튼은 위젯 확장의 SwiftUI 코드에 있다. 그래서 인텐트를 `LiveActivityIntent`로 만들어 실행 위치를 앱 프로세스로 보장했다.

그런데 잠금화면 탭으로 콜드 런치된 앱 프로세스엔 UIScene이 없다 — `SceneDelegate.scene(willConnectTo:)`가 안 돌아 `usecaseFactory`가 nil이고 SQLite DB도 안 열려 있다. 앱의 살아있는 usecase에 위임하는 설계가 성립하지 않는다는 뜻이다. 그래서 위젯 `TodoToggleIntent`와 같은 사상으로 인텐트가 `perform()` 안에서 자체 부트스트랩(`AppExtensionBase`)으로 repository를 조립한다.

## 접근

**액션을 인텐트 밖의 주입 가능한 타입으로 뺀다.** 인텐트는 시스템이 인스턴스화해 의존을 넣을 자리가 없으니, 판단이 있는 로직만 따로 세워 TC 대상으로 만들었다.

- `EventCountdownActivityEndingImple.endActivities` — 살아있는 액티비티를 전부 즉시 종료. repository도 DB도 필요 없어 종료 경로엔 부트스트랩을 아예 만들지 않는다
- `EventCountdownTodoCompletion.completeTodoAndEndActivity` — 완료가 **성공했을 때만** 액티비티를 종료하고 성공 여부를 반환. 완료 안 됐는데 리마인더가 사라지면 유저가 완료된 줄 안다
- `CompleteTodoAndEndLiveActivityIntent.perform` — 완료 성공일 때만 위젯 캐시 리셋 플래그·전체 리로드로 이어간다

**부트스트랩을 앱 타겟과 공유한다.** 인텐트가 앱 프로세스에서 자체 조립을 하려면 위젯 확장의 `AppExtensions/Base/**`가 앱 타겟에도 컴파일돼야 한다. 그대로 넣으면 두 가지가 깨진다 —

- `DummyFirebaseAuthService`가 `ApplicationBase`의 동명 타입과 같은 모듈에서 재선언 충돌 → 둘 다 파일 안에서만 쓰이므로 `private`으로 격리
- `AppExtensionBase.firebaseAuthService`가 `FirebaseApp.configure()`를 무조건 불러 앱 프로세스에서 이중 초기화 → `FirebaseApp.app() == nil` 가드

**Todo repository 조립을 한곳으로 모은다.** `WidgetUsecaseFactory`에만 있던 조립을 `TodoEventRepositoryFactory`로 옮기고 위젯 팩토리가 위임한다. 인텐트가 세 번째 복사본을 만들지 않도록.

**버튼 노출 조건과 버튼이 넘길 값을 한 곳에서 낸다.** 뷰모델이 `showsCompleteButton: Bool` 대신 `todoId: String?`을 노출해 "버튼은 보이는데 넘길 id가 없다"가 구조적으로 불가능해진다. 소비자를 잃은 `LiveActivityEventTarget.isTodo`는 삭제했다.

## 테스트 배포 피드백 반영

실기기 확인에서 나온 두 가지를 같이 담았다.

**완료 버튼이 눌린 티가 안 난다.** 위젯의 할일 토글은 `Toggle(isOn:intent:)`를 써서 WidgetKit의 낙관적 UI를 받는다 — 탭 즉시 `configuration.isOn`이 뒤집혀 인텐트가 도는 동안 그 상태가 유지된다. 액티비티의 완료 버튼만 `Button(intent:)`이라 그 처리를 못 받았다. `Toggle` + `.toggleStyle(.button)`으로 바꿔 같은 동작을 받게 했다 — 기존 `.bordered` 외형은 그대로다.

**잠금화면 등록이 성공했는지 알 수 없다.** `LiveActivityToggleViewModelImple.startOrStopLiveActivity`가 실패만 안내하고 성공엔 아무 표시가 없었다. 성공 분기에 잠금화면 확인을 안내하는 토스트를 붙였다. 이 뷰모델엔 테스트가 없었어서 등록 성공·실패·해제 세 경로를 덮는 스위트를 함께 만들었다.

## 유저 검증 대기 (실기기)

`LiveActivityIntent`가 실제로 앱 프로세스에서 도는지, 콜드 런치에서 DB 조립이 성립하는지는 시뮬레이터·유닛테스트로 갈음되지 않는다.

1. **앱을 완전히 종료한 상태에서** 잠금화면 액티비티의 "종료" → 액티비티가 사라진다
2. 같은 상태에서 Todo 액티비티의 "완료" → 액티비티가 사라지고, 앱을 켜면 그 Todo가 완료돼 있다
3. 앱을 백그라운드에 둔 상태에서 2를 반복 → 같은 결과
4. 다이나믹아일랜드를 길게 눌러 확장한 상태에서 두 버튼이 같게 동작
5. 완료 후 위젯의 할일 목록에서 그 Todo가 사라진다
