### PR TITLE
[#966] FeatureFlag 정리 — aiAgent·billingPaywall 제거로 정식 노출 전환

### DIFF
--- a/.claude/skills/test-deploy/SKILL.md
+++ b/.claude/skills/test-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-deploy
-description: Use when the user wants a test build distributed to Firebase App Distribution — 개발 완료·핫픽스 검증 시점에 특정 브랜치를 테스터에게 내보내는 절차. 피처플래그를 켠 빌드도 배포 브랜치를 따서 내보낸다. Triggers on "테스트 배포 돌려", "이 브랜치 배포해서 확인해볼게", "aiAgent 켜서 배포해줘". Does NOT trigger on TestFlight·앱스토어 제출(#918 후속 레인 소관), 테스트 실행(run-tests 스킬), PR 생성(pr 스킬), 코드 수정(implement 스킬) — 이 스킬의 FeatureFlag.swift 편집은 사전 규정된 리터럴 치환이라 별도 발동 대상이 아니다.
+description: Use when the user wants a test build distributed to Firebase App Distribution — 개발 완료·핫픽스 검증 시점에 특정 브랜치를 테스터에게 내보내는 절차. 피처플래그를 켠 빌드도 배포 브랜치를 따서 내보낸다. Triggers on "테스트 배포 돌려", "이 브랜치 배포해서 확인해볼게", "ddayWidget 켜서 배포해줘". Does NOT trigger on TestFlight·앱스토어 제출(#918 후속 레인 소관), 테스트 실행(run-tests 스킬), PR 생성(pr 스킬), 코드 수정(implement 스킬) — 이 스킬의 FeatureFlag.swift 편집은 사전 규정된 리터럴 치환이라 별도 발동 대상이 아니다.
 argument-hint: "[flags]"
 ---
 
@@ -57,7 +57,7 @@ Firebase 콘솔 링크: `https://console.firebase.google.com/project/todocalenda
 
 ## 절차 — 피처플래그를 켜고
 
-호출 형식은 `/test-deploy aiAgent,billingPaywall`. 요청에 켤 플래그 지정이 있으면 이 경로, 없으면 위 플래그 없음 경로를 탄다.
+호출 형식은 `/test-deploy ddayWidget`. 요청에 켤 플래그 지정이 있으면 이 경로, 없으면 위 플래그 없음 경로를 탄다.
 
 1. **플래그명 검증** — `Domain/Sources/Utils/FeatureFlag.swift`의 `Flags` enum case와 대조한다. 목록에 없는 이름이 하나라도 있으면 배포하지 않고 중단하고 유효한 case 목록을 보고한다.
    ```bash
@@ -77,14 +77,14 @@ Firebase 콘솔 링크: `https://console.firebase.google.com/project/todocalenda
    ```
    →
    ```swift
-   private var enableFlags: Set<Flags> = [.aiAgent, .billingPaywall]
+   private var enableFlags: Set<Flags> = [.ddayWidget]
    ```
    이 편집은 사전 규정된 리터럴 치환이라 implement 스킬을 별도로 발동하지 않는다.
 4. **커밋** — 메시지에 켠 플래그 목록을 반드시 넣는다. 워크플로우가 릴리즈 노트에 브랜치명과 커밋 subject를 싣기 때문에, 이 목록이 곧 Firebase 릴리즈 노트에서 "어떤 플래그가 켜진 빌드인가"를 알려주는 유일한 단서다.
    대상 브랜치명에서 이슈번호를 뽑을 수 있으면(`features/920-...` → `920`) `[#920]`을 쓰고, 못 뽑으면 `[test-deploy]`를 쓴다 (CLAUDE.md §5는 `[#이슈번호]` 형식을 못 박는다 — 이슈번호를 못 뽑을 때만 쓰는 예외).
    ```bash
    git add Domain/Sources/Utils/FeatureFlag.swift
-   git commit -m "[#920] 테스트 배포용 피처플래그 활성 — aiAgent, billingPaywall"
+   git commit -m "[#920] 테스트 배포용 피처플래그 활성 — ddayWidget"
    ```
    이 커밋은 이 스킬이 형식을 규정한다 — commit 스킬을 별도로 발동하지 않는다.
 5. **push 후 dispatch** — 위 플래그 없음 절차의 3~5단계를 그대로 따르되 ref만 배포 브랜치다. 2단계가 이미 배포 브랜치로 체크아웃을 옮겨놨으므로 현재 체크아웃 상태를 그대로 쓴다. 배포 브랜치는 매번 `-B`로 다시 만들어지므로 두 번째 배포부터 기존 원격 브랜치와 non-fast-forward로 충돌한다 — `--force-with-lease`로 강제 갱신한다.

--- a/Domain/Sources/Utils/FeatureFlag.swift
+++ b/Domain/Sources/Utils/FeatureFlag.swift
@@ -16,9 +16,6 @@ public final class FeatureFlag: @unchecked Sendable {
         /// D-day 위젯(#741) — 배포 보류 중. 켜면 일정 상세에 후보 등록 메뉴가 다시 노출된다.
         /// 위젯 갤러리 노출은 `TodoCalendarWidgetBundle`에서 별도로 막혀 있다.
         case ddayWidget
-        /// AI Agent(#746) — 배포 보류 중. 켜면 캘린더 일별 리스트에 AI 진입 버튼이 노출되고
-        /// 앱 시작 시 orchestration prepare(usage 로드·job 복원)가 재개된다.
-        case aiAgent
         /// Billing paywall(#739) — 배포 보류 중. ASC 상품 메타데이터·서버 productId 정합이
         /// 끝나기 전엔 진입점(한도 초과 화면 · 설정)을 닫아둔다.
         case billingPaywall

--- a/Domain/Sources/Utils/FeatureFlag.swift
+++ b/Domain/Sources/Utils/FeatureFlag.swift
@@ -16,9 +16,6 @@ public final class FeatureFlag: @unchecked Sendable {
         /// D-day 위젯(#741) — 배포 보류 중. 켜면 일정 상세에 후보 등록 메뉴가 다시 노출된다.
         /// 위젯 갤러리 노출은 `TodoCalendarWidgetBundle`에서 별도로 막혀 있다.
         case ddayWidget
-        /// Billing paywall(#739) — 배포 보류 중. ASC 상품 메타데이터·서버 productId 정합이
-        /// 끝나기 전엔 진입점(한도 초과 화면 · 설정)을 닫아둔다.
-        case billingPaywall
     }
     
     private var enableFlags: Set<Flags> = []

--- a/Presentations/AIAgentScene/Snapshots/AIAgentSceneSnapshots.swift
+++ b/Presentations/AIAgentScene/Snapshots/AIAgentSceneSnapshots.swift
@@ -159,7 +159,6 @@ final class AIAgentSceneSnapshots: XCTestCase {
             state.usage = AIAgentUsage(input: 5000, output: 0, limit: 5000)
                 |> \.resetsAt .~ Date().addingTimeInterval(3 * 3600 + 12 * 60 + 30)
             state.userPlan = BillingUserPlan() |> \.planId .~ .free
-            state.isPaywallAvailable = true
             return AIAgentCommandStageView()
                 .environment(state)
                 .environment(AIAgentCommandViewEventHandler())

--- a/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandStageView.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandStageView.swift
@@ -23,13 +23,10 @@ import CommonPresentation
     var commandState: AIAgentCommandState?
     var usage: AIAgentUsage?
     var userPlan: BillingUserPlan?
-    var isPaywallAvailable: Bool = false
 
     func bind(_ viewModel: any AIAgentCommandViewModel) {
         guard self.didBind == false else { return }
         self.didBind = true
-
-        self.isPaywallAvailable = viewModel.isPaywallAvailable
 
         viewModel.commandState
             .receive(on: RunLoop.main)
@@ -425,7 +422,7 @@ private extension AIAgentCommandStageView {
                 text: self.failedMessage(reason: reason, errorCode: errorCode)
             )
 
-            let showsPlansCTA = errorCode == .dailyLimitExceeded && self.state.isPaywallAvailable
+            let showsPlansCTA = errorCode == .dailyLimitExceeded
             if showsPlansCTA {
                 ConfirmButton(
                     title: "aiAgent::failed::showPlans".localized(),

--- a/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandViewModel.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandViewModel.swift
@@ -41,7 +41,6 @@ public protocol AIAgentCommandViewModel: AnyObject, Sendable {
     var commandState: AnyPublisher<AIAgentCommandState?, Never> { get }
     var usage: AnyPublisher<AIAgentUsage, Never> { get }
     var currentUserPlan: AnyPublisher<BillingUserPlan?, Never> { get }
-    var isPaywallAvailable: Bool { get }
 }
 
 
@@ -168,9 +167,5 @@ extension AIAgentCommandViewModelImple {
             .map { $0 as BillingUserPlan? }
             .prepend(nil)
             .eraseToAnyPublisher()
-    }
-
-    var isPaywallAvailable: Bool {
-        return FeatureFlag.isEnable(.billingPaywall)
     }
 }

--- a/Presentations/AIAgentScene/Tests/AIAgentCommandViewModelImpleTests.swift
+++ b/Presentations/AIAgentScene/Tests/AIAgentCommandViewModelImpleTests.swift
@@ -35,7 +35,6 @@ class AIAgentCommandViewModelImpleTests: BaseTestCase, PublisherWaitable {
         self.stubAgent = nil
         self.spyRouter = nil
         self.spyListener = nil
-        FeatureFlag.disable(.billingPaywall)
     }
 
     private func makeViewModel(userPlan: BillingUserPlan? = nil) -> AIAgentCommandViewModelImple {
@@ -286,25 +285,6 @@ extension AIAgentCommandViewModelImpleTests {
 // MARK: - paywall 진입점 (#739)
 
 extension AIAgentCommandViewModelImpleTests {
-
-    func test_isPaywallAvailable_whenFlagOff_isFalse() {
-        // given
-        let viewModel = self.makeViewModel()
-        // when
-        let isAvailable = viewModel.isPaywallAvailable
-        // then
-        XCTAssertEqual(isAvailable, false)
-    }
-
-    func test_isPaywallAvailable_whenFlagOn_isTrue() {
-        // given
-        FeatureFlag.enable(.billingPaywall)
-        let viewModel = self.makeViewModel()
-        // when
-        let isAvailable = viewModel.isPaywallAvailable
-        // then
-        XCTAssertEqual(isAvailable, true)
-    }
 
     func test_showPlans_requestsPaywallViaListener() {
         // given

--- a/Presentations/CalendarScenes/Snapshots/CalendarScenesSnapshots.swift
+++ b/Presentations/CalendarScenes/Snapshots/CalendarScenesSnapshots.swift
@@ -208,7 +208,6 @@ private final class FakeDayEventListViewModel: DayEventListViewModel, @unchecked
     }
 
     // 스냅샷 카탈로그는 AI 상태 화면까지 캡처해야 하므로 항상 노출
-    var isAIAgentEnabled: Bool { true }
 
     var foremostEventModel: AnyPublisher<(any EventCellViewModel)?, Never> {
         Just(self.foremostModel).eraseToAnyPublisher()

--- a/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
@@ -329,12 +329,10 @@ extension CalendarViewModelImple {
         
         self.bindUncompletedTodoRefresh()
 
-        if FeatureFlag.isEnable(.aiAgent) {
-            self.bindShowAICommandResultIfNeed()
-            self.bindVoiceInputLifecycle()
-            self.bindScrollToVoiceInputOnFocusedMonth()
-            self.aiAgentOrchestrationUsecase.prepare()
-        }
+        self.bindShowAICommandResultIfNeed()
+        self.bindVoiceInputLifecycle()
+        self.bindScrollToVoiceInputOnFocusedMonth()
+        self.aiAgentOrchestrationUsecase.prepare()
     }
     
     private func prepareInitialMonths(around today: CalendarComponent.Day) {

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListView.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListView.swift
@@ -46,7 +46,6 @@ enum DayEventListScrollAnchor {
     fileprivate var dayModel: SelectedDayModel?
     fileprivate var cellViewModels: [any EventCellViewModel] = []
     fileprivate var foremostEventMarkingStatus: ForemostMarkingStatus = .idle
-    fileprivate var isAIAgentEnabled: Bool = false
     fileprivate var aiAgentState: AIAgentState = .idle
     fileprivate var recognizingText: String = ""
     fileprivate var voiceLevel: Float = 0
@@ -76,8 +75,6 @@ enum DayEventListScrollAnchor {
 
         guard self.didBind == false else { return }
         self.didBind = true
-
-        self.isAIAgentEnabled = viewModel.isAIAgentEnabled
 
         viewModel.foremostEventModel
             .receive(on: RunLoop.main)
@@ -542,11 +539,9 @@ private struct QuickAddNewTodoView: View {
             }
             .opacity(self.inputDimOpacity)
 
-            if self.state.isAIAgentEnabled {
-                AIAgentEntryButton(badge: self.state.aiCommandBadge) {
-                    self.isFocusInput = false
-                    self.eventHandler.handleAIEntryButtonTap()
-                }
+            AIAgentEntryButton(badge: self.state.aiCommandBadge) {
+                self.isFocusInput = false
+                self.eventHandler.handleAIEntryButtonTap()
             }
         }
     }

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListViewModel.swift
@@ -70,7 +70,6 @@ protocol DayEventListViewModel: AnyObject, Sendable, DayEventListSceneInteractor
     func attachListener(_ listener: any DayEventListSceneListener)
 
     // presenter
-    var isAIAgentEnabled: Bool { get }
     var foremostEventModel: AnyPublisher<(any EventCellViewModel)?, Never> { get }
     var uncompletedTodoEventModels: AnyPublisher<[TodoEventCellViewModel], Never> { get }
     var selectedDay: AnyPublisher<SelectedDayModel, Never> { get }
@@ -434,10 +433,6 @@ extension DayEventListViewModelImple {
 
     var foremostEventMarkingStatus: AnyPublisher<ForemostMarkingStatus, Never> {
         return self.foremostEventUsecase.foremostEventMarkingStatus
-    }
-
-    var isAIAgentEnabled: Bool {
-        return FeatureFlag.isEnable(.aiAgent)
     }
 
     var aiAgentState: AnyPublisher<AIAgentState, Never> {

--- a/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
@@ -75,7 +75,6 @@ class CalendarViewModelImpleTests: BaseTestCase, PublisherWaitable {
         self.spyEventSyncUsecase = nil
         self.spyEventUploadService = nil
         self.stubOrchestration = nil
-        FeatureFlag.disable(.aiAgent)
     }
     
     private func makeViewModel(
@@ -200,9 +199,8 @@ extension CalendarViewModelImpleTests {
         XCTAssertEqual(isForemostEventPrepared, [false, true])
     }
 
-    func testViewModel_whenAIAgentFlagOn_prepareCallsOrchestrationPrepare() async throws {
+    func testViewModel_whenPrepare_callsOrchestrationPrepare() async throws {
         // given
-        FeatureFlag.enable(.aiAgent)
         let viewModel = self.makeViewModel()
 
         // when
@@ -211,18 +209,6 @@ extension CalendarViewModelImpleTests {
         // then
         try await Task.sleep(for: .milliseconds(10))
         XCTAssertEqual(self.stubOrchestration.didPrepare, true)
-    }
-
-    func testViewModel_whenAIAgentFlagOff_prepareNotCallsOrchestrationPrepare() async throws {
-        // given
-        let viewModel = self.makeViewModel()
-
-        // when
-        viewModel.prepare()
-
-        // then
-        try await Task.sleep(for: .milliseconds(10))
-        XCTAssertNil(self.stubOrchestration.didPrepare)
     }
 
     private func makeViewModelWithInitialSetup(_ today: CalendarComponent.Day) -> CalendarViewModelImple {
@@ -1087,7 +1073,6 @@ extension CalendarViewModelImpleTests {
 
     func testViewModel_whenAIEntersCommandPhase_routesToAICommand() {
         // given
-        FeatureFlag.enable(.aiAgent)
         let viewModel = self.makeViewModel()
         viewModel.prepare()
 
@@ -1101,7 +1086,6 @@ extension CalendarViewModelImpleTests {
 
     func testViewModel_whenStayInCommandPhase_routesOnlyOncePerEntry() {
         // given
-        FeatureFlag.enable(.aiAgent)
         let viewModel = self.makeViewModel()
         viewModel.prepare()
 
@@ -1159,7 +1143,6 @@ extension CalendarViewModelImpleTests {
 
     func testViewModel_whenVoiceInputStarts_scrollsOnlyFocusedMonthPaper() async throws {
         // given
-        FeatureFlag.enable(.aiAgent)
         let viewModel = self.makeViewModel()
         viewModel.prepare()
         try await Task.sleep(for: .milliseconds(50))
@@ -1175,7 +1158,6 @@ extension CalendarViewModelImpleTests {
 
     func testViewModel_whenFocusMovedToOtherMonth_scrollsThatMonthPaper() async throws {
         // given
-        FeatureFlag.enable(.aiAgent)
         let viewModel = self.makeViewModel()
         viewModel.prepare()
         try await Task.sleep(for: .milliseconds(50))
@@ -1192,7 +1174,6 @@ extension CalendarViewModelImpleTests {
 
     func testViewModel_whenStayInVoiceListening_scrollsOnlyOncePerEntry() async throws {
         // given
-        FeatureFlag.enable(.aiAgent)
         let viewModel = self.makeViewModel()
         viewModel.prepare()
         try await Task.sleep(for: .milliseconds(50))
@@ -1207,20 +1188,6 @@ extension CalendarViewModelImpleTests {
         XCTAssertEqual(counts, [0, 1, 0])
     }
 
-    func testViewModel_whenAIAgentFlagOff_doesNotScrollOnVoiceInput() async throws {
-        // given
-        let viewModel = self.makeViewModel()
-        viewModel.prepare()
-        try await Task.sleep(for: .milliseconds(50))
-
-        // when
-        self.stubOrchestration.stateSubject.send(.listening(.voice))
-        try await Task.sleep(for: .milliseconds(50))
-
-        // then
-        let counts = self.spyRouter.spyInteractors.map { $0.didScrollToVoiceInputCount }
-        XCTAssertEqual(counts, [0, 0, 0])
-    }
 }
 
 // MARK: - 외부 진입점의 AI 입력 요청 (requestAIEntry)
@@ -1247,8 +1214,8 @@ extension CalendarViewModelImpleTests {
         // when
         viewModel.requestAIEntry()
 
-        // then
-        XCTAssertEqual(self.spyRouter.didRouteToAICommandCount, 1)
+        // then — command phase 진입으로 자동 표시가 1회, 진입 요청이 1회
+        XCTAssertEqual(self.spyRouter.didRouteToAICommandCount, 2)
         XCTAssertNil(self.stubOrchestration.didEnterVoiceInput)
         XCTAssertNil(self.spyRouter.didShowConfirmWith)
     }
@@ -1322,8 +1289,8 @@ extension CalendarViewModelImpleTests {
         self.stubOrchestration.stateSubject.send(.processing(command: "회의"))
         try await Task.sleep(for: .milliseconds(10))
 
-        // then
-        XCTAssertEqual(self.spyRouter.didRouteToAICommandCount, 1)
+        // then — command phase 진입으로 자동 표시가 1회, 대기하던 진입 요청이 1회
+        XCTAssertEqual(self.spyRouter.didRouteToAICommandCount, 2)
         XCTAssertNil(self.stubOrchestration.didEnterVoiceInput)
     }
 
@@ -1584,10 +1551,8 @@ extension CalendarViewModelImpleTests {
 
     private func postAppLifecycleAfterPrepared(
         _ notificationName: Notification.Name,
-        aiAgentEnabled: Bool = true,
         state: AIAgentState?
     ) async throws {
-        if aiAgentEnabled { FeatureFlag.enable(.aiAgent) }
         let viewModel = self.makeViewModel()
         viewModel.prepare()
         try await Task.sleep(for: .milliseconds(50))
@@ -1599,13 +1564,9 @@ extension CalendarViewModelImpleTests {
         withExtendedLifetime(viewModel) { }
     }
 
-    private func enterBackgroundAfterPrepared(
-        aiAgentEnabled: Bool = true,
-        state: AIAgentState?
-    ) async throws {
+    private func enterBackgroundAfterPrepared(state: AIAgentState?) async throws {
         try await self.postAppLifecycleAfterPrepared(
-            UIApplication.didEnterBackgroundNotification,
-            aiAgentEnabled: aiAgentEnabled, state: state
+            UIApplication.didEnterBackgroundNotification, state: state
         )
     }
 
@@ -1633,16 +1594,6 @@ extension CalendarViewModelImpleTests {
         XCTAssertNil(self.stubOrchestration.didStopInput)
     }
 
-    func testViewModel_whenAIAgentFlagOff_doesNotStopInput() async throws {
-        // given, when
-        try await self.enterBackgroundAfterPrepared(
-            aiAgentEnabled: false, state: .listening(.voice)
-        )
-
-        // then
-        XCTAssertNil(self.stubOrchestration.didStopInput)
-    }
-
     func testViewModel_whenAppResignsActiveWhileVoiceListening_keepsInput() async throws {
         // given, when
         try await self.postAppLifecycleAfterPrepared(
@@ -1654,7 +1605,6 @@ extension CalendarViewModelImpleTests {
     }
 
     private func makePreparedViewModel() async throws -> CalendarViewModelImple {
-        FeatureFlag.enable(.aiAgent)
         let viewModel = self.makeViewModel()
         viewModel.prepare()
         try await Task.sleep(for: .milliseconds(50))

--- a/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
@@ -53,7 +53,6 @@ class DayEventListViewModelImpleTests: BaseTestCase, PublisherWaitable {
         self.spyRouter = nil
         self.spyListener = nil
         self.stubOrchestrationUsecase = nil
-        FeatureFlag.disable(.aiAgent)
     }
 
     private var stubOrchestrationUsecase: StubAIAgentOrchestrationUsecase!
@@ -1298,30 +1297,6 @@ extension DayEventListViewModelImpleTests {
 // MARK: - AI agent entry mode
 
 extension DayEventListViewModelImpleTests {
-
-    // 피처플래그 off(릴리즈 기본값): AI 진입 버튼 비노출
-    func testViewModel_whenAIAgentFlagOff_aiAgentEntryIsNotEnabled() {
-        // given
-        let viewModel = self.makeViewModel()
-
-        // when
-        let isEnabled = viewModel.isAIAgentEnabled
-
-        // then
-        XCTAssertEqual(isEnabled, false)
-    }
-
-    func testViewModel_whenAIAgentFlagOn_aiAgentEntryIsEnabled() {
-        // given
-        FeatureFlag.enable(.aiAgent)
-        let viewModel = self.makeViewModel()
-
-        // when
-        let isEnabled = viewModel.isAIAgentEnabled
-
-        // then
-        XCTAssertEqual(isEnabled, true)
-    }
 
     func testViewModel_whenAgentNotifiesListeningMode_emitsListeningState() {
         // given

--- a/Presentations/SettingScene/Sources/Setting/SettingItemListViewModel.swift
+++ b/Presentations/SettingScene/Sources/Setting/SettingItemListViewModel.swift
@@ -291,7 +291,7 @@ extension SettingItemListViewModelImple {
     var sectionModels: AnyPublisher<[any SettingSectionModelType], Never> {
 
         let transform: (AccountInfo?, DeviceInfo?, Bool) -> [any SettingSectionModelType] = { account, device, isUpdateAvailable in
-            let showsBillingPlan = account != nil && FeatureFlag.isEnable(.billingPaywall)
+            let showsBillingPlan = account != nil
             let baseSectionItems: [SettingItemModel] = [
                 .init(.appearance),
                 .init(.editEvent),

--- a/Presentations/SettingScene/Tests/Setting/SettingItemListViewModelImpleTests.swift
+++ b/Presentations/SettingScene/Tests/Setting/SettingItemListViewModelImpleTests.swift
@@ -33,7 +33,6 @@ class SettingItemListViewModelImpleTests: BaseTestCase, PublisherWaitable {
         self.cancelBag = nil
         self.spyRouter = nil
         self.stubAppUpdateCheckUsecase = nil
-        FeatureFlag.disable(.billingPaywall)
     }
 
     private func makeViewModel(
@@ -133,7 +132,7 @@ extension SettingItemListViewModelImpleTests {
         let baseSection = sections?[safe: 0]
         let baseItemIds = baseSection?.items.compactMap { $0 as? SettingItemModel }.map { $0.itemId }
         XCTAssertEqual(baseItemIds, [
-            .appearance, .editEvent, .holidaySetting
+            .appearance, .editEvent, .holidaySetting, .billingPlan
         ])
         let accountItem = baseSection?.items.last as? AccountSettingItemModel
         XCTAssertEqual(accountItem?.isSignIn, true)
@@ -465,9 +464,8 @@ extension SettingItemListViewModelImpleTests {
 
 extension SettingItemListViewModelImpleTests {
 
-    func test_whenSignedInAndFlagOn_showsBillingPlanItem() {
+    func test_whenSignedIn_showsBillingPlanItem() {
         // given
-        FeatureFlag.enable(.billingPaywall)
         let viewModel = self.makeViewModel(AccountInfo("some"))
         let items = self.WaitItemLoaded(viewModel)
 
@@ -478,21 +476,8 @@ extension SettingItemListViewModelImpleTests {
         XCTAssertNotNil(billingItem)
     }
 
-    func test_whenSignedInButFlagOff_hidesBillingPlanItem() {
+    func test_whenNotSignedIn_hidesBillingPlanItem() {
         // given
-        let viewModel = self.makeViewModel(AccountInfo("some"))
-        let items = self.WaitItemLoaded(viewModel)
-
-        // when
-        let billingItem = items.compactMap { $0 as? SettingItemModel }.first(where: { $0.itemId == .billingPlan })
-
-        // then
-        XCTAssertNil(billingItem)
-    }
-
-    func test_whenFlagOnButNotSignedIn_hidesBillingPlanItem() {
-        // given
-        FeatureFlag.enable(.billingPaywall)
         let viewModel = self.makeViewModel(nil)
         let items = self.WaitItemLoaded(viewModel)
 
@@ -505,7 +490,6 @@ extension SettingItemListViewModelImpleTests {
 
     func test_selectBillingPlan_routesToPaywall() {
         // given
-        FeatureFlag.enable(.billingPaywall)
         let viewModel = self.makeViewModel(AccountInfo("some"))
         let items = self.WaitItemLoaded(viewModel)
         guard let billingItem = items.compactMap({ $0 as? SettingItemModel }).first(where: { $0.itemId == .billingPlan })

--- a/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
+++ b/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
@@ -487,15 +487,11 @@ struct LoginUsecaseFactoryImple: UsecaseFactory {
             eventSyncUsecase: self.eventSyncUsecase
         )
 
-        // 결제는 로그인 유저 전용이고, paywall 이 닫힌 동안엔 리스너도 돌 이유가 없다.
-        // 환경 분기는 composition root 소관이라 Domain 이 플래그를 모른다
-        self.billingUsecase = FeatureFlag.isEnable(.billingPaywall)
-            ? BillingUsecaseImple(
-                repository: BillingRepositoryImple(remote: applicationBase.remoteAPI),
-                appStoreService: AppStoreBillingServiceImple(),
-                sharedDataStore: applicationBase.sharedDataStore
-            )
-            : NotNeedBillingUsecase(sharedDataStore: applicationBase.sharedDataStore)
+        self.billingUsecase = BillingUsecaseImple(
+            repository: BillingRepositoryImple(remote: applicationBase.remoteAPI),
+            appStoreService: AppStoreBillingServiceImple(),
+            sharedDataStore: applicationBase.sharedDataStore
+        )
 
         self.eventLiveActivityUsecase = EventLiveActivityUsecaseImple(
             controller: EventCountdownLiveActivityController(),


### PR DESCRIPTION
`FeatureFlag`의 `aiAgent`·`billingPaywall` 두 case를 걷어내고 AI Agent와 결제 진입점을 정식 노출로 전환한다. 두 기능 모두 앱 구현이 끝나 플래그가 배포 보류 스위치 역할만 남아 있었다.

플래그 조회 지점을 지우는 데 그치지 않고, 그 값을 나르던 프로토콜 요구사항(`DayEventListViewModel.isAIAgentEnabled`·`AIAgentCommandViewModel.isPaywallAvailable`)과 뷰 상태 필드까지 함께 걷었다 — 항상 `true`인 값을 계약으로 남겨두면 다음 사람이 그 분기를 다시 살아 있는 것으로 읽는다.

## 동작 변화

- 캘린더 진입 시 AI 결과 시트 자동 표시·음성 입력 라이프사이클·포커스 월 스크롤 바인딩이 항상 걸리고, `aiAgentOrchestrationUsecase.prepare()`(usage 로드·job 복원)가 앱 시작마다 돈다
- 일별 리스트의 AI 진입 버튼이 조건 없이 렌더된다
- 앱이 항상 `BillingUsecaseImple`을 조립한다 (`NotNeedBillingUsecase`는 미로그인 팩토리 경로가 계속 써서 타입은 존치)
- 설정의 플랜 항목은 로그인 여부만으로 노출되고, AI 한도 초과 화면의 플랜 CTA는 `errorCode == .dailyLimitExceeded` 단독 판정으로 노출된다

## 테스트

"플래그 꺼짐" 케이스는 삭제, "켜짐" 케이스는 셋업만 걷고 유지했다. 상시 활성이 되면서 기대값이 달라진 두 자리도 함께 조정했다:

- `SettingItemListViewModelImpleTests.testViewModel_whenSignIn_provideItemSections` — 기본 섹션에 `.billingPlan`이 포함된다
- `CalendarViewModelImpleTests`의 `requestAIEntry` 계열 2건 — 자동 표시 바인딩이 상시 동작해 command phase 전이에서 라우팅이 2회다. `performAIEntry`가 `dismissPresented` 후 재present하므로 최종 상태는 시트 1개로 같다

CalendarScenes 205 / SettingScene 138 / AIAgentScene 27 / TodoCalendarApp 29 전부 통과.

Closes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwttEcCB9zPS9CoLEuFf1Q
