### PR TITLE
[#951] 하네스 정비 신호 판정을 스크립트로 고정하고 정비 항목을 누적 이슈로 모은다

### DIFF
--- a/.claude/scripts/aggregate-usage.py
+++ b/.claude/scripts/aggregate-usage.py
@@ -57,6 +57,10 @@ def aggregate(records):
     marks = improvement_marks(records)
     stats = {}
     axis_stats = {1: 0, 2: 0, 3: 0}
+    contributors = {}
+
+    def contribute(bucket, kind, record):
+        contributors.setdefault((bucket, kind), []).append(record)
 
     invocation_sessions = {}
     end_sessions = {}
@@ -86,16 +90,21 @@ def aggregate(records):
             if name and is_fresh(name, record) and is_first_in_session(end_sessions, name, record, index):
                 entry = stat(name)
                 entry["ends"] += 1
-                entry["partial" if record.get("compliance") == "partial" else "full"] += 1
+                is_partial = record.get("compliance") == "partial"
+                entry["partial" if is_partial else "full"] += 1
+                if is_partial:
+                    contribute(name, "partial", record)
         elif event == "correction":
             for name in record.get("skills") or [UNATTRIBUTED]:
                 if is_fresh(name, record):
                     stat(name)["corrections"] += 1
+                    contribute(name, "correction", record)
         elif event == "axis_leak":
             axis = record.get("missed_axis")
             if axis in (1, 2, 3) and is_fresh(f"axis:{axis}", record):
                 axis_stats[axis] += 1
-    return stats, axis_stats
+                contribute(f"axis:{axis}", "leak", record)
+    return stats, axis_stats, contributors
 
 
 def missing_rate(entry):
@@ -104,8 +113,9 @@ def missing_rate(entry):
     return max(0.0, 1.0 - entry["ends"] / entry["invocations"])
 
 
-def violations(stats, axis_stats, thresholds):
-    lines = []
+def violation_records(stats, axis_stats, thresholds):
+    """임계 초과 신호를 구조로 반환한다 — triage-usage.py가 판정 입력으로 쓴다."""
+    found = []
     plugin_prefixes = tuple(thresholds.get("plugin_prefixes", []))
     excluded = set(thresholds.get("excluded_skills", []))
     missing_rate_exempt = set(thresholds.get("missing_rate_exempt_skills", []))
@@ -114,24 +124,40 @@ def violations(stats, axis_stats, thresholds):
             continue
         is_plugin = bool(plugin_prefixes) and name.startswith(plugin_prefixes)
         if not is_plugin and entry["corrections"] >= thresholds["correction_count"]:
-            lines.append(f"⚠️ {name} — correction {entry['corrections']}건 (임계 {thresholds['correction_count']})")
+            found.append({
+                "bucket": name, "kind": "correction", "count": entry["corrections"],
+                "message": f"⚠️ {name} — correction {entry['corrections']}건 (임계 {thresholds['correction_count']})",
+            })
         if not is_plugin and entry["partial"] >= thresholds["partial_count"]:
-            lines.append(f"⚠️ {name} — 준수 partial {entry['partial']}건 (임계 {thresholds['partial_count']})")
+            found.append({
+                "bucket": name, "kind": "partial", "count": entry["partial"],
+                "message": f"⚠️ {name} — 준수 partial {entry['partial']}건 (임계 {thresholds['partial_count']})",
+            })
         if name not in missing_rate_exempt and entry["invocations"] >= thresholds["min_invocations_for_missing"]:
             rate = missing_rate(entry)
             if rate >= thresholds["missing_rate"]:
-                lines.append(
-                    f"⚠️ {name} — 종료 레코드 누락률 {rate:.0%} "
-                    f"(발동 {entry['invocations']}·종료 {entry['ends']}, 임계 {thresholds['missing_rate']:.0%})"
-                )
+                found.append({
+                    "bucket": name, "kind": "missing_rate", "count": entry["invocations"] - entry["ends"],
+                    "message": (
+                        f"⚠️ {name} — 종료 레코드 누락률 {rate:.0%} "
+                        f"(발동 {entry['invocations']}·종료 {entry['ends']}, 임계 {thresholds['missing_rate']:.0%})"
+                    ),
+                })
     for axis in (1, 2, 3):
         count = axis_stats[axis]
         if count >= thresholds["axis_leak_count"]:
-            lines.append(
-                f"⚠️ 축{axis} 누수 {count}건 (임계 {thresholds['axis_leak_count']}) — "
-                f"implement 스킬 축{axis} 관문 정비 검토 (소비 마킹 버킷 axis:{axis})"
-            )
-    return lines
+            found.append({
+                "bucket": f"axis:{axis}", "kind": "leak", "count": count,
+                "message": (
+                    f"⚠️ 축{axis} 누수 {count}건 (임계 {thresholds['axis_leak_count']}) — "
+                    f"implement 스킬 축{axis} 관문 정비 검토 (소비 마킹 버킷 axis:{axis})"
+                ),
+            })
+    return found
+
+
+def violations(stats, axis_stats, thresholds):
+    return [item["message"] for item in violation_records(stats, axis_stats, thresholds)]
 
 
 def full_table(stats, axis_stats):
@@ -155,7 +181,7 @@ def main():
     with open(CONFIG_PATH, encoding="utf-8") as f:
         thresholds = json.load(f)
 
-    stats, axis_stats = aggregate(load_records())
+    stats, axis_stats, _ = aggregate(load_records())
     lines = full_table(stats, axis_stats) if args.all else violations(stats, axis_stats, thresholds)
     if lines:
         print("\n".join(lines))

--- a/.claude/scripts/triage-usage.py
+++ b/.claude/scripts/triage-usage.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""임계 초과 신호를 오탐/중복/실제로 판정한다 — 보고 가치 있는 것만 남긴다 (#951).
+
+aggregate-usage.py 는 "임계를 넘었다"까지만 말한다. 그 다음 판단(이미 정비된 신호인가,
+이미 이슈에 적힌 신호인가)을 매번 추론으로 하면 세션마다 결론이 튄다. 그 판정을 여기로 옮긴다.
+
+판정 셋:
+- duplicate — 누적 이슈에 이미 적힌 신호(`<!-- signal: <bucket>/<kind> -->`). 재보고하지 않는다.
+- stale — 기여 레코드가 전부 대상 스킬 파일의 마지막 커밋보다 과거다. 정비가 이미 들어갔고
+  소비 마킹만 안 된 상태 → 보고 대상이 아니라 상태 정리 대상이다.
+- actionable — 그 외. 기여 레코드 전문과 함께 보고한다.
+
+stale 판정에 파일 mtime을 쓰지 않는다 — 체크아웃 시각이라 정비 시점을 나타내지 못한다.
+
+stale이 성립하지 않아 항상 actionable로 남는 셋이 있다. 판정 누락이 아니라 구조다:
+- 개정 이력이 없는 대상 — 플러그인 스킬처럼 조항이 이 레포 밖이라 개정 시각을 볼 수 없다.
+- `missing_rate` — 발동/종료 카운트에서 파생된 비율이라 대응하는 개별 레코드가 없다. 비교할
+  기여 레코드가 없으니 소비는 `improvement --name <스킬>` 수동 마킹으로만 된다.
+- `axis:<n>` — 축 누수는 프로덕트 코드에서 나온 finding이고 버킷과 조항 소유 스킬(implement)이
+  일치하지 않는다. implement를 무슨 이유로 고치든 모든 축 누수가 stale로 뒤집혀 진짜 신호가
+  조용히 소비된다. 축 소비도 `improvement --name axis:<n>` 수동 마킹으로만 한다.
+"""
+import argparse
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+
+sys.dont_write_bytecode = True  # aggregate-usage.py 를 exec 할 때 레포에 __pycache__ 를 남기지 않는다
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_SKILLS_ROOT = os.path.join(os.path.dirname(SCRIPT_DIR), "skills")
+CONFIG_PATH = os.path.join(SCRIPT_DIR, "usage-thresholds.json")
+SIGNAL_MARKER = re.compile(r"<!--\s*signal:\s*([^\s>]+)\s*-->")
+AXIS_OWNER = "implement"
+
+
+def load_aggregate_module():
+    spec = importlib.util.spec_from_file_location(
+        "aggregate_usage", os.path.join(SCRIPT_DIR, "aggregate-usage.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def owning_skill(bucket):
+    """신호 버킷 → 조항을 담은 스킬 디렉토리명. 정비 대상이 이 레포 밖이면 None."""
+    if bucket.startswith("axis:"):
+        return AXIS_OWNER
+    if ":" in bucket:
+        return None
+    return bucket
+
+
+def last_revision(skills_root, bucket):
+    skill = owning_skill(bucket)
+    if not skill or skill != bucket:
+        return None
+    relative = os.path.join(skill, "SKILL.md")
+    if not os.path.exists(os.path.join(skills_root, relative)):
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "-C", skills_root, "log", "-1", "--format=%cI", "--", relative],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return result.stdout.strip() or None
+
+
+def recorded_signals(path):
+    if not path:
+        return set()
+    try:
+        with open(path, encoding="utf-8") as f:
+            return set(SIGNAL_MARKER.findall(f.read()))
+    except OSError:
+        return set()
+
+
+def triage(violations, contributors, skills_root, recorded):
+    items = []
+    for violation in violations:
+        bucket, kind = violation["bucket"], violation["kind"]
+        records = contributors.get((bucket, kind), [])
+        newest = max((r.get("ts", "") for r in records), default="")
+        revision = last_revision(skills_root, bucket)
+
+        if f"{bucket}/{kind}" in recorded:
+            verdict = "duplicate"
+        elif revision and newest and revision > newest:
+            verdict = "stale"
+        else:
+            verdict = "actionable"
+
+        items.append({
+            **violation,
+            "signal": f"{bucket}/{kind}",
+            "verdict": verdict,
+            "last_revision": revision,
+            "newest_record": newest,
+            "records": records,
+        })
+    return items
+
+
+def record_gist(record):
+    """레코드 종류별 요지 — 이벤트마다 요지를 담는 필드가 다르다.
+
+    correction은 summary, axis_leak은 finding, skill_end(partial)은 deviations다.
+    폴백이 빠지면 그 종류의 신호가 ts만 찍혀 "요지와 함께 보고한다"는 규약이 지켜지지 않는다.
+    """
+    direct = record.get("summary") or record.get("finding")
+    if direct:
+        return direct
+    deviations = record.get("deviations") or []
+    return "; ".join(f"{d.get('clause', '')}::{d.get('reason', '')}" for d in deviations)
+
+
+def render(items):
+    lines = []
+    actionable = [item for item in items if item["verdict"] == "actionable"]
+    stale = [item for item in items if item["verdict"] == "stale"]
+
+    for item in actionable:
+        lines.append(item["message"])
+        lines.append(f"    signal: {item['signal']}")
+        for record in item["records"]:
+            lines.append(f"    · {record.get('ts', '')} {record_gist(record)}")
+
+    if stale:
+        lines.append("")
+        lines.append("정비가 이미 반영된 신호 — 상태 정리만 하면 된다 (보고 대상 아님):")
+        for item in stale:
+            lines.append(
+                f"    python3 .claude/hooks/log-record.py improvement --name {item['bucket']}"
+                f"    # {item['signal']} (마지막 개정 {item['last_revision']})"
+            )
+    return lines
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="판정 결과를 JSON으로 출력")
+    parser.add_argument("--skills-root", default=DEFAULT_SKILLS_ROOT, help="스킬 디렉토리 루트")
+    parser.add_argument("--recorded-file", help="누적 이슈 본문 파일 — signal 마커를 중복 판정에 쓴다")
+    args = parser.parse_args()
+
+    aggregate_usage = load_aggregate_module()
+    with open(CONFIG_PATH, encoding="utf-8") as f:
+        thresholds = json.load(f)
+
+    stats, axis_stats, contributors = aggregate_usage.aggregate(aggregate_usage.load_records())
+    violations = aggregate_usage.violation_records(stats, axis_stats, thresholds)
+    items = triage(violations, contributors, args.skills_root, recorded_signals(args.recorded_file))
+
+    if args.json:
+        print(json.dumps(items, ensure_ascii=False, indent=2))
+        return
+    lines = render(items)
+    if lines:
+        print("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/scripts/triage-usage.test.sh
+++ b/.claude/scripts/triage-usage.test.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# triage-usage.py 회귀 테스트 — fixture JSONL·기록 파일로 오탐 판정 검증
+cd "$(dirname "$0")" || exit 1
+PASS=0; FAIL=0
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+export USAGE_LOG_DIR="$TMP_DIR"
+
+assert_contains() { # desc substring text
+  case "$3" in *"$2"*) PASS=$((PASS+1));; *) FAIL=$((FAIL+1)); echo "FAIL: $1"; echo "  missing: [$2]"; echo "  in: [$3]";; esac
+}
+assert_not_contains() { # desc substring text
+  case "$3" in *"$2"*) FAIL=$((FAIL+1)); echo "FAIL: $1"; echo "  unexpected: [$2]"; echo "  in: [$3]";; *) PASS=$((PASS+1));; esac
+}
+verdict_of() { # bucket kind json
+  python3 -c "
+import json,sys
+data=json.load(sys.stdin)
+for item in data:
+    if item['bucket']==sys.argv[1] and item['kind']==sys.argv[2]:
+        print(item['verdict']); break
+else:
+    print('(none)')
+" "$1" "$2" <<< "$3"
+}
+
+FIXTURE="$TMP_DIR/2026-01-01.jsonl"
+cat > "$FIXTURE" << 'JSONL'
+{"ts":"2026-01-01T09:00:00+09:00","event":"correction","session_id":"s1","skills":["pr"],"summary":"첫째","gist":"g1"}
+{"ts":"2026-01-01T09:01:00+09:00","event":"correction","session_id":"s2","skills":["pr"],"summary":"둘째","gist":"g2"}
+{"ts":"2026-01-01T09:02:00+09:00","event":"correction","session_id":"s3","skills":["pr"],"summary":"셋째","gist":"g3"}
+{"ts":"2026-01-01T09:03:00+09:00","event":"correction","session_id":"s4","skills":["commit"],"summary":"넷째","gist":"g4"}
+{"ts":"2026-01-01T09:04:00+09:00","event":"correction","session_id":"s5","skills":["commit"],"summary":"다섯째","gist":"g5"}
+{"ts":"2026-01-01T09:05:00+09:00","event":"correction","session_id":"s6","skills":["commit"],"summary":"여섯째","gist":"g6"}
+JSONL
+
+# --- 임계 초과 신호가 항목으로 잡힌다
+OUT=$(python3 triage-usage.py --json --skills-root "$TMP_DIR/skills-missing")
+assert_contains "pr correction 이 항목에 잡힌다" '"bucket": "pr"' "$OUT"
+assert_contains "commit correction 이 항목에 잡힌다" '"bucket": "commit"' "$OUT"
+
+# --- 기여 레코드가 그대로 실린다 (판단을 기억이 아니라 데이터로)
+assert_contains "기여 레코드 summary 가 실린다" '첫째' "$OUT"
+assert_contains "기여 레코드 gist 가 실린다" 'g6' "$OUT"
+
+# --- 스킬 조항이 최신 기여 레코드보다 나중에 개정됐으면 stale (마킹만 하면 되는 오탐)
+# 정비 시점은 파일 mtime(체크아웃 시각)이 아니라 git 커밋 시각으로 판정한다
+SKILLS="$TMP_DIR/skills"
+mkdir -p "$SKILLS/pr" "$SKILLS/commit"
+git -C "$SKILLS" init -q
+git -C "$SKILLS" config user.email t@t; git -C "$SKILLS" config user.name t
+echo "x" > "$SKILLS/pr/SKILL.md"
+echo "x" > "$SKILLS/commit/SKILL.md"
+git -C "$SKILLS" add -A
+GIT_AUTHOR_DATE="2025-12-31T00:00:00+09:00" GIT_COMMITTER_DATE="2025-12-31T00:00:00+09:00" \
+  git -C "$SKILLS" commit -q -m base
+echo "y" >> "$SKILLS/pr/SKILL.md"                 # pr 만 기여 레코드보다 나중에 개정
+git -C "$SKILLS" add -A
+GIT_AUTHOR_DATE="2026-02-01T00:00:00+09:00" GIT_COMMITTER_DATE="2026-02-01T00:00:00+09:00" \
+  git -C "$SKILLS" commit -q -m revise
+OUT=$(python3 triage-usage.py --json --skills-root "$SKILLS")
+assert_contains "정비가 나중에 들어간 스킬은 stale" "stale" "$(verdict_of pr correction "$OUT")"
+assert_contains "정비가 없던 스킬은 actionable" "actionable" "$(verdict_of commit correction "$OUT")"
+
+# --- 이미 기록된 신호는 duplicate (재보고 금지)
+RECORDED="$TMP_DIR/recorded.md"
+echo '<!-- signal: commit/correction -->' > "$RECORDED"
+OUT=$(python3 triage-usage.py --json --skills-root "$SKILLS" --recorded-file "$RECORDED")
+assert_contains "이슈에 이미 있는 신호는 duplicate" "duplicate" "$(verdict_of commit correction "$OUT")"
+
+# --- 사람이 읽는 출력에는 actionable 만 뜬다
+OUT=$(python3 triage-usage.py --skills-root "$SKILLS")
+assert_contains "actionable 은 보고된다" "commit" "$OUT"
+assert_not_contains "stale 은 보고되지 않는다" "⚠️ pr —" "$OUT"
+assert_contains "stale 은 상태 정리 명령으로 안내된다" "improvement --name pr" "$OUT"
+
+# --- 신호가 없으면 무출력
+rm -f "$FIXTURE"
+OUT=$(python3 triage-usage.py --skills-root "$SKILLS")
+assert_contains "신호 없으면 빈 출력" "" "$OUT"
+[ -z "$OUT" ] && PASS=$((PASS+1)) || { FAIL=$((FAIL+1)); echo "FAIL: 신호 없으면 무출력"; }
+
+# --- partial 신호도 요지가 실린다 (deviations 폴백)
+PFIX="$TMP_DIR/2026-01-02.jsonl"
+cat > "$PFIX" << 'JSONL'
+{"ts":"2026-01-02T09:00:00+09:00","event":"skill_end","session_id":"p1","name":"commit","compliance":"partial","deviations":[{"clause":"흡수 절차","reason":"별도 커밋으로 남김"}]}
+{"ts":"2026-01-02T09:01:00+09:00","event":"skill_end","session_id":"p2","name":"commit","compliance":"partial","deviations":[{"clause":"스테이징","reason":"유저가 직접 add"}]}
+{"ts":"2026-01-02T09:02:00+09:00","event":"skill_end","session_id":"p3","name":"commit","compliance":"partial","deviations":[{"clause":"메시지 컨벤션","reason":"핫픽스 예외"}]}
+JSONL
+OUT=$(python3 triage-usage.py --skills-root "$SKILLS")
+assert_contains "partial 도 임계로 잡힌다" "준수 partial" "$OUT"
+assert_contains "partial 요지가 조항::사유로 실린다" "흡수 절차::별도 커밋으로 남김" "$OUT"
+assert_contains "partial 도 signal 키를 그대로 출력한다" "signal: commit/partial" "$OUT"
+rm -f "$PFIX"
+
+# --- missing_rate 는 기여 레코드가 없어 stale 이 성립하지 않는다 (구조적 예외 고정)
+MFIX="$TMP_DIR/2026-01-03.jsonl"
+{ for i in 1 2 3 4 5; do
+    echo "{\"ts\":\"2026-01-03T09:0$i:00+09:00\",\"event\":\"skill\",\"session_id\":\"m$i\",\"name\":\"pr\"}"
+  done; } > "$MFIX"
+OUT=$(python3 triage-usage.py --json --skills-root "$SKILLS")
+assert_contains "pr 조항이 나중에 개정됐어도 missing_rate 는 actionable" \
+  "actionable" "$(verdict_of pr missing_rate "$OUT")"
+OUT=$(python3 triage-usage.py --skills-root "$SKILLS")
+assert_contains "missing_rate 도 signal 키를 그대로 출력한다" "signal: pr/missing_rate" "$OUT"
+rm -f "$MFIX"
+
+# --- 축 누수는 implement 가 다른 사유로 개정돼도 stale 로 뒤집히지 않는다
+mkdir -p "$SKILLS/implement"
+echo "x" > "$SKILLS/implement/SKILL.md"
+git -C "$SKILLS" add -A
+GIT_AUTHOR_DATE="2026-03-01T00:00:00+09:00" GIT_COMMITTER_DATE="2026-03-01T00:00:00+09:00" \
+  git -C "$SKILLS" commit -q -m implement-touch
+AFIX="$TMP_DIR/2026-01-04.jsonl"
+cat > "$AFIX" << 'JSONL'
+{"ts":"2026-01-04T09:00:00+09:00","event":"axis_leak","session_id":"a1","missed_axis":1,"finding":"가드 지워도 초록"}
+{"ts":"2026-01-04T09:01:00+09:00","event":"axis_leak","session_id":"a2","missed_axis":1,"finding":"형제 TC 미이식"}
+{"ts":"2026-01-04T09:02:00+09:00","event":"axis_leak","session_id":"a3","missed_axis":1,"finding":"제거분 미검증"}
+JSONL
+OUT=$(python3 triage-usage.py --json --skills-root "$SKILLS")
+assert_contains "축 누수는 implement 개정에도 actionable 유지" \
+  "actionable" "$(verdict_of axis:1 leak "$OUT")"
+OUT=$(python3 triage-usage.py --skills-root "$SKILLS")
+assert_contains "축 누수 finding 이 요지로 실린다" "가드 지워도 초록" "$OUT"
+rm -f "$AFIX"
+
+echo "---"
+echo "PASS: $PASS / FAIL: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -35,6 +35,7 @@ description: Use when writing or modifying code in this project — 구현 착�
 시작할 때:
 
 - **베이스 브랜치** — 브랜치 지정 지시가 없으면 최신 develop을 pull(`git pull origin develop`)한 뒤 거기서 `features/` 브랜치를 딴다. 이미 지정된 작업 브랜치에 있으면 유지.
+- **워크트리는 새로 만들지 않는다** — 작업 브랜치는 **베이스 브랜치가 이미 체크아웃된 워크트리**에서 딴다. 워크트리는 유저가 미리 만들어 둔 것만 쓰고, 새로 생성하거나 지금 작업 중인 자리를 다른 워크트리로 옮기지 않는다. 유저가 베이스 브랜치를 지정했다면 그게 체크아웃된 워크트리가 곧 작업 자리다. **superpowers SDD의 Setup(`using-git-worktrees`로 격리 워크스페이스 생성·확인)은 이 조항이 오버라이드한다** — 그 지시를 따르면 유저가 열어둔 작업 자리를 벗어나고, 워크트리마다 빌드 캐시가 갈려 증분 빌드도 깨진다. orchestrate 병렬 모드가 sub-work마다 워크트리를 배정하는 것은 이 금지 대상이 아니다 — 그 배정도 **기존 워크트리 중에서** 고른다.
 - 변경 대상 경로에 걸리는 `.claude/rules/*.md` 조항을 확인하고, 구현 결정 시점에 해당 조항을 적극 invoke한다.
 - child CLAUDE.md가 있는 프레임워크(Domain·Repository·각 Presentation 등)를 수정할 땐 해당 child CLAUDE.md를 확인하고, 수정 후 그 규칙과 어긋남이 없는지 재점검한다.
 - 동종 컴포넌트를 grep해 구조 패턴(상태관리·합성·추상화 수준)을 파악하고 그 패턴을 따른다. 요구사항만 보고 즉흥 구현하지 않는다.

--- a/.claude/skills/improve-skill/SKILL.md
+++ b/.claude/skills/improve-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: improve-skill
-description: Use when running a maintenance cycle on a project skill or subagent — usage-log 레코드를 4분류로 진단해 스킬 md 개정안(diff)을 만들고 유저 승인 후 반영·소비 마킹한다. Triggers on "스킬 정비하자", "improve-skill 돌리자", pr 스킬 머지 단계의 임계 초과 제안을 유저가 수락했을 때. Does NOT trigger on 스킬 신규 작성(superpowers:writing-skills), 코드 리뷰 피드백 반영(feedback-reinforcement-learning), 유저가 지시한 일회성 스킬 문구 수정(직접 수정).
+description: Use when running a maintenance cycle on a project skill or subagent — usage-log 레코드를 4분류로 진단해 스킬 md 개정안(diff)을 만들고 유저 승인 후 반영·소비 마킹한다. Triggers on "스킬 정비하자", "improve-skill 돌리자", "하네스 신호 기록해"(§5 누적 이슈 기록), pr 스킬 머지 단계의 임계 초과 제안을 유저가 수락했을 때. Does NOT trigger on 스킬 신규 작성(superpowers:writing-skills), 코드 리뷰 피드백 반영(feedback-reinforcement-learning), 유저가 지시한 일회성 스킬 문구 수정(직접 수정).
 ---
 
 # Improve Skill — 스킬 정비 사이클
@@ -8,6 +8,8 @@ description: Use when running a maintenance cycle on a project skill or subagent
 usage-log에 쌓인 신호(발동·skill_end·correction)를 근거로 대상 스킬을 진단하고 개정한다. **반영은 유저 승인 후에만** — 하네스는 모든 후속 작업에 곱해지는 레버리지라 무감독 self-modify 금지.
 
 ## 1. 레코드 수집
+
+**누적 이슈에서 진입한 정비면 그 이슈 본문이 1차 입력이다** — §5가 쌓아둔 항목별 기여 레코드를 그대로 쓰고, 아래 스캔은 그 뒤에 새로 쌓인 레코드를 보태는 용도로만 돌린다. 이슈를 안 읽고 raw 스캔부터 하면 §5가 근거를 정리해둔 이유가 사라진다.
 
 대상 스킬의 미소비 레코드(마지막 improvement 마킹 이후)를 모은다:
 
@@ -64,3 +66,15 @@ EOF
 ```bash
 python3 .claude/hooks/log-record.py improvement --name <대상 스킬>
 ```
+
+## 5. 누적 이슈 기록 — 유저가 "기록해" 라고 할 때
+
+정비가 필요한 항목은 **열려 있는 누적 이슈 하나에 모은다.** 신호마다 이슈를 따로 따면 이슈가 불어나고 정비 단위가 잘게 쪼개진다.
+
+1. 열린 누적 이슈를 찾는다 — `gh issue list --label harness --state open`. 없으면 새로 만든다 (`harness` 라벨, 제목에 누적 이슈임이 드러나게).
+2. `triage-usage.py` 의 **actionable 항목만** 그 이슈에 더한다. 항목마다 셋을 넣는다:
+   - `<!-- signal: <bucket>/<kind> -->` 마커 — 다음 런의 중복 판정 입력이다. 값은 추론하지 말고 `triage-usage.py` 출력의 `signal:` 줄을 그대로 옮긴다. **빠뜨리거나 틀리면 같은 신호가 계속 재보고된다.**
+   - 기여 레코드(ts·요지) 목록 — 정비 시점에 근거를 다시 캐지 않게
+   - 확정된 사실만. 처방이 이미 서면 적고, 안 섰으면 적지 않는다
+3. 기존 이슈에 더할 땐 **본문을 편집한다** (`gh issue edit --body-file`). 코멘트로 쌓지 않는다 — 정비 시점에 한 번에 읽을 목록이라 본문에 있어야 한다.
+4. **기록까지가 이 절차다.** 정비는 하지 않는다. 항목이 모이면 유저가 정비를 지시하고(§1~4), 완료 후 그 이슈를 닫는다.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -67,6 +67,15 @@ PR을 올리면 대응 이슈를 개발 대시보드(Project #2)의 `Review + QA
 - 머지는 `gh pr merge --rebase`, squash 금지 — 단계별 커밋이 develop에 보존돼야 회귀 분석 시 변경 의도를 추적할 수 있다.
 - 머지 후 브랜치(로컬·리모트) 정리 여부를 유저에게 확인한다. 확인을 요청한 시점이 이 조항의 이행이다 — 답변 대기로 끝나도 이탈이 아니다.
 - 브랜치가 워크트리에 체크아웃돼 있으면 삭제가 거부된다 — 그 워크트리에서 임시 브랜치를 만들어 이동(`git switch -c <임시-브랜치>`)한 뒤 대상 브랜치를 삭제한다.
-- 머지 후 `python3 .claude/scripts/aggregate-usage.py` 실행 (#690 flywheel). 무출력이면 조용히 넘어간다.
-  - **보고 전 중복 확인**: `gh issue list --label harness --state open --json number,title,body` — ⚠️ 줄의 **스킬명 + 신호 유형**(partial·correction·누락률·축N)이 이미 열린 이슈에 잡혀 있으면 보고하지 않는다. 이슈로 따둔 건 인지하고 나중에 고치기로 한 것이라, 다시 올리면 노이즈다. 조항 단위까지는 대조하지 않는다 — 집계 출력에 조항명이 없다(`deviations[].clause`는 raw usage-log에만 있다).
-  - 남은 신호만 유저에게 보고한다. 유저가 정비를 지시하면 improve-skill, 이슈로 남기라고 하면 issue 스킬로 생성하고 `harness` 라벨을 붙인다.
+- 머지 후 신호 판정 (#690 flywheel):
+
+  ```bash
+  gh issue list --label harness --state open --json body --jq '.[].body' > /tmp/harness-open.md
+  python3 .claude/scripts/triage-usage.py --recorded-file /tmp/harness-open.md
+  ```
+
+  - **판정은 스크립트가 한다 — 추론으로 다시 하지 않는다.** duplicate(이미 누적 이슈에 적힘)·stale(대상 조항이 그 신호보다 나중에 개정됨 = 정비는 됐고 소비 마킹만 안 됨)·actionable 셋으로 갈린다. 판정을 세션마다 추론으로 하면 같은 신호가 런마다 다르게 읽힌다.
+  - **무출력이면 아무 말도 하지 않는다.** "신호 없음"도 보고하지 않는다 — 보고할 게 없다는 뜻이지 언급할 자리가 아니다.
+  - **stale 블록이 나오면 출력된 마킹 명령을 그대로 실행한다.** 유저 보고 대상이 아니다. 이 정리를 건너뛰면 이미 정비된 신호를 다음 런이 또 판단한다.
+  - **actionable 만 유저에게 보고한다.** 기여 레코드(ts·요지)가 함께 출력되니 그 데이터로 보고한다 — 기억으로 재구성하지 않는다.
+  - 유저가 **"기록해"** 라고 지시하면 improve-skill §5(누적 이슈 기록)로 간다. 정비를 지시하면 improve-skill §1~4로 간다. 신호마다 이슈를 새로 따지 않는다.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -89,4 +89,4 @@ python3 .claude/hooks/log-record.py axis_leak --missed-axis <1|2|3> --finding "<
 
 - 판정 기준: 결함이 **TC가 명세를 못 담음**(누락 케이스·false positive test)이면 축1 / **TC가 있는데도 동작 오류가 통과**면 축2 / **구현 구조·효율·역할 분배**면 축3.
 - 축1~3 어디서도 잡을 수 없는 종류(기획 홀·요구사항 자체의 결함)는 태깅하지 않는다 — 관문 누수가 아니다.
-- 집계·임계 판정은 aggregate-usage.py가 축별로 수행하고 pr 스킬 머지 단계에서 출력된다 — 초과 시 해당 축 관문(implement 스킬) 정비를 제안. 정비 반영 후 소비 마킹은 `improvement --name axis:<n>`.
+- 집계·임계 판정은 aggregate-usage.py가 축별로 수행하고, 오탐·중복 판정은 triage-usage.py가 이어받아 pr 스킬 머지 단계에서 출력된다 — actionable로 남은 축은 누적 이슈에 항목으로 쌓이고(improve-skill §5), 정비 반영 후 소비 마킹은 `improvement --name axis:<n>`.


### PR DESCRIPTION
하네스 정비 신호가 이슈를 계속 불려왔다. 신호 하나당 이슈 하나가 나가고, 그 판정이 세션마다 추론으로 다시 이뤄져 결론도 튀었다. 판정을 스크립트로 고정하고 정비 항목을 누적 이슈 한 곳으로 모은다.

## 문제

`aggregate-usage.py` 는 "임계를 넘었다"까지만 말한다. 그 다음 판단 — 이미 정비된 신호인가, 이미 이슈에 적힌 신호인가 — 은 매번 세션이 추론으로 했다. 그래서 두 가지가 났다.

- **결론이 튄다.** 같은 신호를 어떤 런은 "이전에 쌓인 것"으로 흘려보내고 어떤 런은 정비 대상으로 올렸다. 실제로 직전 런에서 `implement` correction 3건 중 2건을 "이미 반영됨"으로 잘못 보고했다.
- **이슈가 불어난다.** 신호마다 `issue` 스킬로 새 이슈를 따는 경로였다.

## 접근

**판정을 `triage-usage.py` 로 옮긴다.** 집계 결과를 받아 신호마다 셋 중 하나로 가른다.

| 판정 | 기준 | 처리 |
|---|---|---|
| `duplicate` | 누적 이슈 본문에 `<!-- signal: <bucket>/<kind> -->` 마커가 있다 | 재보고 안 함 |
| `stale` | 대상 조항의 마지막 커밋이 그 신호의 최신 기여 레코드보다 나중이다 | 마킹 명령만 출력 — 보고 대상 아님 |
| `actionable` | 그 외 | 기여 레코드(ts·요지)와 함께 보고 |

`stale` 판정에 파일 mtime을 쓰지 않는다 — 체크아웃 시각이라 정비 시점을 나타내지 못한다. `git log -1 --format=%cI` 로 조항의 실제 개정 시각을 본다.

`aggregate-usage.py` 는 `violation_records()` 로 구조화 산출을 내고 기여 레코드를 함께 수집하게 확장했다. 기존 문자열 출력은 `violations()` 래퍼로 유지해 회귀 27건이 그대로 산다.

**보고 규칙을 pr 스킬 §머지·정리에 못박는다.** 무출력이면 아무 말도 하지 않는다("신호 없음"도 보고하지 않는다). `stale` 은 출력된 마킹 명령을 그 자리에서 실행해 다음 런이 다시 판단할 일을 없앤다. `actionable` 만 유저에게 보고하되 기억이 아니라 출력된 기여 레코드로 보고한다.

**정비 항목은 누적 이슈 하나에 모은다** (improve-skill §5). 유저가 "기록해" 라고 하면 열린 `harness` 이슈를 찾아 — 없으면 만들어 — 본문에 항목을 더한다. 항목마다 `signal` 마커가 붙고, 그게 다음 런의 중복 판정 입력이 된다. 기록까지가 그 절차고 정비는 항목이 모인 뒤 유저 지시로 한다.

기존 #939·#947 은 #951 로 흡수해 닫았다.

## 함께 담은 것

`implement` §착수에 워크트리 고정 조항을 넣었다. 작업 브랜치는 베이스가 이미 체크아웃된 워크트리에서 딴다 — 새 워크트리 생성도, 다른 워크트리로의 전환도 금지다. superpowers SDD 의 Setup 이 `using-git-worktrees` 로 격리 워크스페이스를 만들라고 지시하고 있어 오버라이드를 문언으로 박았다. 근거는 correction 레코드(2026-08-19T16:47).
