### PR TITLE
[#941][#953] 라이브액티비티 태그색을 이벤트명 좌측 막대로 분리하고 배지를 카운트다운 링으로

### DIFF
--- a/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownActivityViewModel.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownActivityViewModel.swift
@@ -19,7 +19,6 @@ struct EventCountdownActivityViewModel {
     let startDate: Date
     let subtitle: String?
     let tagColor: Color
-    let usesDarkGlyph: Bool
     let todoId: String?
 
     init(_ attributes: EventCountdownActivityAttributes, _ state: EventCountdownActivityAttributes.State) {
@@ -38,28 +37,6 @@ struct EventCountdownActivityViewModel {
 
         let uiColor = UIColor.from(hex: state.tagColorHex) ?? .gray
         self.tagColor = uiColor.asColor
-        self.usesDarkGlyph = uiColor.needsDarkGlyphOnBadge
-    }
-}
-
-
-private enum Constant {
-    /// 흰 글리프를 기본으로 두려는 의도라 `UIColor.isLight`(0.5)보다 높게 잡는다 — 확실히 연한 배경만 검은 글리프로 뒤집힌다.
-    static let darkGlyphLuminanceThreshold: CGFloat = 0.75
-}
-
-
-private extension UIColor {
-
-    var needsDarkGlyphOnBadge: Bool {
-        var red: CGFloat = 0
-        var green: CGFloat = 0
-        var blue: CGFloat = 0
-        var alpha: CGFloat = 0
-        self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-
-        let luminance: CGFloat = 0.2126 * red + 0.7152 * green + 0.0722 * blue
-        return luminance > Constant.darkGlyphLuminanceThreshold
     }
 }
 

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLiveActivity.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLiveActivity.swift
@@ -83,19 +83,7 @@ private struct EventCountdownExpandedTextBlock: View {
                 .truncationMode(.tail)
                 .foregroundStyle(.primary)
 
-            HStack(spacing: 5) {
-                Text(model.eventTimeText)
-
-                if let subtitle = model.subtitle {
-                    Text(verbatim: "|")
-
-                    Text(subtitle)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                }
-            }
-            .font(.system(size: 12))
-            .foregroundStyle(.secondary)
+            EventCountdownTimeAndSubtitleText(model: model, font: .system(size: 12))
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLiveActivity.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLiveActivity.swift
@@ -26,7 +26,7 @@ struct EventCountdownLiveActivity: Widget {
 
             return DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
-                    EventTagGlyphBadge(model: model, diameter: 26)
+                    EventCountdownRingBadge(model: model, diameter: 26)
                         // 아일랜드 좌측 라운딩에 배지가 물려 잘린다 — 안쪽으로 들여 피한다.
                         .padding(.leading, 6)
                 }
@@ -51,7 +51,7 @@ struct EventCountdownLiveActivity: Widget {
                     .frame(maxHeight: .infinity, alignment: .bottom)
                 }
             } compactLeading: {
-                EventTagGlyphBadge(model: model, diameter: 26)
+                EventCountdownRingBadge(model: model, diameter: 26)
             } compactTrailing: {
                 Text(model.eventName)
                     .font(.system(size: 13, weight: .medium))
@@ -59,7 +59,7 @@ struct EventCountdownLiveActivity: Widget {
                     .truncationMode(.tail)
             } minimal: {
                 // 최소 표시 영역이 배지보다 작아 링이 잘린다 — 지름을 줄여 영역 안쪽에 들인다.
-                EventTagGlyphBadge(model: model, diameter: 27)
+                EventCountdownRingBadge(model: model, diameter: 27)
             }
         }
     }
@@ -76,14 +76,18 @@ private struct EventCountdownExpandedTextBlock: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(model.eventName)
-                .font(.system(size: 15, weight: .semibold))
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .foregroundStyle(.primary)
+        HStack(alignment: .center, spacing: 8) {
+            EventCountdownTagColorBar(color: model.tagColor, width: 3)
 
-            EventCountdownTimeAndSubtitleText(model: model, font: .system(size: 12))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(model.eventName)
+                    .font(.system(size: 15, weight: .semibold))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .foregroundStyle(.primary)
+
+                EventCountdownTimeAndSubtitleText(model: model, font: .system(size: 12))
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLockScreenView.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLockScreenView.swift
@@ -23,16 +23,20 @@ struct EventCountdownLockScreenView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .center, spacing: 12) {
-                EventTagGlyphBadge(model: model, diameter: 34)
+                EventCountdownRingBadge(model: model, diameter: 34)
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(model.eventName)
-                        .font(.system(size: 17, weight: .semibold))
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                        .foregroundStyle(.primary)
+                HStack(alignment: .center, spacing: 10) {
+                    EventCountdownTagColorBar(color: model.tagColor, width: 4)
 
-                    EventCountdownTimeAndSubtitleText(model: model, font: .system(size: 13))
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(model.eventName)
+                            .font(.system(size: 17, weight: .semibold))
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                            .foregroundStyle(.primary)
+
+                        EventCountdownTimeAndSubtitleText(model: model, font: .system(size: 13))
+                    }
                 }
                 .layoutPriority(1)
 
@@ -85,6 +89,23 @@ struct EventCountdownTimerText: View {
                 .multilineTextAlignment(.trailing)
                 .foregroundStyle(.primary)
         }
+    }
+}
+
+struct EventCountdownTagColorBar: View {
+
+    private let color: Color
+    private let width: CGFloat
+
+    init(color: Color, width: CGFloat) {
+        self.color = color
+        self.width = width
+    }
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: width / 2)
+            .fill(color)
+            .frame(width: width)
     }
 }
 

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLockScreenView.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLockScreenView.swift
@@ -32,9 +32,7 @@ struct EventCountdownLockScreenView: View {
                         .truncationMode(.tail)
                         .foregroundStyle(.primary)
 
-                    Text(model.eventTimeText)
-                        .font(.system(size: 13))
-                        .foregroundStyle(.secondary)
+                    EventCountdownTimeAndSubtitleText(model: model, font: .system(size: 13))
                 }
                 .layoutPriority(1)
 
