### PR TITLE
[#983] 앱 업데이트 정보 조회처를 TodoCalendar-Terms 레포로 이전

### DIFF
--- a/Repository/Sources/Remote/Endpoint.swift
+++ b/Repository/Sources/Remote/Endpoint.swift
@@ -421,7 +421,7 @@ public struct RemoteEnvironment: Sendable {
             return appendSubpathIfNotEmpty(prefix, googleCalendar.subPath)
 
         case let app as AppEndpoints:
-            let prefix = "https://raw.githubusercontent.com/sudopark/TodoCalendar/develop/app-config"
+            let prefix = "https://raw.githubusercontent.com/sudopark/TodoCalendar-Terms/main/app-config"
             return appendSubpathIfNotEmpty(prefix, app.subPath)
 
         case let ai as AIAPIEndpoints:

--- a/Repository/Tests/Remote/RemoteEnvironmentPathTests.swift
+++ b/Repository/Tests/Remote/RemoteEnvironmentPathTests.swift
@@ -75,3 +75,16 @@ extension RemoteEnvironmentPathTests {
         #expect(path == "https://api.example.com/v1/billing/purchases")
     }
 }
+
+
+// MARK: - calendarAPIHost 밖 고정 호스트 엔드포인트 검증
+
+extension RemoteEnvironmentPathTests {
+
+    @Test func path_appUpdateInfoEndpoint_returnsTermsRepositoryRawURL() {
+        // when
+        let path = self.env.path(AppEndpoints.updateInfo)
+        // then
+        #expect(path == "https://raw.githubusercontent.com/sudopark/TodoCalendar-Terms/main/app-config/update-info.json")
+    }
+}

--- a/docs/spec/infrastructure.md
+++ b/docs/spec/infrastructure.md
@@ -318,8 +318,8 @@ ApplicationDeepLinkHandlerImple:
 
 ### 7.1 원격 설정
 
-**위치**: `app-config/update-info.json` (저장소 루트의 `app-config/` 디렉토리)
-**서빙**: `https://raw.githubusercontent.com/sudopark/TodoCalendar/develop/app-config/update-info.json` (GitHub raw URL)
+**위치**: `sudopark/TodoCalendar-Terms` 레포 `main` 브랜치의 `app-config/update-info.json`
+**서빙**: `https://raw.githubusercontent.com/sudopark/TodoCalendar-Terms/main/app-config/update-info.json` (GitHub raw URL)
 **포맷**:
 ```json
 {
@@ -333,6 +333,7 @@ ApplicationDeepLinkHandlerImple:
 - `force_update_version` / `recommend_update_version` — 업데이트 **강제·권장 하한선**. 팝업 트리거용.
 - `latest_version` — **스토어에 올라간 최신 배포 버전**. 설정 화면의 "업데이트 가능" 안내(비강제) 판정용.
 - 디코딩은 Repository 레이어의 `AppUpdateInfoMapper`가 담당. Domain 모델 `AppUpdateInfo`는 Decodable 채택하지 않음.
+- 이 저장소 루트의 `app-config/update-info.json`은 2.9.6 이하 구버전 앱이 여전히 바라보는 옛 경로다 (#983). 구버전을 2.9.7 이상으로 밀어낼 때까지 함께 갱신해야 하며, 그 전에 이 저장소를 비공개로 돌리면 구버전은 §7.6대로 업데이트 안내를 전혀 못 받는다.
 
 ### 7.2 판정 알고리즘
 
@@ -415,7 +416,7 @@ ApplicationDeepLinkHandlerImple:
 | Root VM | `TodoCalendarApp/Sources/Root/ApplicationRootViewModel.swift`의 `bindUpdateRequirement` + `handleWillEnterForeground` |
 | Setting VM | `Presentations/SettingScene/Sources/Setting/SettingItemListViewModel.swift`의 `isUpdateAvailable` 구독 + `openAppUpdate()` |
 | Factory | `Presentations/Scenes/Sources/Factories.swift` `SupportUsecaseFactory.appUpdateCheckUsecase` (단일 인스턴스 공유 계약) |
-| 원격 설정 | `app-config/update-info.json` |
+| 원격 설정 | `sudopark/TodoCalendar-Terms` 레포의 `app-config/update-info.json` |
 
 ### 7.6 한계 / 후속 과제
 


### PR DESCRIPTION
- RemoteEnvironment.path — AppEndpoints prefix 를 앱 레포 develop/app-config 에서 sudopark/TodoCalendar-Terms main/app-config 로 변경
- RemoteEnvironmentPathTests.path_appUpdateInfoEndpoint_returnsTermsRepositoryRawURL — 고정 호스트 엔드포인트 회귀 테스트 추가

이 저장소의 app-config/ 는 남겨둔다. 2.9.6 이하 앱이 여전히 옛 URL 을 보는데 loadUpdateInfoWithoutError 가 실패를 삼켜서, 지금 끊으면 구버전이 강제 업데이트 팝업조차 못 받는다.


Claude-Session: https://claude.ai/code/session_01NwttEcCB9zPS9CoLEuFf1Q