### PR TITLE
[#950] 일별 이벤트 목록에서 단건 텍스트 공유

### DIFF
--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventCellViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventCellViewModel.swift
@@ -153,6 +153,7 @@ public enum EventListMoreAction: Sendable, Equatable {
     case skipTodo
     case edit
     case copy
+    case share
 }
 
 public struct EventListMoreActionModel: Sendable, Equatable {
@@ -267,7 +268,7 @@ public struct TodoEventCellViewModel: EventCellViewModel {
             ? [.toggleLiveActivity(isRegistered: self.isLiveActivityRegistered)]
             : []
         let basicActions: [EventListMoreAction] = [.toggleTo(isForemost: self.isForemost)]
-            + liveActivityActions + skipActions + [.edit, .copy]
+            + liveActivityActions + skipActions + [.edit, .copy, .share]
         return .init(
             basicActions: basicActions,
             removeActions: removeActions
@@ -370,7 +371,7 @@ public struct ScheduleEventCellViewModel: EventCellViewModel {
             ? [.toggleLiveActivity(isRegistered: self.isLiveActivityRegistered)]
             : []
         return .init(
-            basicActions: [.toggleTo(isForemost: self.isForemost)] + liveActivityActions + [.edit, .copy],
+            basicActions: [.toggleTo(isForemost: self.isForemost)] + liveActivityActions + [.edit, .copy, .share],
             removeActions: removeActions
         )
     }

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventCellViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventCellViewModel.swift
@@ -467,11 +467,12 @@ public struct AppleCalendarEventCellViewModel: EventCellViewModel {
     }
 
     public var moreActions: EventListMoreActionModel? {
-        guard self.isWritable else { return nil }
-        let removeActions: [EventListMoreAction] = self.isRepeating
-            ? [.remove(scope: .onlyThisTime), .remove(scope: .thisAndFuture)]
-            : [.remove(scope: .all)]
-        return .init(basicActions: [], removeActions: removeActions)
+        let removeActions: [EventListMoreAction] = self.isWritable
+            ? (self.isRepeating
+                ? [.remove(scope: .onlyThisTime), .remove(scope: .thisAndFuture)]
+                : [.remove(scope: .all)])
+            : []
+        return .init(basicActions: [.share], removeActions: removeActions)
     }
 
     public var customCompareKey: String {
@@ -519,11 +520,12 @@ public struct GoogleCalendarEventCellViewModel: EventCellViewModel {
     }
 
     public var moreActions: EventListMoreActionModel? {
-        guard self.isWritable else { return nil }
-        let removeActions: [EventListMoreAction] = self.isRepeating
-            ? [.remove(scope: .onlyThisTime), .remove(scope: .all)]
-            : [.remove(scope: .all)]
-        return .init(basicActions: [], removeActions: removeActions)
+        let removeActions: [EventListMoreAction] = self.isWritable
+            ? (self.isRepeating
+                ? [.remove(scope: .onlyThisTime), .remove(scope: .all)]
+                : [.remove(scope: .all)])
+            : []
+        return .init(basicActions: [.share], removeActions: removeActions)
     }
 
     public var customCompareKey: String {

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleRouter.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleRouter.swift
@@ -26,6 +26,7 @@ protocol EventListCellEventHanleRouting: Routing, Sendable {
     )
     func routeToAppleCalendarEventDetail(calendarId: String, eventId: String)
     func routeToMakeNewEvent(_ withParams: MakeEventParams)
+    func showShareSheet(text: String)
 }
 
 

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModel.swift
@@ -13,6 +13,7 @@ import Optics
 import Domain
 import Scenes
 import Extensions
+import CommonPresentation
 
 enum DoneTodoResult {
     case success(_ id: String)
@@ -48,6 +49,9 @@ final class EventListCellEventHanleViewModelImple: EventListCellEventHanleViewMo
     private let googleCalendarUsecase: any GoogleCalendarUsecase
     private let appleCalendarUsecase: any AppleCalendarUsecase
     private let externalCalendarIntegrationUsecase: any ExternalCalendarIntegrationUsecase
+    private let eventTagUsecase: any EventTagUsecase
+    private let eventDetailDataUsecase: any EventDetailDataUsecase
+    private let calendarSettingUsecase: any CalendarSettingUsecase
     private let liveActivityToggleViewModel: any LiveActivityToggleViewModel
 
     var router: (any EventListCellEventHanleRouting)?
@@ -59,6 +63,9 @@ final class EventListCellEventHanleViewModelImple: EventListCellEventHanleViewMo
         googleCalendarUsecase: any GoogleCalendarUsecase,
         appleCalendarUsecase: any AppleCalendarUsecase,
         externalCalendarIntegrationUsecase: any ExternalCalendarIntegrationUsecase,
+        eventTagUsecase: any EventTagUsecase,
+        eventDetailDataUsecase: any EventDetailDataUsecase,
+        calendarSettingUsecase: any CalendarSettingUsecase,
         liveActivityToggleViewModel: any LiveActivityToggleViewModel
     ) {
         self.todoEventUsecase = todoEventUsecase
@@ -67,6 +74,9 @@ final class EventListCellEventHanleViewModelImple: EventListCellEventHanleViewMo
         self.googleCalendarUsecase = googleCalendarUsecase
         self.appleCalendarUsecase = appleCalendarUsecase
         self.externalCalendarIntegrationUsecase = externalCalendarIntegrationUsecase
+        self.eventTagUsecase = eventTagUsecase
+        self.eventDetailDataUsecase = eventDetailDataUsecase
+        self.calendarSettingUsecase = calendarSettingUsecase
         self.liveActivityToggleViewModel = liveActivityToggleViewModel
 
         self.internalBind()
@@ -166,6 +176,9 @@ extension EventListCellEventHanleViewModelImple {
             
         case .copy:
             self.copyEvent(cellViewModel)
+
+        case .share:
+            self.shareEvent(cellViewModel)
         }
     }
 
@@ -431,7 +444,89 @@ extension EventListCellEventHanleViewModelImple {
         default: return
         }
     }
-    
+
+    private func shareEvent(_ cellViewModel: any EventCellViewModel) {
+        switch cellViewModel {
+        case let todo as TodoEventCellViewModel:
+            self.shareTodoEvent(todo)
+        case let schedule as ScheduleEventCellViewModel:
+            self.shareScheduleEvent(schedule)
+        default: return
+        }
+    }
+
+    private func shareTodoEvent(_ cellViewModel: TodoEventCellViewModel) {
+        self.todoEventUsecase.todoEvent(cellViewModel.eventIdentifier)
+            .first()
+            .sink(receiveCompletion: { [weak self] completion in
+                guard case .failure(let error) = completion else { return }
+                self?.router?.showError(error)
+            }, receiveValue: { [weak self] todo in
+                self?.assembleAndShareText(
+                    name: todo.name, isTodo: true,
+                    time: todo.time, repeating: todo.repeating,
+                    eventTagId: todo.eventTagId ?? .default, detailId: todo.uuid
+                )
+            })
+            .store(in: &self.cancellables)
+    }
+
+    private func shareScheduleEvent(_ cellViewModel: ScheduleEventCellViewModel) {
+        self.scheduleEventUsecase.scheduleEvent(cellViewModel.eventIdWithoutTurn)
+            .first()
+            .sink(receiveCompletion: { [weak self] completion in
+                guard case .failure(let error) = completion else { return }
+                self?.router?.showError(error)
+            }, receiveValue: { [weak self] schedule in
+                let eventTime = cellViewModel.eventTimeRawValue ?? schedule.time
+                self?.assembleAndShareText(
+                    name: schedule.name, isTodo: false,
+                    time: eventTime, repeating: schedule.repeating,
+                    eventTagId: schedule.eventTagId ?? .default, detailId: schedule.uuid
+                )
+            })
+            .store(in: &self.cancellables)
+    }
+
+    private func assembleAndShareText(
+        name: String, isTodo: Bool,
+        time: EventTime?, repeating: EventRepeating?,
+        eventTagId: EventTagId, detailId: String
+    ) {
+        let builder = EventDetailShareTextBuilder()
+        Publishers.CombineLatest3(
+            self.eventTagUsecase.eventTag(id: eventTagId),
+            self.eventDetailDataUsecase.loadDetail(detailId)
+                .map { $0 as EventDetailData? }
+                .catch { _ in Just(nil) }
+                .replaceEmpty(with: nil),
+            self.calendarSettingUsecase.currentTimeZone.first()
+        )
+        .first()
+        .sink { [weak self] tag, detail, timeZone in
+            let timeText = time.map { SelectedTime($0, timeZone) }.map(builder.timeText(from:))
+            let repeatSummaryText = repeating.flatMap { repeating -> String? in
+                guard let repeatStart = time.map({ Date(timeIntervalSince1970: $0.lowerBoundWithFixed) })
+                else { return nil }
+                return repeating.repeatOption.summaryText(startTime: repeatStart, timeZone: timeZone)
+            }
+            let model = EventDetailShareModel(
+                name: name,
+                isTodo: isTodo,
+                timeText: timeText,
+                repeatText: repeatSummaryText?.emptyAsNil(),
+                tagLine: tag?.name.emptyAsNil().map { .eventTag($0) },
+                placeName: detail?.place?.placeName.emptyAsNil(),
+                url: detail?.url?.emptyAsNil(),
+                memo: detail?.memo?.emptyAsNil()
+            )
+            let text = builder.build(model)
+            guard !text.isEmpty else { return }
+            self?.router?.showShareSheet(text: text)
+        }
+        .store(in: &self.cancellables)
+    }
+
     private func runMoreActionAfterConfirm(
         _ title: String, _ message: String,
         _ action: @escaping () -> Void

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModel.swift
@@ -451,6 +451,10 @@ extension EventListCellEventHanleViewModelImple {
             self.shareTodoEvent(todo)
         case let schedule as ScheduleEventCellViewModel:
             self.shareScheduleEvent(schedule)
+        case let google as GoogleCalendarEventCellViewModel:
+            self.shareGoogleEvent(google)
+        case let apple as AppleCalendarEventCellViewModel:
+            self.shareAppleEvent(apple)
         default: return
         }
     }
@@ -520,11 +524,106 @@ extension EventListCellEventHanleViewModelImple {
                 url: detail?.url?.emptyAsNil(),
                 memo: detail?.memo?.emptyAsNil()
             )
-            let text = builder.build(model)
-            guard !text.isEmpty else { return }
-            self?.router?.showShareSheet(text: text)
+            self?.showShareSheetIfNeeded(model, builder)
         }
         .store(in: &self.cancellables)
+    }
+
+    private func shareGoogleEvent(_ cellViewModel: GoogleCalendarEventCellViewModel) {
+        let calendarId = cellViewModel.calendarId
+        let accountId = cellViewModel.accountId
+        let eventId = cellViewModel.eventIdentifier
+        self.calendarSettingUsecase.currentTimeZone
+            .first()
+            .setFailureType(to: (any Error).self)
+            .flatMap { [weak self] timeZone -> AnyPublisher<(GoogleCalendar.EventOrigin, [GoogleCalendar.Tag], TimeZone), any Error> in
+                guard let self else { return Empty().eraseToAnyPublisher() }
+                return Publishers.CombineLatest(
+                    self.googleCalendarUsecase.eventDetail(calendarId, eventId, accountId: accountId, at: timeZone),
+                    self.googleCalendarUsecase.calendarTags.setFailureType(to: (any Error).self)
+                )
+                .map { origin, tags in (origin, tags, timeZone) }
+                .eraseToAnyPublisher()
+            }
+            .first()
+            .sink(receiveCompletion: { [weak self] completion in
+                guard case .failure(let error) = completion else { return }
+                self?.router?.showError(error)
+            }, receiveValue: { [weak self] origin, tags, timeZone in
+                self?.shareGoogleEventText(origin, calendarId: calendarId, tags: tags, timeZone: timeZone)
+            })
+            .store(in: &self.cancellables)
+    }
+
+    private func shareGoogleEventText(
+        _ origin: GoogleCalendar.EventOrigin,
+        calendarId: String,
+        tags: [GoogleCalendar.Tag],
+        timeZone: TimeZone
+    ) {
+        let builder = EventDetailShareTextBuilder()
+        let selectedTime = origin.selectedTime(timeZone)
+        let repeatText = origin.shareRepeatText(timeZone)
+        let tagLine = tags.first(where: { $0.id == calendarId })?.name.emptyAsNil()
+            .map { EventDetailShareTagLine.googleCalendar($0) }
+        let model = EventDetailShareModel(
+            name: origin.summaryText,
+            isTodo: false,
+            timeText: selectedTime.map(builder.timeText(from:)),
+            repeatText: repeatText,
+            tagLine: tagLine,
+            placeName: origin.location?.emptyAsNil(),
+            url: nil,
+            memo: origin.description.asPlainShareText
+        )
+        self.showShareSheetIfNeeded(model, builder)
+    }
+
+    private func shareAppleEvent(_ cellViewModel: AppleCalendarEventCellViewModel) {
+        let calendarId = cellViewModel.calendarId
+        Publishers.CombineLatest3(
+            self.appleCalendarUsecase.eventOrigin(id: cellViewModel.eventIdentifier),
+            self.appleCalendarUsecase.calendarTags,
+            self.calendarSettingUsecase.currentTimeZone
+        )
+        .first()
+        .sink { [weak self] origin, tags, timeZone in
+            guard let origin else { return }
+            self?.shareAppleEventText(origin, calendarId: calendarId, tags: tags, timeZone: timeZone)
+        }
+        .store(in: &self.cancellables)
+    }
+
+    private func shareAppleEventText(
+        _ origin: AppleCalendar.EventOrigin,
+        calendarId: String,
+        tags: [AppleCalendar.Tag],
+        timeZone: TimeZone
+    ) {
+        let builder = EventDetailShareTextBuilder()
+        let selectedTime = SelectedTime(origin.eventTime, timeZone)
+        let repeatText = origin.shareRepeatText(timeZone)
+        let tagLine = tags.first(where: { $0.id == calendarId })?.name.emptyAsNil()
+            .map { EventDetailShareTagLine.appleCalendar($0) }
+        let model = EventDetailShareModel(
+            name: origin.name,
+            isTodo: false,
+            timeText: builder.timeText(from: selectedTime),
+            repeatText: repeatText,
+            tagLine: tagLine,
+            placeName: origin.location?.emptyAsNil(),
+            url: origin.url?.emptyAsNil(),
+            memo: origin.notes?.emptyAsNil()
+        )
+        self.showShareSheetIfNeeded(model, builder)
+    }
+
+    private func showShareSheetIfNeeded(
+        _ model: EventDetailShareModel, _ builder: EventDetailShareTextBuilder
+    ) {
+        let text = builder.build(model)
+        guard !text.isEmpty else { return }
+        self.router?.showShareSheet(text: text)
     }
 
     private func runMoreActionAfterConfirm(

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModelBuilder.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModelBuilder.swift
@@ -43,6 +43,9 @@ final class EventListCellEventHanleViewModelBuilderImple: EventListCellEventHanl
             googleCalendarUsecase: self.usecaseFactory.makeGoogleCalendarUsecase(),
             appleCalendarUsecase: self.usecaseFactory.makeAppleCalendarUsecase(),
             externalCalendarIntegrationUsecase: self.usecaseFactory.externalCalenarIntegrationUsecase,
+            eventTagUsecase: self.usecaseFactory.makeEventTagUsecase(),
+            eventDetailDataUsecase: self.usecaseFactory.makeEventDetailDataUsecase(),
+            calendarSettingUsecase: self.usecaseFactory.makeCalendarSettingUsecase(),
             liveActivityToggleViewModel: liveActivityToggleViewModel
         )
         let router = EventListCellEventHanleRouter(

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellView.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellView.swift
@@ -98,7 +98,7 @@ struct EventListCellView: View {
                     moreActionsView(moreActions.basicActions[$0])
                 }
 
-                if !moreActions.basicActions.isEmpty {
+                if !moreActions.basicActions.isEmpty && !moreActions.removeActions.isEmpty {
                     Divider()
                 }
 

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellView.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellView.swift
@@ -123,6 +123,8 @@ struct EventListCellView: View {
             return skipTodoButton().asAnyView()
         case .copy:
             return copyButton().asAnyView()
+        case .share:
+            return shareButton().asAnyView()
         }
     }
 
@@ -208,6 +210,17 @@ struct EventListCellView: View {
             HStack {
                 Text("calednar::event::copy".localized())
                 Image(systemName: "doc.on.doc")
+            }
+        }
+    }
+
+    private func shareButton() -> some View {
+        return Button {
+            self.handleMoreAction(self.cellViewModel, .share)
+        } label: {
+            HStack {
+                Text("calendar::event::more_action:share:item_name".localized())
+                Image(systemName: "square.and.arrow.up")
             }
         }
     }

--- a/Presentations/CalendarScenes/Tests/Common/EventListCellEventHanleViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Common/EventListCellEventHanleViewModelImpleTests.swift
@@ -13,6 +13,7 @@ import Optics
 import Domain
 import Extensions
 import Scenes
+import CommonPresentation
 import UnitTestHelpKit
 import TestDoubles
 
@@ -27,6 +28,9 @@ class EventListCellEventHanleViewModelImpleTests: BaseTestCase, PublisherWaitabl
     private var spyGoogleUsecase: PrivateGoogleCalendarUsecase!
     private var spyAppleUsecase: PrivateAppleCalendarUsecase!
     private var stubIntegrationUsecase: StubExternalCalendarIntegrationUsecase!
+    private var stubEventTagUsecase: StubEventTagUsecase!
+    private var spyEventDetailDataUsecase: PrivateEventDetailDataUsecase!
+    private var stubCalendarSettingUsecase: StubCalendarSettingUsecase!
     private var stubLiveActivityUsecase: StubEventLiveActivityUsecase!
     private var spyRouter: SpyEventListCellEventHanleRouter!
 
@@ -38,6 +42,10 @@ class EventListCellEventHanleViewModelImpleTests: BaseTestCase, PublisherWaitabl
         self.spyGoogleUsecase = .init()
         self.spyAppleUsecase = .init()
         self.stubIntegrationUsecase = .init([])
+        self.stubEventTagUsecase = .init()
+        self.spyEventDetailDataUsecase = .init()
+        self.stubCalendarSettingUsecase = .init()
+        self.stubCalendarSettingUsecase.selectTimeZone(TimeZone(abbreviation: "KST")!)
         self.spyRouter = .init()
     }
 
@@ -49,6 +57,9 @@ class EventListCellEventHanleViewModelImpleTests: BaseTestCase, PublisherWaitabl
         self.spyGoogleUsecase = nil
         self.spyAppleUsecase = nil
         self.stubIntegrationUsecase = nil
+        self.stubEventTagUsecase = nil
+        self.spyEventDetailDataUsecase = nil
+        self.stubCalendarSettingUsecase = nil
         self.stubLiveActivityUsecase = nil
         self.spyRouter = nil
     }