@@ -87,6 +85,33 @@ struct EventCountdownTimerText: View {
                 .multilineTextAlignment(.trailing)
                 .foregroundStyle(.primary)
         }
+    }
+}
+
+struct EventCountdownTimeAndSubtitleText: View {
+
+    private let model: EventCountdownActivityViewModel
+    private let font: Font
+
+    init(model: EventCountdownActivityViewModel, font: Font) {
+        self.model = model
+        self.font = font
+    }
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Text(model.eventTimeText)
+
+            if let subtitle = model.subtitle {
+                Text(verbatim: "|")
+
+                Text(subtitle)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .font(font)
+        .foregroundStyle(.secondary)
     }
 }
 

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownRingBadge.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownRingBadge.swift
@@ -1,5 +1,5 @@
 //
-//  EventTagGlyphBadge.swift
+//  EventCountdownRingBadge.swift
 //  TodoCalendarAppWidget
 //
 //  Created by sudo.park on 8/17/26.
@@ -9,7 +9,7 @@
 import SwiftUI
 
 
-struct EventTagGlyphBadge: View {
+struct EventCountdownRingBadge: View {
 
     private let model: EventCountdownActivityViewModel
     private let diameter: CGFloat
@@ -19,21 +19,16 @@ struct EventTagGlyphBadge: View {
         self.diameter = diameter
     }
 
-    private var circleDiameter: CGFloat { diameter * 0.76 }
-    private var glyphDiameter: CGFloat { circleDiameter * 0.744 }
+    private var symbolDiameter: CGFloat { diameter * 0.58 }
 
     var body: some View {
         ZStack {
-            Circle()
-                .fill(model.tagColor)
-                .frame(width: circleDiameter, height: circleDiameter)
-
             Image("app_symbol")
                 .resizable()
                 .renderingMode(.template)
                 .scaledToFit()
-                .frame(width: glyphDiameter, height: glyphDiameter)
-                .foregroundStyle(model.usesDarkGlyph ? .black : .white)
+                .frame(width: symbolDiameter, height: symbolDiameter)
+                .foregroundStyle(.secondary)
 
             remainRing
         }
@@ -50,7 +45,7 @@ struct EventTagGlyphBadge: View {
                 EmptyView()
             }
             .progressViewStyle(.circular)
-            // 링은 원 바깥이라 바탕이 태그색이 아닌 표면색이다 — 아일랜드(검정)·잠금화면(밝은 머티리얼) 양쪽에서 보이려면 적응색이어야 한다.
+            // 아일랜드(검정)·잠금화면(밝은 머티리얼) 양쪽에서 보이려면 적응색이어야 한다.
             .tint(.primary.opacity(0.55))
             // 시스템 원형 ProgressView는 선 두께를 못 정한다 — 크게 그린 뒤 축소해 상대적으로 얇게 만든다.
             .frame(width: diameter * 2, height: diameter * 2)

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/LiveActivities/EventCountdownActivityViewModelTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/LiveActivities/EventCountdownActivityViewModelTests.swift
@@ -34,32 +34,13 @@ struct EventCountdownActivityViewModelTests {
         return EventCountdownActivityViewModel(attributes, state)
     }
 
-    @Test("light", arguments: ["#EEEEEE", "#F2D64B", "#7FE07F"])
-    func viewModel_whenTagColorIsLight_usesDarkGlyph(colorHex: String) {
-        // given
-        let viewModel = makeViewModel(target: .todo(id: "1"), colorHex: colorHex)
-
-        // when + then
-        #expect(viewModel.usesDarkGlyph == true)
-    }
-
-    @Test("dark", arguments: ["#333333", "#003D82", "#2FB457", "#6FCB6F"])
-    func viewModel_whenTagColorIsDark_usesLightGlyph(colorHex: String) {
-        // given
-        let viewModel = makeViewModel(target: .todo(id: "1"), colorHex: colorHex)
-
-        // when + then
-        #expect(viewModel.usesDarkGlyph == false)
-    }
-
     @Test("invalid", arguments: ["not-a-color", "2FB457"])
-    func viewModel_whenTagColorHexIsInvalid_fallsBackToGrayWithLightGlyph(invalidHex: String) {
+    func viewModel_whenTagColorHexIsInvalid_fallsBackToGray(invalidHex: String) {
         // given
         let viewModel = makeViewModel(target: .todo(id: "1"), colorHex: invalidHex)
 
         // when + then
         #expect(viewModel.tagColor == UIColor.gray.asColor)
-        #expect(viewModel.usesDarkGlyph == false)
     }
 
     @Test("todoId when todo target", arguments: ["t1", "t123"])


### PR DESCRIPTION
카운트다운 라이브액티비티의 배지가 태그색 원 + 앱 심볼 + 잔여 링을 한 자리에 겹쳐 놓고 있었다. 채도 높은 원이 면적을 다 먹어 정작 카운트다운인 링이 안 읽혔고, 앱의 다른 이벤트 표시(리스트 셀·위젯 전부 이벤트명 좌측 세로 막대)와도 어긋났다. 같은 뷰에 장소·메모 부제가 안 그려지는 버그(#941)도 붙어 있었다.

**태그색과 카운트다운을 갈라 각자 제자리로 보낸다.** 태그색은 앱의 보편 표기인 이벤트명 좌측 막대로 옮기고, 배지에는 앱 마크와 잔여 링만 남겨 링이 주인공이 되게 한다. 마크를 HIG 권고(`"display it without a container. Don't use the entire app icon."`)대로 컨테이너 없이 두면서, 태그색 막대가 안 들어가는 컴팩트·미니멀에서도 우리 앱으로 알아볼 단서가 남는다. 잠금화면 행 레이아웃을 통째로 다시 짜는 김에 #941의 부제 자리도 같이 채웠다 — 아일랜드 확장이 갖고 있던 `시각 | 부제` 한 줄을 공유 조각으로 뽑아 양쪽이 쓰므로 재구현이 아니라 재사용이다.

막대는 잠금화면 폭 4 / 아일랜드 확장 폭 3으로 곁의 텍스트 크기에 맞춰 차등을 뒀다 (앱 셀 6pt와 위젯 3pt 사이). 폭이 없는 컴팩트·미니멀에는 두지 않아 거기선 태그색이 빠지고 링만 남는다.

`usesDarkGlyph`와 그 판정(명도 계산·임계 상수)은 마크가 태그색 위가 아니라 표면 위에 놓이면서 근거가 사라져 테스트와 함께 걷어냈다.

### 안 한 것 — 남은 시간 0 패딩

작업 중 "시분초가 한 자리면 `0N`으로 채우자"는 요구가 있었으나 폐기했다. `Text(timerInterval:)`은 `showsHours`가 문서상 *"남은 시간이 60분을 넘을 때만 시(時) 성분을 넣는다"* 로 동작해 60분 경계에서 `H:MM:SS` ↔ `MM:SS` 로 스스로 포맷을 바꾸고, 자릿수 패딩 옵션은 없다. 리터럴 `0`을 앞에 붙이면 경계를 지나는 순간 `042:19` 가 되는데 라이브액티비티는 앱이 push하지 않으면 스냅샷 그대로라 그 시점에 다시 안 그려진다. 직접 포맷하면 패딩은 되지만 초가 멈춘다.

### 검증

`TodoCalendarAppWidget` 70 tests 통과. 잠금화면·다이나믹아일랜드 실물 표시는 Xcode 프리뷰·기기 확인이 필요해 유저 검증 대기 — `EventCountdownLiveActivity.swift` 의 `#Preview` 5종(잠금화면·확장·컴팩트·최소·Schedule)이 밝은 태그·부제 없음·만료 케이스를 덮는다.

Closes #941
Closes #953

