### PR TITLE
[#964] 라이브액티비티 탭 시 이벤트 상세로 진입

### DIFF
--- a/Domain/Sources/Models/Events/EventTime.swift
+++ b/Domain/Sources/Models/Events/EventTime.swift
@@ -36,6 +36,39 @@ public enum EventTime: Comparable, Sendable, Hashable {
             return nil
         }
     }
+
+    public init?(customKey: String) {
+        if customKey.contains("..<") {
+            let parts = customKey.split(separator: "+", maxSplits: 1, omittingEmptySubsequences: false)
+            let rangeString = String(parts[0])
+
+            let components = rangeString.components(separatedBy: "..<")
+
+            guard components.count == 2,
+                  let lowerBound = Int(components[0]).map({ TimeInterval($0) }),
+                  let upperBound = Int(components[1]).map({ TimeInterval($0) }) else {
+                return nil
+            }
+
+            guard lowerBound <= upperBound else {
+                return nil
+            }
+
+            if parts.count > 1 {
+                guard let offset = Int(parts[1]).map({ TimeInterval($0) }) else {
+                    return nil
+                }
+                self = .allDay(lowerBound..<upperBound, secondsFromGMT: offset)
+            } else {
+                self = .period(lowerBound..<upperBound)
+            }
+        } else {
+            guard let time = Int(customKey).map({ TimeInterval($0) }) else {
+                return nil
+            }
+            self = .at(time)
+        }
+    }
     
     public var queryParams: [String: String] {
         switch self {

--- a/Domain/Tests/Models/Events/EventTimeCustomKeyTests.swift
+++ b/Domain/Tests/Models/Events/EventTimeCustomKeyTests.swift
@@ -47,4 +47,50 @@ struct EventTimeCustomKeyTests {
         // then
         #expect(lowerBound == nil)
     }
+
+    @Test("모든 EventTime 형태가 customKey에서 역파싱된다")
+    func initFromCustomKey_roundTripsEveryCase() {
+        // given
+        let at = EventTime.at(1234)
+        let period = EventTime.period(1234..<5678)
+        let allDay = EventTime.allDay(1234..<5678, secondsFromGMT: 32400)
+
+        // when + then
+        #expect(EventTime(customKey: at.customKey) == at)
+        #expect(EventTime(customKey: period.customKey) == period)
+        #expect(EventTime(customKey: allDay.customKey) == allDay)
+    }
+
+    @Test("음수 GMT 오프셋도 역파싱된다")
+    func initFromCustomKey_whenNegativeGMTOffset_roundTrips() {
+        // given
+        let allDay = EventTime.allDay(1234..<5678, secondsFromGMT: -18000)
+
+        // when
+        let restored = EventTime(customKey: allDay.customKey)
+
+        // then
+        #expect(restored == allDay)
+    }
+
+    @Test("음수 시각도 역파싱된다")
+    func initFromCustomKey_whenNegativeBounds_roundTrips() {
+        // given
+        let period = EventTime.period(-5678 ..< -1234)
+
+        // when
+        let restored = EventTime(customKey: period.customKey)
+
+        // then
+        #expect(restored == period)
+    }
+
+    @Test("잘못된 customKey 형식은 nil을 반환한다", arguments: ["", "abc", "..<1234", "1234..<", "1234..<abc", "5678..<1234", "1234..<5678+abc"])
+    func initFromCustomKey_whenMalformed_returnsNil(_ key: String) {
+        // given + when
+        let restored = EventTime(customKey: key)
+
+        // then
+        #expect(restored == nil)
+    }
 }

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Base+Factory/WidgetLink+Extensions.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Base+Factory/WidgetLink+Extensions.swift
@@ -50,6 +50,31 @@ enum EventDeepLinkBuilder {
 }
 
 
+extension LiveActivityEventTarget {
+
+    func eventDetailURL(scheduleTimeQuery: [String: String]?) -> URL? {
+        switch self {
+        case .todo(let id):
+            return EventDeepLinkBuilder.todo(id: id).build()
+
+        case .schedule(let id, _):
+            return scheduleTimeQuery
+                .flatMap { EventTime(deepLink: $0) }
+                .flatMap { EventDeepLinkBuilder.schedule(id: id, time: $0).build() }
+
+        case .holiday(let uuid, _):
+            return EventDeepLinkBuilder.holiday(id: uuid).build()
+
+        case .googleCalendar(let accountId, let calendarId, let eventId):
+            return EventDeepLinkBuilder.google(id: eventId, calendarId: calendarId, accountId: accountId).build()
+
+        case .appleCalendar(let calendarId, let eventId):
+            return EventDeepLinkBuilder.apple(id: eventId, calendarId: calendarId).build()
+        }
+    }
+}
+
+
 extension EventCellViewModel {
     
     var widgetURL: URL? {

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownActivityViewModel.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownActivityViewModel.swift
@@ -20,6 +20,7 @@ struct EventCountdownActivityViewModel {
     let subtitle: String?
     let tagColor: Color
     let todoId: String?
+    let deepLink: URL?
 
     init(_ attributes: EventCountdownActivityAttributes, _ state: EventCountdownActivityAttributes.State) {
         self.eventName = state.eventName
@@ -34,6 +35,8 @@ struct EventCountdownActivityViewModel {
         case .schedule, .holiday, .googleCalendar, .appleCalendar:
             self.todoId = nil
         }
+
+        self.deepLink = attributes.target.eventDetailURL(scheduleTimeQuery: state.scheduleTimeQuery)
 
         let uiColor = UIColor.from(hex: state.tagColorHex) ?? .gray
         self.tagColor = uiColor.asColor

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLiveActivity.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLiveActivity.swift
@@ -61,6 +61,7 @@ struct EventCountdownLiveActivity: Widget {
                 // 최소 표시 영역이 배지보다 작아 링이 잘린다 — 지름을 줄여 영역 안쪽에 들인다.
                 EventCountdownRingBadge(model: model, diameter: 27)
             }
+            .widgetURL(model.deepLink)
         }
     }
 }

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLockScreenView.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLockScreenView.swift
@@ -54,6 +54,7 @@ struct EventCountdownLockScreenView: View {
             EventCountdownActionButtonRow(model: model)
         }
         .padding(16)
+        .widgetURL(model.deepLink)
     }
 }
 

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/LiveActivities/LiveActivityEventTarget+DeepLink+Tests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/LiveActivities/LiveActivityEventTarget+DeepLink+Tests.swift
@@ -1,0 +1,203 @@
+//
+//  LiveActivityEventTarget+DeepLink+Tests.swift
+//  TodoCalendarAppWidgetTests
+//
+//  Created by sudo.park on 8/22/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Domain
+@testable import TodoCalendarAppWidget
+
+
+struct LiveActivityEventTargetDeepLinkTests {
+
+    @Test
+    func todoTarget_buildsTodoDetailLink() {
+        // given
+        let target = LiveActivityEventTarget.todo(id: "t1")
+
+        // when
+        let url = target.eventDetailURL(scheduleTimeQuery: nil)
+
+        // then
+        #expect(url?.eventPathComponents == ["event", "todo"])
+        #expect(url?.eventQueryParams == ["event_id": "t1"])
+    }
+
+    @Test
+    func scheduleTarget_buildsScheduleDetailLink_fromScheduleTimeQuery() {
+        // given
+        let target = LiveActivityEventTarget.schedule(id: "s1", turnKey: "999")
+        let scheduleTimeQuery = EventTime.at(100).queryParams
+
+        // when
+        let url = target.eventDetailURL(scheduleTimeQuery: scheduleTimeQuery)
+
+        // then
+        #expect(url?.eventPathComponents == ["event", "schedule"])
+        #expect(url?.eventQueryParams == ["event_id": "s1", "at": "100.0"])
+    }
+
+    @Test
+    func scheduleTarget_whenTimeQueryIsPeriod_buildsPeriodQuery() {
+        // given
+        let target = LiveActivityEventTarget.schedule(id: "s6", turnKey: nil)
+        let time = EventTime.period(1_755_400_800..<1_755_404_400)
+        let scheduleTimeQuery = time.queryParams
+
+        // when
+        let url = target.eventDetailURL(scheduleTimeQuery: scheduleTimeQuery)
+
+        // then
+        #expect(url?.eventPathComponents == ["event", "schedule"])
+        #expect(url?.eventQueryParams == [
+            "event_id": "s6",
+            "start": "1755400800.0",
+            "end": "1755404400.0"
+        ])
+    }
+
+    @Test
+    func scheduleTarget_whenTimeQueryIsAllDay_buildsAllDayQuery() {
+        // given
+        let target = LiveActivityEventTarget.schedule(id: "s2", turnKey: nil)
+        let time = EventTime.allDay(1_755_400_800..<1_755_487_200, secondsFromGMT: 32_400)
+        let scheduleTimeQuery = time.queryParams
+
+        // when
+        let url = target.eventDetailURL(scheduleTimeQuery: scheduleTimeQuery)
+
+        // then
+        #expect(url?.eventPathComponents == ["event", "schedule"])
+        #expect(url?.eventQueryParams == [
+            "event_id": "s2",
+            "start": "1755400800.0",
+            "end": "1755487200.0",
+            "offset": "32400.0",
+            "isAllDay": "true"
+        ])
+    }
+
+    @Test
+    func scheduleTarget_whenScheduleTimeQueryMissing_returnsNil() {
+        // given
+        let target = LiveActivityEventTarget.schedule(id: "s3", turnKey: nil)
+
+        // when
+        let url = target.eventDetailURL(scheduleTimeQuery: nil)
+
+        // then
+        #expect(url == nil)
+    }
+
+    @Test
+    func scheduleTarget_whenScheduleTimeQueryMalformed_returnsNil() {
+        // given
+        let target = LiveActivityEventTarget.schedule(id: "s4", turnKey: nil)
+
+        // when
+        let url = target.eventDetailURL(scheduleTimeQuery: ["foo": "bar"])
+
+        // then
+        #expect(url == nil)
+    }
+
+    @Test
+    func holidayTarget_buildsHolidayDetailLink() {
+        // given
+        let target = LiveActivityEventTarget.holiday(uuid: "h1", dateString: "2026-08-17")
+
+        // when
+        let url = target.eventDetailURL(scheduleTimeQuery: nil)
+
+        // then
+        #expect(url?.eventPathComponents == ["event", "holiday"])
+        #expect(url?.eventQueryParams == ["event_id": "h1"])
+    }
+
+    @Test
+    func googleTarget_buildsGoogleDetailLink() {
+        // given
+        let target = LiveActivityEventTarget.googleCalendar(accountId: "acc1", calendarId: "cal1", eventId: "evt1")
+
+        // when
+        let url = target.eventDetailURL(scheduleTimeQuery: nil)
+
+        // then
+        #expect(url?.eventPathComponents == ["event", "google"])
+        #expect(url?.eventQueryParams == ["event_id": "evt1", "calendar_id": "cal1", "account_id": "acc1"])
+    }
+
+    @Test
+    func appleTarget_buildsAppleDetailLink() {
+        // given
+        let target = LiveActivityEventTarget.appleCalendar(calendarId: "cal1", eventId: "evt1")
+
+        // when
+        let url = target.eventDetailURL(scheduleTimeQuery: nil)
+
+        // then
+        #expect(url?.eventPathComponents == ["event", "apple"])
+        #expect(url?.eventQueryParams == ["event_id": "evt1", "calendar_id": "cal1"])
+    }
+
+    @Test
+    func activityViewModel_exposesDeepLinkFromTargetAndState() {
+        // given
+        let target = LiveActivityEventTarget.schedule(id: "s5", turnKey: nil)
+        let scheduleTimeQuery = EventTime.at(500).queryParams
+        let attributes = EventCountdownActivityAttributes(target: target)
+        let state = EventCountdownActivityAttributes.State(
+            eventName: "회의", eventTimeText: "오후 2:00",
+            tagColorHex: "#2FB457", eventDate: .now, startDate: .now,
+            scheduleTimeQuery: scheduleTimeQuery
+        )
+
+        // when
+        let viewModel = EventCountdownActivityViewModel(attributes, state)
+
+        // then
+        #expect(viewModel.deepLink?.eventPathComponents == ["event", "schedule"])
+        #expect(viewModel.deepLink?.eventQueryParams == ["event_id": "s5", "at": "500.0"])
+    }
+
+    @Test
+    func activityViewModel_exposesDeepLinkFromTargetAndState_periodTime() {
+        // given
+        let target = LiveActivityEventTarget.schedule(id: "s7", turnKey: nil)
+        let time = EventTime.period(1_755_400_800..<1_755_404_400)
+        let attributes = EventCountdownActivityAttributes(target: target)
+        let state = EventCountdownActivityAttributes.State(
+            eventName: "회의", eventTimeText: "오후 2:00",
+            tagColorHex: "#2FB457", eventDate: .now, startDate: .now,
+            scheduleTimeQuery: time.queryParams
+        )
+
+        // when
+        let viewModel = EventCountdownActivityViewModel(attributes, state)
+
+        // then
+        #expect(viewModel.deepLink?.eventPathComponents == ["event", "schedule"])
+        #expect(viewModel.deepLink?.eventQueryParams == [
+            "event_id": "s7", "start": "1755400800.0", "end": "1755404400.0"
+        ])
+    }
+}
+
+
+private extension URL {
+
+    var eventPathComponents: [String] {
+        self.path.components(separatedBy: "/").filter { !$0.isEmpty }
+    }
+
+    var eventQueryParams: [String: String] {
+        URLComponents(url: self, resolvingAgainstBaseURL: true)?
+            .queryItems?
+            .reduce(into: [String: String]()) { acc, item in acc[item.name] = item.value }
+            ?? [:]
+    }
+}

