### PR TITLE
[#954] 캘린더 하단 배너 노출 + [#955] AI 커맨드 처리 중 MREC 노출

### DIFF
--- a/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandBuilderImple.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandBuilderImple.swift
@@ -13,13 +13,16 @@ public final class AIAgentCommandBuilderImple: AIAgentCommandSceneBuilder {
 
     private let usecaseFactory: any UsecaseFactory
     private let viewAppearance: ViewAppearance
+    private let adViewBuilder: (any AdViewBuilder)?
 
     public init(
         usecaseFactory: any UsecaseFactory,
-        viewAppearance: ViewAppearance
+        viewAppearance: ViewAppearance,
+        adViewBuilder: (any AdViewBuilder)?
     ) {
         self.usecaseFactory = usecaseFactory
         self.viewAppearance = viewAppearance
+        self.adViewBuilder = adViewBuilder
     }
 
     @MainActor
@@ -33,7 +36,8 @@ public final class AIAgentCommandBuilderImple: AIAgentCommandSceneBuilder {
         viewModel.listener = listener
         let viewController = AIAgentCommandViewController(
             viewModel: viewModel,
-            viewAppearance: self.viewAppearance
+            viewAppearance: self.viewAppearance,
+            adViewBuilder: self.adViewBuilder
         )
         let router = AIAgentRouter()
         router.scene = viewController

--- a/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandStageView.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandStageView.swift
@@ -77,19 +77,22 @@ struct AIAgentCommandStageContainerView: View {
     @State private var state: AIAgentCommandViewState = .init()
     private let viewAppearance: ViewAppearance
     private let eventHandlers: AIAgentCommandViewEventHandler
+    private let adViewBuilder: (any AdViewBuilder)?
 
     var stateBinding: (AIAgentCommandViewState) -> Void = { _ in }
 
     init(
         viewAppearance: ViewAppearance,
-        eventHandlers: AIAgentCommandViewEventHandler
+        eventHandlers: AIAgentCommandViewEventHandler,
+        adViewBuilder: (any AdViewBuilder)?
     ) {
         self.viewAppearance = viewAppearance
         self.eventHandlers = eventHandlers
+        self.adViewBuilder = adViewBuilder
     }
 
     var body: some View {
-        return AIAgentCommandStageView()
+        return AIAgentCommandStageView(adViewBuilder: self.adViewBuilder)
             .onAppear {
                 self.stateBinding(self.state)
                 self.eventHandlers.prepare()
@@ -108,6 +111,12 @@ struct AIAgentCommandStageView: View {
     @Environment(ViewAppearance.self) private var appearance
     @Environment(AIAgentCommandViewState.self) private var state
     @Environment(AIAgentCommandViewEventHandler.self) private var eventHandlers
+
+    private let adViewBuilder: (any AdViewBuilder)?
+
+    init(adViewBuilder: (any AdViewBuilder)? = nil) {
+        self.adViewBuilder = adViewBuilder
+    }
 
     // confirm의 expireTime — 만료 시각에 헤더·stage가 함께 재렌더되도록 TimelineView 스케줄 근거로 공유.
     // nil(만료 시각 불명) 또는 confirm이 아니면 빈 스케줄 — 최초 1회 렌더만.
@@ -189,6 +198,8 @@ private extension AIAgentCommandStageView {
             self.userMessageBubble(command)
             self.assistantTypingBubble
 
+            self.mediumRectangleBanner
+
             // 숨김(close)은 헤더 X로 일원화 — 여기선 진행 중지만
             ConfirmButton(
                 title: "aiAgent::stop".localized(),
@@ -200,6 +211,15 @@ private extension AIAgentCommandStageView {
         }
     }
 
+    // 로드 전·실패·유료 플랜이면 높이 0 이라 시트가 안 늘어난다
+    @ViewBuilder
+    var mediumRectangleBanner: some View {
+        if let adViewBuilder = self.adViewBuilder {
+            adViewBuilder.makeBannerView(size: .mediumRectangle)
+                .asAnyView()
+                .frame(maxWidth: .infinity, alignment: .center)
+        }
+    }
 }
 
 

--- a/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandViewController.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandViewController.swift
@@ -19,7 +19,8 @@ final class AIAgentCommandViewController: UIHostingController<AIAgentCommandStag
 
     init(
         viewModel: any AIAgentCommandViewModel,
-        viewAppearance: ViewAppearance
+        viewAppearance: ViewAppearance,
+        adViewBuilder: (any AdViewBuilder)?
     ) {
         self.viewModel = viewModel
         self.viewAppearance = viewAppearance
@@ -28,7 +29,8 @@ final class AIAgentCommandViewController: UIHostingController<AIAgentCommandStag
         eventHandlers.bind(viewModel)
         var containerView = AIAgentCommandStageContainerView(
             viewAppearance: viewAppearance,
-            eventHandlers: eventHandlers
+            eventHandlers: eventHandlers,
+            adViewBuilder: adViewBuilder
         )
         containerView.stateBinding = { $0.bind(viewModel) }
         super.init(rootView: containerView)

--- a/Services/AdService/Sources/AdBannerUIView.swift
+++ b/Services/AdService/Sources/AdBannerUIView.swift
@@ -56,9 +56,9 @@ public final class AdBannerUIView: UIView {
         _ billingUsecase: any BillingUsecase
     ) {
         Publishers.CombineLatest(adService.isStarted, billingUsecase.currentUserPlan)
+            .receive(on: RunLoop.main)
             .map { isStarted, userPlan in isStarted && userPlan.planId == .free }
             .removeDuplicates()
-            .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] isAllowed in
                 self?.apply(isAllowed: isAllowed)
             })

--- a/TodoCalendarApp/Sources/Factories/ApplicationBase.swift
+++ b/TodoCalendarApp/Sources/Factories/ApplicationBase.swift
@@ -186,12 +186,6 @@ final class ApplicationBase {
         return self.mobileAdService
     }()
 
-    func makeAdViewBuilder(billingUsecase: any BillingUsecase) -> (any AdViewBuilder)? {
-        return self.mobileAdService.map {
-            ApplicationAdViewBuilder(adService: $0, billingUsecase: billingUsecase)
-        }
-    }
-
     func makeFullScreenAdRouter(billingUsecase: any BillingUsecase) -> (any FullScreenAdRouter)? {
         return self.mobileAdService.map {
             FullScreenAd(

--- a/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
+++ b/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
@@ -31,7 +31,6 @@ struct NonLoginUsecaseFactoryImple: UsecaseFactory {
     let billingUsecase: any BillingUsecase
     let eventLiveActivityUsecase: any EventLiveActivityUsecase
     let imageTextRecognizeService: any ImageTextRecognizeService = ImageTextRecognizeServiceImple()
-    let adViewBuilder: (any AdViewBuilder)?
     let fullScreenAdRouter: (any FullScreenAdRouter)?
     private let applicationBase: ApplicationBase
 
@@ -51,7 +50,6 @@ struct NonLoginUsecaseFactoryImple: UsecaseFactory {
         self.eventSyncUsecase = NotNeedEventSyncUsecase()
         self.applicationBase = applicationBase
         self.billingUsecase = NotNeedBillingUsecase(sharedDataStore: applicationBase.sharedDataStore)
-        self.adViewBuilder = applicationBase.makeAdViewBuilder(billingUsecase: self.billingUsecase)
         self.fullScreenAdRouter = applicationBase.makeFullScreenAdRouter(billingUsecase: self.billingUsecase)
 
         self.aiAgentOrchestrationUsecase = NotNeedAIAgentOrchestrationUsecase()
@@ -392,7 +390,6 @@ struct LoginUsecaseFactoryImple: UsecaseFactory {
     let billingUsecase: any BillingUsecase
     let eventLiveActivityUsecase: any EventLiveActivityUsecase
     let imageTextRecognizeService: any ImageTextRecognizeService = ImageTextRecognizeServiceImple()
-    let adViewBuilder: (any AdViewBuilder)?
     let fullScreenAdRouter: (any FullScreenAdRouter)?
     private let applicationBase: ApplicationBase
 
@@ -499,7 +496,6 @@ struct LoginUsecaseFactoryImple: UsecaseFactory {
             appStoreService: AppStoreBillingServiceImple(),
             sharedDataStore: applicationBase.sharedDataStore
         )
-        self.adViewBuilder = applicationBase.makeAdViewBuilder(billingUsecase: self.billingUsecase)
         self.fullScreenAdRouter = applicationBase.makeFullScreenAdRouter(billingUsecase: self.billingUsecase)
 
         self.eventLiveActivityUsecase = EventLiveActivityUsecaseImple(

--- a/TodoCalendarApp/Sources/Main/MainBuilderImple.swift
+++ b/TodoCalendarApp/Sources/Main/MainBuilderImple.swift
@@ -23,19 +23,22 @@ public final class MainSceneBuilerImple {
     private let calendarSceneBulder: any CalendarSceneBuilder
     private let settingSceneBuilder: any SettingSceneBuiler
     private let mobileAdService: GoogleMobileAdsServiceImple?
+    private let adViewBuilder: (any AdViewBuilder)?
     
     public init(
         usecaseFactory: any UsecaseFactory,
         viewAppearance: ViewAppearance,
         calendarSceneBulder: any CalendarSceneBuilder,
         settingSceneBuilder: any SettingSceneBuiler,
-        mobileAdService: GoogleMobileAdsServiceImple?
+        mobileAdService: GoogleMobileAdsServiceImple?,
+        adViewBuilder: (any AdViewBuilder)?
     ) {
         self.usecaseFactory = usecaseFactory
         self.viewAppearance = viewAppearance
         self.calendarSceneBulder = calendarSceneBulder
         self.settingSceneBuilder = settingSceneBuilder
         self.mobileAdService = mobileAdService
+        self.adViewBuilder = adViewBuilder
     }
 }
 
@@ -62,7 +65,8 @@ extension MainSceneBuilerImple: MainSceneBuiler {
         let viewController = MainViewController(
             viewModel: viewModel,
             viewAppearance: self.viewAppearance,
-            mobileAdService: self.mobileAdService
+            mobileAdService: self.mobileAdService,
+            adViewBuilder: self.adViewBuilder
         )
         
         let router = MainRouter(

--- a/TodoCalendarApp/Sources/Main/MainViewController.swift
+++ b/TodoCalendarApp/Sources/Main/MainViewController.swift
@@ -24,6 +24,7 @@ final class MainViewController: UIViewController, MainScene {
     private let headerAreaStackView = UIStackView()
     private let headerView = HeaderView()
     private let calendarContainerView = UIView()
+    private let bottomBannerView: UIView?
     private let loadingAllEventsLabel = UILabel()
     private let compositeLoadingBarView = CompositeLoadingBarView()
     
@@ -40,11 +41,13 @@ final class MainViewController: UIViewController, MainScene {
     init(
         viewModel: any MainViewModel,
         viewAppearance: ViewAppearance,
-        mobileAdService: GoogleMobileAdsServiceImple?
+        mobileAdService: GoogleMobileAdsServiceImple?,
+        adViewBuilder: (any AdViewBuilder)?
     ) {
         self.viewModel = viewModel
         self.viewAppearance = viewAppearance
         self.mobileAdService = mobileAdService
+        self.bottomBannerView = adViewBuilder?.makeBannerUIView(size: .banner)
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -218,12 +221,25 @@ extension MainViewController {
             $0.heightAnchor.constraint(equalToConstant: 3.2)
         }
         
+        self.bottomBannerView.map { self.setupBottomBannerLayout($0) }
+        
         self.view.addSubview(calendarContainerView)
         calendarContainerView.autoLayout.active(with: self.view) {
             $0.leadingAnchor.constraint(equalTo: $1.safeAreaLayoutGuide.leadingAnchor)
             $0.trailingAnchor.constraint(equalTo: $1.safeAreaLayoutGuide.trailingAnchor)
             $0.topAnchor.constraint(equalTo: headerAreaStackView.bottomAnchor, constant: 14)
-            $0.bottomAnchor.constraint(equalTo: $1.bottomAnchor)
+            $0.bottomAnchor.constraint(
+                equalTo: self.bottomBannerView?.topAnchor ?? $1.bottomAnchor
+            )
+        }
+    }
+    
+    // 로드 전·실패·유료 플랜이면 배너가 intrinsic size 0 이라 캘린더가 하단까지 채운다
+    private func setupBottomBannerLayout(_ bannerView: UIView) {
+        self.view.addSubview(bannerView)
+        bannerView.autoLayout.active(with: self.view) {
+            $0.centerXAnchor.constraint(equalTo: $1.centerXAnchor)
+            $0.bottomAnchor.constraint(equalTo: $1.safeAreaLayoutGuide.bottomAnchor)
         }
     }
     

--- a/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
@@ -487,7 +487,8 @@ extension ApplicationRootRouter {
     private func aiAgentCommandSceneBuilder() -> any AIAgentCommandSceneBuilder {
         return AIAgentCommandBuilderImple(
             usecaseFactory: self.usecaseFactory,
-            viewAppearance: self.viewAppearanceStore.appearance
+            viewAppearance: self.viewAppearanceStore.appearance,
+            adViewBuilder: self.adViewBuilder()
         )
     }
 

--- a/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootRouter.swift
@@ -391,12 +391,22 @@ extension ApplicationRootRouter {
             viewAppearance: self.viewAppearanceStore.appearance,
             calendarSceneBulder: self.calendarSceneBulder(),
             settingSceneBuilder: self.settingSceneBuilder(),
-            mobileAdService: self.applicationBase.mobileAdService
+            mobileAdService: self.applicationBase.mobileAdService,
+            adViewBuilder: self.adViewBuilder()
         )
         let mainScene = builder.makeMainScene()
         self.window.rootViewController = mainScene
         self.window.makeKeyAndVisible()
         return mainScene.interactor
+    }
+    
+    private func adViewBuilder() -> (any AdViewBuilder)? {
+        return self.applicationBase.mobileAdService.map {
+            ApplicationAdViewBuilder(
+                adService: $0,
+                billingUsecase: self.usecaseFactory.billingUsecase
+            )
+        }
     }
     
     private func calendarSceneBulder() -> any CalendarSceneBuilder {

--- a/docs/troubleshooting/2026-08-22-ad-banner-plan-binding-main-actor-crash.md
+++ b/docs/troubleshooting/2026-08-22-ad-banner-plan-binding-main-actor-crash.md
@@ -1,0 +1,16 @@
+---
+issue: "#954"
+subdomain: Billing
+symptoms: [배너 광고 크래시, _swift_task_checkIsolatedSwift, dispatch_assert_queue_fail, bindLoadWhenFreePlanConfirmed, swift_task_isCurrentExecutorWithFlags, MainActor 격리 위반]
+resolution: fixed
+---
+
+# 캘린더 하단 배너를 붙이자 플랜 구독 합성에서 격리 어서션 크래시
+
+- **증상**: 캘린더 화면 진입 후 `AdBannerUIView.bindLoadWhenFreePlanConfirmed`의 클로저에서 `dispatch_assert_queue_fail` 크래시. 스택 상단이 `_swift_task_checkIsolatedSwift` → `swift_task_isCurrentExecutorWithFlags`. `AIAgentUsageUsecaseImple.loadUsage()`가 `SharedDataStore.put`으로 `billingUserPlan` 키를 채우는 시점이 트리거.
+
+- **근본 원인**: `AdBannerUIView`는 UIView라 `@MainActor` 격리 타입이고 그 메서드 안의 `.map` 클로저도 격리를 물려받는다. 그런데 `.receive(on: RunLoop.main)`이 `.map` **뒤에** 있어서 map은 upstream 방출 스레드에서 돌았다. upstream인 `SharedDataStore.observe`는 `serial-sharedDataStore-event` 백그라운드 큐로 방출하므로 Swift 6 런타임 격리 체크가 트랩했다. #898·#956이 만든 잠복 결함으로, #954가 첫 프로덕션 소비처를 붙이면서 드러났다.
+
+- **해결**: `.receive(on: RunLoop.main)`을 `CombineLatest` 직후·`.map` 앞으로 옮겼다. map·removeDuplicates·sink·apply가 전부 메인에서 돈다.
+
+- **기각 방향**: map 클로저를 `nonisolated`로 분리 — 체인에 연산자가 하나 더 붙으면 같은 함정이 재발해 자리마다 심어야 유지되는 증상 패치다. / `SharedDataStore.observe`를 메인 방출로 변경 — 전 도메인 소비자에 영향이 가는데 원인은 한 소비처의 훅 위치다.

--- a/docs/troubleshooting/INDEX.md
+++ b/docs/troubleshooting/INDEX.md
@@ -25,3 +25,4 @@
 - [2026-08-16 공유 미리보기에서 일부 기본 이벤트의 태그명이 안 나온다](2026-08-16-share-preview-deleted-tag-name-missing.md) — Event / fixed / 태그명 안나옴, 삭제된 태그, 드롭다운 빈 항목, tagName nil, stub이 미스를 못 만듦
 - [2026-08-22 DayEventList 라이브액티비티 해제 표시 테스트 간헐 타임아웃](2026-08-22-dayeventlist-live-activity-clear-mark-flaky.md) — Event / deferred / whenLiveActivityUnregistered_cellViewModelsClearMark·Exceeded timeout of 2 seconds·간헐 실패
 - [2026-08-22 구글 이벤트 개별 색상이 라이브액티비티에서 무시됨](2026-08-22-google-event-custom-color-ignored-in-live-activity.md) — ExternalCalendar / fixed / 구글 이벤트 색상·커스텀 색상 무시·라이브액티비티 색·colorId
+- [2026-08-22 캘린더 하단 배너를 붙이자 플랜 구독 합성에서 격리 어서션 크래시](2026-08-22-ad-banner-plan-binding-main-actor-crash.md) — Billing / fixed / 배너 광고 크래시·_swift_task_checkIsolatedSwift·dispatch_assert_queue_fail·MainActor 격리 위반


### PR DESCRIPTION
#898·#956으로 배너 인프라(`AdBannerUIView`·`AdViewBuilder`·free 플랜 게이팅)는 갖춰졌는데 프로덕션 소비처가 없었다. 노출 지점 두 곳을 붙인다.

## 캘린더 화면 하단 (#954)

`MainViewController`의 safe area 하단에 배너를 고정하고 `calendarContainerView` 하단을 배너 top으로 옮겼다. `CalendarPaper` **바깥**이라는 게 핵심 — 페이퍼는 이전달·이번달·다음달 3장이 동시에 붙어 페이징되므로 안에 두면 배너가 3개 생기고 그중 2개가 화면 밖에서 로드된다.

`AdViewBuilder`는 `ApplicationRootRouter`가 직접 만들어 씬 빌더에 넘긴다. 소비처가 메인 씬 하나뿐이라 `ApplicationBase.makeAdViewBuilder`와 팩토리 두 곳의 저장 프로퍼티는 중개 자리로만 남아 걷어냈다.

붙이고 나서 크래시가 났다. `AdBannerUIView`가 UIView라 `@MainActor` 격리인데 `receive(on: RunLoop.main)`이 `map` 뒤에 있어, 격리를 물려받은 map 클로저가 `SharedDataStore`의 백그라운드 방출 스레드에서 돌았다. 훅을 `CombineLatest` 직후로 옮겨 해소 (`docs/troubleshooting/2026-08-22-ad-banner-plan-binding-main-actor-crash.md`).

## AI 커맨드 처리 중 시트 (#955)

`processing` 상태의 타이핑 말풍선과 중지 버튼 사이에 MREC(300x250)를 얹었다. `AIAgentScene`은 SDK를 의존할 수 없으니 `CommonPresentation.AdViewBuilder`를 init 프로퍼티로 받는다 (`SignInButtonProvider` 선례). 기본값 `nil`이라 프리뷰·스냅샷 16곳은 배너 없는 경로를 그대로 탄다.

로드 지연 가드는 넣지 않았다 — `processing`이 끝나면 뷰가 언마운트돼 "안 띄움"은 자동으로 성립하고, 남는 종료 직전 깜빡임을 막으려면 `AdViewBuilder`에 로드 완료 콜백을 뚫어야 한다.

## 검증

광고 뷰는 SDK 의존이라 유닛·스냅샷으로 못 덮는다. 실물 판정 기준은 #954·#955 코멘트에 인계했다.

두 지점 모두 배너가 없거나(유료 플랜) 로드 전이면 레이아웃이 조금 달라진다 — 캘린더는 하단 34pt(홈 인디케이터 아래로 스크롤되던 영역), 시트는 12pt(높이 0 배너가 먹는 VStack spacing 한 칸). 상세는 각 이슈 코멘트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKN6K8AW1UkaVQowFg78H6
