### PR TITLE
[#876] 구글 이벤트 참석 여부(RSVP) 응답

### DIFF
--- a/Domain/Sources/Models/Events/ExternalCalendar/GoogleCalendarEvent.swift
+++ b/Domain/Sources/Models/Events/ExternalCalendar/GoogleCalendarEvent.swift
@@ -177,7 +177,7 @@ extension GoogleCalendar {
             public init() { }
         }
 
-        public struct Attendee: Codable, Sendable {
+        public struct Attendee: Codable, Sendable, Equatable {
             public var id: String?
             public var email: String?
             public var displayName: String?
@@ -201,7 +201,15 @@ extension GoogleCalendar {
             public var isAccepted: Bool {
                 return self.responseStatus == "accepted"
             }
-            
+
+            public var isSelf: Bool {
+                return self.selfValue == true
+            }
+
+            public var response: GoogleCalendar.AttendeeResponseStatus? {
+                return self.responseStatus.flatMap(GoogleCalendar.AttendeeResponseStatus.init(rawValue:))
+            }
+
             public init() { }
         }
 
@@ -252,6 +260,14 @@ extension GoogleCalendar {
             case confidential
         }
     }
+
+    public enum AttendeeResponseStatus: String, Sendable, Equatable {
+        case needsAction
+        case declined
+        case tentative
+        case accepted
+    }
+
     public struct EventOriginValueList: Decodable, Sendable {
         public var timeZone: String?
         public var items: [EventOrigin] = []

--- a/Domain/Sources/Models/Events/ExternalCalendar/GoogleCalendarEventEditParams.swift
+++ b/Domain/Sources/Models/Events/ExternalCalendar/GoogleCalendarEventEditParams.swift
@@ -19,6 +19,7 @@ extension GoogleCalendar {
         public var description: String?
         public var colorId: String?
         public var recurrence: [String]?
+        public var attendees: [EventOrigin.Attendee]?
 
         public init() { }
 
@@ -30,6 +31,7 @@ extension GoogleCalendar {
                 && self.description == nil
                 && self.colorId == nil
                 && self.recurrence == nil
+                && self.attendees == nil
         }
     }
 

--- a/Domain/Sources/Repositories/Events/GoogleCalendarRepository.swift
+++ b/Domain/Sources/Repositories/Events/GoogleCalendarRepository.swift
@@ -44,6 +44,13 @@ public protocol GoogleCalendarRepository: Sendable {
         _ params: GoogleCalendar.EventEditParams
     ) -> AnyPublisher<GoogleCalendar.EventOrigin, any Error>
 
+    func respondToEvent(
+        _ calendarId: String,
+        _ timeZone: String,
+        _ eventId: String,
+        _ responseStatus: GoogleCalendar.AttendeeResponseStatus
+    ) async throws -> GoogleCalendar.EventOrigin
+
     func removeEvent(
         _ calendarId: String,
         _ eventId: String

--- a/Domain/Sources/Usecases/Events/ExternalCalendar/GoogleCalendarUsecase.swift
+++ b/Domain/Sources/Usecases/Events/ExternalCalendar/GoogleCalendarUsecase.swift
@@ -70,6 +70,14 @@ public protocol GoogleCalendarUsecase: Sendable {
         params: GoogleCalendar.EventEditParams
     ) async throws -> GoogleCalendar.EventOrigin
 
+    func respondToEvent(
+        _ calendarId: String,
+        _ eventId: String,
+        accountId: String,
+        at timeZone: TimeZone,
+        responseStatus: GoogleCalendar.AttendeeResponseStatus
+    ) async throws -> GoogleCalendar.EventOrigin
+
     func removeEvent(
         _ calendarId: String,
         _ eventId: String,
@@ -450,6 +458,20 @@ extension GoogleCalendarUsecaseImple {
             self.cacheUpdatedEvent(origin, calendarId, accountId: accountId, timeZone: timeZone)
         }
         return origin
+    }
+
+    // RSVP 는 목록 표시에 영향 없는 변화라 updateEvent 의 인스턴스 재조회·캐시 갱신을 재사용하지 않는다
+    public func respondToEvent(
+        _ calendarId: String,
+        _ eventId: String,
+        accountId: String,
+        at timeZone: TimeZone,
+        responseStatus: GoogleCalendar.AttendeeResponseStatus
+    ) async throws -> GoogleCalendar.EventOrigin {
+        let repository = self.repositoryPool.repository(for: accountId)
+        return try await repository.respondToEvent(
+            calendarId, timeZone.identifier, eventId, responseStatus
+        )
     }
 
     private func cachedEventsPeriod() -> Range<TimeInterval>? {

--- a/Domain/Tests/Models/Events/ExternalCalendar/GoogleCalendarEventTests.swift
+++ b/Domain/Tests/Models/Events/ExternalCalendar/GoogleCalendarEventTests.swift
@@ -54,3 +54,84 @@ extension GoogleCalendarEventTests {
         #expect(event.recurringEventId == nil)
     }
 }
+
+extension GoogleCalendarEventTests {
+
+    @Test(
+        "response status 문자열을 도메인 enum 으로",
+        arguments: [
+            ("accepted", GoogleCalendar.AttendeeResponseStatus.accepted),
+            ("declined", GoogleCalendar.AttendeeResponseStatus.declined),
+            ("tentative", GoogleCalendar.AttendeeResponseStatus.tentative),
+            ("needsAction", GoogleCalendar.AttendeeResponseStatus.needsAction)
+        ]
+    )
+    func attendee_responseStatusMapsToDomainEnum(
+        _ pair: (String, GoogleCalendar.AttendeeResponseStatus)
+    ) throws {
+        // given
+        let attendee = GoogleCalendar.EventOrigin.Attendee()
+            |> \.responseStatus .~ pair.0
+
+        // when
+        let response = attendee.response
+
+        // then
+        #expect(response == pair.1)
+    }
+
+    @Test func attendee_responseStatus_whenUnsupportedString_isNil() throws {
+        // given
+        let attendee = GoogleCalendar.EventOrigin.Attendee()
+            |> \.responseStatus .~ "unknown_status"
+
+        // when
+        let response = attendee.response
+
+        // then
+        #expect(response == nil)
+    }
+
+    @Test(
+        "selfValue 를 isSelf 로 그대로 반영",
+        arguments: [
+            (true, true), (false, false)
+        ]
+    )
+    func attendee_isSelf_reflectsSelfValue(_ pair: (Bool, Bool)) throws {
+        // given
+        let attendee = GoogleCalendar.EventOrigin.Attendee()
+            |> \.selfValue .~ pair.0
+
+        // when
+        let isSelf = attendee.isSelf
+
+        // then
+        #expect(isSelf == pair.1)
+    }
+
+    @Test func attendee_isSelf_whenSelfValueIsNil_isFalse() throws {
+        // given
+        let attendee = GoogleCalendar.EventOrigin.Attendee()
+
+        // when
+        let isSelf = attendee.isSelf
+
+        // then
+        #expect(isSelf == false)
+    }
+
+    @Test func editParams_isNotEmpty_whenOnlyAttendeesSet() throws {
+        // given
+        let attendee = GoogleCalendar.EventOrigin.Attendee()
+            |> \.email .~ "a@b.com"
+        let params = GoogleCalendar.EventEditParams()
+            |> \.attendees .~ [attendee]
+
+        // when
+        let isEmpty = params.isEmpty
+
+        // then
+        #expect(isEmpty == false)
+    }
+}

--- a/Domain/Tests/Usecases/GoogleCalendarUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/GoogleCalendarUsecaseImpleTests.swift
@@ -930,6 +930,63 @@ extension GoogleCalendarUsecaseImpleTests {
 }
 
 
+// MARK: - 역할 9: respondToEvent()
+
+extension GoogleCalendarUsecaseImpleTests {
+
+    @Test func respondToEvent_delegatesToAccountRepository() async throws {
+        // given
+        let repo = PrivateStubRepository(
+            customRespondOriginStubbing: GoogleCalendar.EventOrigin(id: "event1", summary: "responded")
+        )
+        let usecase = makeUsecase(accounts: ["account@google.com"], defaultRepo: repo)
+
+        // when
+        let origin = try await usecase.respondToEvent(
+            "cal1", "event1", accountId: "account@google.com",
+            at: TimeZone(identifier: "Asia/Seoul")!, responseStatus: .declined
+        )
+
+        // then
+        #expect(repo.didRespondToEventWith?.calendarId == "cal1")
+        #expect(repo.didRespondToEventWith?.timeZone == "Asia/Seoul")
+        #expect(repo.didRespondToEventWith?.eventId == "event1")
+        #expect(repo.didRespondToEventWith?.responseStatus == .declined)
+        #expect(origin.summary == "responded")
+    }
+
+    @Test func respondToEvent_whenRepositoryFails_throws() async throws {
+        // given
+        let repo = PrivateStubRepository(respondToEventShouldFail: true)
+        let usecase = makeUsecase(accounts: ["account@google.com"], defaultRepo: repo)
+
+        // when & then
+        await #expect(throws: (any Error).self) {
+            _ = try await usecase.respondToEvent(
+                "cal1", "event1", accountId: "account@google.com",
+                at: TimeZone(identifier: "Asia/Seoul")!, responseStatus: .accepted
+            )
+        }
+    }
+
+    @Test func respondToEvent_doesNotRunUpdateEventFlow() async throws {
+        // given
+        let repo = PrivateStubRepository()
+        let usecase = makeUsecase(accounts: ["account@google.com"], defaultRepo: repo)
+
+        // when
+        _ = try await usecase.respondToEvent(
+            "cal1", "event1", accountId: "account@google.com",
+            at: TimeZone(identifier: "Asia/Seoul")!, responseStatus: .accepted
+        )
+
+        // then — RSVP 는 updateEvent 와 그 인스턴스 재조회 로직을 타지 않는다
+        #expect(repo.didUpdateEventWith == nil)
+        #expect(repo.didLoadRepeatingInstancesWith == nil)
+    }
+}
+
+
 // MARK: - Event 변환 단위 테스트
 
 extension GoogleCalendarUsecaseImpleTests {
@@ -1040,13 +1097,24 @@ private final class PrivateStubRepository: GoogleCalendarRepository, @unchecked 
     private var stubCalendarTags: [[GoogleCalendar.Tag]]
     var eventsMocking: PassthroughSubject<[GoogleCalendar.Event], any Error>?
     private let customUpdateEventOriginStubbing: GoogleCalendar.EventOrigin?
+    private let customRespondOriginStubbing: GoogleCalendar.EventOrigin?
+    private let respondToEventShouldFail: Bool
+    var didUpdateEventWith: (eventId: String, params: GoogleCalendar.EventEditParams)?
+    var didRespondToEventWith: (
+        calendarId: String, timeZone: String, eventId: String,
+        responseStatus: GoogleCalendar.AttendeeResponseStatus
+    )?
 
     init(
         customCalendarsStubbing: [GoogleCalendar.Tag]? = nil,
         eventsMocking: PassthroughSubject<[GoogleCalendar.Event], any Error>? = nil,
-        customUpdateEventOriginStubbing: GoogleCalendar.EventOrigin? = nil
+        customUpdateEventOriginStubbing: GoogleCalendar.EventOrigin? = nil,
+        customRespondOriginStubbing: GoogleCalendar.EventOrigin? = nil,
+        respondToEventShouldFail: Bool = false
     ) {
         self.customUpdateEventOriginStubbing = customUpdateEventOriginStubbing
+        self.customRespondOriginStubbing = customRespondOriginStubbing
+        self.respondToEventShouldFail = respondToEventShouldFail
         self.stubColors = [
             .init(
                 ownerId: "account@google.com",
@@ -1126,8 +1194,21 @@ private final class PrivateStubRepository: GoogleCalendarRepository, @unchecked 
     func updateEvent(
         _ calendarId: String, _ timeZone: String, _ eventId: String, _ params: GoogleCalendar.EventEditParams
     ) -> AnyPublisher<GoogleCalendar.EventOrigin, any Error> {
+        self.didUpdateEventWith = (eventId, params)
         let origin = self.customUpdateEventOriginStubbing ?? GoogleCalendar.EventOrigin(id: eventId, summary: params.summary)
         return Just(origin).mapAsAnyError().eraseToAnyPublisher()
+    }
+
+    func respondToEvent(
+        _ calendarId: String,
+        _ timeZone: String,
+        _ eventId: String,
+        _ responseStatus: GoogleCalendar.AttendeeResponseStatus
+    ) async throws -> GoogleCalendar.EventOrigin {
+        self.didRespondToEventWith = (calendarId, timeZone, eventId, responseStatus)
+        guard !self.respondToEventShouldFail else { throw TestError() }
+        return self.customRespondOriginStubbing
+            ?? GoogleCalendar.EventOrigin(id: eventId, summary: "some")
     }
 
     func removeEvent(_ calendarId: String, _ eventId: String) -> AnyPublisher<Void, any Error> {

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailView.swift
@@ -45,6 +45,7 @@ import CommonPresentation
     var isSavable: Bool = false
     var isSaving: Bool = false
     var liveActivityActionModel: LiveActivityActionModel?
+    var isRespondingAttendance: Bool = false
 
     func bind(_ viewModel: any GoogleCalendarEventDetailViewModel) {
 
@@ -176,6 +177,13 @@ import CommonPresentation
                 self?.liveActivityActionModel = model
             })
             .store(in: self.cancellables)
+
+        viewModel.isRespondingAttendance
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self] isResponding in
+                self?.isRespondingAttendance = isResponding
+            })
+            .store(in: self.cancellables)
     }
 }
 
@@ -204,6 +212,7 @@ final class GoogleCalendarEventDetailViewEventHandler: Observable {
     var startEditDescription: () -> Void = { }
     var share: () -> Void = { }
     var toggleLiveActivity: (Bool) -> Void = { _ in }
+    var selectAttendanceResponse: () -> Void = { }
 
     func bind(_ viewModel: any GoogleCalendarEventDetailViewModel) {
         onAppear = viewModel.refresh
@@ -227,6 +236,7 @@ final class GoogleCalendarEventDetailViewEventHandler: Observable {
         startEditDescription = viewModel.startEditDescription
         share = viewModel.share
         toggleLiveActivity = viewModel.toggleLiveActivity(isRegistered:)
+        selectAttendanceResponse = viewModel.selectAttendanceResponse
     }
 }
 
@@ -687,11 +697,29 @@ struct GoogleCalendarEventDetailView: View {
     }
 
     private func attendeeView(_ attendee: AttendeeViewModelModel) -> some View {
+        Group {
+            if attendee.isSelf {
+                self.attendeeRow(attendee)
+                    .onTapGesture {
+                        eventHandlers.selectAttendanceResponse()
+                    }
+            } else {
+                self.attendeeRow(attendee)
+            }
+        }
+    }
+
+    private func attendeeRow(_ attendee: AttendeeViewModelModel) -> some View {
         HStack {
 
-            Image(systemName: attendee.isAccepted ? "checkmark.circle.fill" : "circle")
-                .font(.system(size: 12, weight: .light))
-                .foregroundStyle(self.appearance.colorSet.text1.asColor)
+            if attendee.isSelf, state.isRespondingAttendance {
+                LoadingCircleView(appearance.colorSet.text1.asColor)
+                    .frame(width: 12, height: 12)
+            } else {
+                Image(systemName: attendee.isAccepted ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 12, weight: .light))
+                    .foregroundStyle(self.appearance.colorSet.text1.asColor)
+            }
 
             VStack(alignment: .leading) {
                 Text(attendee.name)
@@ -700,6 +728,12 @@ struct GoogleCalendarEventDetailView: View {
 
                 if attendee.isOrganizer {
                     Text("eventDetail::gogoleEvent::attendees::organizer".localized())
+                        .font(appearance.fontSet.subSubNormal.asFont)
+                        .foregroundStyle(appearance.colorSet.text2.asColor)
+                }
+
+                if attendee.isSelf {
+                    Text("\("eventDetail::gogoleEvent::attendees::me".localized()) · \(attendee.responseStatusText)")
                         .font(appearance.fontSet.subSubNormal.asFont)
                         .foregroundStyle(appearance.colorSet.text2.asColor)
                 }

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
@@ -20,22 +20,35 @@ import CommonPresentation
 
 
 struct AttendeeViewModelModel: Equatable {
-    
+
     var id: String?
     let name: String
     var isOrganizer: Bool = false
     var isAccepted: Bool = false
-    
+    var isSelf: Bool = false
+    var response: GoogleCalendar.AttendeeResponseStatus?
+
     init(_ id: String, _ name: String) {
         self.id = id
         self.name = name
     }
-    
+
     init(_ attendee: GoogleCalendar.EventOrigin.Attendee) {
         self.id = attendee.identifier
         self.name = attendee.displayNameOrEmail ?? "eventDetail::gogoleEvent::attendee::unknown".localized()
         self.isOrganizer = attendee.organizer ?? false
         self.isAccepted = attendee.isAccepted
+        self.isSelf = attendee.isSelf
+        self.response = attendee.response
+    }
+
+    var responseStatusText: String {
+        switch self.response {
+        case .accepted: return "eventDetail::gogoleEvent::attendees::response::accepted".localized()
+        case .tentative: return "eventDetail::gogoleEvent::attendees::response::tentative".localized()
+        case .declined: return "eventDetail::gogoleEvent::attendees::response::declined".localized()
+        case .needsAction, .none: return "eventDetail::gogoleEvent::attendees::response::needsAction".localized()
+        }
     }
 }
 
@@ -144,6 +157,7 @@ protocol GoogleCalendarEventDetailViewModel: AnyObject, Sendable, GoogleCalendar
     func startEditDescription()
     func share()
     func toggleLiveActivity(isRegistered: Bool)
+    func selectAttendanceResponse()
 
     // presenter
     var isEditable: AnyPublisher<Bool, Never> { get }
@@ -165,6 +179,7 @@ protocol GoogleCalendarEventDetailViewModel: AnyObject, Sendable, GoogleCalendar
     var isSaving: AnyPublisher<Bool, Never> { get }
     var hasChanges: AnyPublisher<Bool, Never> { get }
     var liveActivityActionModel: AnyPublisher<LiveActivityActionModel?, Never> { get }
+    var isRespondingAttendance: AnyPublisher<Bool, Never> { get }
 }
 
 
@@ -225,6 +240,7 @@ final class GoogleCalendarEventDetailViewModelImple: GoogleCalendarEventDetailVi
         let fields = CurrentValueSubject<OriginalAndCurrent<EditableFields>?, Never>(nil)
         let isSaving = CurrentValueSubject<Bool, Never>(false)
         let isDescriptionPlainEditing = CurrentValueSubject<Bool, Never>(false)
+        let isResponding = CurrentValueSubject<Bool, Never>(false)
     }
     
     private let cancellables = CancelBag()
@@ -731,6 +747,75 @@ extension GoogleCalendarEventDetailViewModelImple {
 }
 
 
+// MARK: - GoogleCalendarEventDetailViewModelImple Attendance Response
+
+extension GoogleCalendarEventDetailViewModelImple {
+
+    func selectAttendanceResponse() {
+        guard !self.subject.isResponding.value else { return }
+        // 저장 버튼과 달리 참석자 행은 readOnlyCalendar 에서도 항상 렌더된다 — 조용히 무시하면 안쪽 탭 제스처가 컨테이너의 토스트를 가려 무반응처럼 보인다
+        guard self.subject.writePermission.value != .readOnlyCalendar else {
+            self.selectNotEditableField()
+            return
+        }
+        self.runWithWritePermission { [weak self] in
+            self?.showAttendanceResponseActionSheet()
+        }
+    }
+
+    private func showAttendanceResponseActionSheet() {
+        var form = ActionSheetForm()
+            |> \.title .~ pure("eventDetail::gogoleEvent::attendees::response::title".localized())
+
+        form.actions.append(
+            .init("eventDetail::gogoleEvent::attendees::response::accepted".localized()) { [weak self] in
+                self?.respondAttendance(.accepted)
+            }
+        )
+        form.actions.append(
+            .init("eventDetail::gogoleEvent::attendees::response::tentative".localized()) { [weak self] in
+                self?.respondAttendance(.tentative)
+            }
+        )
+        form.actions.append(
+            .init("eventDetail::gogoleEvent::attendees::response::declined".localized()) { [weak self] in
+                self?.respondAttendance(.declined)
+            }
+        )
+        form.actions.append(.init("common.cancel".localized(), style: .cancel))
+
+        self.router?.showActionSheet(form)
+    }
+
+    private func respondAttendance(_ responseStatus: GoogleCalendar.AttendeeResponseStatus) {
+        guard let origin = self.subject.origin.value,
+              let timeZone = self.subject.timeZone.value
+        else { return }
+
+        // 참석 의사는 보통 시리즈 단위다 — 탭 한 번에 즉시 반영해야 하는 이 기능 특성상 범위 선택 시트 없이 마스터로 고정한다
+        let eventId = origin.recurringEventId ?? origin.id
+        let calendarId = self.calendarId
+        let accountId = self.accountId
+        self.subject.isResponding.send(true)
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let updated = try await self.googleCalendarUsecase.respondToEvent(
+                    calendarId, eventId, accountId: accountId, at: timeZone, responseStatus: responseStatus
+                )
+                self.subject.isResponding.send(false)
+                guard let current = self.subject.origin.value else { return }
+                self.subject.origin.send(current |> \.attendees .~ updated.attendees)
+            } catch {
+                self.subject.isResponding.send(false)
+                self.router?.showError(error)
+            }
+        }
+        .store(in: self.cancellables)
+    }
+}
+
+
 // MARK: - GoogleCalendarEventDetailViewModelImple Presenter
 
 extension GoogleCalendarEventDetailViewModelImple {
@@ -925,6 +1010,12 @@ extension GoogleCalendarEventDetailViewModelImple {
         .map(transform)
         .removeDuplicates()
         .eraseToAnyPublisher()
+    }
+
+    var isRespondingAttendance: AnyPublisher<Bool, Never> {
+        return self.subject.isResponding
+            .removeDuplicates()
+            .eraseToAnyPublisher()
     }
 
     var descriptionModel: AnyPublisher<GoogleCalendarEventDescriptionModel, Never> {

--- a/Presentations/EventDetailScene/Tests/GoogleCalendarEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/GoogleCalendarEventDetailViewModelImpleTests.swift
@@ -44,7 +44,9 @@ final class GoogleCalendarEventDetailViewModelImpleTests: PublisherWaitable {
         updateEventDelayMilliseconds: UInt64 = 0,
         eventDetailFailsFromCallIndex: Int? = nil,
         registeredLiveActivityTarget: LiveActivityTarget? = nil,
-        liveActivityStartError: (any Error)? = nil
+        liveActivityStartError: (any Error)? = nil,
+        respondedOrigin: GoogleCalendar.EventOrigin? = GoogleCalendarEventDetailViewModelImpleTests.defaultRespondedOrigin(),
+        respondEventDelayMilliseconds: UInt64 = 0
     ) -> GoogleCalendarEventDetailViewModelImple {
         let settingUsecase = StubCalendarSettingUsecase()
         settingUsecase.prepare()
@@ -68,6 +70,8 @@ final class GoogleCalendarEventDetailViewModelImpleTests: PublisherWaitable {
         calendarUsecase.stubUpdatedEventOrigin = updatedOrigin
         calendarUsecase.updateEventDelayMilliseconds = updateEventDelayMilliseconds
         calendarUsecase.eventDetailFailsFromCallIndex = eventDetailFailsFromCallIndex
+        calendarUsecase.stubRespondedEventOrigin = respondedOrigin
+        calendarUsecase.respondEventDelayMilliseconds = respondEventDelayMilliseconds
         calendarUsecase.refreshGoogleCalendarEventTags()
         self.lastCalendarUsecase = calendarUsecase
         self.integrationUsecase.shouldFailReauthenticate = shouldFailReauthenticate
@@ -100,6 +104,18 @@ final class GoogleCalendarEventDetailViewModelImpleTests: PublisherWaitable {
             |> \.start .~ start
             |> \.end .~ end
             |> \.location .~ "updated location"
+    }
+
+    private static func defaultRespondedOrigin() -> GoogleCalendar.EventOrigin {
+        let selfAttendee = GoogleCalendar.EventOrigin.Attendee()
+            |> \.id .~ "id:31"
+            |> \.selfValue .~ true
+            |> \.responseStatus .~ "accepted"
+        let otherAttendee = GoogleCalendar.EventOrigin.Attendee()
+            |> \.id .~ "id:2"
+            |> \.responseStatus .~ "declined"
+        return GoogleCalendar.EventOrigin(id: "id", summary: "name")
+            |> \.attendees .~ [selfAttendee, otherAttendee]
     }
 
     private func makeAllDayViewModel(
@@ -1679,6 +1695,282 @@ extension GoogleCalendarEventDetailViewModelImpleTests {
 }
 
 
+// MARK: - 참석 응답 — 내 attendee 마킹
+
+extension GoogleCalendarEventDetailViewModelImpleTests {
+
+    @Test func attendees_marksSelfAttendee() async throws {
+        // given
+        let expect = expectConfirm("attendee 정보 제공 - self 여부·응답상태")
+        let viewModel = self.makeViewModel()
+
+        // when
+        let list = try await self.firstOutput(expect, for: viewModel.attendees) {
+            viewModel.refresh()
+        } ?? nil
+
+        // then
+        let selfAttendee = list?.attendees.first(where: { $0.id == "id:31" })
+        #expect(selfAttendee?.isSelf == true)
+        #expect(selfAttendee?.response == .needsAction)
+        let others = list?.attendees.filter { $0.id != "id:31" }
+        #expect(others?.allSatisfy { $0.isSelf == false } == true)
+    }
+}
+
+
+// MARK: - 참석 응답 — 쓰기 권한 게이팅
+
+extension GoogleCalendarEventDetailViewModelImpleTests {
+
+    @Test func selectAttendanceResponse_whenReadOnlyCalendar_showsNotEditableToast() async throws {
+        // given — 참석자 행은 저장 버튼과 달리 readOnlyCalendar 에서도 항상 렌더되므로 조용히 무시하면 안 되고 토스트가 떠야 한다
+        let viewModel = self.makeViewModel(writePermission: .readOnlyCalendar)
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+
+        // when
+        viewModel.selectAttendanceResponse()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        #expect(self.spyRouter.didShowActionSheetWith == nil)
+        #expect(self.spyRouter.didShowConfirmWith == nil)
+        #expect(self.lastCalendarUsecase.didRespondToEventWith == nil)
+        #expect(self.spyRouter.didShowToastWithMessage == "eventDetail::gogoleEvent::notEditableField::message".localized())
+    }
+
+    @Test func selectAttendanceResponse_whenNeedReauthentication_confirmsFirst() async throws {
+        // given
+        let viewModel = self.makeViewModel(writePermission: .needReauthentication)
+        self.spyRouter.shouldConfirmNotCancel = true
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+
+        // when
+        viewModel.selectAttendanceResponse()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        #expect(self.integrationUsecase.didReauthenticateForWriteScopeWith?.accountId == "stub@gmail.com")
+        #expect(self.spyRouter.didShowActionSheetWith != nil)
+    }
+
+    @Test func selectAttendanceResponse_showsActionSheetWithThreeResponses() async throws {
+        // given
+        let viewModel = self.makeViewModel(writePermission: .writable)
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+
+        // when
+        viewModel.selectAttendanceResponse()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        let actions = self.spyRouter.didShowActionSheetWith?.actions.map { $0.text }
+        #expect(actions == [
+            "eventDetail::gogoleEvent::attendees::response::accepted".localized(),
+            "eventDetail::gogoleEvent::attendees::response::tentative".localized(),
+            "eventDetail::gogoleEvent::attendees::response::declined".localized(),
+            "common.cancel".localized()
+        ])
+    }
+
+    @Test func selectAttendanceResponse_whileResponding_doesNotShowActionSheet() async throws {
+        // given — 응답 요청이 진행 중인 상태를 실제로 만든다(응답 지연 60ms)
+        let viewModel = self.makeViewModel(writePermission: .writable, respondEventDelayMilliseconds: 60)
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+        viewModel.selectAttendanceResponse()
+        try await Task.sleep(for: .milliseconds(10))
+        let acceptedAction = self.spyRouter.didShowActionSheetWith?.actions.first(where: {
+            $0.text == "eventDetail::gogoleEvent::attendees::response::accepted".localized()
+        })
+        acceptedAction?.selected?()
+        try await Task.sleep(for: .milliseconds(10))
+        self.spyRouter.didShowActionSheetWith = nil
+
+        // when — 응답이 아직 진행 중인 시점에 내 행을 다시 탭
+        viewModel.selectAttendanceResponse()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then — 두 번째 액션시트는 뜨지 않는다
+        #expect(self.spyRouter.didShowActionSheetWith == nil)
+        try await Task.sleep(for: .milliseconds(60))
+    }
+}
+
+
+// MARK: - 참석 응답 — 대상 id·저장 상태와의 독립성
+
+extension GoogleCalendarEventDetailViewModelImpleTests {
+
+    private func selectAcceptedResponse() {
+        self.spyRouter.actionSheetSelectionMocking = { form in
+            form.actions.first(where: {
+                $0.text == "eventDetail::gogoleEvent::attendees::response::accepted".localized()
+            })
+        }
+    }
+
+    @Test func respondAttendance_callsUsecaseWithSeriesMasterId_whenRecurringInstance() async throws {
+        // given
+        let viewModel = self.makeViewModel(recurringEventId: "series_id")
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+        self.selectAcceptedResponse()
+
+        // when
+        viewModel.selectAttendanceResponse()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        #expect(self.lastCalendarUsecase.didRespondToEventWith?.eventId == "series_id")
+        #expect(self.lastCalendarUsecase.didRespondToEventWith?.responseStatus == .accepted)
+    }
+
+    @Test func respondAttendance_doesNotCloseScene() async throws {
+        // given
+        let viewModel = self.makeViewModel()
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+        self.selectAcceptedResponse()
+
+        // when
+        viewModel.selectAttendanceResponse()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        #expect(self.spyRouter.didClosed == nil)
+    }
+
+    @Test func respondAttendance_keepsEditingFields() async throws {
+        // given — 응답 성공이 applyLoaded 를 부르면 편집 중이던 입력이 origin 값으로 되돌아간다
+        let viewModel = self.makeViewModel()
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+        viewModel.enter(name: "editing in progress")
+        self.selectAcceptedResponse()
+
+        // when
+        viewModel.selectAttendanceResponse()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        let hasChanges = try await self.firstOutput(expectConfirm("hasChanges"), for: viewModel.hasChanges)
+        let name = try await self.firstOutput(expectConfirm("eventName"), for: viewModel.eventName)
+        #expect(hasChanges == true)
+        #expect(name == "editing in progress")
+    }
+
+    @Test func respondAttendance_doesNotToggleIsSaving() async throws {
+        // given — 응답 대기 상태가 isSaving 을 재사용하면 저장 버튼 로딩·화면 잠금이 같이 걸린다
+        let viewModel = self.makeViewModel(respondEventDelayMilliseconds: 100)
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+        self.selectAcceptedResponse()
+
+        // when
+        viewModel.selectAttendanceResponse()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then — 응답 요청이 진행 중인 시점에도 isSaving 은 그대로 false
+        let isSavingWhileResponding = try await self.firstOutput(expectConfirm("isSaving"), for: viewModel.isSaving)
+        #expect(isSavingWhileResponding == false)
+        try await Task.sleep(for: .milliseconds(120))
+    }
+
+    @Test func respondAttendance_togglesRespondingState() async throws {
+        // given
+        let viewModel = self.makeViewModel(respondEventDelayMilliseconds: 60)
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+        self.selectAcceptedResponse()
+
+        // when
+        viewModel.selectAttendanceResponse()
+        try await Task.sleep(for: .milliseconds(10))
+        let respondingDuring = try await self.firstOutput(
+            expectConfirm("responding 중"), for: viewModel.isRespondingAttendance
+        )
+
+        // then
+        #expect(respondingDuring == true)
+        try await Task.sleep(for: .milliseconds(80))
+        let respondingAfter = try await self.firstOutput(
+            expectConfirm("responding 완료"), for: viewModel.isRespondingAttendance
+        )
+        #expect(respondingAfter == false)
+    }
+
+    @Test func respondAttendance_whenFails_showsError() async throws {
+        // given
+        let viewModel = self.makeViewModel(respondedOrigin: nil)
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+        self.selectAcceptedResponse()
+
+        // when
+        viewModel.selectAttendanceResponse()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        #expect(self.spyRouter.didShowError != nil)
+        let isResponding = try await self.firstOutput(
+            expectConfirm("isRespondingAttendance false"), for: viewModel.isRespondingAttendance
+        )
+        #expect(isResponding == false)
+    }
+
+    @Test func respondAttendance_updatesSelfAttendeeResponse() async throws {
+        // given — fixture 상 초기 self(id:31) 응답은 needsAction(31 % 2 == 1)
+        let viewModel = self.makeViewModel()
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+        self.selectAcceptedResponse()
+
+        // when
+        viewModel.selectAttendanceResponse()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then — 응답 성공 후 목록의 내 항목 response 가 요청한 값으로 갱신된다
+        let list = try await self.firstOutput(expectConfirm("attendees 갱신"), for: viewModel.attendees) ?? nil
+        let selfAttendee = list?.attendees.first(where: { $0.isSelf })
+        #expect(selfAttendee?.response == .accepted)
+    }
+
+    @Test func respondAttendance_keepsOtherAttendeesInList() async throws {
+        // given
+        let viewModel = self.makeViewModel()
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+        self.selectAcceptedResponse()
+
+        // when
+        viewModel.selectAttendanceResponse()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then — 내 항목만 갈리고 다른 참석자는 목록에 남는다
+        let list = try await self.firstOutput(expectConfirm("attendees 갱신"), for: viewModel.attendees) ?? nil
+        #expect(list?.attendees.count == 2)
+        let other = list?.attendees.first(where: { !$0.isSelf })
+        #expect(other?.response == .declined)
+    }
+}
+
+
 private final class PrivateStubGoogleCalendarUsecase: StubGoogleCalendarUsecase, @unchecked Sendable {
 
     var additionalStubbing: ((GoogleCalendar.EventOrigin) -> GoogleCalendar.EventOrigin)?
@@ -1765,6 +2057,22 @@ private final class PrivateStubGoogleCalendarUsecase: StubGoogleCalendarUsecase,
         }
         return try await super.updateEvent(
             calendarId, eventId, accountId: accountId, at: timeZone, params: params
+        )
+    }
+
+    var respondEventDelayMilliseconds: UInt64 = 0
+    override func respondToEvent(
+        _ calendarId: String,
+        _ eventId: String,
+        accountId: String,
+        at timeZone: TimeZone,
+        responseStatus: GoogleCalendar.AttendeeResponseStatus
+    ) async throws -> GoogleCalendar.EventOrigin {
+        if self.respondEventDelayMilliseconds > 0 {
+            try await Task.sleep(for: .milliseconds(self.respondEventDelayMilliseconds))
+        }
+        return try await super.respondToEvent(
+            calendarId, eventId, accountId: accountId, at: timeZone, responseStatus: responseStatus
         )
     }
 }

--- a/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Google/GoogleCalendar+Mapping.swift
+++ b/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Google/GoogleCalendar+Mapping.swift
@@ -113,6 +113,7 @@ extension GoogleCalendar.EventEditParams {
         json["start"] = self.start?.asJson()
         json["end"] = self.end?.asJson()
         json["recurrence"] = self.recurrence
+        json["attendees"] = self.attendees?.map { $0.asJson() }
         return json
     }
 }
@@ -125,6 +126,20 @@ extension GoogleCalendar.EventOrigin.GoogleEventTime {
         json["date"] = self.date ?? NSNull()
         json["dateTime"] = self.dateTime ?? NSNull()
         json["timeZone"] = self.timeZone
+        return json
+    }
+}
+
+extension GoogleCalendar.EventOrigin.Attendee {
+
+    // id·self·organizer 는 구글 문서상 read-only 라 patch body 에서 뺀다
+    func asJson() -> [String: Any] {
+        var json: [String: Any] = [:]
+        json["email"] = self.email
+        json["displayName"] = self.displayName
+        json["responseStatus"] = self.responseStatus
+        json["optional"] = self.optional
+        json["resource"] = self.resource
         return json
     }
 }

--- a/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Google/GoogleCalendarLocalAggregatedRepositoryImple.swift
+++ b/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Google/GoogleCalendarLocalAggregatedRepositoryImple.swift
@@ -111,6 +111,15 @@ extension GoogleCalendarLocalAggregatedRepositoryImple {
             .eraseToAnyPublisher()
     }
 
+    public func respondToEvent(
+        _ calendarId: String,
+        _ timeZone: String,
+        _ eventId: String,
+        _ responseStatus: GoogleCalendar.AttendeeResponseStatus
+    ) async throws -> GoogleCalendar.EventOrigin {
+        throw RuntimeError("google calendar event write is not supported by the aggregated local repository")
+    }
+
     public func removeEvent(
         _ calendarId: String,
         _ eventId: String

--- a/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Google/GoogleCalendarRepositoryImple.swift
+++ b/Repository/Sources/Repository+Imple/Event/ExternalCalendar/Google/GoogleCalendarRepositoryImple.swift
@@ -315,6 +315,32 @@ extension GoogleCalendarRepositoryImple {
         .eraseToAnyPublisher()
     }
 
+    // patch 는 attendees 배열을 통째 교체한다 — 캐시를 읽으면 그 사이 바뀐 다른 참석자의 응답을 덮어쓴다
+    public func respondToEvent(
+        _ calendarId: String,
+        _ timeZone: String,
+        _ eventId: String,
+        _ responseStatus: GoogleCalendar.AttendeeResponseStatus
+    ) async throws -> GoogleCalendar.EventOrigin {
+
+        let latest = try await self.loadEventDetailFromRemoteWithRecurrenceIfNeed(
+            calendarId, eventId, at: timeZone
+        )
+        guard let attendees = latest.attendees, attendees.contains(where: { $0.isSelf })
+        else {
+            throw RuntimeError("no self attendee to respond")
+        }
+        let params = GoogleCalendar.EventEditParams()
+            |> \.attendees .~ attendees.map {
+                $0.isSelf ? ($0 |> \.responseStatus .~ responseStatus.rawValue) : $0
+            }
+        let updated = try await self.updateEventOnRemote(calendarId, eventId, params)
+        if !updated.isRecurringSeriesMaster {
+            try? await self.cacheStorage.updateEventDetail(calendarId, timeZone, updated, accountId: self.accountId)
+        }
+        return updated
+    }
+
     private func updateEventOnRemote(
         _ calendarId: String,
         _ eventId: String,

--- a/Repository/Tests/Event/ExternalCalendar/GoogleCalendarRepositoryImple+Tests.swift
+++ b/Repository/Tests/Event/ExternalCalendar/GoogleCalendarRepositoryImple+Tests.swift
@@ -796,6 +796,62 @@ extension GoogleCalendarRepositoryImple_Tests {
         }
     }
 
+    @Test func repository_updateEvent_sendsAttendeesArray() async throws {
+        try await self.runTestWithOpenClose("test_google_event_update_attendees_1") {
+            // given
+            let expect = self.expectConfirm("참석자 목록을 실은 patch 요청")
+            let repository = self.makeRepository()
+            let attendee = GoogleCalendar.EventOrigin.Attendee()
+                |> \.id .~ "attendee-id"
+                |> \.email .~ "a@b.com"
+                |> \.displayName .~ "A B"
+                |> \.organizer .~ true
+                |> \.selfValue .~ true
+                |> \.resource .~ true
+                |> \.optional .~ true
+                |> \.responseStatus .~ "accepted"
+            let params = GoogleCalendar.EventEditParams()
+                |> \.attendees .~ [attendee]
+
+            // when
+            let _ = try await self.firstOutput(
+                expect, for: repository.updateEvent("c_id", "Asia/Seoul", "time_is_date", params)
+            )
+
+            // then
+            let requestedParams = try #require(self.stubRemote.didRequestedParams)
+            let attendeesJson = try #require(requestedParams["attendees"] as? [[String: Any]])
+            let attendeeJson = try #require(attendeesJson.first)
+            #expect(attendeeJson["email"] as? String == "a@b.com")
+            #expect(attendeeJson["displayName"] as? String == "A B")
+            #expect(attendeeJson["responseStatus"] as? String == "accepted")
+            #expect(attendeeJson["optional"] as? Bool == true)
+            #expect(attendeeJson["resource"] as? Bool == true)
+            #expect(attendeeJson["id"] == nil)
+            #expect(attendeeJson["self"] == nil)
+            #expect(attendeeJson["organizer"] == nil)
+        }
+    }
+
+    @Test func repository_updateEvent_whenAttendeesIsNil_omitsKey() async throws {
+        try await self.runTestWithOpenClose("test_google_event_update_attendees_2") {
+            // given
+            let expect = self.expectConfirm("참석자를 안 건드리면 patch body 에 attendees 키가 없다")
+            let repository = self.makeRepository()
+            let params = GoogleCalendar.EventEditParams()
+                |> \.summary .~ "updated summary"
+
+            // when
+            let _ = try await self.firstOutput(
+                expect, for: repository.updateEvent("c_id", "Asia/Seoul", "time_is_date", params)
+            )
+
+            // then
+            let requestedParams = try #require(self.stubRemote.didRequestedParams)
+            #expect(requestedParams["attendees"] == nil)
+        }
+    }
+
     @Test func repository_updateEvent_whenResponseIsSeriesMaster_doesNotCacheAsInstanceDetail() async throws {
         try await self.runTestWithOpenClose("test_google_event_update_4") {
             // given — "전체 일정" 저장은 시리즈 마스터(recurringEventId 없음 + recurrence 있음)를 돌려준다

--- a/Repository/Tests/Event/ExternalCalendar/GoogleCalendarRepositoryImple+Tests.swift
+++ b/Repository/Tests/Event/ExternalCalendar/GoogleCalendarRepositoryImple+Tests.swift
@@ -796,43 +796,6 @@ extension GoogleCalendarRepositoryImple_Tests {
         }
     }
 
-    @Test func repository_updateEvent_sendsAttendeesArray() async throws {
-        try await self.runTestWithOpenClose("test_google_event_update_attendees_1") {
-            // given
-            let expect = self.expectConfirm("참석자 목록을 실은 patch 요청")
-            let repository = self.makeRepository()
-            let attendee = GoogleCalendar.EventOrigin.Attendee()
-                |> \.id .~ "attendee-id"
-                |> \.email .~ "a@b.com"
-                |> \.displayName .~ "A B"
-                |> \.organizer .~ true
-                |> \.selfValue .~ true
-                |> \.resource .~ true
-                |> \.optional .~ true
-                |> \.responseStatus .~ "accepted"
-            let params = GoogleCalendar.EventEditParams()
-                |> \.attendees .~ [attendee]
-
-            // when
-            let _ = try await self.firstOutput(
-                expect, for: repository.updateEvent("c_id", "Asia/Seoul", "time_is_date", params)
-            )
-
-            // then
-            let requestedParams = try #require(self.stubRemote.didRequestedParams)
-            let attendeesJson = try #require(requestedParams["attendees"] as? [[String: Any]])
-            let attendeeJson = try #require(attendeesJson.first)
-            #expect(attendeeJson["email"] as? String == "a@b.com")
-            #expect(attendeeJson["displayName"] as? String == "A B")
-            #expect(attendeeJson["responseStatus"] as? String == "accepted")
-            #expect(attendeeJson["optional"] as? Bool == true)
-            #expect(attendeeJson["resource"] as? Bool == true)
-            #expect(attendeeJson["id"] == nil)
-            #expect(attendeeJson["self"] == nil)
-            #expect(attendeeJson["organizer"] == nil)
-        }
-    }
-
     @Test func repository_updateEvent_whenAttendeesIsNil_omitsKey() async throws {
         try await self.runTestWithOpenClose("test_google_event_update_attendees_2") {
             // given
@@ -957,6 +920,139 @@ extension GoogleCalendarRepositoryImple_Tests {
     }
 }
 
+// MARK: - respond to event
+
+extension GoogleCalendarRepositoryImple_Tests {
+
+    private func attendee(
+        email: String, isSelf: Bool, responseStatus: String
+    ) -> GoogleCalendar.EventOrigin.Attendee {
+        return .init()
+            |> \.email .~ email
+            |> \.selfValue .~ isSelf
+            |> \.responseStatus .~ responseStatus
+    }
+
+    /// 캐시에는 other 가 accepted 로 남아 있고 원격에서는 declined 로 바뀐 상태를 만든다.
+    private func saveStaleRsvpCache() async throws {
+        let stale = GoogleCalendar.EventOrigin(id: "rsvp_event", summary: "stale")
+            |> \.attendees .~ [
+                self.attendee(email: "me@email.com", isSelf: true, responseStatus: "needsAction"),
+                self.attendee(email: "other@email.com", isSelf: false, responseStatus: "accepted")
+            ]
+        try await self.cacheStorage.updateEventDetail(
+            "c_id", "Asia/Seoul", stale, accountId: self.testAccountId
+        )
+    }
+
+    @Test func repository_respondToEvent_patchesAttendeesFromRemoteNotCache() async throws {
+        try await self.runTestWithOpenClose("test_google_event_rsvp_1") {
+            // given — 캐시의 other 는 accepted, 원격의 other 는 declined
+            try await self.saveStaleRsvpCache()
+            let repository = self.makeRepository()
+
+            // when
+            let _ = try await repository.respondToEvent("c_id", "Asia/Seoul", "rsvp_event", .accepted)
+
+            // then — 캐시를 읽었다면 other 가 accepted 로 실린다
+            let requestedParams = try #require(self.stubRemote.didRequestedParams)
+            let attendeesJson = try #require(requestedParams["attendees"] as? [[String: Any]])
+            let other = attendeesJson.first { $0["email"] as? String == "other@email.com" }
+            #expect(other?["responseStatus"] as? String == "declined")
+        }
+    }
+
+    @Test func repository_respondToEvent_replacesOnlySelfResponse() async throws {
+        try await self.runTestWithOpenClose("test_google_event_rsvp_2") {
+            // given
+            let repository = self.makeRepository()
+
+            // when
+            let _ = try await repository.respondToEvent("c_id", "Asia/Seoul", "rsvp_event", .tentative)
+
+            // then — 내 항목만 갈리고 배열 전체가 실린다
+            let requestedParams = try #require(self.stubRemote.didRequestedParams)
+            let attendeesJson = try #require(requestedParams["attendees"] as? [[String: Any]])
+            #expect(attendeesJson.count == 2)
+            let me = attendeesJson.first { $0["email"] as? String == "me@email.com" }
+            #expect(me?["responseStatus"] as? String == "tentative")
+            let other = attendeesJson.first { $0["email"] as? String == "other@email.com" }
+            #expect(other?["responseStatus"] as? String == "declined")
+        }
+    }
+
+    @Test func repository_respondToEvent_omitsReadOnlyAttendeeFields() async throws {
+        try await self.runTestWithOpenClose("test_google_event_rsvp_6") {
+            // given
+            let repository = self.makeRepository()
+
+            // when
+            let _ = try await repository.respondToEvent("c_id", "Asia/Seoul", "rsvp_event", .accepted)
+
+            // then — id·self·organizer 는 read-only 라 patch body 에서 빠지고 나머지는 실린다
+            let requestedParams = try #require(self.stubRemote.didRequestedParams)
+            let attendeesJson = try #require(requestedParams["attendees"] as? [[String: Any]])
+            let me = try #require(attendeesJson.first { $0["email"] as? String == "me@email.com" })
+            #expect(me["displayName"] as? String == "Me")
+            #expect(me["responseStatus"] as? String == "accepted")
+            #expect(me["id"] == nil)
+            #expect(me["self"] == nil)
+            #expect(me["organizer"] == nil)
+            let other = try #require(attendeesJson.first { $0["email"] as? String == "other@email.com" })
+            #expect(other["optional"] as? Bool == true)
+            #expect(other["id"] == nil)
+        }
+    }
+
+    @Test func repository_respondToEvent_updatesLocalCache() async throws {
+        try await self.runTestWithOpenClose("test_google_event_rsvp_5") {
+            // given — 캐시는 me=needsAction, other=accepted 인 낡은 상태
+            try await self.saveStaleRsvpCache()
+            let repository = self.makeRepository()
+
+            // when
+            let _ = try await repository.respondToEvent("c_id", "Asia/Seoul", "rsvp_event", .accepted)
+            let cached = try await self.cacheStorage.loadEventDetail(
+                "rsvp_event", accountId: self.testAccountId
+            )
+
+            // then — 응답 결과가 상세 캐시에 반영돼 재진입 시 낡은 값이 안 뜬다
+            let cachedAttendees = try #require(cached.attendees)
+            let me = cachedAttendees.first { $0.email == "me@email.com" }
+            #expect(me?.responseStatus == "accepted")
+            let other = cachedAttendees.first { $0.email == "other@email.com" }
+            #expect(other?.responseStatus == "declined")
+        }
+    }
+
+    @Test func repository_respondToEvent_whenNoSelfAttendee_throwsWithoutPatch() async throws {
+        try await self.runTestWithOpenClose("test_google_event_rsvp_3") {
+            // given — 내가 참석자가 아닌 이벤트
+            let repository = self.makeRepository()
+
+            // when + then
+            await #expect(throws: (any Error).self) {
+                _ = try await repository.respondToEvent("c_id", "Asia/Seoul", "rsvp_no_self", .accepted)
+            }
+            #expect(self.stubRemote.didRequestedMethod == .get)
+        }
+    }
+
+    @Test func repository_respondToEvent_whenRemoteLoadFails_doesNotPatch() async throws {
+        try await self.runTestWithOpenClose("test_google_event_rsvp_4") {
+            // given
+            let repository = self.makeRepository()
+
+            // when + then
+            await #expect(throws: (any Error).self) {
+                _ = try await repository.respondToEvent("c_id", "Asia/Seoul", "rsvp_load_fail", .accepted)
+            }
+            #expect(self.stubRemote.didRequestedMethod == .get)
+        }
+    }
+}
+
+
 extension GoogleCalendarRepositoryImple_Tests {
 
     @Test func storage_whenConnectionNotAvailable_throwsError() async throws {
@@ -1060,8 +1156,97 @@ private struct DummyResponse {
                 method: .delete,
                 endpoint: GoogleCalendarEndpoint.event(calendarId: "c_id", eventId: "fail_event"),
                 resultJsonString: .failure(RuntimeError("failed"))
+            ),
+            .init(
+                method: .get,
+                endpoint: GoogleCalendarEndpoint.event(calendarId: "c_id", eventId: "rsvp_event"),
+                resultJsonString: .success(self.dummyRsvpEvent("rsvp_event", attendees: self.rsvpAttendees))
+            ),
+            .init(
+                method: .patch,
+                endpoint: GoogleCalendarEndpoint.event(calendarId: "c_id", eventId: "rsvp_event"),
+                resultJsonString: .success(
+                    self.dummyRsvpEvent("rsvp_event", attendees: self.rsvpPatchedAttendees)
+                )
+            ),
+            .init(
+                method: .get,
+                endpoint: GoogleCalendarEndpoint.event(calendarId: "c_id", eventId: "rsvp_no_self"),
+                resultJsonString: .success(
+                    self.dummyRsvpEvent("rsvp_no_self", attendees: self.rsvpAttendeesWithoutSelf)
+                )
+            ),
+            .init(
+                method: .get,
+                endpoint: GoogleCalendarEndpoint.event(calendarId: "c_id", eventId: "rsvp_load_fail"),
+                resultJsonString: .failure(RuntimeError("failed"))
             )
         ]
+    }
+
+    /// 원격 기준값 — other 는 declined 다 (캐시에 심는 값과 갈린다)
+    private var rsvpAttendees: String {
+        return """
+        {
+          "id": "me-id",
+          "email": "me@email.com",
+          "displayName": "Me",
+          "self": true,
+          "organizer": true,
+          "responseStatus": "needsAction"
+        },
+        {
+          "id": "other-id",
+          "email": "other@email.com",
+          "displayName": "Other",
+          "optional": true,
+          "responseStatus": "declined"
+        }
+        """
+    }
+
+    /// patch 응답 — 내 응답이 accepted 로 적용된 상태
+    private var rsvpPatchedAttendees: String {
+        return """
+        {
+          "email": "me@email.com",
+          "self": true,
+          "responseStatus": "accepted"
+        },
+        {
+          "email": "other@email.com",
+          "responseStatus": "declined"
+        }
+        """
+    }
+
+    private var rsvpAttendeesWithoutSelf: String {
+        return """
+        {
+          "email": "other@email.com",
+          "responseStatus": "declined"
+        }
+        """
+    }
+
+    private func dummyRsvpEvent(_ id: String, attendees: String) -> String {
+        return """
+        {
+         "attendees": [
+        \(attendees)
+         ],
+         "kind": "calendar#event",
+         "id": "\(id)",
+         "status": "confirmed",
+         "summary": "rsvp",
+         "start": {
+          "date": "2025-04-11"
+         },
+         "end": {
+          "date": "2025-04-12"
+         }
+        }
+        """
     }
     
     private var dummyColors: String {

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Unknown";
 "eventDetail::gogoleEvent::attendees" = "Attendees (%d people)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Organizer";
+"eventDetail::gogoleEvent::attendees::me" = "You";
+"eventDetail::gogoleEvent::attendees::response::title" = "Will you attend?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Yes";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Maybe";
+"eventDetail::gogoleEvent::attendees::response::declined" = "No";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "No response";
 "eventDetail::gogoleEvent::conference::accessCode" = "Access Code";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Meeting Code";
 "eventDetail::gogoleEvent::conference::passCode" = "Pass Code";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "알수없음";
 "eventDetail::gogoleEvent::attendees" = "참석자 (%d명)";
 "eventDetail::gogoleEvent::attendees::organizer" = "주최자";
+"eventDetail::gogoleEvent::attendees::me" = "나";
+"eventDetail::gogoleEvent::attendees::response::title" = "참석하시나요?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "예";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "미정";
+"eventDetail::gogoleEvent::attendees::response::declined" = "아니오";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "응답 없음";
 "eventDetail::gogoleEvent::conference::accessCode" = "액세스 코드";
 "eventDetail::gogoleEvent::conference::meetingCode" = "미팅코드";
 "eventDetail::gogoleEvent::conference::passCode" = "패스코드";

--- a/Supports/TestDoubles/Sources/Usecases/StubGoogleCalendarUsecase.swift
+++ b/Supports/TestDoubles/Sources/Usecases/StubGoogleCalendarUsecase.swift
@@ -116,6 +116,26 @@ open class StubGoogleCalendarUsecase: GoogleCalendarUsecase, @unchecked Sendable
         return origin
     }
 
+    public var didRespondToEventWith: (calendarId: String, eventId: String, accountId: String, responseStatus: GoogleCalendar.AttendeeResponseStatus)?
+    public var stubRespondedEventOrigin: GoogleCalendar.EventOrigin?
+    open func respondToEvent(
+        _ calendarId: String,
+        _ eventId: String,
+        accountId: String,
+        at timeZone: TimeZone,
+        responseStatus: GoogleCalendar.AttendeeResponseStatus
+    ) async throws -> GoogleCalendar.EventOrigin {
+        self.didRespondToEventWith = (calendarId, eventId, accountId, responseStatus)
+        if shouldFailWrite {
+            throw RuntimeError("failed to respond to google calendar event")
+        }
+        guard let origin = self.stubRespondedEventOrigin
+        else {
+            throw RuntimeError("stubRespondedEventOrigin not set")
+        }
+        return origin
+    }
+
     public var didRemoveEventWith: (calendarId: String, eventId: String, accountId: String, scope: GoogleCalendar.EventRemoveScope)?
     open func removeEvent(
         _ calendarId: String,

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/Doubles/StubRepositories.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/Doubles/StubRepositories.swift
@@ -97,6 +97,13 @@ final class StubGoogleCalendarRepository: GoogleCalendarRepository, @unchecked S
         return Empty().eraseToAnyPublisher()
     }
 
+    func respondToEvent(
+        _ calendarId: String, _ timeZone: String, _ eventId: String,
+        _ responseStatus: GoogleCalendar.AttendeeResponseStatus
+    ) async throws -> GoogleCalendar.EventOrigin {
+        throw RuntimeError("read db cannot write")
+    }
+
     func removeEvent(_ calendarId: String, _ eventId: String) -> AnyPublisher<Void, any Error> {
         return Empty().eraseToAnyPublisher()
     }

--- a/docs/spec/google-calendar.md
+++ b/docs/spec/google-calendar.md
@@ -349,7 +349,7 @@ activeCalendars() = 전체 캘린더 - offTagIds에 포함된 캘린더
 | 설명 | `description` | 가능 |
 | 색상 | calendarId → 캘린더 색상 + eventColorId 오버라이드 | 가능 |
 | 반복 규칙 | `recurrence` | 가능 (앱 반복 옵션으로 왕복 못 시키는 규칙·복수 RRULE 줄은 잠금 → 탭 시 토스트) |
-| 참석자 목록 | `attendees[]` (이름, 이메일, 응답 상태) | 불가 (탭 시 토스트) |
+| 참석자 목록 | `attendees[]` (이름, 이메일, 응답 상태) | 내 항목만 가능(탭 → 수락/미정/거절 선택 시트) — 나머지는 불가 (탭 시 토스트) |
 | 회의 정보 | `conferenceData.entryPoints[].uri` | 불가 (헤더 탭 시 토스트, 링크/코드는 열기·복사 그대로) |
 | 첨부파일 | `attachments[]` (title, fileUrl, mimeType) | 불가 (탭하면 Safari로 열기 — 토스트 아님) |
 | 캘린더 | calendarId → 캘린더명 | 불가 (탭 시 토스트) |
@@ -374,7 +374,7 @@ activeCalendars() = 전체 캘린더 - offTagIds에 포함된 캘린더
 
 ### 8.3 편집 대상 필드
 
-`summary` · `start`/`end`(종일 토글 포함) · `location` · `description` · `colorId` · `recurrence` 를 편집한다. `attendees`·`conferenceData`·`attachments` 는 `EventEditParams` 에 필드를 두지 않아 PATCH 바디에 실릴 경로 자체가 없다 — 구글 PATCH 는 부분 업데이트라 안 보낸 필드는 서버 원본이 유지된다.
+`summary` · `start`/`end`(종일 토글 포함) · `location` · `description` · `colorId` · `recurrence` 를 편집한다. `conferenceData`·`attachments` 는 `EventEditParams` 에 필드를 두지 않아 PATCH 바디에 실릴 경로 자체가 없다 — 구글 PATCH 는 부분 업데이트라 안 보낸 필드는 서버 원본이 유지된다. `attendees` 는 이 경로를 안 탄다 — 본인 참석 응답(`respondToEvent`)만 별도 API 로 처리하고, 쓰기 직전 재조회로 얻은 최신 참석자 배열 전체를 실어 PATCH 한다(구글이 참석자 배열의 부분 patch 를 지원하지 않는다).
 
 `recurrence` 는 배열 전체를 보내되 RRULE 줄만 갈아끼운다(`replacingRRuleLine`) — EXDATE·RDATE 는 원본 그대로 보존된다. 규칙을 바꾼 저장은 회차가 아니라 시리즈 마스터(`recurringEventId ?? id`)를 대상으로 하고 수정 범위 선택 시트를 띄우지 않는다. 반복 옵션 선택 화면은 RRULE 로 표현 가능한 옵션만 제공한다(음력 제외).
 


### PR DESCRIPTION
구글 이벤트 상세에서 본인 참석 여부(수락·미정·거절)를 응답한다. 이슈 #876.

## 문제

구글 캘린더는 RSVP 전용 엔드포인트가 없다. `events.patch` 의 `attendees` 가 유일한 경로인데, [patch 는 배열 필드를 통째 교체한다](https://developers.google.com/workspace/calendar/api/v3/reference/events/patch) — *"Array fields, if specified, overwrite the existing arrays; this discards any previous array elements."* 내 응답 하나를 바꾸려 해도 참석자 배열 전체를 다시 실어야 하고, 화면 진입 시점에 읽어둔 배열을 그대로 보내면 그 사이 서버에서 바뀐 다른 참석자의 응답을 덮어쓴다.

`GoogleCalendar.EventEditParams` 에 `attendees` 필드를 아예 두지 않았던 것도 이 위험 때문이었다 (#863). 그래서 이번 작업은 필드를 추가하는 게 아니라 덮어쓰기 안전장치를 함께 설계하는 일이다.

## 접근

**읽기·병합·쓰기를 리포지토리가 한 단위로 진다.** `GoogleCalendarRepository.respondToEvent` 가 원격 상세 조회(캐시 미경유) → `isSelf` 항목만 교체 → 배열 전체 patch 를 수행한다. patch 의 배열 교체 대응은 구글 API 스펙 대응이지 도메인 정책이 아니라, 그 절차를 유스케이스에 펼치면 transport 제약이 도메인으로 샌다. 같은 파일의 `loadEventDetailFromRemoteWithRecurrenceIfNeed` 가 이미 같은 이유로 다단계 원격 조회를 흡수하고 있다.

**재조회는 캐시를 거치지 않는다.** `loadEventDetail` 은 캐시 먼저 → 리모트 순으로 방출하는데, 상세 화면 진입이 이미 그 캐시를 채워두기 때문에 캐시를 읽으면 "화면을 연 시점의 배열"로 patch 가 나간다 — 이슈가 막으려던 상황 그대로다. 회귀 TC 는 실 SQLite 캐시에 낡은 배열을 심고 원격엔 다른 값을 물려, patch body 가 원격 기준인지를 단언한다.

원격 조회에 실패하면 patch 를 시도하지 않고, 내가 참석자가 아니면(`isSelf` 항목 부재) 던진다 — 참석자가 아닌 이벤트에 나를 밀어넣는 쓰기를 막는다.

`etag`/`If-Match` 낙관적 잠금은 도입하지 않았다. [구글 문서상](https://developers.google.com/workspace/calendar/api/concepts/inviting-attendees-to-events) 비조직자 참석자가 보낸 shared property 변경은 *"only reflected on their own copy"* 라 전역 파괴가 없고, 내가 조직자인 경우는 쓰기 직전 재조회가 덮는다. 앱 전체에 낙관적 잠금 선례가 0건이기도 하다.

**편집 폼 저장과 독립.** 참석 응답은 저장 버튼을 거치지 않고 탭 즉시 반영된다. 진행 상태를 기존 `subject.isSaving` 에 얹으면 화면 전체가 `.allowsHitTesting(!isSaving)` 으로 잠겨 그 독립성이 깨지므로 `subject.isResponding` 으로 분리했다. 성공 뒤에도 `applyLoaded` 를 부르지 않고 `subject.origin` 의 `attendees` 만 갈아끼운다 — 폼을 재설정하면 편집 중이던 입력이 날아가고, 시리즈 마스터를 대상으로 썼을 때 응답의 시간 필드가 인스턴스와 달라 표시가 튄다.

**반복 이벤트는 범위 선택 없이 시리즈 마스터 대상.** 참석 의사는 보통 시리즈 단위이고, 탭 한 번에 즉시 반영해야 하는 이 기능 특성상 "이번만 / 전체" 시트가 성립하지 않는다.

**쓰기 권한은 기존 3분기 게이트를 그대로 탄다.** 다만 `readOnlyCalendar` 에서는 조용히 무시하지 않고 안내 토스트를 띄운다 — 저장 버튼은 읽기 전용일 때 아예 안 보이지만 참석자 행은 항상 렌더되므로, 그냥 return 하면 안쪽 탭 제스처가 컨테이너의 토스트를 가려 무반응처럼 보인다.

화면에서는 참석자 목록의 내 행만 탭 대상이 되고(나머지는 지금처럼 "편집 불가" 토스트), 내 행에 "나 · 현재 응답" 표기와 진행 스피너가 붙는다.

## 커밋

1. `attendees` 를 쓰기 파라미터에 싣고 응답 상태를 도메인 enum 으로 표현 — `id`·`self`·`organizer` 는 read-only 라 patch body 에서 뺀다
2. 참석 응답을 원격 재조회 기반 read-modify-write 로 반영 — 리포지토리 전용 계약
3. 상세 화면 진입점 + en·ko 로컬라이즈 + 스펙 문서 갱신

## 유저 검증 대기

유닛 테스트로는 덮을 수 없는 실서버 계약이라 실기기·실계정 확인이 남는다.

- read-only 필드(`id`·`self`·`organizer`)를 뺀 `attendees` 배열을 patch 했을 때 구글이 400 을 내지 않는지
- 다른 참석자가 있는 이벤트에서 내 응답만 바꿨을 때 나머지 참석자의 응답이 서버에 그대로 남는지
- 반복 이벤트에서 마스터 대상 응답이 전체 회차에 반영되는지
- 읽기 전용으로 구독 중인 캘린더의 이벤트에서 내 행을 탭했을 때 안내 토스트가 뜨는지
