### PR TITLE
[#975] 구글 캘린더 읽기 전용 우선 연동과 쓰기 scope 점진 승격

### DIFF
--- a/Domain/Sources/Models/Events/ExternalCalendar/GoogleCalendarWriteScopeFailReason.swift
+++ b/Domain/Sources/Models/Events/ExternalCalendar/GoogleCalendarWriteScopeFailReason.swift
@@ -1,0 +1,14 @@
+//
+//  GoogleCalendarWriteScopeFailReason.swift
+//  Domain
+//
+//  Created by sudo.park on 8/22/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+
+public enum GoogleCalendarWriteScopeFailReason: Error, Sendable {
+    case notGranted // 조직 정책으로 write 가 막힌 계정
+}

--- a/Domain/Sources/Usecases/Account/ExternalServiceIntegration/ExternalCalendarIntegrationUsecase.swift
+++ b/Domain/Sources/Usecases/Account/ExternalServiceIntegration/ExternalCalendarIntegrationUsecase.swift
@@ -35,7 +35,7 @@ public protocol ExternalCalendarIntegrationUsecase: Sendable {
         
     func integrate(external service: any ExternalCalendarService) async throws -> ExternalServiceAccountinfo
 
-    func reauthenticate(
+    func reauthenticateForWriteScope(
         external service: any ExternalCalendarService, accountId: String
     ) async throws -> ExternalServiceAccountinfo
 
@@ -125,17 +125,19 @@ extension ExternalCalendarIntegrationUsecaseImple {
         let usecase = try self.resolveOAuthUsecase(for: service)
         self.lastestUsedOAuthUsecase = usecase; defer { self.lastestUsedOAuthUsecase = nil }
         let credential = try await usecase.requestAuthentication()
-        return try await self.applyIntegration(credential, for: service)
+        return try await self.applyNewIntegration(credential, for: service)
     }
 
-    public func reauthenticate(
+    public func reauthenticateForWriteScope(
         external service: any ExternalCalendarService, accountId: String
     ) async throws -> ExternalServiceAccountinfo {
-        let usecase = try self.resolveOAuthUsecase(for: service)
+        let promotedService = self.resolveWriteScopePromotedService(for: service)
+        let usecase = try self.resolveOAuthUsecase(for: promotedService)
         self.lastestUsedOAuthUsecase = usecase; defer { self.lastestUsedOAuthUsecase = nil }
         let credential = try await usecase.requestAuthentication(hint: accountId)
         try self.verifyReauthenticatedAccountIdentity(credential, expected: accountId)
-        return try await self.applyIntegration(credential, for: service)
+        try self.verifyWriteScopeGranted(credential)
+        return try await self.applyPromotedCredential(credential, for: service)
     }
 
     private func resolveOAuthUsecase(
@@ -148,6 +150,13 @@ extension ExternalCalendarIntegrationUsecaseImple {
         return usecase
     }
 
+    private func resolveWriteScopePromotedService(
+        for service: any ExternalCalendarService
+    ) -> any ExternalCalendarService {
+        guard service is GoogleCalendarService else { return service }
+        return GoogleCalendarService(scopes: [.readWrite])
+    }
+
     // 다른 구글 계정으로 로그인하면 엉뚱한 계정의 토큰이 덮이므로 재인증 결과 이메일을 검증한다.
     private func verifyReauthenticatedAccountIdentity(
         _ credential: any OAuth2Credential, expected accountId: String
@@ -158,21 +167,43 @@ extension ExternalCalendarIntegrationUsecaseImple {
         }
     }
 
-    private func applyIntegration(
+    private func verifyWriteScopeGranted(_ credential: any OAuth2Credential) throws {
+        guard let google = credential as? GoogleOAuth2Credential,
+              let scopes = google.grantedScopes,
+              scopes.contains(GoogleCalendarService.Scope.readWrite.rawValue)
+        else {
+            throw GoogleCalendarWriteScopeFailReason.notGranted
+        }
+    }
+
+    private func applyNewIntegration(
+        _ credential: any OAuth2Credential, for service: any ExternalCalendarService
+    ) async throws -> ExternalServiceAccountinfo {
+        let account = try await self.saveAndUpdateAccountsMap(credential, for: service)
+        try? await self.dbConnectionController.open(serviceId: service.identifier)
+        self.integrationStatusChangedSubject.send(
+            .integrated(serviceId: service.identifier, account: account)
+        )
+        return account
+    }
+
+    private func applyPromotedCredential(
+        _ credential: any OAuth2Credential, for service: any ExternalCalendarService
+    ) async throws -> ExternalServiceAccountinfo {
+        return try await self.saveAndUpdateAccountsMap(credential, for: service)
+    }
+
+    private func saveAndUpdateAccountsMap(
         _ credential: any OAuth2Credential, for service: any ExternalCalendarService
     ) async throws -> ExternalServiceAccountinfo {
         let account = try await self.externalServiceIntegrateRepository.save(credential, for: service)
             |> \.intergrationTime .~ Date()
-        try? await self.dbConnectionController.open(serviceId: service.identifier)
         self.sharedDataStore.update(AccountsMap.self, key: self.shareKey) { old in
             var map = old ?? [:]
             map[service.identifier, default: []].removeAll { $0.email == account.email }
             map[service.identifier, default: []].append(account)
             return map
         }
-        self.integrationStatusChangedSubject.send(
-            .integrated(serviceId: service.identifier, account: account)
-        )
         return account
     }
 

--- a/Domain/Sources/Usecases/Account/ExternalServiceIntegration/ExternalService.swift
+++ b/Domain/Sources/Usecases/Account/ExternalServiceIntegration/ExternalService.swift
@@ -45,6 +45,7 @@ public struct AppleCalendarService: ExternalCalendarService {
 public struct GoogleCalendarService: ExternalCalendarService {
     
     public enum Scope: String, Sendable {
+        case readonly = "https://www.googleapis.com/auth/calendar.readonly"
         case readWrite = "https://www.googleapis.com/auth/calendar"
     }
     

--- a/Domain/Tests/Usecases/AppleCalendarUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AppleCalendarUsecaseImpleTests.swift
@@ -672,7 +672,7 @@ private final class PrivateStubIntegrationUsecase: ExternalCalendarIntegrationUs
 
     func prepareIntegratedAccounts() async throws {}
     func integrate(external service: any ExternalCalendarService) async throws -> ExternalServiceAccountinfo { fatalError() }
-    func reauthenticate(
+    func reauthenticateForWriteScope(
         external service: any ExternalCalendarService, accountId: String
     ) async throws -> ExternalServiceAccountinfo { fatalError() }
     func stopIntegrate(external service: any ExternalCalendarService, accountId: String) async throws {}

--- a/Domain/Tests/Usecases/ExternalCalendarIntegrationUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/ExternalCalendarIntegrationUsecaseImpleTests.swift
@@ -312,8 +312,8 @@ extension ExternalCalendarIntegrationUsecaseImpleTests {
         #expect(account.email == AppleCalendarService.localAccountId)
     }
 
-    // reauthenticate — 계정 힌트 전달 + 결과 계정 동일성 검증
-    @Test func usecase_reauthenticate_succeed_updatesGrantedScopes() async throws {
+    // reauthenticateForWriteScope — 계정 힌트 전달 + 결과 계정 동일성 검증 + write scope 부여 검증
+    @Test func usecase_reauthenticateForWriteScope_succeed_updatesGrantedScopes() async throws {
         // given
         let service = GoogleCalendarService(scopes: [.readWrite])
         let account = ExternalServiceAccountinfo(service.identifier, email: "google@email.com")
@@ -322,55 +322,171 @@ extension ExternalCalendarIntegrationUsecaseImpleTests {
         try await usecase.prepareIntegratedAccounts()
 
         // when
-        let reauthenticated = try await usecase.reauthenticate(external: service, accountId: "google@email.com")
+        let reauthenticated = try await usecase.reauthenticateForWriteScope(external: service, accountId: "google@email.com")
 
         // then
         #expect(reauthenticated.email == "google@email.com")
         #expect(reauthenticated.grantedScopes == [GoogleCalendarService.Scope.readWrite.rawValue])
+        let stored = usecase.currentIntegratedAccounts(for: service.identifier).first
+        #expect(stored?.grantedScopes == [GoogleCalendarService.Scope.readWrite.rawValue])
     }
 
-    @Test func usecase_reauthenticate_passesAccountIdAsOAuthHint() async throws {
+    @Test func usecase_reauthenticateForWriteScope_passesAccountIdAsOAuthHint() async throws {
         // given
         let service = GoogleCalendarService(scopes: [.readWrite])
         let account = ExternalServiceAccountinfo(service.identifier, email: "google@email.com")
+        self.fakeOauthProvider.stubGoogleGrantedScopes = [GoogleCalendarService.Scope.readWrite.rawValue]
         let usecase = self.makeUsecase(startWithIntegrated: [account])
         try await usecase.prepareIntegratedAccounts()
 
         // when
-        _ = try await usecase.reauthenticate(external: service, accountId: "google@email.com")
+        _ = try await usecase.reauthenticateForWriteScope(external: service, accountId: "google@email.com")
 
         // then
         #expect(self.fakeOauthProvider.latestGoogleUsecase?.didRequestAuthenticationWithHint == "google@email.com")
     }
 
-    @Test func usecase_reauthenticate_whenResultAccountMismatches_throws() async throws {
-        // given — 재인증 결과가 다른 계정으로 로그인됨
+    @Test func usecase_reauthenticateForWriteScope_whenResultAccountMismatches_throws() async throws {
+        // given — 재인증 결과가 다른 계정으로 로그인됨. write scope 는 정상 승인돼 있어
+        // 계정 동일성 검증이 write scope 검증보다 먼저 실행돼야만 이 케이스가 던진다
         let service = GoogleCalendarService(scopes: [.readWrite])
         let account = ExternalServiceAccountinfo(service.identifier, email: "google@email.com")
         self.fakeOauthProvider.stubGoogleEmail = "other@email.com"
+        self.fakeOauthProvider.stubGoogleGrantedScopes = [GoogleCalendarService.Scope.readWrite.rawValue]
         let usecase = self.makeUsecase(startWithIntegrated: [account])
         try await usecase.prepareIntegratedAccounts()
 
         // when
-        let result = try? await usecase.reauthenticate(external: service, accountId: "google@email.com")
-
-        // then
-        #expect(result == nil)
+        do {
+            _ = try await usecase.reauthenticateForWriteScope(external: service, accountId: "google@email.com")
+            Issue.record("계정 불일치로 실패해야 함")
+        } catch is GoogleCalendarWriteScopeFailReason {
+            Issue.record("write scope 검증이 아니라 계정 동일성 검증에서 실패해야 함")
+        } catch {
+            // then — GoogleCalendarWriteScopeFailReason 이 아닌 다른 에러(RuntimeError)로 실패
+        }
     }
 
-    @Test func usecase_reauthenticate_doesNotDuplicateAccount() async throws {
+    @Test func usecase_reauthenticateForWriteScope_doesNotDuplicateAccount() async throws {
         // given
         let service = GoogleCalendarService(scopes: [.readWrite])
         let account = ExternalServiceAccountinfo(service.identifier, email: "google@email.com")
+        self.fakeOauthProvider.stubGoogleGrantedScopes = [GoogleCalendarService.Scope.readWrite.rawValue]
         let usecase = self.makeUsecase(startWithIntegrated: [account])
         try await usecase.prepareIntegratedAccounts()
 
         // when
-        _ = try await usecase.reauthenticate(external: service, accountId: "google@email.com")
+        _ = try await usecase.reauthenticateForWriteScope(external: service, accountId: "google@email.com")
 
         // then — 같은 이메일이므로 교체일 뿐 계정이 늘어나지 않는다
         let accounts = usecase.currentIntegratedAccounts(for: service.identifier)
         #expect(accounts.count == 1)
+    }
+
+    // 서비스에 주입된 scope 와 무관하게 항상 write scope 로 승격 재인증을 요청한다
+    @Test func usecase_reauthenticateForWriteScope_requestsWriteScopeRegardlessOfServiceScopes() async throws {
+        // given — readonly 로 만든 서비스를 넘긴다
+        let readonlyService = GoogleCalendarService(scopes: [.readonly])
+        let account = ExternalServiceAccountinfo(readonlyService.identifier, email: "google@email.com")
+        self.fakeOauthProvider.stubGoogleGrantedScopes = [GoogleCalendarService.Scope.readWrite.rawValue]
+        let usecase = self.makeUsecase(startWithIntegrated: [account])
+        try await usecase.prepareIntegratedAccounts()
+
+        // when
+        _ = try await usecase.reauthenticateForWriteScope(external: readonlyService, accountId: "google@email.com")
+
+        // then — provider 가 실제로 받은 서비스의 scopes 는 write 다
+        #expect(self.fakeOauthProvider.didRequestUsecaseForGoogleService?.scopes == [.readWrite])
+    }
+
+    @Test func usecase_reauthenticateForWriteScope_whenWriteScopeNotGranted_throwsNotGranted() async throws {
+        // given — write 를 요청했지만 readonly 만 승인됨
+        let service = GoogleCalendarService(scopes: [.readWrite])
+        let account = ExternalServiceAccountinfo(service.identifier, email: "google@email.com")
+        self.fakeOauthProvider.stubGoogleGrantedScopes = [GoogleCalendarService.Scope.readonly.rawValue]
+        let usecase = self.makeUsecase(startWithIntegrated: [account])
+        try await usecase.prepareIntegratedAccounts()
+
+        // when
+        do {
+            _ = try await usecase.reauthenticateForWriteScope(external: service, accountId: "google@email.com")
+            Issue.record("notGranted 로 실패해야 함")
+        } catch is GoogleCalendarWriteScopeFailReason {
+            // then — expected
+        } catch {
+            Issue.record("GoogleCalendarWriteScopeFailReason 이어야 하는데: \(error)")
+        }
+    }
+
+    @Test func usecase_reauthenticateForWriteScope_whenGrantedScopesIsNil_throwsNotGranted() async throws {
+        // given — grantedScopes 가 nil (fail-closed)
+        let service = GoogleCalendarService(scopes: [.readWrite])
+        let account = ExternalServiceAccountinfo(service.identifier, email: "google@email.com")
+        let usecase = self.makeUsecase(startWithIntegrated: [account])
+        try await usecase.prepareIntegratedAccounts()
+
+        // when
+        do {
+            _ = try await usecase.reauthenticateForWriteScope(external: service, accountId: "google@email.com")
+            Issue.record("notGranted 로 실패해야 함")
+        } catch is GoogleCalendarWriteScopeFailReason {
+            // then — expected
+        } catch {
+            Issue.record("GoogleCalendarWriteScopeFailReason 이어야 하는데: \(error)")
+        }
+    }
+
+    // 애플처럼 scope 개념이 없는 서비스는 write scope 승격 대상에서 제외한다
+    @Test func usecase_reauthenticateForWriteScope_forNonGoogleService_doesNotRequestGoogleScope() async throws {
+        // given — 계정 동일성 검증은 구글 자격증명만 다루므로 호출 자체는 실패하지만, 여기서 보는 건 provider 승격 여부다
+        let service = AppleCalendarService()
+        let usecase = self.makeUsecase()
+
+        // when
+        _ = try? await usecase.reauthenticateForWriteScope(
+            external: service, accountId: AppleCalendarService.localAccountId
+        )
+
+        // then
+        #expect(self.fakeOauthProvider.didRequestUsecaseForGoogleService == nil)
+    }
+
+    // 승격은 신규 연동이 아니라 기존 계정의 자격증명 교체이므로 .integrated 를 재방출하지 않는다
+    @Test func usecase_reauthenticateForWriteScope_doesNotBroadcastIntegratedStatus() async throws {
+        // given
+        let service = GoogleCalendarService(scopes: [.readWrite])
+        let account = ExternalServiceAccountinfo(service.identifier, email: "google@email.com")
+        self.fakeOauthProvider.stubGoogleGrantedScopes = [GoogleCalendarService.Scope.readWrite.rawValue]
+        let usecase = self.makeUsecase(startWithIntegrated: [account])
+        try await usecase.prepareIntegratedAccounts()
+        let confirm = self.expectConfirm("승격은 integrationStatusChanged 를 방출하지 않는다")
+        confirm.count = 0
+        confirm.timeout = .milliseconds(200)
+
+        // when
+        let statuses = try await self.outputs(confirm, for: usecase.integrationStatusChanged) {
+            _ = try await usecase.reauthenticateForWriteScope(external: service, accountId: "google@email.com")
+        }
+
+        // then
+        #expect(statuses.isEmpty)
+    }
+
+    // dbConnectionController.open 은 호출마다 refcount +1 이라, 승격에서 재호출하면 대응 close 없이 카운트만 누적된다
+    @Test func usecase_reauthenticateForWriteScope_doesNotReopenDBConnection() async throws {
+        // given
+        let service = GoogleCalendarService(scopes: [.readWrite])
+        let account = ExternalServiceAccountinfo(service.identifier, email: "google@email.com")
+        self.fakeOauthProvider.stubGoogleGrantedScopes = [GoogleCalendarService.Scope.readWrite.rawValue]
+        let usecase = self.makeUsecase(startWithIntegrated: [account])
+        try await usecase.prepareIntegratedAccounts()
+        let openCountBeforeReauth = self.spyConnectionController.didOpenedServiceIds.count
+
+        // when
+        _ = try await usecase.reauthenticateForWriteScope(external: service, accountId: "google@email.com")
+
+        // then
+        #expect(self.spyConnectionController.didOpenedServiceIds.count == openCountBeforeReauth)
     }
 
     @Test func currentOrNewIntegratedAccount_whenAlreadyIntegrated_emitsCurrentThenStops() async throws {
@@ -473,10 +589,12 @@ private final class FakeOauth2ServiceProvider: ExternalCalendarOAuthUsecaseProvi
     var stubGoogleEmail: String = "google@email.com"
     var stubGoogleGrantedScopes: [String]?
     private(set) var latestGoogleUsecase: StubGoogleOAuth2ServiceUsecase?
+    private(set) var didRequestUsecaseForGoogleService: GoogleCalendarService?
 
     func usecase(for service: any ExternalCalendarService) -> (any OAuth2ServiceUsecase)? {
         switch service {
-        case is GoogleCalendarService:
+        case let google as GoogleCalendarService:
+            self.didRequestUsecaseForGoogleService = google
             let usecase = StubGoogleOAuth2ServiceUsecase(email: stubGoogleEmail, grantedScopes: stubGoogleGrantedScopes)
                 |> \.authenticationWaitMocking .~ authenticationWaitMocking
             self.latestGoogleUsecase = usecase

--- a/Domain/Tests/Usecases/GoogleCalendarUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/GoogleCalendarUsecaseImpleTests.swift
@@ -1014,7 +1014,7 @@ private final class PrivateStubIntegrationUsecase: ExternalCalendarIntegrationUs
 
     func prepareIntegratedAccounts() async throws {}
     func integrate(external service: any ExternalCalendarService) async throws -> ExternalServiceAccountinfo { fatalError() }
-    func reauthenticate(
+    func reauthenticateForWriteScope(
         external service: any ExternalCalendarService, accountId: String
     ) async throws -> ExternalServiceAccountinfo { fatalError() }
     func stopIntegrate(external service: any ExternalCalendarService, accountId: String) async throws {}

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModel.swift
@@ -231,11 +231,23 @@ extension EventListCellEventHanleViewModelImple {
                     external: service, accountId: accountId
                 )
                 self.confirmAndRemoveEvent(google, scope)
+            } catch let reason as GoogleCalendarWriteScopeFailReason {
+                self.showWriteScopeNotGrantedGuide(reason)
             } catch {
                 self.router?.showError(error)
             }
         }
         .store(in: &self.cancellables)
+    }
+
+    private func showWriteScopeNotGrantedGuide(_ reason: GoogleCalendarWriteScopeFailReason) {
+        switch reason {
+        case .notGranted:
+            let info = ConfirmDialogInfo()
+                |> \.message .~ pure("eventDetail::gogoleEvent::writeScopeNotGranted::message".localized())
+                |> \.withCancel .~ false
+            self.router?.showConfirm(dialog: info)
+        }
     }
 
     private func confirmAndRemoveEvent(

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModel.swift
@@ -227,7 +227,7 @@ extension EventListCellEventHanleViewModelImple {
         Task { [weak self] in
             guard let self else { return }
             do {
-                _ = try await self.externalCalendarIntegrationUsecase.reauthenticate(
+                _ = try await self.externalCalendarIntegrationUsecase.reauthenticateForWriteScope(
                     external: service, accountId: accountId
                 )
                 self.confirmAndRemoveEvent(google, scope)

--- a/Presentations/CalendarScenes/Tests/Common/EventListCellEventHanleViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Common/EventListCellEventHanleViewModelImpleTests.swift
@@ -706,7 +706,7 @@ extension EventListCellEventHanleViewModelImpleTests {
         self.wait(for: [expect], timeout: self.timeout)
 
         // then
-        XCTAssertEqual(self.stubIntegrationUsecase.didReauthenticateWith?.accountId, "stub@gmail.com")
+        XCTAssertEqual(self.stubIntegrationUsecase.didReauthenticateForWriteScopeWith?.accountId, "stub@gmail.com")
         XCTAssertEqual(self.spyGoogleUsecase.didRemoveEventWith?.eventId, "google")
     }
 
@@ -742,7 +742,7 @@ extension EventListCellEventHanleViewModelImpleTests {
         self.wait(for: [notCalled], timeout: 0.3)
 
         // then
-        XCTAssertNil(self.stubIntegrationUsecase.didReauthenticateWith)
+        XCTAssertNil(self.stubIntegrationUsecase.didReauthenticateForWriteScopeWith)
         XCTAssertNil(self.spyGoogleUsecase.didRemoveEventWith)
     }
 

--- a/Presentations/CalendarScenes/Tests/Common/EventListCellEventHanleViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Common/EventListCellEventHanleViewModelImpleTests.swift
@@ -70,6 +70,7 @@ class EventListCellEventHanleViewModelImpleTests: BaseTestCase, PublisherWaitabl
         appleShouldFailWrite: Bool = false,
         googleShouldFailWrite: Bool = false,
         shouldFailReauthenticate: Bool = false,
+        shouldFailReauthenticateWithNotGranted: Bool = false,
         stubTodoEvent: TodoEvent? = nil,
         stubScheduleEvent: ScheduleEvent? = nil,
         stubDetailData: EventDetailData? = nil,
@@ -89,6 +90,7 @@ class EventListCellEventHanleViewModelImpleTests: BaseTestCase, PublisherWaitabl
         self.spyAppleUsecase.shouldFailWrite = appleShouldFailWrite
         self.spyGoogleUsecase.shouldFailWrite = googleShouldFailWrite
         self.stubIntegrationUsecase.shouldFailReauthenticate = shouldFailReauthenticate
+        self.stubIntegrationUsecase.shouldFailReauthenticateWithNotGranted = shouldFailReauthenticateWithNotGranted
         if let stubTodoEvent {
             self.spyTodoUsecase.setStub(todo: stubTodoEvent)
         }
@@ -708,6 +710,29 @@ extension EventListCellEventHanleViewModelImpleTests {
         // then
         XCTAssertEqual(self.stubIntegrationUsecase.didReauthenticateForWriteScopeWith?.accountId, "stub@gmail.com")
         XCTAssertEqual(self.spyGoogleUsecase.didRemoveEventWith?.eventId, "google")
+    }
+
+    func testViewModel_whenRemoveGoogleEventAndWriteScopeNotGranted_showGuideAndNotRemove() {
+        // given
+        let notCalled = expectation(description: "승격 실패 시 삭제 실행 안 함")
+        notCalled.isInverted = true
+        self.spyGoogleUsecase.didRemoveEventWithCallback = { notCalled.fulfill() }
+        let viewModel = self.makeViewModel(
+            googleWritePermission: .needReauthentication, shouldFailReauthenticateWithNotGranted: true
+        )
+        let cellViewModel = GoogleCalendarEventCellViewModel.dummy(isWritable: true, recurringEventId: nil)
+
+        // when
+        viewModel.handleMoreAction(cellViewModel, .remove(scope: .all))
+        self.wait(for: [notCalled], timeout: 0.3)
+
+        // then
+        XCTAssertEqual(
+            self.spyRouter.didShowConfirmWith?.message,
+            "eventDetail::gogoleEvent::writeScopeNotGranted::message".localized()
+        )
+        XCTAssertEqual(self.spyRouter.didShowConfirmWith?.withCancel, false)
+        XCTAssertNil(self.spyGoogleUsecase.didRemoveEventWith)
     }
 
     func testViewModel_whenRemoveGoogleEventAndReauthenticateFailed_showError() {

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
@@ -460,11 +460,23 @@ extension GoogleCalendarEventDetailViewModelImple {
                     external: service, accountId: accountId
                 )
                 action()
+            } catch let reason as GoogleCalendarWriteScopeFailReason {
+                self.showWriteScopeNotGrantedGuide(reason)
             } catch {
                 self.router?.showError(error)
             }
         }
         .store(in: &self.cancellables)
+    }
+
+    private func showWriteScopeNotGrantedGuide(_ reason: GoogleCalendarWriteScopeFailReason) {
+        switch reason {
+        case .notGranted:
+            let info = ConfirmDialogInfo()
+                |> \.message .~ pure("eventDetail::gogoleEvent::writeScopeNotGranted::message".localized())
+                |> \.withCancel .~ false
+            self.router?.showConfirm(dialog: info)
+        }
     }
 
     private func saveChanges() {

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
@@ -456,7 +456,7 @@ extension GoogleCalendarEventDetailViewModelImple {
         Task { [weak self] in
             guard let self else { return }
             do {
-                _ = try await self.externalCalendarIntegrationUsecase.reauthenticate(
+                _ = try await self.externalCalendarIntegrationUsecase.reauthenticateForWriteScope(
                     external: service, accountId: accountId
                 )
                 action()

--- a/Presentations/EventDetailScene/Tests/GoogleCalendarEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/GoogleCalendarEventDetailViewModelImpleTests.swift
@@ -804,7 +804,7 @@ extension GoogleCalendarEventDetailViewModelImpleTests {
         try await self.waitSaveCompleted { viewModel.save() }
 
         // then
-        #expect(self.integrationUsecase.didReauthenticateWith?.accountId == "stub@gmail.com")
+        #expect(self.integrationUsecase.didReauthenticateForWriteScopeWith?.accountId == "stub@gmail.com")
         #expect(self.lastCalendarUsecase.didUpdateEventWith?.params.summary == "new name")
     }
 
@@ -822,7 +822,7 @@ extension GoogleCalendarEventDetailViewModelImpleTests {
         try await Task.sleep(for: .milliseconds(10))
 
         // then
-        #expect(self.integrationUsecase.didReauthenticateWith == nil)
+        #expect(self.integrationUsecase.didReauthenticateForWriteScopeWith == nil)
         #expect(self.lastCalendarUsecase.didUpdateEventWith == nil)
         let name = try await self.firstOutput(expectConfirm("입력값 유지"), for: viewModel.eventName)
         #expect(name == "new name")
@@ -1124,7 +1124,7 @@ extension GoogleCalendarEventDetailViewModelImpleTests {
         try await Task.sleep(for: .milliseconds(10))
 
         // then
-        #expect(self.integrationUsecase.didReauthenticateWith?.accountId == "stub@gmail.com")
+        #expect(self.integrationUsecase.didReauthenticateForWriteScopeWith?.accountId == "stub@gmail.com")
         #expect(self.lastCalendarUsecase.didRemoveEventWith?.eventId == "id")
         #expect(self.spyRouter.didClosed == true)
     }

--- a/Presentations/EventDetailScene/Tests/GoogleCalendarEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/GoogleCalendarEventDetailViewModelImpleTests.swift
@@ -35,6 +35,7 @@ final class GoogleCalendarEventDetailViewModelImpleTests: PublisherWaitable {
         customAttendees: [GoogleCalendar.EventOrigin.Attendee]? = nil,
         writePermission: GoogleCalendar.EventWritePermission? = .writable,
         shouldFailReauthenticate: Bool = false,
+        shouldFailReauthenticateWithNotGranted: Bool = false,
         summaryPerCall: [String]? = nil,
         recurringEventId: String? = nil,
         htmlLink: String? = "link",
@@ -70,6 +71,7 @@ final class GoogleCalendarEventDetailViewModelImpleTests: PublisherWaitable {
         calendarUsecase.refreshGoogleCalendarEventTags()
         self.lastCalendarUsecase = calendarUsecase
         self.integrationUsecase.shouldFailReauthenticate = shouldFailReauthenticate
+        self.integrationUsecase.shouldFailReauthenticateWithNotGranted = shouldFailReauthenticateWithNotGranted
         self.stubLiveActivityUsecase.registeredTargetSubject.send(registeredLiveActivityTarget)
         self.stubLiveActivityUsecase.stubStartError = liveActivityStartError
         let liveActivityToggleViewModel = LiveActivityToggleViewModelImple(
@@ -847,6 +849,26 @@ extension GoogleCalendarEventDetailViewModelImpleTests {
         #expect(self.lastCalendarUsecase.didUpdateEventWith == nil)
     }
 
+    @Test func save_whenReauthenticateFailsWithWriteScopeNotGranted_showsGuideAndDoesNotSave() async throws {
+        // given
+        let viewModel = self.makeViewModel(
+            writePermission: .needReauthentication, shouldFailReauthenticateWithNotGranted: true
+        )
+        self.spyRouter.shouldConfirmNotCancel = true
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+        viewModel.enter(name: "new name")
+
+        // when
+        try await self.waitSaveCompleted { viewModel.save() }
+
+        // then
+        #expect(self.spyRouter.didShowConfirmWith?.message == "eventDetail::gogoleEvent::writeScopeNotGranted::message".localized())
+        #expect(self.spyRouter.didShowConfirmWith?.withCancel == false)
+        #expect(self.lastCalendarUsecase.didUpdateEventWith == nil)
+    }
+
     @Test func save_whenReadOnlyCalendar_inputIsIgnoredSoNoUpdateRequested() async throws {
         // given — enter(name:) 가 updateCurrentFields 의 읽기 전용 가드에서 이미 무시된다.
         // runWithWritePermission 의 readOnlyCalendar 게이트 자체는 remove_whenReadOnlyCalendar_doesNothing 이 덮는다.
@@ -1127,6 +1149,27 @@ extension GoogleCalendarEventDetailViewModelImpleTests {
         #expect(self.integrationUsecase.didReauthenticateForWriteScopeWith?.accountId == "stub@gmail.com")
         #expect(self.lastCalendarUsecase.didRemoveEventWith?.eventId == "id")
         #expect(self.spyRouter.didClosed == true)
+    }
+
+    @Test func remove_whenReauthenticateFailsWithWriteScopeNotGranted_showsGuideAndDoesNotRemove() async throws {
+        // given
+        let viewModel = self.makeViewModel(
+            writePermission: .needReauthentication, shouldFailReauthenticateWithNotGranted: true
+        )
+        self.spyRouter.shouldConfirmNotCancel = true
+        _ = try await self.firstOutput(expectConfirm("origin 로드"), for: viewModel.eventName) {
+            viewModel.refresh()
+        }
+
+        // when
+        viewModel.remove()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // then
+        #expect(self.spyRouter.didShowConfirmWith?.message == "eventDetail::gogoleEvent::writeScopeNotGranted::message".localized())
+        #expect(self.spyRouter.didShowConfirmWith?.withCancel == false)
+        #expect(self.lastCalendarUsecase.didRemoveEventWith == nil)
+        #expect(self.spyRouter.didClosed == nil)
     }
 
     @Test func remove_whenReadOnlyCalendar_doesNothing() async throws {

--- a/Presentations/SettingScene/Snapshots/SettingSceneSnapshots.swift
+++ b/Presentations/SettingScene/Snapshots/SettingSceneSnapshots.swift
@@ -148,7 +148,7 @@ final class SettingSceneSnapshots: XCTestCase {
             state.selectedAllDayEventNotificationTimeText = "so long text hahahahhahahha hahah"
             state.externalCalendarServiceModels = [
                 ExternalCalanserServiceModel(
-                    GoogleCalendarService(scopes: [.readWrite]),
+                    GoogleCalendarService(scopes: [.readonly]),
                     accountId: nil
                 )!
             ]

--- a/Presentations/SettingScene/Sources/Event/EventSettingView.swift
+++ b/Presentations/SettingScene/Sources/Event/EventSettingView.swift
@@ -509,7 +509,7 @@ struct EventSettingViewPreviewProvider: PreviewProvider {
         state.selectedAllDayEventNotificationTimeText = "so long text hahahahhahahha hahah"
         state.externalCalendarServiceModels = [
             ExternalCalanserServiceModel(
-                GoogleCalendarService(scopes: [.readWrite]),
+                GoogleCalendarService(scopes: [.readonly]),
                 accountId: nil
             )!
         ]

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -294,7 +294,8 @@
 "eventDetail::gogoleEvent::saved::message" = "The event has been saved.";
 "eventDetail::gogoleEvent::readOnlyCalendar::message" = "This calendar is read-only, so the event can't be edited here.";
 "eventDetail::gogoleEvent::reauthenticate::title" = "Additional permission needed";
-"eventDetail::gogoleEvent::reauthenticate::message" = "Sign in to this Google account again to edit events.";
+"eventDetail::gogoleEvent::reauthenticate::message" = "This Google account is connected with read-only access. To edit events, you need to grant edit permission separately.";
+"eventDetail::gogoleEvent::writeScopeNotGranted::message" = "Edit permission was not granted. If this is a work or school account, your administrator may not allow it.";
 "eventDetail::gogoleEvent::repeating::title" = "This is a repeating event";
 "eventDetail::gogoleEvent::repeating::onlyThisTime::button" = "This event only";
 "eventDetail::gogoleEvent::repeating::all::button" = "All events";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -294,7 +294,8 @@
 "eventDetail::gogoleEvent::saved::message" = "일정을 저장했습니다.";
 "eventDetail::gogoleEvent::readOnlyCalendar::message" = "읽기 전용 캘린더라 여기서는 일정을 수정할 수 없어요.";
 "eventDetail::gogoleEvent::reauthenticate::title" = "권한 추가가 필요해요";
-"eventDetail::gogoleEvent::reauthenticate::message" = "일정을 수정하려면 이 구글 계정에 다시 로그인해 주세요.";
+"eventDetail::gogoleEvent::reauthenticate::message" = "이 구글 계정은 읽기 전용으로 연동돼 있어요. 일정을 수정하려면 편집 권한을 따로 허용해야 해요.";
+"eventDetail::gogoleEvent::writeScopeNotGranted::message" = "편집 권한을 받지 못했어요. 회사·학교 계정이라면 관리자 정책으로 막혀 있을 수 있어요.";
 "eventDetail::gogoleEvent::repeating::title" = "반복되는 일정이에요";
 "eventDetail::gogoleEvent::repeating::onlyThisTime::button" = "이번 일정만";
 "eventDetail::gogoleEvent::repeating::all::button" = "전체 일정";

--- a/Supports/TestDoubles/Sources/Usecases/StubExternalCalendarIntegrationUsecase.swift
+++ b/Supports/TestDoubles/Sources/Usecases/StubExternalCalendarIntegrationUsecase.swift
@@ -34,14 +34,19 @@ open class StubExternalCalendarIntegrationUsecase: ExternalCalendarIntegrationUs
         return account
     }
 
-    public var didReauthenticateWith: (serviceId: String, accountId: String)?
-    public var didReauthenticateWithService: (any ExternalCalendarService)?
+    public var didReauthenticateForWriteScopeWith: (serviceId: String, accountId: String)?
+    public var didReauthenticateForWriteScopeWithService: (any ExternalCalendarService)?
     public var shouldFailReauthenticate: Bool = false
-    open func reauthenticate(
+    public var shouldFailReauthenticateWithNotGranted: Bool = false
+    open func reauthenticateForWriteScope(
         external service: any ExternalCalendarService, accountId: String
     ) async throws -> ExternalServiceAccountinfo {
-        self.didReauthenticateWith = (service.identifier, accountId)
-        self.didReauthenticateWithService = service
+        self.didReauthenticateForWriteScopeWith = (service.identifier, accountId)
+        self.didReauthenticateForWriteScopeWithService = service
+        guard !self.shouldFailReauthenticateWithNotGranted
+        else {
+            throw GoogleCalendarWriteScopeFailReason.notGranted
+        }
         guard !self.shouldFailReauthenticate
         else {
             throw RuntimeError("failed to reauthenticate")

--- a/TodoCalendarApp/Sources/AppEnvironment.swift
+++ b/TodoCalendarApp/Sources/AppEnvironment.swift
@@ -65,7 +65,7 @@ struct AppEnvironment {
     
     static let eventUploadMaxFailCount: Int = 10
     
-    static let googleCalendarService = GoogleCalendarService(scopes: [.readWrite])
+    static let googleCalendarService = GoogleCalendarService(scopes: [.readonly])
     static let appleCalendarService = AppleCalendarService()
     static var supportExternalCalendarServices: [ExternalCalendarService] {
         return [googleCalendarService, appleCalendarService]

--- a/docs/spec/google-calendar.md
+++ b/docs/spec/google-calendar.md
@@ -18,13 +18,15 @@
 ### 2.1 인증 프로바이더
 
 ```
-GoogleOAuth2ServiceProvider
+AppEnvironment.googleCalendarService (GoogleCalendarService)
 ├── identifier: "google"
-├── scopes: ["https://www.googleapis.com/auth/calendar"]
+├── scopes: ["https://www.googleapis.com/auth/calendar.readonly"]
 └── 인증 SDK: GIDSignIn (Firebase GoogleSignIn)
 ```
 
-읽기·쓰기를 모두 포함하는 sensitive scope다. 이 scope 로 바꾸면 구글 OAuth 재심사가 필요하고, 승인 전에 요청하면 유저에게 미인증 앱 화면이 뜨고 100명 캡이 걸린다 (#402).
+최초 연동은 읽기 전용 scope 로만 요청한다. 일부 회사 워크스페이스가 구글 캘린더 연동을 읽기 전용일 때만 허용하기 때문이다. 쓰기(`https://www.googleapis.com/auth/calendar`)는 유저가 이벤트를 저장·삭제하는 시점에 승격으로 요청한다(§8.2).
+
+쓰기 scope 는 읽기·쓰기를 모두 포함하는 sensitive scope 다. 이 scope 를 요청하면 구글 OAuth 재심사가 필요하고, 승인 전에 요청하면 유저에게 미인증 앱 화면이 뜨고 100명 캡이 걸린다 (#402).
 
 ### 2.2 자격증명 구조 (GoogleOAuth2Credential)
 
@@ -361,10 +363,12 @@ activeCalendars() = 전체 캘린더 - offTagIds에 포함된 캘린더
 | 판정 | 조건 | 동작 |
 |---|---|---|
 | `readOnlyCalendar` | `Tag.isWritable == false` | 입력 필드 비활성 + 하단 안내문. 저장 버튼·삭제 메뉴 노출 안 함 |
-| `needReauthentication` | 캘린더는 쓰기 가능 + 계정 `grantedScopes` 에 쓰기 scope 없음 | 편집은 자유롭게 가능. 저장·삭제 실행 시 재인증 확인 다이얼로그 → 성공하면 이어서 저장·삭제 실행 |
+| `needReauthentication` | 캘린더는 쓰기 가능 + 계정 `grantedScopes` 에 쓰기 scope 없음 | 편집은 자유롭게 가능. 저장·삭제 실행 시 재인증 확인 다이얼로그 → 성공하면 이어서 저장·삭제 실행. 재인증 결과에 쓰기 scope 가 없으면 저장·삭제를 실행하지 않고 조직 정책 가능성을 안내한다(fail-closed) |
 | `writable` | 둘 다 만족 | 저장·삭제 바로 실행 |
 
 `readOnlyCalendar` 상태에서는 `updateCurrentFields` 가드가 입력 자체를 무시해 저장 불가능한 변경이 쌓이지 않는다.
+
+`needReauthentication` 의 재인증·승격 실패 판정은 `ExternalCalendarIntegrationUsecase.reauthenticateForWriteScope` 소관이다. 승격은 기존에 연동된 계정의 자격증명 교체일 뿐 신규 연동이 아니므로, 성공해도 `integrationStatusChanged(.integrated)` 브로드캐스트와 DB 재오픈은 하지 않는다 — 둘 다 신규 연동 시점에만 필요한 부수효과라 승격에서 재실행하면 유저가 직접 켠 캘린더 on/off 상태가 초기화된다.
 
 점점점 메뉴의 링크 항목은 `isEditable` 에 따라 문구가 갈린다 — 편집 가능이면 "구글 캘린더에서 수정", 읽기 전용이면 "구글 캘린더에서 보기". 둘 다 `htmlLink` 를 Safari 로 연다 (메뉴 자체가 편집 액션은 아님). 삭제 항목은 `isEditable` 일 때만 노출된다.
 


### PR DESCRIPTION
일부 회사 워크스페이스는 구글 캘린더 연동을 **읽기 전용일 때만** 허용한다. 그런데 지금은 최초 연동부터 쓰기 scope(`calendar`)를 요구해서, 그런 계정은 캘린더를 읽어올 기회조차 없다.

그래서 연동을 `calendar.readonly` 로 내리고, 쓰기 scope 는 유저가 실제로 이벤트를 저장·삭제하는 순간에만 승격으로 요청한다.

## 접근

**승격 요청 scope 는 서비스 인스턴스가 아니라 요청 시점이 정한다.** `GoogleCalendarService.Scope` 에 `readonly` 를 되살리고 `AppEnvironment` 주입을 그걸로 바꿨지만, 승격 재인증은 그 주입값을 보지 않는다 — `ExternalCalendarIntegrationUsecase.reauthenticateForWriteScope` 가 write scope 를 요청하는 서비스 값을 그 자리에서 만들어 OAuth usecase 를 resolve 한다. 주입 scope 를 따라갔다면 readonly 계정은 영영 승격할 수 없다.

**승격 결과를 다시 검증한다 (fail-closed).** 재인증이 성공해도 `grantedScopes` 에 write 가 없으면 `GoogleCalendarWriteScopeFailReason.notGranted` 로 실패시킨다. 조직 정책으로 쓰기가 막힌 계정이 이 작업이 겨냥한 바로 그 유저층이라, "재인증 성공 = write 획득" 전제를 그대로 두면 저장 단계에서 구글 403 이 그대로 노출된다. 검증은 `applyIntegration` 앞에 둬서 미승인 자격증명이 저장되지 않는다.

**승격은 신규 연동의 부수효과를 재실행하지 않는다.** `applyIntegration` 을 신규 연동과 승격 두 진입으로 갈랐다. 승격이 `.integrated` 를 브로드캐스트하면 `GoogleCalendarUsecase` 가 `refreshCalendarTags(isNew: true)` 로 받아 구글에서 체크 해제된 캘린더를 초기 off 태그로 다시 심고, 유저가 앱에서 직접 켜둔 상태를 덮는다 — 방금 편집한 캘린더가 달력에서 사라진다. `dbConnectionController.open` 재호출(대응 close 없는 refcount +1)도 같이 빠졌다.

**유저에게 보이는 건 문구 둘.** 기존 재인증 확인 다이얼로그가 "연동이 읽기 전용이라 편집 권한을 따로 허용해야 한다"를 알리고, 승격 실패 시에는 저장·삭제를 실행하지 않고 조직 정책 가능성을 안내한다. 상세 화면 저장·삭제와 일별 리스트 셀 삭제 두 진입점에 모두 붙었다.

애플(EventKit)은 scope 개념이 없고 읽으려면 fullAccess 가 필요해 읽기/쓰기를 가를 수 없다 — 이번 변경 범위 밖이다.

## 검증

- 14개 테스트 스킴 전부 통과. en↔ko 로컬라이즈 파리티 0 위반.
- **실기기 검증 2건이 남아 있다** — GIDSignIn 승격이 기존 readonly grant 를 보존하는지, 워크스페이스 정책 계정이 정말 "sign-in 성공 + write 미포함"으로 응답하는지. 확인 방법·판정 기준은 https://github.com/sudopark/TodoCalendar/issues/975#issuecomment-5379513493 에 정리해뒀다. 후자가 에러로 끊기면 그 에러를 `notGranted` 로 매핑하는 후속이 필요하다.

## 남은 판단

`notGranted` 안내 문구가 원인만 알려주고 출구를 주지 않는다. 상세 화면은 점점점 메뉴의 "구글 캘린더에서 수정"이 대안이 되지만 일별 리스트 셀엔 그 경로가 없다. "구글 캘린더 앱·웹에서는 수정할 수 있어요" 를 덧붙일지는 제품 판단이라 이번 PR 에 넣지 않았다.

Closes #975