--- a/TodoCalendarApp/Sources/LiveActivity/EventCountdownActivityAttributes.swift
+++ b/TodoCalendarApp/Sources/LiveActivity/EventCountdownActivityAttributes.swift
@@ -25,5 +25,6 @@ struct EventCountdownActivityAttributes: ActivityAttributes {
         var startDate: Date
         var placeName: String? = nil
         var memo: String? = nil
+        var scheduleTimeQuery: [String: String]? = nil
     }
 }

--- a/TodoCalendarApp/Sources/Root/EventLiveActivityUsecaseImple.swift
+++ b/TodoCalendarApp/Sources/Root/EventLiveActivityUsecaseImple.swift
@@ -92,7 +92,8 @@ extension EventLiveActivityUsecaseImple {
             eventDate: observed.eventDate,
             startDate: startDate,
             placeName: detail?.place?.placeName ?? observed.placeName,
-            memo: detail?.memo
+            memo: detail?.memo,
+            scheduleTimeQuery: observed.scheduleTimeQuery
         )
     }
 
@@ -363,8 +364,16 @@ extension EventLiveActivityUsecaseImple {
             placeName: nil,
             repeatingTurn: todo.repeatingTurn,
             scheduleOriginTimeKey: nil,
-            isTurnExcluded: false
+            isTurnExcluded: false,
+            scheduleTimeQuery: nil
         )