@@ -59,6 +70,11 @@ class EventListCellEventHanleViewModelImpleTests: BaseTestCase, PublisherWaitabl
         appleShouldFailWrite: Bool = false,
         googleShouldFailWrite: Bool = false,
         shouldFailReauthenticate: Bool = false,
+        stubTodoEvent: TodoEvent? = nil,
+        stubScheduleEvent: ScheduleEvent? = nil,
+        stubDetailData: EventDetailData? = nil,
+        shouldFailLoadDetail: Bool = false,
+        shouldFailTodoEventFetch: Bool = false,
         registeredLiveActivityTarget: LiveActivityTarget? = nil,
         liveActivityStartError: (any Error)? = nil
     ) -> EventListCellEventHanleViewModelImple {
@@ -68,6 +84,13 @@ class EventListCellEventHanleViewModelImpleTests: BaseTestCase, PublisherWaitabl
         self.spyAppleUsecase.shouldFailWrite = appleShouldFailWrite
         self.spyGoogleUsecase.shouldFailWrite = googleShouldFailWrite
         self.stubIntegrationUsecase.shouldFailReauthenticate = shouldFailReauthenticate
+        if let stubTodoEvent {
+            self.spyTodoUsecase.setStub(todo: stubTodoEvent)
+        }
+        self.spySchedleUsecase.stubEvent = stubScheduleEvent
+        self.spyEventDetailDataUsecase.stubDetail = stubDetailData
+        self.spyEventDetailDataUsecase.shouldFailLoadDetail = shouldFailLoadDetail
+        self.spyTodoUsecase.shouldFailTodoEvent = shouldFailTodoEventFetch
         self.stubLiveActivityUsecase = .init(registeredTarget: registeredLiveActivityTarget)
         self.stubLiveActivityUsecase.stubStartError = liveActivityStartError
 
@@ -82,6 +105,9 @@ class EventListCellEventHanleViewModelImpleTests: BaseTestCase, PublisherWaitabl
             googleCalendarUsecase: self.spyGoogleUsecase,
             appleCalendarUsecase: self.spyAppleUsecase,
             externalCalendarIntegrationUsecase: self.stubIntegrationUsecase,
+            eventTagUsecase: self.stubEventTagUsecase,
+            eventDetailDataUsecase: self.spyEventDetailDataUsecase,
+            calendarSettingUsecase: self.stubCalendarSettingUsecase,
             liveActivityToggleViewModel: liveActivityToggleViewModel
         )
         viewModel.router = self.spyRouter
@@ -884,9 +910,212 @@ extension EventListCellEventHanleViewModelImpleTests {
     }
 }
 
