### PR TITLE
[#906] 외부 캘린더 이벤트 상세 단건 공유

### DIFF
--- a/Presentations/EventDetailScene/Sources/EventDetailShareTextBuilder.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailShareTextBuilder.swift
@@ -10,12 +10,31 @@ import Foundation
 import Extensions
 
 
+enum EventDetailShareTagLine: Equatable {
+    case eventTag(String)
+    case externalCalendar(String)
+
+    var labelKey: String {
+        switch self {
+        case .eventTag: return "eventTag.title"
+        case .externalCalendar: return "event_detail::share::field::calendar"
+        }
+    }
+
+    var name: String {
+        switch self {
+        case .eventTag(let name): return name
+        case .externalCalendar(let name): return name
+        }
+    }
+}
+
 struct EventDetailShareModel: Equatable {
     let name: String
     var isTodo: Bool = false
     var timeText: String?
     var repeatText: String?
-    var tagName: String?
+    var tagLine: EventDetailShareTagLine?
     var placeName: String?
     var url: String?
     var memo: String?
@@ -25,7 +44,6 @@ struct EventDetailShareTextBuilder {
 
     private enum Constant {
         static let labelSeparator: String = ": "
-        static let tagLabelKey: String = "eventTag.title"
         static let todoTextKey: String = "calendar::event_time::todo"
         static let periodSeparator: String = " ~ "
         static let lineSeparator: String = "\n"
@@ -35,8 +53,10 @@ struct EventDetailShareTextBuilder {
     func build(_ model: EventDetailShareModel) -> String {
         let fields: [(labelKey: String, value: String?)] = [
             ("event_detail::share::field::time", model.timeText),
-            ("event_detail::share::field::repeating", model.repeatText),
-            (Constant.tagLabelKey, model.tagName),
+            ("event_detail::share::field::repeating", model.repeatText)
+        ]
+        + self.tagFields(model.tagLine)
+        + [
             ("event_detail::share::field::place", model.placeName),
             ("event_detail::share::field::url", model.url),
             ("event_detail::share::field::memo", model.memo)
@@ -45,6 +65,11 @@ struct EventDetailShareTextBuilder {
             field.value.map { "\(field.labelKey.localized())\(Constant.labelSeparator)\($0)" }
         }
         return ([self.nameLine(model)] + fieldLines).joined(separator: Constant.lineSeparator)
+    }
+
+    private func tagFields(_ line: EventDetailShareTagLine?) -> [(labelKey: String, value: String?)] {
+        guard let line else { return [] }
+        return [(line.labelKey, line.name)]
     }
 
     private func nameLine(_ model: EventDetailShareModel) -> String {

--- a/Presentations/EventDetailScene/Sources/EventDetailShareTextBuilder.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailShareTextBuilder.swift
@@ -12,19 +12,37 @@ import Extensions
 
 enum EventDetailShareTagLine: Equatable {
     case eventTag(String)
-    case externalCalendar(String)
+    case googleCalendar(String)
+    case appleCalendar(String)
+
+    private enum Constant {
+        static let serviceNameSeparator: String = " - "
+    }
 
     var labelKey: String {
         switch self {
         case .eventTag: return "eventTag.title"
-        case .externalCalendar: return "event_detail::share::field::calendar"
+        case .googleCalendar, .appleCalendar: return "event_detail::share::field::calendar"
         }
     }
 
     var name: String {
+        guard let serviceNameKey else { return self.calendarName }
+        return [serviceNameKey.localized(), self.calendarName].joined(separator: Constant.serviceNameSeparator)
+    }
+
+    private var serviceNameKey: String? {
         switch self {
-        case .eventTag(let name): return name
-        case .externalCalendar(let name): return name
+        case .eventTag: return nil
+        case .googleCalendar: return "event_setting::external_calendar::google::serviceName"
+        case .appleCalendar: return "event_setting::external_calendar::apple::serviceName"
+        }
+    }
+
+    private var calendarName: String {
+        switch self {
+        case .eventTag(let name), .googleCalendar(let name), .appleCalendar(let name):
+            return name
         }
     }
 }

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailRouter.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailRouter.swift
@@ -23,6 +23,8 @@ protocol AppleCalendarEventDetailRouting: Routing, Sendable {
         previousSelected repeating: EventRepeating?,
         listener: (any SelectEventRepeatOptionSceneListener)?
     )
+
+    func showShareSheet(text: String)
 }
 
 // MARK: - Router

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailView.swift
@@ -150,6 +150,7 @@ final class AppleCalendarEventDetailViewEventHandler: Observable {
     var remove: () -> Void = { }
     var selectNotEditableField: () -> Void = { }
     var selectRepeatOption: () -> Void = { }
+    var share: () -> Void = { }
 
     func bind(_ viewModel: any AppleCalendarEventDetailViewModel) {
         self.onAppear = viewModel.refresh
@@ -166,6 +167,7 @@ final class AppleCalendarEventDetailViewEventHandler: Observable {
         self.remove = viewModel.remove
         self.selectNotEditableField = viewModel.selectNotEditableField
         self.selectRepeatOption = viewModel.selectRepeatOption
+        self.share = viewModel.share
     }
 }
 
@@ -311,6 +313,16 @@ struct AppleCalendarEventDetailView: View {
                             ? "eventDetail::appleCalendarEvent::editOnCalendar".localized()
                             : "eventDetail::appleCalendarEvent::viewOnCalendar".localized(),
                         systemImage: "arrow.up.forward.square"
+                    )
+                }
+            }
+            Section {
+                Button {
+                    eventHandlers.share()
+                } label: {
+                    Label(
+                        "calendar::event::more_action:share:item_name".localized(),
+                        systemImage: "square.and.arrow.up"
                     )
                 }
             }

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewModel.swift
@@ -42,6 +42,7 @@ protocol AppleCalendarEventDetailViewModel: AnyObject, Sendable, AppleCalendarEv
     func remove()
     func selectNotEditableField()
     func selectRepeatOption()
+    func share()
 
     // presenter
     var isEditable: AnyPublisher<Bool, Never> { get }
@@ -435,6 +436,39 @@ extension AppleCalendarEventDetailViewModelImple {
             }
         }
         .store(in: &self.cancellables)
+    }
+}
+
+
+// MARK: - AppleCalendarEventDetailViewModelImple Share
+
+extension AppleCalendarEventDetailViewModelImple {
+
+    func share() {
+        guard let fields = self.subject.fields.value?.current else { return }
+
+        let builder = EventDetailShareTextBuilder()
+        let timeText = fields.time.map(builder.timeText(from:))
+        let tagName = self.subject.calendarTag.value?.name.emptyAsNil()
+
+        self.repeatText
+            .first()
+            .sink { [weak self] repeatText in
+                let model = EventDetailShareModel(
+                    name: fields.name,
+                    isTodo: false,
+                    timeText: timeText,
+                    repeatText: repeatText == R.String.EventDetail.Repeating.notRepeatingTitle ? nil : repeatText,
+                    tagName: tagName,
+                    placeName: fields.location?.emptyAsNil(),
+                    url: fields.url?.emptyAsNil(),
+                    memo: fields.notes?.emptyAsNil()
+                )
+                let text = builder.build(model)
+                guard !text.isEmpty else { return }
+                self?.router?.showShareSheet(text: text)
+            }
+            .store(in: &self.cancellables)
     }
 }
 

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewModel.swift
@@ -449,7 +449,7 @@ extension AppleCalendarEventDetailViewModelImple {
 
         let builder = EventDetailShareTextBuilder()
         let timeText = fields.time.map(builder.timeText(from:))
-        let tagLine = self.subject.calendarTag.value?.name.emptyAsNil().map { EventDetailShareTagLine.externalCalendar($0) }
+        let tagLine = self.subject.calendarTag.value?.name.emptyAsNil().map { EventDetailShareTagLine.appleCalendar($0) }
 
         self.repeatText
             .first()

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewModel.swift
@@ -449,7 +449,7 @@ extension AppleCalendarEventDetailViewModelImple {
 
         let builder = EventDetailShareTextBuilder()
         let timeText = fields.time.map(builder.timeText(from:))
-        let tagName = self.subject.calendarTag.value?.name.emptyAsNil()
+        let tagLine = self.subject.calendarTag.value?.name.emptyAsNil().map { EventDetailShareTagLine.externalCalendar($0) }
 
         self.repeatText
             .first()
@@ -459,7 +459,7 @@ extension AppleCalendarEventDetailViewModelImple {
                     isTodo: false,
                     timeText: timeText,
                     repeatText: repeatText == R.String.EventDetail.Repeating.notRepeatingTitle ? nil : repeatText,
-                    tagName: tagName,
+                    tagLine: tagLine,
                     placeName: fields.location?.emptyAsNil(),
                     url: fields.url?.emptyAsNil(),
                     memo: fields.notes?.emptyAsNil()

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailRouter.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailRouter.swift
@@ -23,6 +23,8 @@ protocol GoogleCalendarEventDetailRouting: Routing, Sendable {
         previousSelected repeating: EventRepeating?,
         listener: (any SelectEventRepeatOptionSceneListener)?
     )
+
+    func showShareSheet(text: String)
 }
 
 // MARK: - Router

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailView.swift
@@ -192,6 +192,7 @@ final class GoogleCalendarEventDetailViewEventHandler: Observable {
     var selectNotEditableField: () -> Void = { }
     var selectRepeatOption: () -> Void = { }
     var startEditDescription: () -> Void = { }
+    var share: () -> Void = { }
 
     func bind(_ viewModel: any GoogleCalendarEventDetailViewModel) {
         onAppear = viewModel.refresh
@@ -213,6 +214,7 @@ final class GoogleCalendarEventDetailViewEventHandler: Observable {
         selectNotEditableField = viewModel.selectNotEditableField
         selectRepeatOption = viewModel.selectRepeatOption
         startEditDescription = viewModel.startEditDescription
+        share = viewModel.share
     }
 }
 
@@ -347,9 +349,7 @@ struct GoogleCalendarEventDetailView: View {
                     )
                     .eventHandler(\.onTap, eventHandlers.save)
                 }
-                if self.state.isEditable || self.state.hasDetailLink {
-                    self.moreActionMenu
-                }
+                self.moreActionMenu
             }
         }
         .padding()
@@ -374,6 +374,16 @@ struct GoogleCalendarEventDetailView: View {
                             systemImage: "arrow.up.forward.square"
                         )
                     }
+                }
+            }
+            Section {
+                Button {
+                    eventHandlers.share()
+                } label: {
+                    Label(
+                        "calendar::event::more_action:share:item_name".localized(),
+                        systemImage: "square.and.arrow.up"
+                    )
                 }
             }
             if state.isEditable {

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
@@ -141,6 +141,7 @@ protocol GoogleCalendarEventDetailViewModel: AnyObject, Sendable, GoogleCalendar
     func selectNotEditableField()
     func selectRepeatOption()
     func startEditDescription()
+    func share()
 
     // presenter
     var isEditable: AnyPublisher<Bool, Never> { get }
@@ -660,6 +661,40 @@ extension GoogleCalendarEventDetailViewModelImple {
 }
 
 
+// MARK: - GoogleCalendarEventDetailViewModelImple Share
+
+extension GoogleCalendarEventDetailViewModelImple {
+
+    func share() {
+        guard let fields = self.subject.fields.value?.current else { return }
+
+        let builder = EventDetailShareTextBuilder()
+        let timeText = fields.time.map(builder.timeText(from:))
+        let memoText = fields.memo.asPlainShareText
+        let tagName = self.subject.calendarTag.value?.name.emptyAsNil()
+
+        self.repeatOption
+            .first()
+            .sink { [weak self] repeatText in
+                let model = EventDetailShareModel(
+                    name: fields.name,
+                    isTodo: false,
+                    timeText: timeText,
+                    repeatText: repeatText == R.String.EventDetail.Repeating.notRepeatingTitle ? nil : repeatText,
+                    tagName: tagName,
+                    placeName: fields.location?.emptyAsNil(),
+                    url: nil,
+                    memo: memoText
+                )
+                let text = builder.build(model)
+                guard !text.isEmpty else { return }
+                self?.router?.showShareSheet(text: text)
+            }
+            .store(in: &self.cancellables)
+    }
+}
+
+
 // MARK: - GoogleCalendarEventDetailViewModelImple Presenter
 
 extension GoogleCalendarEventDetailViewModelImple {
@@ -891,6 +926,17 @@ private extension String {
             of: Constant.htmlTagPattern,
             options: [.regularExpression, .caseInsensitive]
         ) != nil
+    }
+}
+
+
+private extension Optional where Wrapped == String {
+
+    var asPlainShareText: String? {
+        guard let memo = self else { return nil }
+        guard memo.hasHTMLTag else { return memo.emptyAsNil() }
+        guard let attributed = memo.asHTMLAttributeText else { return memo.emptyAsNil() }
+        return String(attributed.characters).emptyAsNil()
     }
 }
 

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
@@ -671,7 +671,7 @@ extension GoogleCalendarEventDetailViewModelImple {
         let builder = EventDetailShareTextBuilder()
         let timeText = fields.time.map(builder.timeText(from:))
         let memoText = fields.memo.asPlainShareText
-        let tagLine = self.subject.calendarTag.value?.name.emptyAsNil().map { EventDetailShareTagLine.externalCalendar($0) }
+        let tagLine = self.subject.calendarTag.value?.name.emptyAsNil().map { EventDetailShareTagLine.googleCalendar($0) }
 
         self.repeatOption
             .first()

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
@@ -671,7 +671,7 @@ extension GoogleCalendarEventDetailViewModelImple {
         let builder = EventDetailShareTextBuilder()
         let timeText = fields.time.map(builder.timeText(from:))
         let memoText = fields.memo.asPlainShareText
-        let tagName = self.subject.calendarTag.value?.name.emptyAsNil()
+        let tagLine = self.subject.calendarTag.value?.name.emptyAsNil().map { EventDetailShareTagLine.externalCalendar($0) }
 
         self.repeatOption
             .first()
@@ -681,7 +681,7 @@ extension GoogleCalendarEventDetailViewModelImple {
                     isTodo: false,
                     timeText: timeText,
                     repeatText: repeatText == R.String.EventDetail.Repeating.notRepeatingTitle ? nil : repeatText,
-                    tagName: tagName,
+                    tagLine: tagLine,
                     placeName: fields.location?.emptyAsNil(),
                     url: nil,
                     memo: memoText

--- a/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
@@ -185,7 +185,7 @@ extension EditScheduleEventDetailViewModelImple: EventDetailInputListener {
                     isTodo: false,
                     timeText: timeText,
                     repeatText: basic.eventRepeating?.text.emptyAsNil(),
-                    tagName: tag?.name.emptyAsNil(),
+                    tagLine: tag?.name.emptyAsNil().map { .eventTag($0) },
                     placeName: addition?.place?.placeName.emptyAsNil(),
                     url: addition?.url?.emptyAsNil(),
                     memo: addition?.memo?.emptyAsNil()

--- a/Presentations/EventDetailScene/Sources/ViewModels/EditTodoEventDetailViewModelImple.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/EditTodoEventDetailViewModelImple.swift
@@ -173,7 +173,7 @@ extension EditTodoEventDetailViewModelImple: EventDetailInputListener {
                     isTodo: true,
                     timeText: timeText,
                     repeatText: basic.eventRepeating?.text.emptyAsNil(),
-                    tagName: tag?.name.emptyAsNil(),
+                    tagLine: tag?.name.emptyAsNil().map { .eventTag($0) },
                     placeName: addition?.place?.placeName.emptyAsNil(),
                     url: addition?.url?.emptyAsNil(),
                     memo: addition?.memo?.emptyAsNil()

--- a/Presentations/EventDetailScene/Tests/AppleCalendarEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/AppleCalendarEventDetailViewModelImpleTests.swift
@@ -1138,6 +1138,11 @@ private final class SpyRouter: BaseSpyRouter, AppleCalendarEventDetailRouting, @
     ) {
         self.didRouteToRepeatOptionSelectWith = (selectTime, repeating)
     }
+
+    var didShareText: String?
+    func showShareSheet(text: String) {
+        self.didShareText = text
+    }
 }
 
 
@@ -1145,5 +1150,78 @@ private final class MockAppleCalendarUsecase: StubAppleCalendarUsecase, @uncheck
     let isWritableSubject = CurrentValueSubject<Bool?, Never>(true)
     override func isCalendarWritable(_ calendarId: String) -> AnyPublisher<Bool?, Never> {
         return self.isWritableSubject.eraseToAnyPublisher()
+    }
+}
+
+
+// MARK: - 공유
+
+extension AppleCalendarEventDetailViewModelImpleTests {
+
+    private func shareFieldLabel(_ key: String) -> String {
+        return "event_detail::share::field::\(key)".localized()
+    }
+
+    private var shareTagLabel: String { "eventTag.title".localized() }
+
+    @Test func viewModel_whenShare_composeTextWithVisibleFields() async throws {
+        // given
+        let viewModel = self.makeViewModelWithOrigin {
+            $0.location = "Conference Room A"
+            $0.url = "https://example.com"
+            $0.notes = "메모"
+        }
+        viewModel.refresh()
+        try await Task.sleep(for: .milliseconds(10))
+        let time = try await self.firstOutput(expectConfirm("현재 시간값"), for: viewModel.timeText)
+        let expectedTimeText = time.flatMap { $0 }.map { EventDetailShareTextBuilder().timeText(from: $0) }
+
+        // when
+        viewModel.share()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        let text = try #require(self.spyRouter.didShareText)
+        let lines = text.components(separatedBy: "\n")
+        #expect(lines.first == "Meeting")
+        #expect(lines.contains("\(self.shareFieldLabel("time")): \(expectedTimeText ?? "")"))
+        #expect(lines.contains("\(self.shareTagLabel): Work"))
+        #expect(lines.contains("\(self.shareFieldLabel("place")): Conference Room A"))
+        #expect(lines.contains("\(self.shareFieldLabel("url")): https://example.com"))
+        #expect(lines.contains("\(self.shareFieldLabel("memo")): 메모"))
+    }
+
+    @Test func viewModel_whenShareAfterEnterName_shareEditedName() async throws {
+        // given
+        let viewModel = self.makeViewModelWithOrigin { _ in }
+        viewModel.refresh()
+        try await Task.sleep(for: .milliseconds(10))
+        viewModel.enter(name: "수정된 이름")
+
+        // when
+        viewModel.share()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        let text = try #require(self.spyRouter.didShareText)
+        let lines = text.components(separatedBy: "\n")
+        #expect(lines.first == "수정된 이름")
+        #expect(!lines.contains("Meeting"))
+    }
+
+    @Test func viewModel_whenShareNotRepeatingEvent_withoutRepeatLine() async throws {
+        // given
+        let viewModel = self.makeViewModelWithOrigin { _ in }
+        viewModel.refresh()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // when
+        viewModel.share()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        let text = try #require(self.spyRouter.didShareText)
+        let lines = text.components(separatedBy: "\n")
+        #expect(!lines.contains(where: { $0.hasPrefix("\(self.shareFieldLabel("repeating")):") }))
     }
 }

--- a/Presentations/EventDetailScene/Tests/AppleCalendarEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/AppleCalendarEventDetailViewModelImpleTests.swift
@@ -1162,7 +1162,7 @@ extension AppleCalendarEventDetailViewModelImpleTests {
         return "event_detail::share::field::\(key)".localized()
     }
 
-    private var shareTagLabel: String { "eventTag.title".localized() }
+    private var shareTagLabel: String { self.shareFieldLabel("calendar") }
 
     @Test func viewModel_whenShare_composeTextWithVisibleFields() async throws {
         // given

--- a/Presentations/EventDetailScene/Tests/AppleCalendarEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/AppleCalendarEventDetailViewModelImpleTests.swift
@@ -1163,6 +1163,9 @@ extension AppleCalendarEventDetailViewModelImpleTests {
     }
 
     private var shareTagLabel: String { self.shareFieldLabel("calendar") }
+    private var appleServiceName: String {
+        "event_setting::external_calendar::apple::serviceName".localized()
+    }
 
     @Test func viewModel_whenShare_composeTextWithVisibleFields() async throws {
         // given
@@ -1185,7 +1188,7 @@ extension AppleCalendarEventDetailViewModelImpleTests {
         let lines = text.components(separatedBy: "\n")
         #expect(lines.first == "Meeting")
         #expect(lines.contains("\(self.shareFieldLabel("time")): \(expectedTimeText ?? "")"))
-        #expect(lines.contains("\(self.shareTagLabel): Work"))
+        #expect(lines.contains("\(self.shareTagLabel): \(self.appleServiceName) - Work"))
         #expect(lines.contains("\(self.shareFieldLabel("place")): Conference Room A"))
         #expect(lines.contains("\(self.shareFieldLabel("url")): https://example.com"))
         #expect(lines.contains("\(self.shareFieldLabel("memo")): 메모"))

--- a/Presentations/EventDetailScene/Tests/EventDetailShareTextBuilderTests.swift
+++ b/Presentations/EventDetailScene/Tests/EventDetailShareTextBuilderTests.swift
@@ -65,16 +65,43 @@ extension EventDetailShareTextBuilderTests {
         #expect(result == expected)
     }
 
-    @Test func builder_whenTagLineIsExternalCalendar_rendersCalendarLabel() {
+    @Test func builder_whenTagLineIsGoogleCalendar_rendersServiceNamePrefixedCalendarLabel() {
         // given
-        let model = EventDetailShareModel(name: "이름", tagLine: .externalCalendar("업무"))
+        let model = EventDetailShareModel(name: "이름", tagLine: .googleCalendar("업무"))
 
         // when
         let result = self.builder.build(model)
 
         // then
+        let serviceName = "event_setting::external_calendar::google::serviceName".localized()
         #expect(self.calendarLabel != self.tagLabel)
-        #expect(result == "이름\n\(self.calendarLabel): 업무")
+        #expect(result == "이름\n\(self.calendarLabel): \(serviceName) - 업무")
+    }
+
+    @Test func builder_whenTagLineIsAppleCalendar_rendersServiceNamePrefixedCalendarLabel() {
+        // given
+        let model = EventDetailShareModel(name: "이름", tagLine: .appleCalendar("업무"))
+
+        // when
+        let result = self.builder.build(model)
+
+        // then
+        let serviceName = "event_setting::external_calendar::apple::serviceName".localized()
+        #expect(self.calendarLabel != self.tagLabel)
+        #expect(result == "이름\n\(self.calendarLabel): \(serviceName) - 업무")
+    }
+
+    @Test func builder_googleAndAppleCalendarTagLines_produceDifferentServiceNamePrefixes() {
+        // given
+        let googleModel = EventDetailShareModel(name: "이름", tagLine: .googleCalendar("업무"))
+        let appleModel = EventDetailShareModel(name: "이름", tagLine: .appleCalendar("업무"))
+
+        // when
+        let googleResult = self.builder.build(googleModel)
+        let appleResult = self.builder.build(appleModel)
+
+        // then
+        #expect(googleResult != appleResult)
     }
 
     @Test func builder_whenFieldIsNil_omitsThatLine() {

--- a/Presentations/EventDetailScene/Tests/EventDetailShareTextBuilderTests.swift
+++ b/Presentations/EventDetailScene/Tests/EventDetailShareTextBuilderTests.swift
@@ -29,6 +29,7 @@ extension EventDetailShareTextBuilderTests {
     }
 
     private var tagLabel: String { "eventTag.title".localized() }
+    private var calendarLabel: String { "event_detail::share::field::calendar".localized() }
     private var todoText: String { "calendar::event_time::todo".localized() }
 
     private func fullModel() -> EventDetailShareModel {
@@ -37,7 +38,7 @@ extension EventDetailShareTextBuilderTests {
             isTodo: true,
             timeText: "2026.08.15 (금) 09:00 ~ 10:00",
             repeatText: "매일",
-            tagName: "건강",
+            tagLine: .eventTag("건강"),
             placeName: "강남약국",
             url: "https://example.com",
             memo: "식후 30분"
@@ -64,11 +65,23 @@ extension EventDetailShareTextBuilderTests {
         #expect(result == expected)
     }
 
+    @Test func builder_whenTagLineIsExternalCalendar_rendersCalendarLabel() {
+        // given
+        let model = EventDetailShareModel(name: "이름", tagLine: .externalCalendar("업무"))
+
+        // when
+        let result = self.builder.build(model)
+
+        // then
+        #expect(self.calendarLabel != self.tagLabel)
+        #expect(result == "이름\n\(self.calendarLabel): 업무")
+    }
+
     @Test func builder_whenFieldIsNil_omitsThatLine() {
         // given
         let model = EventDetailShareModel(
             name: "이름", timeText: "시간", repeatText: nil,
-            tagName: nil, placeName: nil, url: nil, memo: nil
+            tagLine: nil, placeName: nil, url: nil, memo: nil
         )
 
         // when

--- a/Presentations/EventDetailScene/Tests/GoogleCalendarEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/GoogleCalendarEventDetailViewModelImpleTests.swift
@@ -1736,7 +1736,7 @@ extension GoogleCalendarEventDetailViewModelImpleTests {
         return "event_detail::share::field::\(key)".localized()
     }
 
-    private var shareTagLabel: String { "eventTag.title".localized() }
+    private var shareTagLabel: String { self.shareFieldLabel("calendar") }
 
     @Test func viewModel_whenShare_composeTextWithVisibleFields() async throws {
         // given

--- a/Presentations/EventDetailScene/Tests/GoogleCalendarEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/GoogleCalendarEventDetailViewModelImpleTests.swift
@@ -1737,6 +1737,9 @@ extension GoogleCalendarEventDetailViewModelImpleTests {
     }
 
     private var shareTagLabel: String { self.shareFieldLabel("calendar") }
+    private var googleServiceName: String {
+        "event_setting::external_calendar::google::serviceName".localized()
+    }
 
     @Test func viewModel_whenShare_composeTextWithVisibleFields() async throws {
         // given
@@ -1757,7 +1760,7 @@ extension GoogleCalendarEventDetailViewModelImpleTests {
         #expect(lines.first == "name")
         #expect(lines.contains("\(self.shareFieldLabel("time")): \(expectedTimeText ?? "")"))
         #expect(lines.contains("\(self.shareFieldLabel("repeating")): \(repeatText ?? "")"))
-        #expect(lines.contains("\(self.shareTagLabel): g:7"))
+        #expect(lines.contains("\(self.shareTagLabel): \(self.googleServiceName) - g:7"))
         #expect(lines.contains("\(self.shareFieldLabel("place")): location"))
         #expect(!lines.contains(where: { $0.hasPrefix("\(self.shareFieldLabel("url")):") }))
         #expect(lines.contains(where: { $0.hasPrefix("\(self.shareFieldLabel("memo")):") }))

--- a/Presentations/EventDetailScene/Tests/GoogleCalendarEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/GoogleCalendarEventDetailViewModelImpleTests.swift
@@ -1720,4 +1720,97 @@ private final class SpyRouter: BaseSpyRouter, GoogleCalendarEventDetailRouting, 
     ) {
         self.didRouteToRepeatOptionSelectWith = (selectTime, repeating)
     }
+
+    var didShareText: String?
+    func showShareSheet(text: String) {
+        self.didShareText = text
+    }
+}
+
+
+// MARK: - 공유
+
+extension GoogleCalendarEventDetailViewModelImpleTests {
+
+    private func shareFieldLabel(_ key: String) -> String {
+        return "event_detail::share::field::\(key)".localized()
+    }
+
+    private var shareTagLabel: String { "eventTag.title".localized() }
+
+    @Test func viewModel_whenShare_composeTextWithVisibleFields() async throws {
+        // given
+        let viewModel = self.makeViewModel(recurrence: "RRULE:FREQ=DAILY")
+        viewModel.refresh()
+        try await Task.sleep(for: .milliseconds(10))
+        let time = try await self.firstOutput(expectConfirm("현재 시간값"), for: viewModel.timeText)
+        let repeatText = try await self.firstOutput(expectConfirm("현재 반복옵션"), for: viewModel.repeatOption)
+        let expectedTimeText = time.flatMap { $0 }.map { EventDetailShareTextBuilder().timeText(from: $0) }
+
+        // when
+        viewModel.share()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        let text = try #require(self.spyRouter.didShareText)
+        let lines = text.components(separatedBy: "\n")
+        #expect(lines.first == "name")
+        #expect(lines.contains("\(self.shareFieldLabel("time")): \(expectedTimeText ?? "")"))
+        #expect(lines.contains("\(self.shareFieldLabel("repeating")): \(repeatText ?? "")"))
+        #expect(lines.contains("\(self.shareTagLabel): g:7"))
+        #expect(lines.contains("\(self.shareFieldLabel("place")): location"))
+        #expect(!lines.contains(where: { $0.hasPrefix("\(self.shareFieldLabel("url")):") }))
+        #expect(lines.contains(where: { $0.hasPrefix("\(self.shareFieldLabel("memo")):") }))
+    }
+
+    @Test func viewModel_whenShareEventWithHTMLDescription_shareAsPlainText() async throws {
+        // given
+        let viewModel = self.makeViewModel()
+        viewModel.refresh()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // when
+        viewModel.share()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        let text = try #require(self.spyRouter.didShareText)
+        #expect(!text.contains("<br>"))
+        #expect(!text.contains("<b>"))
+        #expect(text.contains("볼드"))
+    }
+
+    @Test func viewModel_whenShareAfterEnterName_shareEditedName() async throws {
+        // given
+        let viewModel = self.makeViewModel()
+        viewModel.refresh()
+        try await Task.sleep(for: .milliseconds(10))
+        viewModel.enter(name: "수정된 이름")
+
+        // when
+        viewModel.share()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        let text = try #require(self.spyRouter.didShareText)
+        let lines = text.components(separatedBy: "\n")
+        #expect(lines.first == "수정된 이름")
+        #expect(!lines.contains("name"))
+    }
+
+    @Test func viewModel_whenShareNotRepeatingEvent_withoutRepeatLine() async throws {
+        // given
+        let viewModel = self.makeViewModel()
+        viewModel.refresh()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // when
+        viewModel.share()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        let text = try #require(self.spyRouter.didShareText)
+        let lines = text.components(separatedBy: "\n")
+        #expect(!lines.contains(where: { $0.hasPrefix("\(self.shareFieldLabel("repeating")):") }))
+    }
 }

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -143,6 +143,7 @@
 "calendar::event::more_action:share:item_name" = "Share";
 "event_detail::share::field::time" = "Time";
 "event_detail::share::field::repeating" = "Repeat";
+"event_detail::share::field::calendar" = "Calendar";
 "event_detail::share::field::place" = "Location";
 "event_detail::share::field::url" = "Link";
 "event_detail::share::field::memo" = "Memo";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -143,6 +143,7 @@
 "calendar::event::more_action:share:item_name" = "공유";
 "event_detail::share::field::time" = "시간";
 "event_detail::share::field::repeating" = "반복옵션";
+"event_detail::share::field::calendar" = "캘린더";
 "event_detail::share::field::place" = "장소";
 "event_detail::share::field::url" = "링크";
 "event_detail::share::field::memo" = "메모";


### PR DESCRIPTION
구글·애플 캘린더 이벤트 상세에서도 단건 공유가 된다. 지금까지 공유 액션은 앱 자체 할일·일정 상세에만 있었다.

## 접근

조립기(`EventDetailShareTextBuilder`)와 공유시트(`BaseRouterImple.showShareSheet(text:)`)는 이미 있는 걸 그대로 쓴다. 각 ViewModel에 `share()` 인터랙터를 더해 **화면에 보이는 현재 편집 값**으로 `EventDetailShareModel`을 조립하고, 각 `Routing` 프로토콜엔 선언만 추가했다 — 구현은 `BaseRouterImple` 상속으로 충족된다. 공유 모델에 필드를 늘리지 않았다.

**나가는 필드는 앱 내부와 같은 6종**(시간·반복옵션·이벤트 종류·장소·링크·메모)뿐이다. 구글 회의링크·참석자·첨부, 애플 참석자는 싣지 않는다.

서비스별로 갈리는 지점:

- **구글** — `htmlLink`는 권한 없는 수신자에게 무의미해 링크 줄을 비운다. description은 HTML이라 평문화해서 싣는다.
- **애플** — url·notes가 평문이라 링크·메모 줄을 그대로 싣는다.

저장 여부와 무관하게 편집 중 값을 쓴다. #753의 "보이는 것과 나가는 것이 항상 일치" 원칙이라, 이름을 고치고 저장 전에 공유하면 고친 이름이 나간다.

태그 줄 라벨도 갈랐다. 지금까지 `이벤트 종류`(`eventTag.title`) 하나로 4곳이 공통이었는데, 구글·애플은 그 자리가 이벤트 종류가 아니라 캘린더 이름이라 라벨이 틀렸다 — 상세 화면은 이미 `캘린더`로 쓰고 있어서 공유 텍스트만 어긋나 있었다. `EventDetailShareTagLine` enum이 라벨 키를 케이스에 실어 `.eventTag` / `.googleCalendar` / `.appleCalendar`로 가르고, 신규 키 `event_detail::share::field::calendar`를 en·ko에 추가했다(나머지 29개 언어는 #810). 값에도 서비스명을 실어 `캘린더: 구글 캘린더 - Work`로 나간다 — 받는 쪽에서 어느 서비스 캘린더인지 드러난다. 서비스명은 기존 키(`event_setting::external_calendar::{google,apple}::serviceName`) 재사용이라 추가 번역이 없다.

구글은 more 메뉴 노출 조건(`isEditable || hasDetailLink`)을 제거했다. 읽기 전용 캘린더이고 링크도 없는 이벤트에서 메뉴 자체가 안 떠 공유에 닿을 수 없었다.

## 검증

- 신규 TC 7건 포함 `EventDetailScene` 스킴 161건 PASS
- 스냅샷(`test_googleEventDetail`·`test_appleEventDetail`) 재캡처 — 변화 없음. more 메뉴는 탭해야 펼쳐지는 `Menu`라 정적 캡처에 안 잡힌다

Closes #906