+    }
+
+    /// 원본 회차·비반복은 `schedule.time`을 그대로 쓴다 — turnKey(customKey)는 초 미만을 잘라내서,
+    /// 되돌린 값이 시리즈 시작 시각과 정확히 같지 않으면 상세의 "전체 일정" 판정이 어긋난다.
+    private func occurrenceTime(of schedule: ScheduleEvent, turnKey: String?) -> EventTime {
+        guard let turnKey, turnKey != schedule.time.customKey else { return schedule.time }
+        return EventTime(customKey: turnKey) ?? schedule.time
     }
 
     private func observedEvent(
@@ -382,7 +391,8 @@ extension EventLiveActivityUsecaseImple {
             placeName: nil,
             repeatingTurn: nil,
             scheduleOriginTimeKey: schedule.time.customKey,
-            isTurnExcluded: turnKey.map { schedule.repeatingTimeToExcludes.contains($0) } ?? false
+            isTurnExcluded: turnKey.map { schedule.repeatingTimeToExcludes.contains($0) } ?? false,
+            scheduleTimeQuery: self.occurrenceTime(of: schedule, turnKey: turnKey).queryParams
         )
     }
 
@@ -398,7 +408,8 @@ extension EventLiveActivityUsecaseImple {
             placeName: nil,
             repeatingTurn: nil,
             scheduleOriginTimeKey: nil,
-            isTurnExcluded: false
+            isTurnExcluded: false,
+            scheduleTimeQuery: nil
         )
     }
 