+// MARK: - 목록 셀 롱탭 공유
+
+extension EventListCellEventHanleViewModelImpleTests {
+
+    func testViewModel_whenShareTodoEvent_showShareSheetWithDetailFields() {
+        // given
+        let todo = TodoEvent(uuid: "todo-1", name: "회의 준비")
+            |> \.time .~ .at(1_700_000_000)
+            |> \.repeating .~ EventRepeating(repeatingStartTime: 1_700_000_000, repeatOption: EventRepeatingOptions.EveryDay())
+            |> \.eventTagId .~ .custom("tag-1")
+        let detail = EventDetailData("todo-1")
+            |> \.place .~ Place("회의실")
+            |> \.url .~ "https://example.com"
+            |> \.memo .~ "준비물 챙기기"
+        let viewModel = self.makeViewModel(stubTodoEvent: todo, stubDetailData: detail)
+        let cellViewModel = TodoEventCellViewModel("todo-1", name: "회의 준비")
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .share)
+
+        // then
+        let text = self.spyRouter.didShareText
+        let todoMarker = "calendar::event_time::todo".localized()
+        let everyDayTitle = "eventDetail.repeating.everyDay:title".localized()
+        XCTAssertEqual(text?.hasPrefix("(\(todoMarker)) 회의 준비"), true)
+        XCTAssertEqual(text?.contains("\(self.shareFieldLabel("repeating")): \(everyDayTitle)"), true)
+        XCTAssertEqual(text?.contains("\("eventTag.title".localized()): some"), true)
+        XCTAssertEqual(text?.contains("\(self.shareFieldLabel("place")): 회의실"), true)
+        XCTAssertEqual(text?.contains("\(self.shareFieldLabel("url")): https://example.com"), true)
+        XCTAssertEqual(text?.contains("\(self.shareFieldLabel("memo")): 준비물 챙기기"), true)
+    }
+
+    func testViewModel_whenShareScheduleEvent_showShareSheetWithDetailFields() {
+        // given
+        let schedule = ScheduleEvent(uuid: "schedule-1", name: "팀 회의", time: .at(1_700_000_000))
+            |> \.repeating .~ EventRepeating(repeatingStartTime: 1_700_000_000, repeatOption: EventRepeatingOptions.EveryDay())
+            |> \.eventTagId .~ .custom("tag-1")
+        let detail = EventDetailData("schedule-1")
+            |> \.place .~ Place("회의실 B")
+            |> \.url .~ "https://example.com/schedule"
+            |> \.memo .~ "자료 준비"
+        let viewModel = self.makeViewModel(stubScheduleEvent: schedule, stubDetailData: detail)
+        let cellViewModel = ScheduleEventCellViewModel("schedule-1", name: "팀 회의")
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .share)
+
+        // then
+        let text = self.spyRouter.didShareText
+        let everyDayTitle = "eventDetail.repeating.everyDay:title".localized()
+        XCTAssertEqual(text?.hasPrefix("팀 회의"), true)
+        XCTAssertEqual(text?.contains("\(self.shareFieldLabel("repeating")): \(everyDayTitle)"), true)
+        XCTAssertEqual(text?.contains("\("eventTag.title".localized()): some"), true)
+        XCTAssertEqual(text?.contains("\(self.shareFieldLabel("place")): 회의실 B"), true)
+        XCTAssertEqual(text?.contains("\(self.shareFieldLabel("url")): https://example.com/schedule"), true)
+        XCTAssertEqual(text?.contains("\(self.shareFieldLabel("memo")): 자료 준비"), true)
+    }
+
+    func testViewModel_whenShareEventWithoutDetailData_shareWithoutPlaceUrlMemo() {
+        // given
+        let todo = TodoEvent(uuid: "todo-2", name: "빠른 확인")
+            |> \.time .~ .at(1_700_000_000)
+        let viewModel = self.makeViewModel(stubTodoEvent: todo, shouldFailLoadDetail: true)
+        let cellViewModel = TodoEventCellViewModel("todo-2", name: "빠른 확인")
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .share)
+
+        // then
+        let text = self.spyRouter.didShareText
+        XCTAssertEqual(text?.contains("빠른 확인"), true)
+        XCTAssertEqual(text?.contains(self.shareFieldLabel("place")), false)
+        XCTAssertEqual(text?.contains(self.shareFieldLabel("url")), false)
+        XCTAssertEqual(text?.contains(self.shareFieldLabel("memo")), false)
+    }
+
+    func testViewModel_whenShareEventWithNoDetailRow_stillShowsShareSheet() {
+        // given — 상세 로우 자체가 없는 이벤트(빠른 추가 todo 등)는 loadDetail 이 값 없이 finished 한다
+        let todo = TodoEvent(uuid: "todo-5", name: "빠른 추가")
+            |> \.time .~ .at(1_700_000_000)
+        let viewModel = self.makeViewModel(stubTodoEvent: todo)
+        let cellViewModel = TodoEventCellViewModel("todo-5", name: "빠른 추가")
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .share)
+
+        // then
+        let text = self.spyRouter.didShareText
+        XCTAssertEqual(text?.contains("빠른 추가"), true)
+    }
+
+    func testViewModel_whenShareRepeatingSchedule_useEventIdWithoutTurn() {
+        // given
+        let schedule = ScheduleEvent(uuid: "repeating-schedule", name: "반복 회의", time: .at(1_700_000_000))
+        let viewModel = self.makeViewModel(stubScheduleEvent: schedule, shouldFailLoadDetail: true)
+        let cellViewModel = ScheduleEventCellViewModel(
+            "repeating-schedule", turn: 3, name: "반복 회의", isRepeating: true
+        )
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .share)
+
+        // then
+        XCTAssertEqual(self.spySchedleUsecase.didFetchScheduleEventWithId, "repeating-schedule")
+        XCTAssertNotEqual(self.spySchedleUsecase.didFetchScheduleEventWithId, cellViewModel.eventIdentifier)
+    }
+
+    func testViewModel_whenShareRepeatingScheduleTurn_useCellTurnTimeNotOriginTime() {
+        // given
+        let timeZone = TimeZone(abbreviation: "KST")!
+        let originTime: TimeInterval = 1_700_000_000
+        let turnTime: TimeInterval = 1_705_000_000
+        let schedule = ScheduleEvent(uuid: "repeating-schedule", name: "반복 회의", time: .at(originTime))
+        let viewModel = self.makeViewModel(stubScheduleEvent: schedule, shouldFailLoadDetail: true)
+        let cellViewModel = ScheduleEventCellViewModel(
+            "repeating-schedule", turn: 3, name: "반복 회의", isRepeating: true
+        )
+        |> \.eventTimeRawValue .~ .at(turnTime)
+        let expectedTimeText = EventDetailShareTextBuilder().timeText(from: SelectedTime(.at(turnTime), timeZone))
+        let originTimeText = EventDetailShareTextBuilder().timeText(from: SelectedTime(.at(originTime), timeZone))
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .share)
+
+        // then
+        let text = self.spyRouter.didShareText
+        XCTAssertEqual(text?.contains("\(self.shareFieldLabel("time")): \(expectedTimeText)"), true)
+        XCTAssertEqual(text?.contains(originTimeText), false)
+    }
+
+    func testViewModel_whenShareEventWithRepeatEndOption_repeatTextOmitsEndOption() {
+        // given
+        let repeating = EventRepeating(repeatingStartTime: 1_700_000_000, repeatOption: EventRepeatingOptions.EveryDay())
+            |> \.repeatingEndOption .~ .count(5)
+        let todo = TodoEvent(uuid: "todo-3", name: "반복 회의")
+            |> \.time .~ .at(1_700_000_000)
+            |> \.repeating .~ repeating
+        let viewModel = self.makeViewModel(stubTodoEvent: todo, shouldFailLoadDetail: true)
+        let cellViewModel = TodoEventCellViewModel("todo-3", name: "반복 회의")
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .share)
+
+        // then
+        let text = self.spyRouter.didShareText
+        let everyDayTitle = "eventDetail.repeating.everyDay:title".localized()
+        let endOptionText = "eventDetail.repeating::endoption_times".localized(with: 5)
+        XCTAssertEqual(text?.contains("\(self.shareFieldLabel("repeating")): \(everyDayTitle)"), true)
+        XCTAssertEqual(text?.contains(endOptionText), false)
+    }
+
+    func testViewModel_whenShareEventFetchFails_showErrorWithoutSharing() {
+        // given
+        let viewModel = self.makeViewModel(shouldFailTodoEventFetch: true)
+        let cellViewModel = TodoEventCellViewModel("todo-4", name: "원본 조회 실패")
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .share)
+
+        // then
+        XCTAssertNotNil(self.spyRouter.didShowError)
+        XCTAssertNil(self.spyRouter.didShareText)
+    }
+
+    func testViewModel_whenShareRepeatingTodoAdvancedByComplete_repeatTextFollowsEventTime() {
+        // given: "매월 31일" 반복 할일이 완료로 전진해 이벤트 시각(3/3)과 반복 시작(1/31)이 갈린 상태
+        let timeZone = TimeZone(abbreviation: "KST")!
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        let repeatStart = calendar.date(from: DateComponents(year: 2026, month: 1, day: 31, hour: 9))!
+        let advanced = calendar.date(from: DateComponents(year: 2026, month: 3, day: 3, hour: 9))!
+        let everyMonth = EventRepeatingOptions.EveryMonth(timeZone: timeZone)
+            |> \.selection .~ .days([31])
+        let repeating = EventRepeating(
+            repeatingStartTime: repeatStart.timeIntervalSince1970, repeatOption: everyMonth
+        )
+        let todo = TodoEvent(uuid: "todo-5", name: "월세 내기")
+            |> \.time .~ .at(advanced.timeIntervalSince1970)
+            |> \.repeating .~ repeating
+        let viewModel = self.makeViewModel(stubTodoEvent: todo, shouldFailLoadDetail: true)
+        let cellViewModel = TodoEventCellViewModel("todo-5", name: "월세 내기")
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .share)
+
+        // then: 반복 시작(1/31) 기준이면 "매월", 이벤트 시각(3/3) 기준이라야 "매월 31일"이 된다
+        let text = self.spyRouter.didShareText
+        let someDayTitle = "eventDetail.repeating.everyMonth_someDay:title"
+            .localized(with: 31.ordinal ?? "31")
+        XCTAssertEqual(text?.contains("\(self.shareFieldLabel("repeating")): \(someDayTitle)"), true)
+    }
+
+    private func shareFieldLabel(_ key: String) -> String {
+        return "event_detail::share::field::\(key)".localized()
+    }
+}
+
+
 final class SpyEventListCellEventHanleRouter: BaseSpyRouter, EventListCellEventHanleRouting, @unchecked Sendable {
-    
+
     func attach(_ scene: any Scene) { }
+
+    var didShareText: String?
+    func showShareSheet(text: String) {
+        self.didShareText = text
+    }
     
     var didRouteToTodoDetail: Bool?
     func routeToTodoEventDetail(_ eventId: String) {
@@ -943,13 +1172,22 @@ private final class PrivateStubTodoEventUsecase: StubTodoEventUsecase {
         self.didRemoveTodoWithParamsCallback?(id, onlyThisTime)
     }
     
+    var shouldFailTodoEvent: Bool = false
     private let fakeTodo = CurrentValueSubject<TodoEvent, Never>(TodoEvent(uuid: "some", name: "origin"))
     override func todoEvent(_ id: String) -> AnyPublisher<TodoEvent, any Error> {
+        guard self.shouldFailTodoEvent == false
+        else {
+            return Fail(error: RuntimeError("failed")).eraseToAnyPublisher()
+        }
         return fakeTodo
             .mapNever()
             .eraseToAnyPublisher()
     }
-    
+
+    func setStub(todo: TodoEvent) {
+        self.fakeTodo.send(todo)
+    }
+
     override func skipRepeatingTodo(_ todoId: String) async throws -> TodoEvent {
 
         let newTodo = TodoEvent(uuid: todoId, name: "skipped")
@@ -959,10 +1197,28 @@ private final class PrivateStubTodoEventUsecase: StubTodoEventUsecase {
 }
 
 private final class PrivateScheduleEventUsecase: StubScheduleEventUsecase {
-    
+
     var didRemoveEventWithParamsCallback: ((String, EventTime?) -> Void)?
     override func removeScheduleEvent(_ eventId: String, onlyThisTime: EventTime?) async throws {
         self.didRemoveEventWithParamsCallback?(eventId, onlyThisTime)
+    }
+
+    var didFetchScheduleEventWithId: String?
+    override func scheduleEvent(_ eventId: String) -> AnyPublisher<ScheduleEvent, any Error> {
+        self.didFetchScheduleEventWithId = eventId
+        return super.scheduleEvent(eventId)
+    }
+}
+
+private final class PrivateEventDetailDataUsecase: StubEventDetailDataUsecase {
+
+    var shouldFailLoadDetail: Bool = false
+    override func loadDetail(_ id: String) -> AnyPublisher<EventDetailData, any Error> {
+        guard self.shouldFailLoadDetail == false
+        else {
+            return Fail(error: RuntimeError("failed")).eraseToAnyPublisher()
+        }
+        return super.loadDetail(id)
     }
 }
 

--- a/Presentations/CalendarScenes/Tests/Common/EventListCellEventHanleViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Common/EventListCellEventHanleViewModelImpleTests.swift
@@ -75,6 +75,11 @@ class EventListCellEventHanleViewModelImpleTests: BaseTestCase, PublisherWaitabl
         stubDetailData: EventDetailData? = nil,
         shouldFailLoadDetail: Bool = false,
         shouldFailTodoEventFetch: Bool = false,
+        stubGoogleEventOrigin: GoogleCalendar.EventOrigin? = nil,
+        shouldFailGoogleEventDetail: Bool = false,
+        stubGoogleCalendarTags: [GoogleCalendar.Tag]? = nil,
+        stubAppleEventOrigin: AppleCalendar.EventOrigin? = nil,
+        stubAppleCalendarTags: [AppleCalendar.Tag]? = nil,
         registeredLiveActivityTarget: LiveActivityTarget? = nil,
         liveActivityStartError: (any Error)? = nil
     ) -> EventListCellEventHanleViewModelImple {
@@ -91,6 +96,13 @@ class EventListCellEventHanleViewModelImpleTests: BaseTestCase, PublisherWaitabl
         self.spyEventDetailDataUsecase.stubDetail = stubDetailData
         self.spyEventDetailDataUsecase.shouldFailLoadDetail = shouldFailLoadDetail
         self.spyTodoUsecase.shouldFailTodoEvent = shouldFailTodoEventFetch
+        self.spyGoogleUsecase.stubDetail = stubGoogleEventOrigin
+        self.spyGoogleUsecase.shouldFailEventDetail = shouldFailGoogleEventDetail
+        self.spyGoogleUsecase.stubCalendarTags = stubGoogleCalendarTags
+        self.spyGoogleUsecase.refreshGoogleCalendarEventTags()
+        self.spyAppleUsecase.stubEventOrigin = stubAppleEventOrigin
+        self.spyAppleUsecase.stubCalendarTags = stubAppleCalendarTags
+        self.spyAppleUsecase.refreshCalendarTags()
         self.stubLiveActivityUsecase = .init(registeredTarget: registeredLiveActivityTarget)
         self.stubLiveActivityUsecase.stubStartError = liveActivityStartError
 
@@ -202,17 +214,6 @@ extension EventListCellEventHanleViewModelImpleTests {
 
 extension EventListCellEventHanleViewModelImpleTests {
 
-    func testGoogleCell_moreActionsIsNil_whenCalendarIsNotWritable() {
-        // given
-        let model = GoogleCalendarEventCellViewModel.dummy(isWritable: false)
-
-        // when
-        let actions = model.moreActions
-
-        // then
-        XCTAssertNil(actions)
-    }
-
     func testGoogleCell_removeActions_whenNotRepeating() {
         // given
         let model = GoogleCalendarEventCellViewModel.dummy(isWritable: true, recurringEventId: nil)
@@ -235,7 +236,7 @@ extension EventListCellEventHanleViewModelImpleTests {
         XCTAssertEqual(actions?.removeActions, [.remove(scope: .onlyThisTime), .remove(scope: .all)])
     }
 
-    func testGoogleCell_basicActionsIsEmpty() {
+    func testGoogleCell_basicActionsIsShareOnly() {
         // given
         let model = GoogleCalendarEventCellViewModel.dummy(isWritable: true)
 
@@ -243,18 +244,7 @@ extension EventListCellEventHanleViewModelImpleTests {
         let actions = model.moreActions
 
         // then
-        XCTAssertEqual(actions?.basicActions, [])
-    }
-
-    func testAppleCell_moreActionsIsNil_whenCalendarIsNotWritable() {
-        // given
-        let model = AppleCalendarEventCellViewModel.dummy(isWritable: false)
-
-        // when
-        let actions = model.moreActions
-
-        // then
-        XCTAssertNil(actions)
+        XCTAssertEqual(actions?.basicActions, [.share])
     }
 
     func testAppleCell_removeActions_whenRepeating() {
@@ -277,6 +267,19 @@ extension EventListCellEventHanleViewModelImpleTests {
 
         // then
         XCTAssertEqual(actions?.removeActions, [.remove(scope: .all)])
+    }
+
+    func testViewModel_readOnlyExternalCalendarCell_moreActionsHasShareOnly() {
+        // given
+        func parameterizeTest(_ actions: EventListMoreActionModel?) {
+            // then
+            XCTAssertNotNil(actions)
+            XCTAssertEqual(actions?.basicActions, [.share])
+            XCTAssertEqual(actions?.removeActions, [])
+        }
+        // when + then
+        parameterizeTest(GoogleCalendarEventCellViewModel.dummy(isWritable: false).moreActions)
+        parameterizeTest(AppleCalendarEventCellViewModel.dummy(isWritable: false).moreActions)
     }
 }
 
@@ -1104,6 +1107,175 @@ extension EventListCellEventHanleViewModelImpleTests {
 
     private func shareFieldLabel(_ key: String) -> String {
         return "event_detail::share::field::\(key)".localized()
+    }
+}
+
+
+// MARK: - 목록 셀 롱탭 공유 — 구글·애플
+
+extension EventListCellEventHanleViewModelImpleTests {
+
+    private func googleEventTime(_ isoText: String) -> GoogleCalendar.EventOrigin.GoogleEventTime {
+        return GoogleCalendar.EventOrigin.GoogleEventTime() |> \.dateTime .~ isoText
+    }
+
+    func testViewModel_whenShareGoogleEvent_showShareSheetWithoutUrlLine() {
+        // given
+        let origin = GoogleCalendar.EventOrigin(id: "google", summary: "구글 회의")
+            |> \.start .~ self.googleEventTime("2026-08-21T10:00:00+09:00")
+            |> \.end .~ self.googleEventTime("2026-08-21T11:00:00+09:00")
+            |> \.htmlLink .~ "https://calendar.google.com/event?eid=xxx"
+            |> \.location .~ "회의실 A"
+        let viewModel = self.makeViewModel(stubGoogleEventOrigin: origin)
+        let cellViewModel = GoogleCalendarEventCellViewModel.dummy(isWritable: true)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .share)
+
+        // then
+        let text = self.spyRouter.didShareText
+        XCTAssertEqual(text?.contains("구글 회의"), true)
+        XCTAssertEqual(text?.contains(self.shareFieldLabel("url")), false)
+        XCTAssertEqual(text?.contains("https://calendar.google.com"), false)
+    }
+
+    func testViewModel_whenShareGoogleEvent_showShareSheetWithCalendarNameLine() {
+        // given
+        let origin = GoogleCalendar.EventOrigin(id: "google", summary: "구글 회의")
+            |> \.start .~ self.googleEventTime("2026-08-21T10:00:00+09:00")
+            |> \.end .~ self.googleEventTime("2026-08-21T11:00:00+09:00")
+        let tags = [GoogleCalendar.Tag(id: "calendar", name: "업무")]
+        let viewModel = self.makeViewModel(stubGoogleEventOrigin: origin, stubGoogleCalendarTags: tags)
+        let cellViewModel = GoogleCalendarEventCellViewModel.dummy(isWritable: true)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .share)
+
+        // then
+        let text = self.spyRouter.didShareText
+        let googleServiceName = "event_setting::external_calendar::google::serviceName".localized()
+        XCTAssertEqual(
+            text?.contains("\(self.shareFieldLabel("calendar")): \(googleServiceName) - 업무"), true
+        )
+    }
+
+    func testViewModel_whenShareGoogleEventWithHtmlDescription_shareAsPlainText() {
+        // given
+        let origin = GoogleCalendar.EventOrigin(id: "google", summary: "구글 회의")
+            |> \.start .~ self.googleEventTime("2026-08-21T10:00:00+09:00")
+            |> \.end .~ self.googleEventTime("2026-08-21T11:00:00+09:00")
+            |> \.description .~ "<p>준비물</p><br>노트북"
+        let viewModel = self.makeViewModel(stubGoogleEventOrigin: origin)
+        let cellViewModel = GoogleCalendarEventCellViewModel.dummy(isWritable: true)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .share)
+
+        // then
+        let text = self.spyRouter.didShareText
+        XCTAssertEqual(text?.contains("<p>"), false)
+        XCTAssertEqual(text?.contains("준비물"), true)
+        XCTAssertEqual(text?.contains("노트북"), true)
+    }
+
+    func testViewModel_whenShareGoogleEventWithRepeatRule_repeatTextIncludesEndOption() {
+        // given
+        let origin = GoogleCalendar.EventOrigin(id: "google", summary: "구글 반복 회의")
+            |> \.start .~ self.googleEventTime("2026-08-21T10:00:00+09:00")
+            |> \.end .~ self.googleEventTime("2026-08-21T11:00:00+09:00")
+            |> \.recurrence .~ ["RRULE:FREQ=DAILY;COUNT=5"]
+        let viewModel = self.makeViewModel(stubGoogleEventOrigin: origin)
+        let cellViewModel = GoogleCalendarEventCellViewModel.dummy(isWritable: true)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .share)
+
+        // then
+        let text = self.spyRouter.didShareText
+        let everyDayTitle = "eventDetail.repeating.everyDay:title".localized()
+        let endOptionText = "eventDetail.repeating::endoption_times".localized(with: 5)
+        XCTAssertEqual(text?.contains("\(self.shareFieldLabel("repeating")): \(everyDayTitle)"), true)
+        XCTAssertEqual(text?.contains(endOptionText), true)
+    }
+
+    func testViewModel_whenShareGoogleEventFetchFails_showErrorWithoutSharing() {
+        // given
+        let viewModel = self.makeViewModel(shouldFailGoogleEventDetail: true)
+        let cellViewModel = GoogleCalendarEventCellViewModel.dummy(isWritable: true)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .share)
+
+        // then
+        XCTAssertNotNil(self.spyRouter.didShowError)
+        XCTAssertNil(self.spyRouter.didShareText)
+    }
+
+    func testViewModel_whenShareAppleEvent_showShareSheetWithUrlAndNotes() {
+        // given
+        let origin = AppleCalendar.EventOrigin(
+            eventId: "apple-event", originalEventId: "apple-event",
+            calendarId: "apple-calendar", name: "애플 회의", eventTime: .at(1_700_000_000)
+        )
+        |> \.location .~ "회의실 B"
+        |> \.url .~ "https://example.com/apple"
+        |> \.notes .~ "메모입니다"
+        let tags = [AppleCalendar.Tag(id: "apple-calendar", name: "개인", colorHex: "hex")]
+        let viewModel = self.makeViewModel(stubAppleEventOrigin: origin, stubAppleCalendarTags: tags)
+        let cellViewModel = AppleCalendarEventCellViewModel.dummy(isWritable: true)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .share)
+
+        // then
+        let text = self.spyRouter.didShareText
+        XCTAssertEqual(text?.contains("애플 회의"), true)
+        XCTAssertEqual(text?.contains("\(self.shareFieldLabel("url")): https://example.com/apple"), true)
+        XCTAssertEqual(text?.contains("\(self.shareFieldLabel("memo")): 메모입니다"), true)
+        XCTAssertEqual(text?.contains("개인"), true)
+    }
+
+    func testViewModel_whenShareAppleEventWithLockedRepeatUntil_reanchorsUTCDayEndToLocalDate() {
+        // given — BYSETPOS 는 앱 옵션으로 왕복 못 시켜 잠금 분기(원본 규칙 폴백)를 탄다
+        let timeZone = TimeZone(abbreviation: "KST")!
+        let rruleText = "RRULE:FREQ=DAILY;UNTIL=20261231T235959Z;BYSETPOS=1"
+        let origin = AppleCalendar.EventOrigin(
+            eventId: "apple-event", originalEventId: "apple-event",
+            calendarId: "apple-calendar", name: "애플 반복 회의", eventTime: .at(1_700_000_000)
+        )
+        |> \.recurrenceRules .~ [rruleText]
+        let viewModel = self.makeViewModel(stubAppleEventOrigin: origin)
+        let cellViewModel = AppleCalendarEventCellViewModel.dummy(isWritable: true)
+
+        let rawRRule = RRuleParser.parse(rruleText)!
+        let reanchoredRRule = rawRRule.reanchoringUTCDayEndUntil(to: timeZone)
+        let dateForm = "date_form.yyyy_MMM_dd".localized()
+        let expectedEndOptionText = "eventDetail.repeating::endoption_until"
+            .localized(with: reanchoredRRule.until!.text(dateForm, timeZone: timeZone))
+        let unreanchoredEndOptionText = "eventDetail.repeating::endoption_until"
+            .localized(with: rawRRule.until!.text(dateForm, timeZone: timeZone))
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .share)
+
+        // then
+        let text = self.spyRouter.didShareText
+        XCTAssertNotEqual(expectedEndOptionText, unreanchoredEndOptionText)
+        XCTAssertEqual(text?.contains(expectedEndOptionText), true)
+        XCTAssertEqual(text?.contains(unreanchoredEndOptionText), false)
+    }
+
+    func testViewModel_whenShareAppleEventOriginIsNil_doesNotShare() {
+        // given
+        let viewModel = self.makeViewModel()
+        let cellViewModel = AppleCalendarEventCellViewModel.dummy(isWritable: true)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .share)
+
+        // then
+        XCTAssertNil(self.spyRouter.didShareText)
+        XCTAssertNil(self.spyRouter.didShowError)
     }
 }
 

