### PR TITLE
[#904] AdMob 식별자를 커밋되는 자리로 옮기고 실계정 값으로 교체

### DIFF
--- a/TodoCalendarApp/Sources/AppEnvironment.swift
+++ b/TodoCalendarApp/Sources/AppEnvironment.swift
@@ -77,12 +77,13 @@ struct AppEnvironment {
         let fullScreen: String
     }
     
-    // Google 공개 테스트 단위 — 실단위 발급은 #904
     static var admobUnitIds: AdUnitIds {
+        // MREC 전용 단위를 따로 발급하지 않아 캘린더 하단 배너와 한 단위를 공유한다
+        let banner: String = "ca-app-pub-4980913859277199/4855632588"
         return AdUnitIds(
-            calendarBottomBanner: "ca-app-pub-3940256099942544/2934735716",
-            aiCommandMediumRectangle: "ca-app-pub-3940256099942544/2934735716",
-            fullScreen: "ca-app-pub-3940256099942544/4411468910"
+            calendarBottomBanner: banner,
+            aiCommandMediumRectangle: banner,
+            fullScreen: "ca-app-pub-4980913859277199/7394166018"
         )
     }
     

--- a/Tuist/ProjectDescriptionHelpers/AdMobIdentifiers.swift
+++ b/Tuist/ProjectDescriptionHelpers/AdMobIdentifiers.swift
@@ -12,6 +12,5 @@ import ProjectDescription
 // 바이너리에 박혀 나가는 값이라 비밀이 아니다 — secrets 파일이 아닌 여기 둔다
 extension Project {
 
-    // Google이 공개한 테스트 앱 ID — 실계정 발급은 #904
-    static let admobAppId: String = "ca-app-pub-3940256099942544~1458002511"
+    static let admobAppId: String = "ca-app-pub-4980913859277199~9010500013"
 }

--- a/Tuist/ProjectDescriptionHelpers/AdMobIdentifiers.swift
+++ b/Tuist/ProjectDescriptionHelpers/AdMobIdentifiers.swift
@@ -1,0 +1,17 @@
+//
+//  AdMobIdentifiers.swift
+//  TodoCalendarAppManifests
+//
+//  Created by sudo.park on 8/22/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import ProjectDescription
+
+
+// 바이너리에 박혀 나가는 값이라 비밀이 아니다 — secrets 파일이 아닌 여기 둔다
+extension Project {
+
+    // Google이 공개한 테스트 앱 ID — 실계정 발급은 #904
+    static let admobAppId: String = "ca-app-pub-3940256099942544~1458002511"
+}

--- a/install/InfoPlist_Secrets.swift
+++ b/install/InfoPlist_Secrets.swift
@@ -13,9 +13,6 @@ extension Project {
     static let googleClientId: String = "dummy.id"
     static let googleReverseAppId: String = "id.dummy"
 
-    // Google이 공개한 테스트 앱 ID — 실계정 없이도 빌드·구동된다
-    static let admobAppId: String = "ca-app-pub-3940256099942544~1458002511"
-
     // debug signing
     public static let debugAppSigningSetting: SettingsDictionary = [:]
     


### PR DESCRIPTION
AdMob 식별자가 gitignore된 `InfoPlist_Secrets.swift`에 있어 값을 아는 사람만 광고 설정이 붙은 빌드를 낼 수 있었다. 광고 식별자는 앱 바이너리에 그대로 박혀 나가 애초에 비밀이 될 수 없는 값이다 — IPA를 뜯으면 보이고, 가짜 트래픽 대응은 ID 은닉이 아니라 `app-ads.txt`와 AdMob invalid traffic 감지 소관이다.

커밋되는 자리로 옮기고 발급받은 실계정 값을 채웠다.

| 값 | 자리 |
|---|---|
| 앱 ID | `AdMobIdentifiers.swift` 신설 → Info.plist `GADApplicationIdentifier`로 주입 |
| 배너·MREC·전면 단위 | `AppEnvironment.admobUnitIds` — 원래 자리 유지 |

`install.sh`가 복사하는 secrets에서 AdMob 값이 빠져, clean clone에서도 실 광고 설정으로 빌드된다.

MREC 전용 단위는 발급하지 않아 캘린더 하단 배너와 한 단위를 공유한다. 노출 지점은 `ApplicationAdViewBuilder`에서 둘로 갈려 있어 필드는 그대로 두고, 값이 같다는 사실만 로컬 `banner` 상수로 드러냈다.

## 검증

유닛테스트가 닿지 않는 변경이라 실물로 확인했다 — `tuist generate` 후 생성된 `TodoCalendarApp-Info.plist`의 `GADApplicationIdentifier`가 실 앱 ID를 가리키고, TodoCalendarApp 스킴 빌드가 통과한다.

Closes #904
