### PR TITLE
[#983] 앱 업데이트 정보 조회처를 TodoCalendar-Terms 레포로 이전

### DIFF
--- a/Repository/Sources/Remote/Endpoint.swift
+++ b/Repository/Sources/Remote/Endpoint.swift
@@ -421,7 +421,7 @@ public struct RemoteEnvironment: Sendable {
             return appendSubpathIfNotEmpty(prefix, googleCalendar.subPath)
 
         case let app as AppEndpoints:
-            let prefix = "https://raw.githubusercontent.com/sudopark/TodoCalendar/develop/app-config"
+            let prefix = "https://raw.githubusercontent.com/sudopark/TodoCalendar-Terms/main/app-config"
             return appendSubpathIfNotEmpty(prefix, app.subPath)
 
         case let ai as AIAPIEndpoints:

--- a/Repository/Tests/Remote/RemoteEnvironmentPathTests.swift
+++ b/Repository/Tests/Remote/RemoteEnvironmentPathTests.swift
@@ -75,3 +75,16 @@ extension RemoteEnvironmentPathTests {
         #expect(path == "https://api.example.com/v1/billing/purchases")
     }
 }
+
+
+// MARK: - calendarAPIHost 밖 고정 호스트 엔드포인트 검증
+
+extension RemoteEnvironmentPathTests {
+
+    @Test func path_appUpdateInfoEndpoint_returnsTermsRepositoryRawURL() {
+        // when
+        let path = self.env.path(AppEndpoints.updateInfo)
+        // then
+        #expect(path == "https://raw.githubusercontent.com/sudopark/TodoCalendar-Terms/main/app-config/update-info.json")
+    }
+}

--- a/docs/spec/infrastructure.md
+++ b/docs/spec/infrastructure.md
@@ -318,8 +318,8 @@ ApplicationDeepLinkHandlerImple:
 
 ### 7.1 원격 설정
 
-**위치**: `app-config/update-info.json` (저장소 루트의 `app-config/` 디렉토리)
-**서빙**: `https://raw.githubusercontent.com/sudopark/TodoCalendar/develop/app-config/update-info.json` (GitHub raw URL)
+**위치**: `sudopark/TodoCalendar-Terms` 레포 `main` 브랜치의 `app-config/update-info.json`
+**서빙**: `https://raw.githubusercontent.com/sudopark/TodoCalendar-Terms/main/app-config/update-info.json` (GitHub raw URL)
 **포맷**:
 ```json
 {
@@ -333,6 +333,7 @@ ApplicationDeepLinkHandlerImple:
 - `force_update_version` / `recommend_update_version` — 업데이트 **강제·권장 하한선**. 팝업 트리거용.
 - `latest_version` — **스토어에 올라간 최신 배포 버전**. 설정 화면의 "업데이트 가능" 안내(비강제) 판정용.
 - 디코딩은 Repository 레이어의 `AppUpdateInfoMapper`가 담당. Domain 모델 `AppUpdateInfo`는 Decodable 채택하지 않음.
+- 이 저장소 루트의 `app-config/update-info.json`은 2.9.6 이하 구버전 앱이 여전히 바라보는 옛 경로다 (#983). 구버전을 2.9.7 이상으로 밀어낼 때까지 함께 갱신해야 하며, 그 전에 이 저장소를 비공개로 돌리면 구버전은 §7.6대로 업데이트 안내를 전혀 못 받는다.
 
 ### 7.2 판정 알고리즘
 
@@ -415,7 +416,7 @@ ApplicationDeepLinkHandlerImple:
 | Root VM | `TodoCalendarApp/Sources/Root/ApplicationRootViewModel.swift`의 `bindUpdateRequirement` + `handleWillEnterForeground` |
 | Setting VM | `Presentations/SettingScene/Sources/Setting/SettingItemListViewModel.swift`의 `isUpdateAvailable` 구독 + `openAppUpdate()` |
 | Factory | `Presentations/Scenes/Sources/Factories.swift` `SupportUsecaseFactory.appUpdateCheckUsecase` (단일 인스턴스 공유 계약) |
-| 원격 설정 | `app-config/update-info.json` |
+| 원격 설정 | `sudopark/TodoCalendar-Terms` 레포의 `app-config/update-info.json` |
 
 ### 7.6 한계 / 후속 과제
 


### PR DESCRIPTION
## 문제

앱 업데이트 정보(`update-info.json`)가 앱 소스 레포에 같이 들어 있어서, 앱 레포를 비공개로 돌리는 순간 설정 서빙도 같이 끊긴다. 설정은 앱 소스와 수명 주기가 다르니 공개 유지가 필요한 정적 컨텐츠 레포(`sudopark/TodoCalendar-Terms` — 약관·개인정보처리방침·서비스 가이드가 이미 여기 있다)로 옮긴다.

## 접근

`sudopark/TodoCalendar-Terms` `main` 브랜치에 `app-config/update-info.json` 을 추가하고 (sudopark/TodoCalendar-Terms@6cce5c9), 앱이 그쪽을 보게 한다.

- `RemoteEnvironment.path` — `AppEndpoints` prefix 를 `TodoCalendar/develop/app-config` → `TodoCalendar-Terms/main/app-config` 로 변경
- `RemoteEnvironmentPathTests` — 고정 호스트 엔드포인트 회귀 테스트 추가. 기존 케이스는 전부 `calendarAPIHost` 기반이라 이 계열이 비어 있었다
- `docs/spec/infrastructure.md` §7.1·§7.5 — 위치·서빙 URL 갱신

**이 레포의 `app-config/` 는 지우지 않았다.** 2.9.6 이하 앱은 여전히 옛 URL 을 보는데, `AppUpdateCheckUsecaseImple.loadUpdateInfoWithoutError` 가 실패를 nil 로 삼켜서(§7.6) 지금 끊으면 구버전이 강제 업데이트 팝업조차 못 받고 영영 갇힌다.

`appVersion` bump 도 뺐다 — 릴리즈 시점에 별도로.

## 남은 과제

코드 밖 운영 작업이고, 순서를 지켜야 한다:

1. 2.9.7 배포
2. **이 레포** `app-config/update-info.json` 의 `force_update_version` 을 2.9.7 로 올려 구버전을 밀어내기
3. 충분히 전환된 뒤 앱 레포 비공개 + 이 레포의 `app-config/` 삭제

이후 설정 갱신은 `TodoCalendar-Terms` 쪽 파일이 정본.

Closes #983