--- a/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
@@ -539,21 +539,21 @@ extension DayEventListViewModelImpleTests {
         XCTAssertEqual(
             todoNotRepeating.moreActions,
             .init(
-                basicActions: [.toggleTo(isForemost: false), .edit, .copy],
+                basicActions: [.toggleTo(isForemost: false), .edit, .copy, .share],
                 removeActions: [.remove(scope: .all)]
             )
         )
         XCTAssertEqual(
             todoWithRepeating.moreActions,
             .init(
-                basicActions: [.toggleTo(isForemost: false), .skipTodo, .edit, .copy],
+                basicActions: [.toggleTo(isForemost: false), .skipTodo, .edit, .copy, .share],
                 removeActions: [.remove(scope: .onlyThisTime), .remove(scope: .all)]
             )
         )
         XCTAssertEqual(
             todoAsForemost.moreActions,
             .init(
-                basicActions: [.toggleTo(isForemost: true), .edit, .copy],
+                basicActions: [.toggleTo(isForemost: true), .edit, .copy, .share],
                 removeActions: [.remove(scope: .all)]
             )
         )
@@ -566,23 +566,23 @@ extension DayEventListViewModelImpleTests {
         let repeatingSchedule = ScheduleEvent(uuid: "id", name: "some", time: .at(10))
             |> \.repeating .~ dummyRepeating
         let notRepeatingSchedule = repeatingSchedule |> \.repeating .~  nil
-        
+
         // when
         let repeating = ScheduleEventCellViewModel(ScheduleCalendarEvent.events(from: repeatingSchedule, in: kst).first!, in: 0..<20, timeZone: kst, true)
         let notRepeating = ScheduleEventCellViewModel(ScheduleCalendarEvent.events(from: notRepeatingSchedule, in: kst).first!, in: 0..<20, timeZone: kst, true)
         let foremostEvent = ScheduleEventCellViewModel(ScheduleCalendarEvent.events(from: notRepeatingSchedule, in: kst, foremostId: "id").first!, in: 0..<20, timeZone: kst, true)
-        
+
         // then
         XCTAssertEqual(repeating?.moreActions, .init(
-            basicActions: [.toggleTo(isForemost: false), .toggleLiveActivity(isRegistered: false), .edit, .copy],
+            basicActions: [.toggleTo(isForemost: false), .toggleLiveActivity(isRegistered: false), .edit, .copy, .share],
             removeActions: [.remove(scope: .onlyThisTime), .remove(scope: .all)]
         ))
         XCTAssertEqual(notRepeating?.moreActions, .init(
-            basicActions: [.toggleTo(isForemost: false), .toggleLiveActivity(isRegistered: false), .edit, .copy],
+            basicActions: [.toggleTo(isForemost: false), .toggleLiveActivity(isRegistered: false), .edit, .copy, .share],
             removeActions: [.remove(scope: .all)]
         ))
         XCTAssertEqual(foremostEvent?.moreActions, .init(
-            basicActions: [.toggleTo(isForemost: true), .toggleLiveActivity(isRegistered: false), .edit, .copy],
+            basicActions: [.toggleTo(isForemost: true), .toggleLiveActivity(isRegistered: false), .edit, .copy, .share],
             removeActions: [.remove(scope: .all)]
         ))
     }

--- a/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
@@ -604,7 +604,7 @@ extension DayEventListViewModelImpleTests {
         ))
     }
     