@@ -419,7 +430,8 @@ extension EventLiveActivityUsecaseImple {
             placeName: event.location,
             repeatingTurn: nil,
             scheduleOriginTimeKey: nil,
-            isTurnExcluded: false
+            isTurnExcluded: false,
+            scheduleTimeQuery: nil
         )
     }
 
@@ -437,7 +449,8 @@ extension EventLiveActivityUsecaseImple {
             placeName: event.location,
             repeatingTurn: nil,
             scheduleOriginTimeKey: nil,
-            isTurnExcluded: false
+            isTurnExcluded: false,
+            scheduleTimeQuery: nil
         )
     }
 
@@ -555,6 +568,7 @@ extension EventLiveActivityUsecaseImple {
             |> \.eventTimeText .~ observed.eventTimeText
             |> \.eventDate .~ observed.eventDate
             |> \.placeName .~ observed.placeName
+            |> \.scheduleTimeQuery .~ observed.scheduleTimeQuery
     }
 
     /// Todo·Schedule·공휴일은 공유 상태에 장소 정보가 없다 — 규칙 7의 장소 비교 대상에서
@@ -587,6 +601,7 @@ private struct LiveActivityObservedEvent {
     var repeatingTurn: Int?
     var scheduleOriginTimeKey: String?
     var isTurnExcluded: Bool
+    var scheduleTimeQuery: [String: String]?
 }
 
 private struct LiveActivityBaseline {

--- a/TodoCalendarApp/TodoCalendarAppTests/EventLiveActivityUsecaseImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/EventLiveActivityUsecaseImpleTests.swift
@@ -760,6 +760,39 @@ extension EventLiveActivityUsecaseImpleTests {
         #expect(stub.didUpdateWith == nil)
     }
 
+    /// 복원 기준선은 첫 관찰값으로 잡혀 규칙 5가 안 끊는다 — 규칙 7 갱신에서 회차 쿼리도
+    /// 복원 시점 값이 아니라 관찰된 새 시각을 따라가야 한다.
+    @Test func usecase_afterRestore_whenRuleSevenFires_updatesScheduleTimeQuery() async throws {
+        // given
+        let staleTime = Date().addingTimeInterval(60)
+        let newTime = Date().addingTimeInterval(120)
+        let staleContent = self.content(name: "schedule", eventDate: staleTime)
+            |> \.scheduleTimeQuery .~ EventTime.at(staleTime.timeIntervalSince1970).queryParams
+        let registration = LiveActivityRegistration(
+            target: .schedule(id: "s1", turnKey: nil), content: staleContent
+        )
+        let (usecase, stub, store) = self.makeUsecase(stubRestoredRegistration: registration)
+        store.put(
+            MemorizedEventsContainer<ScheduleEvent>.self, key: ShareDataKeys.schedules.rawValue,
+            MemorizedEventsContainer<ScheduleEvent>()
+                .append(self.makeSchedule(id: "s1", name: "schedule", eventDate: newTime))
+        )
+        await usecase.prepare()
+        try await self.waitForEffects()
+
+        // when
+        store.put(
+            MemorizedEventsContainer<ScheduleEvent>.self, key: ShareDataKeys.schedules.rawValue,
+            MemorizedEventsContainer<ScheduleEvent>()
+                .append(self.makeSchedule(id: "s1", name: "changed", eventDate: newTime))
+        )
+        try await self.waitForEffects()
+
+        // then
+        let expectedQuery = EventTime.at(newTime.timeIntervalSince1970).queryParams
+        #expect(stub.didUpdateWith?.scheduleTimeQuery == expectedQuery)
+    }
+
     @Test func usecase_handleWillEnterForeground_whenEventDatePassed_endsActivity() async throws {
         // given
         let past = Date().addingTimeInterval(-60)
@@ -1282,6 +1315,75 @@ extension EventLiveActivityUsecaseImpleTests {
         let startDate = try #require(stub.didStartWith?.1.startDate)
         #expect(startDate >= before)
         #expect(startDate <= Date())
+    }
+
+    @Test func usecase_startScheduleActivity_fillsScheduleTimeQueryFromOriginTime() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        let schedule = self.makeSchedule(id: "s1", eventDate: future)
+        store.put(
+            MemorizedEventsContainer<ScheduleEvent>.self, key: ShareDataKeys.schedules.rawValue,
+            MemorizedEventsContainer<ScheduleEvent>().append(schedule)
+        )
+
+        // when
+        try await usecase.startActivity(.schedule(id: "s1", turnKey: nil))
+
+        // then
+        #expect(stub.didStartWith?.1.scheduleTimeQuery == schedule.time.queryParams)
+    }
+
+    /// 원본 회차는 `schedule.time`을 그대로 실어야 초 미만 정밀도가 보존된다.
+    @Test func usecase_startScheduleActivity_originOccurrence_fillsScheduleTimeQueryLosslessly() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60.4)
+        let schedule = self.makeSchedule(id: "s1", eventDate: future)
+        store.put(
+            MemorizedEventsContainer<ScheduleEvent>.self, key: ShareDataKeys.schedules.rawValue,
+            MemorizedEventsContainer<ScheduleEvent>().append(schedule)
+        )
+
+        // when
+        try await usecase.startActivity(.schedule(id: "s1", turnKey: nil))
+
+        // then
+        let query = try #require(stub.didStartWith?.1.scheduleTimeQuery)
+        #expect(EventTime(deepLink: query) == schedule.time)
+    }
+
+    @Test func usecase_startRepeatingScheduleActivity_fillsScheduleTimeQueryFromTurnKey() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let originTime = Date().addingTimeInterval(60)
+        let turnTime = Date().addingTimeInterval(3600)
+        let turnKey = EventTime.at(turnTime.timeIntervalSince1970).customKey
+        store.put(
+            MemorizedEventsContainer<ScheduleEvent>.self, key: ShareDataKeys.schedules.rawValue,
+            MemorizedEventsContainer<ScheduleEvent>()
+                .append(self.makeSchedule(id: "s1", eventDate: originTime))
+        )
+
+        // when
+        try await usecase.startActivity(.schedule(id: "s1", turnKey: turnKey))
+
+        // then
+        let expectedQuery = try #require(EventTime(customKey: turnKey)).queryParams
+        #expect(stub.didStartWith?.1.scheduleTimeQuery == expectedQuery)
+    }
+
+    @Test func usecase_startTodoActivity_leavesScheduleTimeQueryNil() async throws {
+        // given
+        let (usecase, stub, store) = self.makeUsecase()
+        let future = Date().addingTimeInterval(60)
+        self.putTodos(store, [self.makeTodo(id: "t1", eventDate: future)])
+
+        // when
+        try await usecase.startActivity(.todo(id: "t1"))
+
+        // then
+        #expect(stub.didStartWith?.1.scheduleTimeQuery == nil)
     }
 }
 


