### PR TITLE
[#948] 앱 재시작 시 라이브액티비티 복원 결함 2건 수정

### DIFF
--- a/TodoCalendarApp/Sources/Root/EventLiveActivityUsecaseImple.swift
+++ b/TodoCalendarApp/Sources/Root/EventLiveActivityUsecaseImple.swift
@@ -202,7 +202,7 @@ extension EventLiveActivityUsecaseImple {
 extension EventLiveActivityUsecaseImple {
 
     /// 등록 경로는 조회 시점 관찰값을 기준선으로 넘긴다 — 첫 배달을 기다리면 그 사이 변화가
-    /// 기준선에 흡수돼 파기 판정이 사라진다. 복원 경로는 넘길 값이 없어 nil(첫 관찰값 채택)이다.
+    /// 기준선에 흡수돼 파기 판정이 사라진다. 복원 경로는 넘길 값이 없어 nil(첫 non-nil 관찰값 채택)이다.
     private func startWatching(
         _ target: LiveActivityTarget,
         seedContent: EventCountdownActivityAttributes.State,
@@ -495,9 +495,11 @@ extension EventLiveActivityUsecaseImple {
         return (self.advancedState(state, observed: observed, judgement: judgement), judgement)
     }
 
+    /// 구독 즉시 흐르는 nil을 기준선으로 굳히면 뒤늦은 로드가 변경으로 오판된다.
     private func seededState(
         _ state: LiveActivityWatchState, observed: LiveActivityObservedEvent?
     ) -> LiveActivityWatchState {
+        guard let observed else { return state }
         return state
             |> \.hasBaseline .~ true
             |> \.baseline .~ LiveActivityBaseline(observed)

--- a/TodoCalendarApp/Sources/Root/EventLiveActivityUsecaseImple.swift
+++ b/TodoCalendarApp/Sources/Root/EventLiveActivityUsecaseImple.swift
@@ -136,19 +136,26 @@ extension EventLiveActivityUsecaseImple {
         }
         guard await self.endIfExpired(registration) == false else { return }
 
-        self.subject.registeredTarget.send(registration.target)
-        self.startWatching(registration.target, seedContent: registration.content, seedBaseline: nil)
+        self.restore(registration)
     }
 
+    /// 콜드런치 직후엔 ActivityKit이 `Activity.activities`를 아직 안 채워뒀을 수 있어 복귀마다
+    /// 재조회한다. 이미 등록됐으면 재복원하지 않는다 — 감시 기준선이 리셋된다.
     func handleWillEnterForeground() async {
-        guard self.subject.registeredTarget.value != nil else { return }
-
         guard let registration = await self.controller.currentActivity()
         else {
             self.clearRegistration()
             return
         }
-        _ = await self.endIfExpired(registration)
+        guard await self.endIfExpired(registration) == false else { return }
+        guard self.subject.registeredTarget.value == nil else { return }
+
+        self.restore(registration)
+    }
+
+    private func restore(_ registration: LiveActivityRegistration) {
+        self.subject.registeredTarget.send(registration.target)
+        self.startWatching(registration.target, seedContent: registration.content, seedBaseline: nil)
     }
 
     private func endIfExpired(_ registration: LiveActivityRegistration) async -> Bool {

--- a/TodoCalendarApp/TodoCalendarAppTests/EventLiveActivityUsecaseImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/EventLiveActivityUsecaseImpleTests.swift
@@ -899,6 +899,93 @@ extension EventLiveActivityUsecaseImpleTests {
 }
 
 
+// MARK: - 앱 재시작 복원 재시도
+
+extension EventLiveActivityUsecaseImpleTests {
+
+    /// 콜드런치 직후엔 `Activity.activities`가 아직 비어 있을 수 있다.
+    @Test func usecase_whenActivityNotVisibleAtColdLaunch_handleWillEnterForegroundRestoresTarget() async throws {
+        // given
+        let future = Date().addingTimeInterval(60)
+        let (usecase, stub, _) = self.makeUsecase(stubRestoredRegistration: nil)
+        await usecase.prepare()
+        try await self.waitForEffects()
+
+        // when
+        stub.stubRestoredRegistration = LiveActivityRegistration(
+            target: .todo(id: "t1"), content: self.content(eventDate: future)
+        )
+        await usecase.handleWillEnterForeground()
+
+        // then
+        let expect = self.expectConfirm("뒤늦게 보인 액티비티 복원")
+        let target = try await self.firstOutput(expect, for: usecase.registeredTarget)
+        #expect(target == .todo(id: "t1"))
+    }
+
+    @Test func usecase_whenRestoredOnForeground_watchesSharedStateChanges() async throws {
+        // given
+        let future = Date().addingTimeInterval(60)
+        let (usecase, stub, store) = self.makeUsecase(stubRestoredRegistration: nil)
+        await usecase.prepare()
+        try await self.waitForEffects()
+        stub.stubRestoredRegistration = LiveActivityRegistration(
+            target: .todo(id: "t1"), content: self.content(eventDate: future)
+        )
+        await usecase.handleWillEnterForeground()
+        self.putTodos(store, [self.makeTodo(id: "t1", name: "event", eventDate: future)])
+        try await self.waitForEffects()
+
+        // when
+        self.putTodos(store, [self.makeTodo(id: "t1", name: "changed", eventDate: future)])
+        try await self.waitForEffects()
+
+        // then
+        #expect(stub.didUpdateWith?.eventName == "changed")
+    }
+
+    @Test func usecase_whenActivityRestoredOnForegroundAlreadyExpired_endsImmediately() async throws {
+        // given
+        let past = Date().addingTimeInterval(-60)
+        let (usecase, stub, _) = self.makeUsecase(stubRestoredRegistration: nil)
+        await usecase.prepare()
+        try await self.waitForEffects()
+
+        // when
+        stub.stubRestoredRegistration = LiveActivityRegistration(
+            target: .todo(id: "t1"), content: self.content(eventDate: past)
+        )
+        await usecase.handleWillEnterForeground()
+
+        // then
+        #expect(stub.didEnd == true)
+        let expect = self.expectConfirm("만료된 액티비티는 복원 대신 종료")
+        let target = try await self.firstOutput(expect, for: usecase.registeredTarget)
+        #expect(target == .some(nil))
+    }
+
+    /// 재복원은 기준선을 리셋해 그 사이 바뀐 회차를 흡수해버린다.
+    @Test func usecase_handleWillEnterForeground_whenAlreadyRegistered_keepsExistingBaseline() async throws {
+        // given
+        let future = Date().addingTimeInterval(60)
+        let (usecase, stub, store) = self.makeUsecase()
+        self.putTodos(store, [self.makeTodo(id: "t1", eventDate: future)])
+        try await usecase.startActivity(.todo(id: "t1"))
+        stub.stubRestoredRegistration = LiveActivityRegistration(
+            target: .todo(id: "t1"), content: self.content(eventDate: future)
+        )
+
+        // when
+        await usecase.handleWillEnterForeground()
+        self.putTodos(store, [self.makeTodo(id: "t1", eventDate: future, turn: 3)])
+        try await self.waitForEffects()
+
+        // then
+        #expect(stub.didEnd == true)
+    }
+}
+
+
 // MARK: - 5종 대상 구독 배선
 
 extension EventLiveActivityUsecaseImpleTests {

--- a/TodoCalendarApp/TodoCalendarAppTests/EventLiveActivityUsecaseImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/EventLiveActivityUsecaseImpleTests.swift
@@ -720,6 +720,8 @@ extension EventLiveActivityUsecaseImpleTests {
         let (usecase, stub, store) = self.makeUsecase(stubRestoredRegistration: registration)
         await usecase.prepare()
         try await self.waitForEffects()
+        self.putTodos(store, [self.makeTodo(id: "t1", name: "restored", eventDate: future)])
+        try await self.waitForEffects()
 
         // when
         store.put(
@@ -978,6 +980,71 @@ extension EventLiveActivityUsecaseImpleTests {
         // when
         await usecase.handleWillEnterForeground()
         self.putTodos(store, [self.makeTodo(id: "t1", eventDate: future, turn: 3)])
+        try await self.waitForEffects()
+
+        // then
+        #expect(stub.didEnd == true)
+    }
+}
+
+
+// MARK: - 복원 기준선 시딩
+
+extension EventLiveActivityUsecaseImpleTests {
+
+    @Test func usecase_afterRestore_whenScheduleLoadsLater_keepsActivity() async throws {
+        // given
+        let future = Date().addingTimeInterval(60)
+        let registration = LiveActivityRegistration(
+            target: .schedule(id: "s1", turnKey: nil), content: self.content(eventDate: future)
+        )
+        let (usecase, stub, store) = self.makeUsecase(stubRestoredRegistration: registration)
+        await usecase.prepare()
+        try await self.waitForEffects()
+
+        // when
+        store.put(
+            MemorizedEventsContainer<ScheduleEvent>.self, key: ShareDataKeys.schedules.rawValue,
+            MemorizedEventsContainer<ScheduleEvent>().append(self.makeSchedule(id: "s1", eventDate: future))
+        )
+        try await self.waitForEffects()
+
+        // then
+        #expect(stub.didEnd == false)
+    }
+
+    @Test func usecase_afterRestore_whenRepeatingTodoLoadsLater_keepsActivity() async throws {
+        // given
+        let future = Date().addingTimeInterval(60)
+        let registration = LiveActivityRegistration(
+            target: .todo(id: "t1"), content: self.content(eventDate: future)
+        )
+        let (usecase, stub, store) = self.makeUsecase(stubRestoredRegistration: registration)
+        await usecase.prepare()
+        try await self.waitForEffects()
+
+        // when
+        self.putTodos(store, [self.makeTodo(id: "t1", eventDate: future, turn: 3)])
+        try await self.waitForEffects()
+
+        // then
+        #expect(stub.didEnd == false)
+    }
+
+    @Test func usecase_afterRestore_whenTurnChangesAfterBaselineSeeded_endsActivity() async throws {
+        // given
+        let future = Date().addingTimeInterval(60)
+        let registration = LiveActivityRegistration(
+            target: .todo(id: "t1"), content: self.content(eventDate: future)
+        )
+        let (usecase, stub, store) = self.makeUsecase(stubRestoredRegistration: registration)
+        await usecase.prepare()
+        try await self.waitForEffects()
+        self.putTodos(store, [self.makeTodo(id: "t1", eventDate: future, turn: 3)])
+        try await self.waitForEffects()
+
+        // when
+        self.putTodos(store, [self.makeTodo(id: "t1", eventDate: future, turn: 4)])
         try await self.waitForEffects()
 
         // then

--- a/TodoCalendarApp/TodoCalendarAppTests/StubLiveActivityController.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/StubLiveActivityController.swift
@@ -16,7 +16,7 @@ import Domain
 
 final class StubLiveActivityController: LiveActivityController, @unchecked Sendable {
 
-    private let stubRestoredRegistration: LiveActivityRegistration?
+    var stubRestoredRegistration: LiveActivityRegistration?
     private let stubStartError: (any Error)?
     /// 실제 ActivityKit이 `end()` 직후 `activityStateUpdates`로 종료를 알리는 것을 흉내낸다 —
     /// 교체 흐름 중 도착하는 stale nil 레이스(F3) 재현용.


### PR DESCRIPTION
앱을 재시작하면 라이브액티비티 복원이 두 군데서 깨진다. 둘 다 `EventLiveActivityUsecaseImple`의 복원 경로이고, #912 테스트 배포 실기기 확인에서 나왔다.

## 1. 등록 상태 유실

콜드런치 직후엔 ActivityKit이 `Activity.activities`를 아직 안 채워뒀을 수 있다. 그때 `prepare()`가 nil을 받으면 등록을 nil로 확정하는데, 되돌릴 경로가 없었다 — `Activity.activityUpdates`는 새로 생성되는 액티비티만 흘리고, `handleWillEnterForeground`는 `registeredTarget != nil`을 전제로 가드가 걸려 있었다. 결과적으로 잠금화면엔 액티비티가 살아 있는데 앱은 그 세션 내내 미등록으로 보고, 상세 more 메뉴가 "잠금화면에 표시"로 돌아가 해제조차 못 했다.

그 가드를 걷고 등록이 비어 있어도 포그라운드 복귀마다 `currentActivity()`를 재조회한다. ActivityKit이 기존 액티비티용 스트림을 안 주므로 재조회 외의 경로가 없다. 대신 이미 등록돼 있으면 재복원을 건너뛴다 — 재복원은 감시 기준선을 리셋해 그 사이 바뀐 회차를 흡수해버린다.

## 2. 복원 후 오파기

복원에 성공해도 이벤트가 로드되는 순간 액티비티가 종료됐다. 일정과 2회차 이상 반복 할일만 해당했다.

복원 경로는 넘길 기준선이 없어 "첫 관찰값을 채택"하는데, `SharedDataStore.observe`는 구독 즉시 nil을 흘리고 `prepare()`는 이벤트가 공유 상태에 올라오기 전에 돈다. 그래서 그 nil이 기준선으로 굳어 `repeatingTurn`·`scheduleOriginTimeKey`가 모두 nil이 되고, 뒤늦게 실제 값이 로드되면 판정 규칙 3·5가 시리즈 변경으로 오판했다.

관찰값이 nil인 동안은 기준선을 굳히지 않고 첫 non-nil에서 잡는다. "한 번도 못 찾음"은 규칙 2가 이미 `.keep`으로 처리해 잃는 동작이 없다.

## 검증

유닛 테스트 7개 추가 — 복원 재시도 4개(복귀 시 복원·감시 배선·만료 시 종료·이미 등록 시 기준선 유지), 기준선 시딩 3개(일정·반복 할일 늦은 로드·시딩 후 회차 변경은 여전히 파기).

실기기 콜드런치가 필요한 확인은 이슈 #948 코멘트로 인계했다.