-    func testGoogleCalendarEventCellViewModel_hasNoMoreActions() {
+    func testGoogleCalendarEventCellViewModel_hasShareOnlyMoreActionsRegardlessOfDetailLink() {
         // given
         func parameterizeTest(_ link: String?) {
             // given
@@ -614,7 +614,7 @@ extension DayEventListViewModelImpleTests {
             let actions = cvm.moreActions
 
             // then
-            XCTAssertNil(actions)
+            XCTAssertEqual(actions, .init(basicActions: [.share], removeActions: []))
         }
 
         // when + then

--- a/Presentations/CommonPresentation/Sources/Extensions/ExternalCalendarEventOrigin+Share.swift
+++ b/Presentations/CommonPresentation/Sources/Extensions/ExternalCalendarEventOrigin+Share.swift
@@ -1,0 +1,129 @@
+//
+//  ExternalCalendarEventOrigin+Share.swift
+//  CommonPresentation
+//
+//  Created by sudo.park on 8/21/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Domain
+import Extensions
+
+
+// MARK: - GoogleCalendar.EventOrigin time <-> SelectedTime mapping
+
+public extension GoogleCalendar.EventOrigin {
+
+    func selectedTime(_ timeZone: TimeZone) -> SelectedTime? {
+        let start = self.start?.supportEventTimeElemnt(timeZone.identifier)
+        let end = self.end?.supportEventTimeElemnt(timeZone.identifier)
+        switch (start, end) {
+        case (.period(let st), .period(let et)):
+            return SelectedTime(
+                .period(st.timeIntervalSince1970..<et.timeIntervalSince1970), timeZone
+            )
+        case (.allDay(let st, let sz), .allDay(let et, _)):
+            return SelectedTime(
+                .allDay(
+                    st.timeIntervalSince1970..<et.timeIntervalSince1970,
+                    secondsFromGMT: TimeInterval(sz.secondsFromGMT())
+                ),
+                timeZone
+            )
+        default:
+            return nil
+        }
+    }
+}
+
+
+// MARK: - 반복 규칙 공유 텍스트 — 상세 화면의 잠김·파싱실패 분기와 동일하게 판정
+
+public extension GoogleCalendar.EventOrigin {
+
+    private var rruleLines: [String] {
+        self.recurrence?.filter { $0.hasPrefix("RRULE:") } ?? []
+    }
+
+    private func editableRepeating(_ timeZone: TimeZone) -> EventRepeating? {
+        guard self.rruleLines.count == 1,
+              let rruleLine = self.rruleLines.first,
+              let startTime = self.selectedTime(timeZone)?.startDate.timeIntervalSince1970,
+              let rrule = RRuleParser.parse(rruleLine)
+        else { return nil }
+        return rrule.asEventRepeating(startTime: startTime, timeZone: timeZone)
+    }
+
+    func shareRepeatText(_ timeZone: TimeZone) -> String? {
+        guard self.rruleLines.isEmpty == false else { return nil }
+        guard let editableRepeating = self.editableRepeating(timeZone) else {
+            guard let rruleLine = self.rruleLines.first, let rrule = RRuleParser.parse(rruleLine) else {
+                return self.rruleLines.first?.strippingRRulePrefix
+            }
+            return rrule.appendingEndOptionText(to: rrule.frequencyText(), timeZone)
+        }
+        let displayText = editableRepeating.repeatOptionDisplayText(timeZone)
+        return displayText == R.String.EventDetail.Repeating.notRepeatingTitle ? nil : displayText
+    }
+}
+
+
+public extension AppleCalendar.EventOrigin {
+
+    private var rruleLines: [String] {
+        self.recurrenceRules.filter { $0.hasPrefix("RRULE:") }
+    }
+
+    // EventKit 은 반복 종료 날짜를 UTC 하루 끝 instant 로 돌려준다 — 재앵커링 없이 그대로 쓰면 종료일이 하루 밀린다
+    private func editableRepeating(_ timeZone: TimeZone) -> EventRepeating? {
+        guard self.rruleLines.count == 1,
+              let rruleLine = self.rruleLines.first,
+              let rrule = RRuleParser.parse(rruleLine)?.reanchoringUTCDayEndUntil(to: timeZone)
+        else { return nil }
+        return rrule.asEventRepeating(startTime: self.eventTime.lowerBoundWithFixed, timeZone: timeZone)
+    }
+
+    func shareRepeatText(_ timeZone: TimeZone) -> String? {
+        guard self.rruleLines.isEmpty == false else { return nil }
+        guard let editableRepeating = self.editableRepeating(timeZone) else {
+            guard let rruleLine = self.rruleLines.first,
+                  let rrule = RRuleParser.parse(rruleLine)?.reanchoringUTCDayEndUntil(to: timeZone)
+            else {
+                return self.rruleLines.first?.strippingRRulePrefix
+            }
+            return rrule.appendingEndOptionText(to: rrule.frequencyText(), timeZone)
+        }
+        let displayText = editableRepeating.repeatOptionDisplayText(timeZone)
+        return displayText == R.String.EventDetail.Repeating.notRepeatingTitle ? nil : displayText
+    }
+}
+
+
+// MARK: - HTML description -> plain share text
+
+private enum ShareTextConstant {
+    // 구글 캘린더 설명에 실제로 쓰이는 태그만 화이트리스트. 각괄호 이메일(<user@x.com>)·URL(<https://...>) 오탐 방지 — 태그명 뒤 경계(공백/슬래시/닫힘)를 요구해 <abbr> 같은 미등재 태그 접두 매치도 차단한다.
+    static let htmlTagPattern =
+        "</?(?:br|b|i|u|p|div|span|a|ul|ol|li|strong|em|h[1-6]|table|tr|td|img|font)(?=[\\s/>])"
+}
+
+public extension String {
+
+    var hasHTMLTag: Bool {
+        self.range(
+            of: ShareTextConstant.htmlTagPattern,
+            options: [.regularExpression, .caseInsensitive]
+        ) != nil
+    }
+}
+
+public extension Optional where Wrapped == String {
+
+    var asPlainShareText: String? {
+        guard let memo = self else { return nil }
+        guard memo.hasHTMLTag else { return memo.emptyAsNil() }
+        guard let attributed = memo.asHTMLAttributeText else { return memo.emptyAsNil() }
+        return String(attributed.characters).emptyAsNil()
+    }
+}

--- a/Presentations/CommonPresentation/Sources/Extensions/RRule+DisplayText.swift
+++ b/Presentations/CommonPresentation/Sources/Extensions/RRule+DisplayText.swift
@@ -1,18 +1,19 @@
 //
 //  RRule+DisplayText.swift
-//  EventDetailScene
+//  CommonPresentation
 //
 //  Created by sudo.park on 4/7/26.
 //  Copyright © 2026 com.sudo.park. All rights reserved.
 //
 
+import Foundation
 import Domain
 import Extensions
 
 
 // MARK: - RRule display text helpers (shared across Google/Apple calendar detail)
 
-extension RRule {
+public extension RRule {
 
     func frequencyText() -> String {
         switch self.freq {
@@ -46,6 +47,22 @@ extension RRule {
         }
     }
 
+    func appendingEndOptionText(to frequencyText: String, _ timeZone: TimeZone) -> String {
+        guard let endOptionText = self.endOptionText(timeZone) else { return frequencyText }
+        return "\(frequencyText)\n\(endOptionText)"
+    }
+
+    func displayText(startTime: Date, _ timeZone: TimeZone) -> String {
+        let frequencyText = self.asEventRepeating(
+            startTime: startTime.timeIntervalSince1970, timeZone: timeZone
+        )?.repeatOption.summaryText(startTime: startTime, timeZone: timeZone)
+            ?? self.frequencyText()
+        return self.appendingEndOptionText(to: frequencyText, timeZone)
+    }
+}
+
+extension RRule {
+
     func endOptionText(_ timeZone: TimeZone) -> String? {
         if let until = self.until {
             let dateText = until.text("date_form.yyyy_MMM_dd".localized(), timeZone: timeZone)
@@ -56,29 +73,28 @@ extension RRule {
             return nil
         }
     }
-
-    func appendingEndOptionText(to frequencyText: String, _ timeZone: TimeZone) -> String {
-        guard let endOptionText = self.endOptionText(timeZone) else { return frequencyText }
-        return "\(frequencyText)\n\(endOptionText)"
-    }
 }
 
-extension EventRepeating {
+public extension EventRepeating {
 
     func repeatOptionDisplayText(_ timeZone: TimeZone) -> String {
         guard let rruleLine = self.asRRuleText(timeZone), let rrule = RRuleParser.parse(rruleLine)
         else { return R.String.EventDetail.Repeating.notRepeatingTitle }
-        let frequencyText = EventRepeatingTimeSelectResult(self, timeZone: timeZone)?.text
-            ?? rrule.frequencyText()
+        let frequencyText = self.repeatOption.summaryText(
+            startTime: Date(timeIntervalSince1970: self.repeatingStartTime), timeZone: timeZone
+        ) ?? rrule.frequencyText()
         return rrule.appendingEndOptionText(to: frequencyText, timeZone)
     }
 }
 
-extension String {
+public extension String {
 
     var strippingRRulePrefix: String {
         self.hasPrefix("RRULE:") ? String(self.dropFirst("RRULE:".count)) : self
     }
+}
+
+extension String {
 
     func appendDaysText(_ byDays: [RRule.ByDay]) -> String {
         guard !byDays.isEmpty else { return self }

--- a/Presentations/CommonPresentation/Sources/Utils/EventDetailShareTextBuilder.swift
+++ b/Presentations/CommonPresentation/Sources/Utils/EventDetailShareTextBuilder.swift
@@ -1,6 +1,6 @@
 //
 //  EventDetailShareTextBuilder.swift
-//  EventDetailScene
+//  CommonPresentation
 //
 //  Created by sudo.park on 8/15/26.
 //  Copyright © 2026 com.sudo.park. All rights reserved.
@@ -8,10 +8,9 @@
 
 import Foundation
 import Extensions
-import CommonPresentation
 
 
-enum EventDetailShareTagLine: Equatable {
+public enum EventDetailShareTagLine: Equatable {
     case eventTag(String)
     case googleCalendar(String)
     case appleCalendar(String)
@@ -20,14 +19,14 @@ enum EventDetailShareTagLine: Equatable {
         static let serviceNameSeparator: String = " - "
     }
 
-    var labelKey: String {
+    public var labelKey: String {
         switch self {
         case .eventTag: return "eventTag.title"
         case .googleCalendar, .appleCalendar: return "event_detail::share::field::calendar"
         }
     }
 
-    var name: String {
+    public var name: String {
         guard let serviceNameKey else { return self.calendarName }
         return [serviceNameKey.localized(), self.calendarName].joined(separator: Constant.serviceNameSeparator)
     }
@@ -48,18 +47,40 @@ enum EventDetailShareTagLine: Equatable {
     }
 }
 
-struct EventDetailShareModel: Equatable {
-    let name: String
-    var isTodo: Bool = false
-    var timeText: String?
-    var repeatText: String?
-    var tagLine: EventDetailShareTagLine?
-    var placeName: String?
-    var url: String?
-    var memo: String?
+public struct EventDetailShareModel: Equatable {
+    public let name: String
+    public var isTodo: Bool = false
+    public var timeText: String?
+    public var repeatText: String?
+    public var tagLine: EventDetailShareTagLine?
+    public var placeName: String?
+    public var url: String?
+    public var memo: String?
+
+    public init(
+        name: String,
+        isTodo: Bool = false,
+        timeText: String? = nil,
+        repeatText: String? = nil,
+        tagLine: EventDetailShareTagLine? = nil,
+        placeName: String? = nil,
+        url: String? = nil,
+        memo: String? = nil
+    ) {
+        self.name = name
+        self.isTodo = isTodo
+        self.timeText = timeText
+        self.repeatText = repeatText
+        self.tagLine = tagLine
+        self.placeName = placeName
+        self.url = url
+        self.memo = memo
+    }
 }
 
-struct EventDetailShareTextBuilder {
+public struct EventDetailShareTextBuilder {
+
+    public init() {}
 
     private enum Constant {
         static let labelSeparator: String = ": "
@@ -69,7 +90,7 @@ struct EventDetailShareTextBuilder {
         static let allDayTextKey: String = "calendar::event_time::allday"
     }
 
-    func build(_ model: EventDetailShareModel) -> String {
+    public func build(_ model: EventDetailShareModel) -> String {
         let fields: [(labelKey: String, value: String?)] = [
             ("event_detail::share::field::time", model.timeText),
             ("event_detail::share::field::repeating", model.repeatText)
@@ -96,7 +117,7 @@ struct EventDetailShareTextBuilder {
         return "(\(Constant.todoTextKey.localized())) \(model.name)"
     }
 
-    func timeText(from selectedTime: SelectedTime) -> String {
+    public func timeText(from selectedTime: SelectedTime) -> String {
         switch selectedTime {
         case .at(let time):
             return self.joinedParts(time)

--- a/Presentations/CommonPresentation/Sources/Utils/SelectedTime.swift
+++ b/Presentations/CommonPresentation/Sources/Utils/SelectedTime.swift
@@ -1,0 +1,120 @@
+//
+//  SelectedTime.swift
+//  CommonPresentation
+//
+//  Created by sudo.park on 8/21/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Prelude
+import Optics
+import Domain
+import Extensions
+
+
+// MARK: - selectedTime
+
+public struct SelectTimeText: Equatable {
+    public var year: String?
+    public let day: String
+    public var time: String?
+    public let date: Date
+
+    public init(_ timeStamp: TimeInterval, _ timeZone: TimeZone, withoutTime: Bool = false) {
+        let date = Date(timeIntervalSince1970: timeStamp)
+        let isSameYear = Date().components(timeZone).0 == date.components(timeZone).0
+        self.year = isSameYear ? nil : date.yearText(at: timeZone)
+        self.day = date.dateText(at: timeZone)
+        self.time = withoutTime ? nil : date.timeText(at: timeZone)
+        self.date = date
+    }
+
+    public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
+        return lhs.year == rhs.year && lhs.day == rhs.day && lhs.time == rhs.time
+    }
+}
+
+public enum SelectedTime: Equatable {
+    case at(SelectTimeText)
+    case period(SelectTimeText, SelectTimeText)
+    case singleAllDay(SelectTimeText)
+    case alldayPeriod(SelectTimeText, SelectTimeText)
+
+    public var isAllDay: Bool {
+        switch self {
+        case .singleAllDay, .alldayPeriod: return true
+        default: return false
+        }
+    }
+
+    public init(_ time: EventTime, _ timeZone: TimeZone) {
+        switch time {
+        case .at(let timeStamp):
+            self = .at(
+                .init(timeStamp, timeZone)
+            )
+
+        case .period(let range):
+            self = .period(
+                .init(range.lowerBound, timeZone), .init(range.upperBound, timeZone)
+            )
+
+        case .allDay:
+            let range = time.rangeWithShifttingifNeed(on: timeZone)
+            let isSameDay = Date(timeIntervalSince1970: range.lowerBound)
+                .isSameDay(Date(timeIntervalSince1970: range.upperBound), at: timeZone)
+            self = isSameDay
+            ? .singleAllDay(.init(range.lowerBound, timeZone, withoutTime: true))
+            : .alldayPeriod(.init(range.lowerBound, timeZone, withoutTime: true), .init(range.upperBound, timeZone, withoutTime: true))
+        }
+    }
+
+    public var startDate: Date {
+        switch self {
+        case .at(let time): return time.date
+        case .singleAllDay(let time): return time.date
+        case .period(let start, _): return start.date
+        case .alldayPeriod(let start, _): return start.date
+        }
+    }
+}
+
+
+extension Date {
+
+    public func yearText(at timeZone: TimeZone) -> String {
+        let dateForm = DateFormatter()
+        dateForm.timeZone = timeZone
+        dateForm.dateFormat = R.String.DateForm.yyyy
+        return dateForm.string(from: self)
+    }
+
+    public func dateText(at timeZone: TimeZone) -> String {
+        let dateForm = DateFormatter()
+        dateForm.timeZone = timeZone
+        dateForm.dateFormat = R.String.DateForm.mmmDdE
+        return dateForm.string(from: self)
+    }
+
+    public func timeText(at timeZone: TimeZone) -> String {
+        let timeForm = DateFormatter()
+        timeForm.timeZone = timeZone
+        timeForm.dateFormat = R.String.DateForm.hhMm
+        return timeForm.string(from: self)
+    }
+
+    public func isSameDay(_ other: Date, at timeZone: TimeZone) -> Bool {
+        let lhsCompos = self.components(timeZone)
+        let rhsCompos = other.components(timeZone)
+        return lhsCompos.0 == rhsCompos.0
+            && lhsCompos.1 == rhsCompos.1
+            && lhsCompos.2 == rhsCompos.2
+    }
+
+    public func components(_ timeZone: TimeZone) -> (Int?, Int?, Int?) {
+        let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
+        let compos = calendar.dateComponents([.year, .month, .day], from: self)
+        return (compos.year, compos.month, compos.day)
+    }
+}

--- a/Presentations/EventDetailScene/Sources/DoneTodoDetail/DoneTodoDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/DoneTodoDetail/DoneTodoDetailViewModel.swift
@@ -14,6 +14,7 @@ import Prelude
 import Optics
 import Domain
 import Scenes
+import CommonPresentation
 
 
 // MARK: - DoneTodoDetailViewModel

--- a/Presentations/EventDetailScene/Sources/EventDetailShareTextBuilder.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailShareTextBuilder.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Extensions
+import CommonPresentation
 
 
 enum EventDetailShareTagLine: Equatable {

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewModel.swift
@@ -13,6 +13,7 @@ import Optics
 import Domain
 import Extensions
 import Scenes
+import CommonPresentation
 
 
 // MARK: - AppleCalendarTagModel

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
@@ -16,6 +16,7 @@ import Optics
 import Domain
 import Extensions
 import Scenes
+import CommonPresentation
 
 
 struct AttendeeViewModelModel: Equatable {

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
@@ -914,34 +914,6 @@ extension GoogleCalendarEventDetailViewModelImple {
 }
 
 
-private extension String {
-
-    private enum Constant {
-        // 구글 캘린더 설명에 실제로 쓰이는 태그만 화이트리스트. 각괄호 이메일(<user@x.com>)·URL(<https://...>) 오탐 방지 — 태그명 뒤 경계(공백/슬래시/닫힘)를 요구해 <abbr> 같은 미등재 태그 접두 매치도 차단한다.
-        static let htmlTagPattern =
-            "</?(?:br|b|i|u|p|div|span|a|ul|ol|li|strong|em|h[1-6]|table|tr|td|img|font)(?=[\\s/>])"
-    }
-
-    var hasHTMLTag: Bool {
-        self.range(
-            of: Constant.htmlTagPattern,
-            options: [.regularExpression, .caseInsensitive]
-        ) != nil
-    }
-}
-
-
-private extension Optional where Wrapped == String {
-
-    var asPlainShareText: String? {
-        guard let memo = self else { return nil }
-        guard memo.hasHTMLTag else { return memo.emptyAsNil() }
-        guard let attributed = memo.asHTMLAttributeText else { return memo.emptyAsNil() }
-        return String(attributed.characters).emptyAsNil()
-    }
-}
-
-
 private extension Array where Element == GoogleCalendar.EventOrigin.Attendee {
     
     func sortAttendees() -> Array {
@@ -976,27 +948,6 @@ private extension GoogleCalendar.EventOrigin.Attendee {
 // MARK: - GoogleCalendar time <-> SelectedTime mapping
 
 private extension GoogleCalendar.EventOrigin {
-
-    func selectedTime(_ timeZone: TimeZone) -> SelectedTime? {
-        let start = self.start?.supportEventTimeElemnt(timeZone.identifier)
-        let end = self.end?.supportEventTimeElemnt(timeZone.identifier)
-        switch (start, end) {
-        case (.period(let st), .period(let et)):
-            return SelectedTime(
-                .period(st.timeIntervalSince1970..<et.timeIntervalSince1970), timeZone
-            )
-        case (.allDay(let st, let sz), .allDay(let et, _)):
-            return SelectedTime(
-                .allDay(
-                    st.timeIntervalSince1970..<et.timeIntervalSince1970,
-                    secondsFromGMT: TimeInterval(sz.secondsFromGMT())
-                ),
-                timeZone
-            )
-        default:
-            return nil
-        }
-    }
 
     var rruleLines: [String] {
         self.recurrence?.filter { $0.hasPrefix("RRULE:") } ?? []

--- a/Presentations/EventDetailScene/Sources/Models/EventDetailBasicData.swift
+++ b/Presentations/EventDetailScene/Sources/Models/EventDetailBasicData.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Domain
+import CommonPresentation
 
 struct EventDetailBasicData: Equatable {
     var name: String?

--- a/Presentations/EventDetailScene/Sources/Models/SelectedTime.swift
+++ b/Presentations/EventDetailScene/Sources/Models/SelectedTime.swift
@@ -10,65 +10,13 @@ import Prelude
 import Optics
 import Domain
 import Extensions
+import CommonPresentation
 
 
 // MARK: - selectedTime
 
-struct SelectTimeText: Equatable {
-    var year: String?
-    let day: String
-    var time: String?
-    let date: Date
-    
-    init(_ timeStamp: TimeInterval, _ timeZone: TimeZone, withoutTime: Bool = false) {
-        let date = Date(timeIntervalSince1970: timeStamp)
-        let isSameYear = Date().components(timeZone).0 == date.components(timeZone).0
-        self.year = isSameYear ? nil : date.yearText(at: timeZone)
-        self.day = date.dateText(at: timeZone)
-        self.time = withoutTime ? nil : date.timeText(at: timeZone)
-        self.date = date
-    }
-    
-    static func == (_ lhs: Self, _ rhs: Self) -> Bool {
-        return lhs.year == rhs.year && lhs.day == rhs.day && lhs.time == rhs.time
-    }
-}
+extension SelectedTime {
 
-enum SelectedTime: Equatable {
-    case at(SelectTimeText)
-    case period(SelectTimeText, SelectTimeText)
-    case singleAllDay(SelectTimeText)
-    case alldayPeriod(SelectTimeText, SelectTimeText)
-    
-    var isAllDay: Bool {
-        switch self {
-        case .singleAllDay, .alldayPeriod: return true
-        default: return false
-        }
-    }
-    
-    init(_ time: EventTime, _ timeZone: TimeZone) {
-        switch time {
-        case .at(let timeStamp):
-            self = .at(
-                .init(timeStamp, timeZone)
-            )
-            
-        case .period(let range):
-            self = .period(
-                .init(range.lowerBound, timeZone), .init(range.upperBound, timeZone)
-            )
-            
-        case .allDay:
-            let range = time.rangeWithShifttingifNeed(on: timeZone)
-            let isSameDay = Date(timeIntervalSince1970: range.lowerBound)
-                .isSameDay(Date(timeIntervalSince1970: range.upperBound), at: timeZone)
-            self = isSameDay
-            ? .singleAllDay(.init(range.lowerBound, timeZone, withoutTime: true))
-            : .alldayPeriod(.init(range.lowerBound, timeZone, withoutTime: true), .init(range.upperBound, timeZone, withoutTime: true))
-        }
-    }
-    
     var isValid: Bool {
         switch self {
         case .period(let start, let end): return start.date < end.date
@@ -77,26 +25,17 @@ enum SelectedTime: Equatable {
         }
     }
 
-    var startDate: Date {
-        switch self {
-        case .at(let time): return time.date
-        case .singleAllDay(let time): return time.date
-        case .period(let start, _): return start.date
-        case .alldayPeriod(let start, _): return start.date
-        }
-    }
-    
     func eventTime(_ timeZone: TimeZone) -> EventTime? {
         let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
         let secondsFromGMT = timeZone.secondsFromGMT() |> TimeInterval.init
         switch self {
         case .at(let time):
             return .at(time.date.timeIntervalSince1970)
-            
+
         case .period(let start, let end):
             guard start.date < end.date else { return nil }
             return .period(start.date.timeIntervalSince1970..<end.date.timeIntervalSince1970)
-            
+
         case .singleAllDay(let time):
             guard let end = calendar.endOfDay(for: time.date) else { return nil }
             let start = calendar.startOfDay(for: time.date)
@@ -114,7 +53,7 @@ enum SelectedTime: Equatable {
             )
         }
     }
-    
+
     func toggleIsAllDay(_ timeZone: TimeZone) -> SelectedTime? {
         let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
         switch self {
@@ -141,11 +80,11 @@ enum SelectedTime: Equatable {
 }
 
 extension Optional where Wrapped == SelectedTime {
-    
+
     func periodStartChanged(_ date: Date, _ timeZone: TimeZone) -> SelectedTime {
-    
+
         let timeText = SelectTimeText(date.timeIntervalSince1970, timeZone)
-        
+
         return switch self {
             case .none, .at: .at(timeText)
             case .period(_, let end): .period(timeText, end)
@@ -156,7 +95,7 @@ extension Optional where Wrapped == SelectedTime {
             case .alldayPeriod(_, let end): .alldayPeriod(timeText |> \.time .~ nil, end)
         }
     }
-    
+
     func periodEndTimeChanged(_ date: Date, _ timeZone: TimeZone) -> SelectedTime? {
         let timeText = SelectTimeText(date.timeIntervalSince1970, timeZone)
         return switch self {
@@ -168,51 +107,12 @@ extension Optional where Wrapped == SelectedTime {
             case .alldayPeriod(let start, _): .alldayPeriod(start, timeText |> \.time .~ nil)
         }
     }
-    
+
     func removePeriodEndTime(_ timeZone: TimeZone) -> SelectedTime? {
         return switch self {
         case .period(let start, _): .at(start)
         case .alldayPeriod(let start, _): .singleAllDay(start)
         default: nil
         }
-    }
-}
-
-
-extension Date {
-    
-    func yearText(at timeZone: TimeZone) -> String {
-        let dateForm = DateFormatter()
-        dateForm.timeZone = timeZone
-        dateForm.dateFormat = R.String.DateForm.yyyy
-        return dateForm.string(from: self)
-    }
-    
-    func dateText(at timeZone: TimeZone) -> String {
-        let dateForm = DateFormatter()
-        dateForm.timeZone = timeZone
-        dateForm.dateFormat = R.String.DateForm.mmmDdE
-        return dateForm.string(from: self)
-    }
-    
-    func timeText(at timeZone: TimeZone) -> String {
-        let timeForm = DateFormatter()
-        timeForm.timeZone = timeZone
-        timeForm.dateFormat = R.String.DateForm.hhMm
-        return timeForm.string(from: self)
-    }
-    
-    func isSameDay(_ other: Date, at timeZone: TimeZone) -> Bool {
-        let lhsCompos = self.components(timeZone)
-        let rhsCompos = other.components(timeZone)
-        return lhsCompos.0 == rhsCompos.0
-            && lhsCompos.1 == rhsCompos.1
-            && lhsCompos.2 == rhsCompos.2
-    }
-    
-    func components(_ timeZone: TimeZone) -> (Int?, Int?, Int?) {
-        let calendar = Calendar(identifier: .gregorian) |> \.timeZone .~ timeZone
-        let compos = calendar.dateComponents([.year, .month, .day], from: self)
-        return (compos.year, compos.month, compos.day)
     }
 }

--- a/Presentations/EventDetailScene/Sources/ViewModels/AddEventViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/AddEventViewModel.swift
@@ -14,6 +14,7 @@ import Optics
 import Domain
 import Extensions
 import Scenes
+import CommonPresentation
 
 
 // MARK: - AddEventViewModelImple

--- a/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
@@ -12,6 +12,7 @@ import Optics
 import Domain
 import Extensions
 import Scenes
+import CommonPresentation
 
 
 final class EditScheduleEventDetailViewModelImple: EventDetailViewModel, @unchecked Sendable {

--- a/Presentations/EventDetailScene/Sources/ViewModels/EditTodoEventDetailViewModelImple.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/EditTodoEventDetailViewModelImple.swift
@@ -12,6 +12,7 @@ import Optics
 import Domain
 import Extensions
 import Scenes
+import CommonPresentation
 
 
 final class EditTodoEventDetailViewModelImple: EventDetailViewModel, @unchecked Sendable {

--- a/Presentations/EventDetailScene/Tests/AddEventViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/AddEventViewModelImpleTests.swift
@@ -11,6 +11,7 @@ import Prelude
 import Optics
 import Domain
 import Scenes
+import CommonPresentation
 import UnitTestHelpKit
 import TestDoubles
 

--- a/Presentations/EventDetailScene/Tests/AppleCalendarEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/AppleCalendarEventDetailViewModelImpleTests.swift
@@ -14,6 +14,7 @@ import Domain
 import Extensions
 import UnitTestHelpKit
 import TestDoubles
+import CommonPresentation
 
 @testable import EventDetailScene
 

--- a/Presentations/EventDetailScene/Tests/EditScheduleEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/EditScheduleEventDetailViewModelImpleTests.swift
@@ -11,6 +11,7 @@ import Prelude
 import Optics
 import Domain
 import Scenes
+import CommonPresentation
 import Extensions
 import UnitTestHelpKit
 import TestDoubles

--- a/Presentations/EventDetailScene/Tests/EditTodoEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/EditTodoEventDetailViewModelImpleTests.swift
@@ -11,6 +11,7 @@ import Prelude
 import Optics
 import Domain
 import Scenes
+import CommonPresentation
 import Extensions
 import UnitTestHelpKit
 import TestDoubles

--- a/Presentations/EventDetailScene/Tests/EventDetailInputViewModelTests.swift
+++ b/Presentations/EventDetailScene/Tests/EventDetailInputViewModelTests.swift
@@ -11,6 +11,7 @@ import Prelude
 import Optics
 import Domain
 import Scenes
+import CommonPresentation
 import UnitTestHelpKit
 import TestDoubles
 

--- a/Presentations/EventDetailScene/Tests/EventDetailShareTextBuilderTests.swift
+++ b/Presentations/EventDetailScene/Tests/EventDetailShareTextBuilderTests.swift
@@ -9,6 +9,7 @@
 import Testing
 import Foundation
 import Extensions
+import CommonPresentation
 
 @testable import EventDetailScene
 

--- a/Presentations/EventDetailScene/Tests/GoogleCalendarEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/GoogleCalendarEventDetailViewModelImpleTests.swift
@@ -12,6 +12,7 @@ import Prelude
 import Optics
 import Domain
 import Scenes
+import CommonPresentation
 import Extensions
 import UnitTestHelpKit
 import TestDoubles

--- a/Presentations/EventDetailScene/Tests/RRuleDisplayTextTests.swift
+++ b/Presentations/EventDetailScene/Tests/RRuleDisplayTextTests.swift
@@ -1,0 +1,74 @@
+//
+//  RRuleDisplayTextTests.swift
+//  EventDetailSceneTests
+//
+//  Created by sudo.park on 8/21/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Domain
+import CommonPresentation
+
+
+struct RRuleDisplayTextTests {
+
+    @Test func rrule_displayText_weeklyWithUntil_showsFrequencyAndEndOption() throws {
+        // given
+        let rruleLine = "RRULE:FREQ=WEEKLY;BYDAY=MO,WE;UNTIL=20261231T235959Z"
+        let rrule = try #require(RRuleParser.parse(rruleLine))
+        let timeZone = try #require(TimeZone(identifier: "UTC"))
+        let startTime = Date(timeIntervalSince1970: 1_700_000_000)
+
+        // when
+        let text = rrule.displayText(startTime: startTime, timeZone)
+
+        // then
+        let lines = text.components(separatedBy: "\n")
+        #expect(lines.count == 2)
+        #expect(lines[0] == rrule.frequencyText())
+        #expect(lines[1].contains("2026"))
+    }
+
+    @Test func rrule_displayText_unsupportedFreq_fallsBackToFrequencyText() throws {
+        // given
+        let rruleLine = "RRULE:FREQ=MONTHLY;BYMONTHDAY=15;BYDAY=MO"
+        let rrule = try #require(RRuleParser.parse(rruleLine))
+        let timeZone = try #require(TimeZone(identifier: "UTC"))
+        let startTime = Date(timeIntervalSince1970: 1_700_000_000)
+
+        // when
+        let text = rrule.displayText(startTime: startTime, timeZone)
+
+        // then
+        let asEventRepeating = rrule.asEventRepeating(
+            startTime: startTime.timeIntervalSince1970, timeZone: timeZone
+        )
+        #expect(asEventRepeating == nil)
+        #expect(text == rrule.frequencyText())
+    }
+
+    @Test func repeatOptionDisplayText_usesRepeatOptionSummary() throws {
+        // given
+        let timeZone = try #require(TimeZone(identifier: "UTC"))
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        let startTime = try #require(
+            calendar.date(from: DateComponents(year: 2026, month: 8, day: 24, hour: 10))
+        )
+        var everyWeek = EventRepeatingOptions.EveryWeek(timeZone)
+        everyWeek.interval = 1
+        everyWeek.dayOfWeeks = [.monday]
+        var repeating = EventRepeating(
+            repeatingStartTime: startTime.timeIntervalSince1970, repeatOption: everyWeek
+        )
+        repeating.repeatingEndOption = .count(5)
+
+        // when
+        let text = repeating.repeatOptionDisplayText(timeZone)
+
+        // then
+        #expect(text == "Every Week\n5 time(s)")
+    }
+}

--- a/Supports/TestDoubles/Sources/Usecases/StubGoogleCalendarUsecase.swift
+++ b/Supports/TestDoubles/Sources/Usecases/StubGoogleCalendarUsecase.swift
@@ -63,9 +63,14 @@ open class StubGoogleCalendarUsecase: GoogleCalendarUsecase, @unchecked Sendable
     }
     
     public var stubDetail: GoogleCalendar.EventOrigin?
+    public var shouldFailEventDetail: Bool = false
     open func eventDetail(
         _ calendarId: String, _ eventId: String, accountId: String, at timeZone: TimeZone
     ) -> AnyPublisher<GoogleCalendar.EventOrigin, any Error> {
+        guard self.shouldFailEventDetail == false
+        else {
+            return Fail(error: RuntimeError("failed to load google calendar event")).eraseToAnyPublisher()
+        }
         guard let detail = self.stubDetail
         else {
             return Empty().eraseToAnyPublisher()


### PR DESCRIPTION
일별 이벤트 목록 셀을 롱탭하면 메뉴에 `공유`가 뜨고, 그 이벤트 1건이 텍스트로 나간다. 지금까지 단건 공유는 이벤트 상세로 들어가야만 닿을 수 있었다.

## 접근

진입점(`EventListCellView`의 `contextMenu`)은 `CalendarScenes`에 있는데 단건 공유 조립기는 `EventDetailScene`에 있었고, Presentation 모듈 간 직접 import가 금지다. 그래서 앞 세 커밋이 조립기와 그 의존을 `CommonPresentation`으로 승격하는 리팩터이고, 뒤 두 커밋이 기능이다.

승격은 **"도메인 값 → 표시 문자열" 변환 코어만** 옮기고 편집 조작은 `EventDetailScene`에 남겼다. `SelectedTime`이 대표적인데, 케이스·`init(EventTime,TimeZone)`·`startDate`는 올라가고 `toggleIsAllDay`·`periodStartChanged` 같은 편집 조작은 `extension`으로 잔류한다.

탐색 중 승격 범위가 계속 줄었다. 처음엔 반복 옵션 포맷터와 RRULE 왕복 체인까지 옮겨야 하나 싶었는데, `EventRepeatingOption.summaryText`가 이미 `CommonPresentation`에 있고 `RRuleParser`·`asEventRepeating`은 Domain이라 실제로 옮긴 건 세 덩어리(시간 포맷터·공유 조립기·RRULE 표시 텍스트)뿐이다.

`RRule.displayText(startTime:_:)`를 하나 신설했다. 구글·애플 이벤트는 `EventRepeating` 없이 RRULE 원문만 갖고 있어서, 앱 옵션 요약을 먼저 시도하고 실패하면 빈도 텍스트로 떨어지는 상세와 같은 우선순위를 태우려면 진입점이 필요했다.

## 텍스트는 상세와 같아야 한다

이 작업의 구속 조건이다. **같은 이벤트를 목록에서 공유하든 상세에서 공유하든 결과가 같아야 한다.** 리뷰에서 잡힌 결함 대부분이 이 축에서 나왔다.

**반복 문구는 서비스별로 갈린다.** 앱 이벤트(할일·일정)는 `summaryText`로 빈도만 싣는다 — 상세가 `EventRepeatingTimeSelectResult.text`를 쓰고, 화면 자체가 빈도와 기간을 별개 필드로 나누기 때문이다. 구글·애플은 `displayText`로 종료 옵션까지 싣는다 — 각 상세의 publisher가 `repeatOptionDisplayText` 계열이기 때문이다. 이 비대칭은 각자의 상세에 맞춘 결과다.

`Router`에는 구현을 쓰지 않았다. `EventListCellEventHanleRouter`가 `BaseRouterImple`을 상속하므로 프로토콜에 `showShareSheet(text:)` 선언만 더하면 충족된다 — #906이 상세 4곳에서 쓴 방식과 같다.

**읽기 전용 외부 캘린더 셀의 메뉴 가드를 풀었다.** `moreActions`가 `guard isWritable else { return nil }`로 시작해서, 쓰기 권한 없는 구글·애플 셀은 롱탭해도 메뉴가 통째로 안 떴다. 공유는 권한과 무관하므로 `basicActions`에 `.share`를 상시 두고 `removeActions`만 권한으로 게이팅한다. #906이 구글 상세에서 같은 이유로 `isEditable || hasDetailLink` 가드를 제거한 선례가 있다. 그러면서 읽기 전용 셀은 `removeActions`가 비어 뒤에 항목 없는 구분선이 남으므로, `Divider` 조건을 양쪽 다 비어있지 않을 때로 좁혔다.

## 리뷰에서 고친 것

머지 전 whole-branch 리뷰에서 Critical 2건이 나왔고 둘 다 위 구속 조건 위반이다.

- **반복 일정을 목록에서 공유하면 원본(1회차) 날짜가 나갔다.** 셀은 자기 회차 시각(`eventTimeRawValue`)을 들고 있고 셀 탭으로 들어간 상세도 그 값을 쓰는데, 목록 공유만 `schedule.time`을 넘겼다. `ScheduleEvent.time`은 회차로 전진하지 않아서 2회차 이상이 전부 첫 회차 날짜로 나갔다.
- **상세 로우가 없는 이벤트를 로그인 상태에서 공유하면 아무 일도 안 일어났다.** 로그인 유저의 `loadDetail`은 캐시·리모트가 둘 다 nil이면 `compactMap`으로 **값 없이 finished** 한다. `CombineLatest`가 출력을 못 내 시트도 에러도 안 떴다. 상세 화면은 `.catch{}` + `.replaceEmpty(with:)`를 둘 다 두고 있었는데 목록은 `.catch`만 있었다. 캘린더 하단 입력의 빠른 추가 todo가 대표 케이스이고, 비로그인은 로컬 repository가 항상 값을 방출해 정상 동작한다.

Important 4건은 애플 반복 종료일(UNTIL) 재앵커링 누락으로 종료일이 하루 밀리던 것, 구글·애플 상세의 잠긴 규칙·파싱 실패 폴백을 목록이 복제하지 않던 것, 앱 이벤트 반복 문구의 기준 시각이 상세와 달랐던 것, 그리고 6필드 중 시간 줄을 단언하는 TC가 하나도 없어 위 결함들이 전부 초록으로 통과하던 것이다.

## 검증

- `CalendarScenes` 197 · `EventDetailScene` 161 — 0 failures
- `TodoCalendarApp` 스킴 전체 빌드 — `CommonPresentation` 승격이 다른 모듈 컴파일을 깨지 않는지 확인
- 신규 TC는 되돌리면 빨개지는 지점을 각각 갖는다. 반복 회차 시각, 상세 로우 없는 이벤트, 종료 옵션 제외, 조회 실패 시 미공유, 기준 시각 전진

## 남은 과제

- 읽기 전용 외부 캘린더 셀의 메뉴가 `공유` 한 줄 + 구분선 없이 뜨는지는 **실기 확인이 필요하다.** `contextMenu`는 탭해야 펼쳐지는 SwiftUI `Menu`라 정적 스냅샷에 안 잡힌다 (#906도 같은 이유로 스냅샷 검증을 못 했다).
- 4종 이벤트 → `EventDetailShareModel` 조립이 핸들러 ViewModel에 인라인으로 100줄 붙었다. 같은 프레임워크의 `EventCellViewModelMapper`(#914) 선례처럼 전용 타입으로 빼면 상세와의 필드 대조를 그 타입 단위 테스트로 직접 할 수 있다. 이번엔 기능 스코프를 지키느라 뺐다.

closes #950