### PR DESCRIPTION
잠금화면·다이나믹아일랜드의 라이브액티비티를 탭하면 표시 중인 이벤트 상세로 진입한다. 지금까지는 아무 링크도 안 붙어 있어 앱만 열렸다.

## 접근

딥링크 빌더(`EventDeepLinkBuilder`)와 수신부(`EventDeepLinkHandlerImple`)는 위젯용으로 이미 완성돼 있고, 라이브액티비티 뷰도 같은 위젯 확장 타겟 소속이라 그대로 쓸 수 있다. 5종 대상(todo·일정·공휴일·구글·애플)을 그 빌더에 매핑하고 `widgetURL`을 붙이는 게 뼈대다.

걸린 건 **일정**이다. 일정 딥링크는 완전한 `EventTime`을 요구하는데(`EventDeepLinkHandlerImple`의 `EventTime(deepLink:)`), 위젯 확장은 스케줄을 로드하지 않아 뷰에서 시각을 알 수 없다. 그래서 앱 쪽 usecase가 관찰 시점에 회차 시각을 계산해 `ActivityAttributes.State`로 실어 보낸다.

싣는 값은 `EventTime.queryParams`다. 처음엔 회차 키(`customKey`) 문자열을 실었는데, `customKey`는 `"\(Int(time))"`로 **초 미만을 잘라내는 lossy 키**다. 일정은 소수점 초를 실제로 갖고(`Calendar.dateBySetting`이 `now`의 나노초를 그대로 보존한다), 그 상태로 되돌리면 상세의 시리즈 시작 판정(`EditScheduleEventDetailViewModelImple`의 `repeatingStartTime == repeatingEventTargetTime`)이 뒤집혀 **"전체 일정" 액션이 사라지고, 저장하면 반복 시리즈가 둘로 쪼개진다.** 같은 이벤트를 목록 셀에서 열면 정확한 시각이 넘어가 정상 동작하므로, 진입 경로에 따라 저장 결과가 갈리는 상태였다.

usecase는 정확한 `schedule.time`을 이미 쥐고 있으니 그걸 무손실로 싣는다. `occurrenceTime(of:turnKey:)`이 비반복·원본 회차면 `schedule.time`을 그대로 쓰고, 2회차 이상만 `turnKey`를 복원한다 — 그쪽은 시리즈 시작 판정이 어차피 false여야 맞고 `.onlyThisTime`·`.fromNow`가 초 단위 오차에 내성이 있다.

`State`에 기본값 있는 옵셔널을 더하는 것이라 합성 Codable이 `decodeIfPresent`로 처리한다. 이미 떠 있는 액티비티는 디코딩이 깨지지 않고 링크만 없는 상태로 남는다.

회차 시각은 규칙 7 갱신 대상에도 넣었다. 복원 경로는 기준선을 첫 관찰값으로 잡아 규칙 5가 안 끊으므로, 앱이 꺼진 사이 시각이 바뀌면 표시 시각만 갱신되고 링크가 낡는 경로가 생긴다.

## 유저 검증 대기

`.widgetURL` 부착은 위젯 확장의 SwiftUI modifier라 단위 검증 자리가 없다(기존 위젯 3곳도 같은 이유로 URL 값만 테스트한다). 실기기 확인 항목은 이슈 #964 코멘트에 정리해뒀다 — 특히 다이나믹아일랜드 **확장** 표시가 안 열리면 `DynamicIslandExpandedRegion(.bottom)`에 `.widgetURL`을 따로 붙여야 한다.
