### PR TITLE
[#881] 약관·개인정보처리방침 개정 앱 내 고지 배너

### DIFF
--- a/Domain/Sources/Models/LegalNotice.swift
+++ b/Domain/Sources/Models/LegalNotice.swift
@@ -1,0 +1,36 @@
+//
+//  LegalNotice.swift
+//  Domain
+//
+//  Created by sudo.park on 8/23/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+public enum LegalDocumentType: String, Sendable, CaseIterable {
+    case terms
+    case privacy
+
+    public var linkPath: String {
+        switch self {
+        case .terms: return LegalLink.termsPath
+        case .privacy: return LegalLink.privacyPolicyPath
+        }
+    }
+}
+
+public struct LegalNoticeUpdateInfo: Sendable, Equatable {
+
+    public let id: String
+    public let documentType: LegalDocumentType
+    public let effectiveDate: Date
+
+    public init(id: String, documentType: LegalDocumentType, effectiveDate: Date) {
+        self.id = id
+        self.documentType = documentType
+        self.effectiveDate = effectiveDate
+    }
+}
+
+public typealias LegalNoticeUpdates = [LegalDocumentType: LegalNoticeUpdateInfo]

--- a/Domain/Sources/Repositories/LegalNoticeRepository.swift
+++ b/Domain/Sources/Repositories/LegalNoticeRepository.swift
@@ -1,0 +1,16 @@
+//
+//  LegalNoticeRepository.swift
+//  Domain
+//
+//  Created by sudo.park on 8/23/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+public protocol LegalNoticeRepository: Sendable {
+
+    func loadNoticeUpdates() async throws -> LegalNoticeUpdates
+    func fetchConfirmedNoticeId(_ documentType: LegalDocumentType) -> String?
+    func updateConfirmedNoticeId(_ id: String, for documentType: LegalDocumentType)
+}

--- a/Domain/Sources/Usecases/Support/LegalNoticeUsecase.swift
+++ b/Domain/Sources/Usecases/Support/LegalNoticeUsecase.swift
@@ -1,0 +1,105 @@
+//
+//  LegalNoticeUsecase.swift
+//  Domain
+//
+//  Created by sudo.park on 8/23/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Combine
+import CombineExt
+import AsyncFlatMap
+import Extensions
+
+
+// MARK: - LegalNoticeUsecase
+
+public protocol LegalNoticeUsecase: Sendable {
+    func checkNoticeIsNeed()
+    var pendingNoticeUpdates: AnyPublisher<[LegalNoticeUpdateInfo], Never> { get }
+    func confirmNotice(_ documentType: LegalDocumentType)
+}
+
+
+// MARK: - LegalNoticeUsecaseImple
+
+public final class LegalNoticeUsecaseImple: LegalNoticeUsecase, @unchecked Sendable {
+
+    private let legalNoticeRepository: any LegalNoticeRepository
+
+    public init(legalNoticeRepository: any LegalNoticeRepository) {
+        self.legalNoticeRepository = legalNoticeRepository
+        self.bindCheckTrigger()
+    }
+
+    private struct Subject {
+        let checkTrigger = PassthroughSubject<Void, Never>()
+        let pendingUpdates = CurrentValueSubject<[LegalNoticeUpdateInfo], Never>([])
+    }
+    private let subject = Subject()
+    private var cancellables: Set<AnyCancellable> = []
+}
+
+
+extension LegalNoticeUsecaseImple {
+
+    public func checkNoticeIsNeed() {
+        self.subject.checkTrigger.send(())
+    }
+
+    private func bindCheckTrigger() {
+
+        self.subject.checkTrigger
+            .mapAsAnyError()
+            .flatMapLatest { [weak self] in
+                return self?.loadUpdatesWithoutError() ?? Empty().eraseToAnyPublisher()
+            }
+            .map { [weak self] updates -> [LegalNoticeUpdateInfo] in
+                guard let self else { return [] }
+                return self.unconfirmedUpdates(from: updates)
+            }
+            .sink(receiveValue: { [weak self] updates in
+                self?.subject.pendingUpdates.send(updates)
+            })
+            .store(in: &self.cancellables)
+    }
+
+    private func loadUpdatesWithoutError() -> AnyPublisher<LegalNoticeUpdates, any Error> {
+        let repository = self.legalNoticeRepository
+        return Publishers.create(do: {
+            do {
+                return try await repository.loadNoticeUpdates()
+            } catch {
+                return [:] as LegalNoticeUpdates
+            }
+        })
+        .eraseToAnyPublisher()
+    }
+
+    private func unconfirmedUpdates(from updates: LegalNoticeUpdates) -> [LegalNoticeUpdateInfo] {
+        return LegalDocumentType.allCases.compactMap { documentType -> LegalNoticeUpdateInfo? in
+            guard let info = updates[documentType],
+                  info.id != self.legalNoticeRepository.fetchConfirmedNoticeId(documentType)
+            else { return nil }
+            return info
+        }
+    }
+}
+
+extension LegalNoticeUsecaseImple {
+
+    public var pendingNoticeUpdates: AnyPublisher<[LegalNoticeUpdateInfo], Never> {
+        return self.subject.pendingUpdates
+            .eraseToAnyPublisher()
+    }
+
+    public func confirmNotice(_ documentType: LegalDocumentType) {
+        guard let info = self.subject.pendingUpdates.value.first(where: { $0.documentType == documentType })
+        else { return }
+        self.legalNoticeRepository.updateConfirmedNoticeId(info.id, for: documentType)
+        self.subject.pendingUpdates.send(
+            self.subject.pendingUpdates.value.filter { $0.documentType != documentType }
+        )
+    }
+}

--- a/Domain/Tests/Usecases/LegalNoticeUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/LegalNoticeUsecaseImpleTests.swift
@@ -1,0 +1,263 @@
+//
+//  LegalNoticeUsecaseImpleTests.swift
+//  DomainTests
+//
+//  Created by sudo.park on 8/23/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Combine
+import Extensions
+import UnitTestHelpKit
+
+@testable import Domain
+
+
+final class LegalNoticeUsecaseImpleTests: PublisherWaitable {
+
+    var cancelBag: Set<AnyCancellable>! = .init()
+
+    private let fixedDate = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func makeUsecase(
+        updates: LegalNoticeUpdates = [:],
+        confirmedIds: [LegalDocumentType: String] = [:],
+        shouldFail: Bool = false
+    ) -> (LegalNoticeUsecaseImple, StubLegalNoticeRepository) {
+        let stubRepository = StubLegalNoticeRepository(
+            updates: updates, confirmedIds: confirmedIds, shouldFail: shouldFail
+        )
+        let usecase = LegalNoticeUsecaseImple(legalNoticeRepository: stubRepository)
+        return (usecase, stubRepository)
+    }
+
+    private func info(_ documentType: LegalDocumentType, id: String) -> LegalNoticeUpdateInfo {
+        return LegalNoticeUpdateInfo(id: id, documentType: documentType, effectiveDate: self.fixedDate)
+    }
+}
+
+
+// MARK: - 미확인 고지 판정
+
+extension LegalNoticeUsecaseImpleTests {
+
+    @Test func usecase_whenUnconfirmedUpdatesExist_emitsThemSortedByDocumentType() async throws {
+        // given
+        let termsInfo = self.info(.terms, id: "terms-1")
+        let privacyInfo = self.info(.privacy, id: "privacy-1")
+        let expect = expectConfirm("미확인 고지 문서 순서대로 방출")
+        expect.count = 2
+        let (usecase, _) = self.makeUsecase(
+            updates: [.privacy: privacyInfo, .terms: termsInfo]
+        )
+
+        // when
+        let updates = try await self.outputs(expect, for: usecase.pendingNoticeUpdates) {
+            usecase.checkNoticeIsNeed()
+        }
+
+        // then
+        #expect(updates == [[], [termsInfo, privacyInfo]])
+    }
+
+    @Test func usecase_whenSomeDocumentAlreadyConfirmed_emitsOnlyUnconfirmedOnes() async throws {
+        // given
+        let termsInfo = self.info(.terms, id: "terms-1")
+        let privacyInfo = self.info(.privacy, id: "privacy-1")
+        let expect = expectConfirm("확인한 문서는 빠지고 나머지만 방출")
+        expect.count = 2
+        let (usecase, _) = self.makeUsecase(
+            updates: [.terms: termsInfo, .privacy: privacyInfo],
+            confirmedIds: [.terms: "terms-1"]
+        )
+
+        // when
+        let updates = try await self.outputs(expect, for: usecase.pendingNoticeUpdates) {
+            usecase.checkNoticeIsNeed()
+        }
+
+        // then
+        #expect(updates == [[], [privacyInfo]])
+    }
+
+    @Test func usecase_whenAllDocumentsConfirmed_emitsEmpty() async throws {
+        // given
+        let termsInfo = self.info(.terms, id: "terms-1")
+        let privacyInfo = self.info(.privacy, id: "privacy-1")
+        let expect = expectConfirm("전부 확인했으면 빈 배열")
+        expect.count = 2
+        let (usecase, _) = self.makeUsecase(
+            updates: [.terms: termsInfo, .privacy: privacyInfo],
+            confirmedIds: [.terms: "terms-1", .privacy: "privacy-1"]
+        )
+
+        // when
+        let updates = try await self.outputs(expect, for: usecase.pendingNoticeUpdates) {
+            usecase.checkNoticeIsNeed()
+        }
+
+        // then
+        #expect(updates == [[], []])
+    }
+
+    @Test func usecase_whenRemoteHasNoUpdates_emitsEmpty() async throws {
+        // given
+        let expect = expectConfirm("원격에 갱신 없으면 빈 배열")
+        expect.count = 2
+        let (usecase, _) = self.makeUsecase(updates: [:])
+
+        // when
+        let updates = try await self.outputs(expect, for: usecase.pendingNoticeUpdates) {
+            usecase.checkNoticeIsNeed()
+        }
+
+        // then
+        #expect(updates == [[], []])
+    }
+
+    @Test func usecase_whenLoadFails_emitsEmpty() async throws {
+        // given
+        let termsInfo = self.info(.terms, id: "terms-1")
+        let expect = expectConfirm("조회 실패해도 빈 배열")
+        expect.count = 2
+        let (usecase, _) = self.makeUsecase(updates: [.terms: termsInfo], shouldFail: true)
+
+        // when
+        let updates = try await self.outputs(expect, for: usecase.pendingNoticeUpdates) {
+            usecase.checkNoticeIsNeed()
+        }
+
+        // then
+        #expect(updates == [[], []])
+    }
+}
+
+
+// MARK: - 고지 확인 처리
+
+extension LegalNoticeUsecaseImpleTests {
+
+    @Test func usecase_confirmNotice_persistsIdForThatDocumentTypeOnly() async throws {
+        // given
+        let termsInfo = self.info(.terms, id: "terms-1")
+        let privacyInfo = self.info(.privacy, id: "privacy-1")
+        let expect = expectConfirm("confirm 은 해당 문서 id 만 저장")
+        expect.count = 3
+        let (usecase, stubRepository) = self.makeUsecase(
+            updates: [.terms: termsInfo, .privacy: privacyInfo]
+        )
+
+        // when
+        _ = try await self.outputs(expect, for: usecase.pendingNoticeUpdates) {
+            usecase.checkNoticeIsNeed()
+            try await Task.sleep(for: .milliseconds(50))
+            usecase.confirmNotice(.terms)
+        }
+
+        // then
+        #expect(stubRepository.didUpdateConfirmedId?.id == "terms-1")
+        #expect(stubRepository.didUpdateConfirmedId?.documentType == .terms)
+        #expect(stubRepository.fetchConfirmedNoticeId(.privacy) == nil)
+    }
+
+    @Test func usecase_confirmNotice_removesOnlyThatDocumentFromPending() async throws {
+        // given
+        let termsInfo = self.info(.terms, id: "terms-1")
+        let privacyInfo = self.info(.privacy, id: "privacy-1")
+        let expect = expectConfirm("confirm 한 문서만 pending 에서 빠진다")
+        expect.count = 3
+        let (usecase, _) = self.makeUsecase(
+            updates: [.terms: termsInfo, .privacy: privacyInfo]
+        )
+
+        // when
+        let updates = try await self.outputs(expect, for: usecase.pendingNoticeUpdates) {
+            usecase.checkNoticeIsNeed()
+            try await Task.sleep(for: .milliseconds(50))
+            usecase.confirmNotice(.terms)
+        }
+
+        // then
+        #expect(updates == [[], [termsInfo, privacyInfo], [privacyInfo]])
+    }
+
+    @Test func usecase_confirmNotice_whenDocumentNotPending_doesNothing() async throws {
+        // given
+        let termsInfo = self.info(.terms, id: "terms-1")
+        let expect = expectConfirm("pending 에 없는 문서는 confirm 해도 무시")
+        expect.count = 2
+        let (usecase, stubRepository) = self.makeUsecase(
+            updates: [.terms: termsInfo]
+        )
+
+        // when
+        let updates = try await self.outputs(expect, for: usecase.pendingNoticeUpdates) {
+            usecase.checkNoticeIsNeed()
+            try await Task.sleep(for: .milliseconds(50))
+            usecase.confirmNotice(.privacy)
+        }
+
+        // then
+        #expect(updates == [[], [termsInfo]])
+        #expect(stubRepository.didUpdateConfirmedId == nil)
+    }
+
+    @Test func usecase_afterConfirm_recheckKeepsItConfirmed() async throws {
+        // given
+        let termsInfo = self.info(.terms, id: "terms-1")
+        let privacyInfo = self.info(.privacy, id: "privacy-1")
+        let expect = expectConfirm("confirm 후 재체크해도 확인한 문서는 안 돌아온다")
+        expect.count = 4
+        let (usecase, _) = self.makeUsecase(
+            updates: [.terms: termsInfo, .privacy: privacyInfo]
+        )
+
+        // when
+        let updates = try await self.outputs(expect, for: usecase.pendingNoticeUpdates) {
+            usecase.checkNoticeIsNeed()
+            try await Task.sleep(for: .milliseconds(50))
+            usecase.confirmNotice(.terms)
+            try await Task.sleep(for: .milliseconds(50))
+            usecase.checkNoticeIsNeed()
+        }
+
+        // then
+        #expect(updates == [[], [termsInfo, privacyInfo], [privacyInfo], [privacyInfo]])
+    }
+}
+
+
+// MARK: - Stub
+
+private final class StubLegalNoticeRepository: LegalNoticeRepository, @unchecked Sendable {
+
+    private let updates: LegalNoticeUpdates
+    private let shouldFail: Bool
+    private var confirmedIds: [LegalDocumentType: String]
+    private(set) var didUpdateConfirmedId: (id: String, documentType: LegalDocumentType)?
+
+    init(
+        updates: LegalNoticeUpdates = [:],
+        confirmedIds: [LegalDocumentType: String] = [:],
+        shouldFail: Bool = false
+    ) {
+        self.updates = updates
+        self.confirmedIds = confirmedIds
+        self.shouldFail = shouldFail
+    }
+
+    func loadNoticeUpdates() async throws -> LegalNoticeUpdates {
+        if self.shouldFail { throw RuntimeError("load notice updates failed") }
+        return self.updates
+    }
+
+    func fetchConfirmedNoticeId(_ documentType: LegalDocumentType) -> String? {
+        return self.confirmedIds[documentType]
+    }
+
+    func updateConfirmedNoticeId(_ id: String, for documentType: LegalDocumentType) {
+        self.confirmedIds[documentType] = id
+        self.didUpdateConfirmedId = (id, documentType)
+    }
+}

--- a/Presentations/Scenes/Sources/Factories.swift
+++ b/Presentations/Scenes/Sources/Factories.swift
@@ -66,6 +66,7 @@ public protocol SupportUsecaseFactory {
 
     func makeFeedbackUsecase() -> any FeedbackUsecase
     func makeGuideTodoUsecase() -> any GuideTodoUsecase
+    func makeLegalNoticeUsecase() -> any LegalNoticeUsecase
     var appUpdateCheckUsecase: any AppUpdateCheckUsecase { get }
 }
 

--- a/Repository/Sources/Remote/Endpoint.swift
+++ b/Repository/Sources/Remote/Endpoint.swift
@@ -253,11 +253,14 @@ enum EventSyncEndPoints: Endpoint {
 
 public enum AppEndpoints: Endpoint {
     case updateInfo
+    case legalNotice
 
     public var subPath: String {
         switch self {
         case .updateInfo:
             return "update-info.json"
+        case .legalNotice:
+            return "legal-notice.json"
         }
     }
 }

--- a/Repository/Sources/Repository+Imple/Support/LegalNotice+Mapping.swift
+++ b/Repository/Sources/Repository+Imple/Support/LegalNotice+Mapping.swift
@@ -1,0 +1,54 @@
+//
+//  LegalNotice+Mapping.swift
+//  Repository
+//
+//  Created by sudo.park on 8/23/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Domain
+
+
+struct LegalNoticeMapper: Decodable {
+
+    let updates: LegalNoticeUpdates
+
+    private struct DocumentCodingKey: CodingKey {
+        let stringValue: String
+        init?(stringValue: String) { self.stringValue = stringValue }
+        var intValue: Int? { nil }
+        init?(intValue: Int) { nil }
+    }
+
+    private enum ItemCodingKeys: String, CodingKey {
+        case id
+        case effectiveDate = "effective_date"
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: DocumentCodingKey.self)
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+
+        let entries: [(LegalDocumentType, LegalNoticeUpdateInfo)] = LegalDocumentType.allCases
+            .compactMap { documentType in
+                guard let codingKey = DocumentCodingKey(stringValue: documentType.rawValue),
+                      let itemContainer = try? container.nestedContainer(
+                        keyedBy: ItemCodingKeys.self, forKey: codingKey
+                      ),
+                      let id = try? itemContainer.decode(String.self, forKey: .id),
+                      let dateString = try? itemContainer.decode(String.self, forKey: .effectiveDate),
+                      let effectiveDate = dateFormatter.date(from: dateString)
+                else { return nil }
+                let info = LegalNoticeUpdateInfo(
+                    id: id, documentType: documentType, effectiveDate: effectiveDate
+                )
+                return (documentType, info)
+            }
+        self.updates = Dictionary(uniqueKeysWithValues: entries)
+    }
+}

--- a/Repository/Sources/Repository+Imple/Support/LegalNoticeRepositoryImple.swift
+++ b/Repository/Sources/Repository+Imple/Support/LegalNoticeRepositoryImple.swift
@@ -1,0 +1,41 @@
+//
+//  LegalNoticeRepositoryImple.swift
+//  Repository
+//
+//  Created by sudo.park on 8/23/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Domain
+
+
+public final class LegalNoticeRepositoryImple: LegalNoticeRepository, @unchecked Sendable {
+
+    private let remoteAPI: any RemoteAPI
+    private let environmentStorage: any EnvironmentStorage
+
+    public init(remoteAPI: any RemoteAPI, environmentStorage: any EnvironmentStorage) {
+        self.remoteAPI = remoteAPI
+        self.environmentStorage = environmentStorage
+    }
+
+    private func confirmedNoticeIdKey(for documentType: LegalDocumentType) -> String {
+        return "confirmed_legal_notice_id_\(documentType.rawValue)"
+    }
+
+    public func loadNoticeUpdates() async throws -> LegalNoticeUpdates {
+        let mapper: LegalNoticeMapper = try await self.remoteAPI.request(
+            .get, AppEndpoints.legalNotice
+        )
+        return mapper.updates
+    }
+
+    public func fetchConfirmedNoticeId(_ documentType: LegalDocumentType) -> String? {
+        return self.environmentStorage.load(self.confirmedNoticeIdKey(for: documentType))
+    }
+
+    public func updateConfirmedNoticeId(_ id: String, for documentType: LegalDocumentType) {
+        self.environmentStorage.update(self.confirmedNoticeIdKey(for: documentType), id)
+    }
+}

--- a/Repository/Tests/Remote/RemoteEnvironmentPathTests.swift
+++ b/Repository/Tests/Remote/RemoteEnvironmentPathTests.swift
@@ -94,4 +94,11 @@ extension RemoteEnvironmentPathTests {
         // then
         #expect(path == "https://raw.githubusercontent.com/sudopark/TodoCalendar-Terms/main/app-config/update-info.json")
     }
+
+    @Test func path_legalNoticeEndpoint_returnsTermsRepositoryRawURL() {
+        // when
+        let path = self.env.path(AppEndpoints.legalNotice)
+        // then
+        #expect(path == "https://raw.githubusercontent.com/sudopark/TodoCalendar-Terms/main/app-config/legal-notice.json")
+    }
 }

--- a/Repository/Tests/Supports/LegalNoticeRepositoryImpleTests.swift
+++ b/Repository/Tests/Supports/LegalNoticeRepositoryImpleTests.swift
@@ -1,0 +1,192 @@
+//
+//  LegalNoticeRepositoryImpleTests.swift
+//  RepositoryTests
+//
+//  Created by sudo.park on 8/23/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Domain
+import Extensions
+
+@testable import Repository
+
+struct LegalNoticeRepositoryImpleTests {
+
+    private func makeRepository(
+        responseJson: String = "{}",
+        shouldFail: Bool = false
+    ) -> LegalNoticeRepositoryImple {
+        let stub = StubRemoteAPI(responses: [
+            .init(endpoint: AppEndpoints.legalNotice, resultJsonString: .success(responseJson))
+        ])
+        stub.shouldFailRequest = shouldFail
+        return LegalNoticeRepositoryImple(
+            remoteAPI: stub, environmentStorage: FakeEnvironmentStorage()
+        )
+    }
+
+    private var utcDateFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter
+    }
+}
+
+// MARK: - loadNoticeUpdates 매핑
+
+extension LegalNoticeRepositoryImpleTests {
+
+    @Test func repository_whenNoUpdates_returnsEmptyUpdates() async throws {
+        // given
+        let repository = self.makeRepository(responseJson: "{}")
+
+        // when
+        let updates = try await repository.loadNoticeUpdates()
+
+        // then
+        #expect(updates.isEmpty)
+    }
+
+    @Test func repository_loadNoticeUpdates_mapsBothDocuments() async throws {
+        // given
+        let json = """
+        {
+          "terms": { "id": "2026-09-01-terms", "effective_date": "2026-09-01" },
+          "privacy": { "id": "2026-09-15-privacy", "effective_date": "2026-09-15" }
+        }
+        """
+        let repository = self.makeRepository(responseJson: json)
+
+        // when
+        let updates = try await repository.loadNoticeUpdates()
+
+        // then
+        #expect(updates[.terms]?.id == "2026-09-01-terms")
+        #expect(updates[.terms]?.documentType == .terms)
+        #expect(updates[.terms]?.effectiveDate == self.utcDateFormatter.date(from: "2026-09-01"))
+        #expect(updates[.privacy]?.id == "2026-09-15-privacy")
+        #expect(updates[.privacy]?.effectiveDate == self.utcDateFormatter.date(from: "2026-09-15"))
+    }
+
+    @Test func repository_whenTopLevelKeyUnknown_returnsEmptyUpdates() async throws {
+        // given
+        let json = """
+        { "unknown": { "id": "some-id", "effective_date": "2026-09-01" } }
+        """
+        let repository = self.makeRepository(responseJson: json)
+
+        // when
+        let updates = try await repository.loadNoticeUpdates()
+
+        // then
+        #expect(updates.isEmpty)
+    }
+
+    @Test func repository_whenSomeTopLevelKeysUnknown_keepsKnownOnes() async throws {
+        // given
+        let json = """
+        {
+          "terms": { "id": "2026-09-01-terms", "effective_date": "2026-09-01" },
+          "unknown": { "id": "some-id", "effective_date": "2026-09-01" }
+        }
+        """
+        let repository = self.makeRepository(responseJson: json)
+
+        // when
+        let updates = try await repository.loadNoticeUpdates()
+
+        // then
+        #expect(Set(updates.keys) == Set([.terms]))
+    }
+
+    @Test func repository_whenOneItemMissingId_dropsOnlyThatItem() async throws {
+        // given
+        let json = """
+        {
+          "terms": { "effective_date": "2026-09-01" },
+          "privacy": { "id": "2026-09-15-privacy", "effective_date": "2026-09-15" }
+        }
+        """
+        let repository = self.makeRepository(responseJson: json)
+
+        // when
+        let updates = try await repository.loadNoticeUpdates()
+
+        // then
+        #expect(updates[.terms] == nil)
+        #expect(updates[.privacy]?.id == "2026-09-15-privacy")
+    }
+
+    @Test func repository_whenOneItemEffectiveDateMalformed_dropsOnlyThatItem() async throws {
+        // given
+        let json = """
+        {
+          "terms": { "id": "2026-09-01-terms", "effective_date": "September 1" },
+          "privacy": { "id": "2026-09-15-privacy", "effective_date": "2026-09-15" }
+        }
+        """
+        let repository = self.makeRepository(responseJson: json)
+
+        // when
+        let updates = try await repository.loadNoticeUpdates()
+
+        // then
+        #expect(updates[.terms] == nil)
+        #expect(updates[.privacy]?.id == "2026-09-15-privacy")
+    }
+
+    @Test func repository_whenLoadFails_throws() async throws {
+        // given
+        let repository = self.makeRepository(shouldFail: true)
+
+        // when, then
+        await #expect(throws: (any Error).self) {
+            try await repository.loadNoticeUpdates()
+        }
+    }
+}
+
+// MARK: - 확인 이력 저장 (문서별)
+
+extension LegalNoticeRepositoryImpleTests {
+
+    @Test func repository_confirmedNoticeId_roundTrips() async throws {
+        // given
+        let repository = self.makeRepository()
+
+        // when
+        repository.updateConfirmedNoticeId("2026-09-01-terms", for: .terms)
+        let confirmed = repository.fetchConfirmedNoticeId(.terms)
+
+        // then
+        #expect(confirmed == "2026-09-01-terms")
+    }
+
+    @Test func repository_fetchConfirmedNoticeId_whenNeverConfirmed_returnsNil() async throws {
+        // given
+        let repository = self.makeRepository()
+
+        // when
+        let confirmed = repository.fetchConfirmedNoticeId(.terms)
+
+        // then
+        #expect(confirmed == nil)
+    }
+
+    @Test func repository_confirmedNoticeId_isIndependentPerDocumentType() async throws {
+        // given
+        let repository = self.makeRepository()
+
+        // when
+        repository.updateConfirmedNoticeId("2026-09-01-terms", for: .terms)
+
+        // then
+        #expect(repository.fetchConfirmedNoticeId(.terms) == "2026-09-01-terms")
+        #expect(repository.fetchConfirmedNoticeId(.privacy) == nil)
+    }
+}

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -740,3 +740,9 @@
 "webview::error::message" = "Couldn't load this page.";
 "webview::error::retry" = "Try again";
 "webview::openInBrowser" = "Open in browser";
+
+// MARK: - legal notice
+
+"legal_notice.message::terms" = "Our Terms of Service have been updated.";
+"legal_notice.message::privacy" = "Our Privacy Policy has been updated.";
+"legal_notice.effectiveDate" = "Effective %@";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -740,3 +740,9 @@
 "webview::error::message" = "페이지를 불러오지 못했어요.";
 "webview::error::retry" = "다시 시도";
 "webview::openInBrowser" = "브라우저로 열기";
+
+// MARK: - legal notice
+
+"legal_notice.message::terms" = "이용약관이 개정됐어요.";
+"legal_notice.message::privacy" = "개인정보처리방침이 개정됐어요.";
+"legal_notice.effectiveDate" = "시행일 %@";

--- a/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
+++ b/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
@@ -343,6 +343,15 @@ extension NonLoginUsecaseFactoryImple {
             sharedDataStore: self.applicationBase.sharedDataStore
         )
     }
+
+    func makeLegalNoticeUsecase() -> any LegalNoticeUsecase {
+        return LegalNoticeUsecaseImple(
+            legalNoticeRepository: LegalNoticeRepositoryImple(
+                remoteAPI: self.applicationBase.remoteAPI,
+                environmentStorage: self.applicationBase.userDefaultEnvironmentStorage
+            )
+        )
+    }
 }
 
 extension NonLoginUsecaseFactoryImple {
@@ -845,6 +854,15 @@ extension LoginUsecaseFactoryImple {
                 environmentStorage: self.applicationBase.userDefaultEnvironmentStorage
             ),
             sharedDataStore: self.applicationBase.sharedDataStore
+        )
+    }
+
+    func makeLegalNoticeUsecase() -> any LegalNoticeUsecase {
+        return LegalNoticeUsecaseImple(
+            legalNoticeRepository: LegalNoticeRepositoryImple(
+                remoteAPI: self.applicationBase.remoteAPI,
+                environmentStorage: self.applicationBase.userDefaultEnvironmentStorage
+            )
         )
     }
 }

--- a/TodoCalendarApp/Sources/Main/LegalNoticeBannerView.swift
+++ b/TodoCalendarApp/Sources/Main/LegalNoticeBannerView.swift
@@ -1,0 +1,267 @@
+//
+//  LegalNoticeBannerView.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 8/23/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import UIKit
+import Combine
+import Domain
+import CommonPresentation
+
+
+// MARK: - LegalNoticeBannerRowView
+
+final class LegalNoticeBannerRowView: UIView {
+
+    private enum Constant {
+        static let horizontalPadding: CGFloat = 16
+        static let verticalPadding: CGFloat = 10
+        static let iconSize: CGFloat = 18
+        static let closeButtonSize: CGFloat = 24
+    }
+
+    private let contentStackView = UIStackView()
+    private let iconImageView = UIImageView()
+    private let textStackView = UIStackView()
+    private let messageLabel = UILabel()
+    private let effectiveDateLabel = UILabel()
+    private let closeButton = UIButton()
+
+    private let tapSubject = PassthroughSubject<Void, Never>()
+    private let closeSubject = PassthroughSubject<Void, Never>()
+    private var cancellables: Set<AnyCancellable> = []
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.setupLayout()
+        self.bind()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+
+// MARK: - bind
+
+extension LegalNoticeBannerRowView {
+
+    var tapped: AnyPublisher<Void, Never> {
+        return self.tapSubject.eraseToAnyPublisher()
+    }
+
+    var closeTapped: AnyPublisher<Void, Never> {
+        return self.closeSubject.eraseToAnyPublisher()
+    }
+
+    private func bind() {
+        let rowTapPublisher = self.addTapGestureRecognizerPublisher()
+        self.gestureRecognizers?.first(where: { $0 is UITapGestureRecognizer })?.delegate = self
+
+        rowTapPublisher
+            .sink(receiveValue: { [weak self] in self?.tapSubject.send(()) })
+            .store(in: &self.cancellables)
+
+        self.closeButton.addTapGestureRecognizerPublisher()
+            .sink(receiveValue: { [weak self] in self?.closeSubject.send(()) })
+            .store(in: &self.cancellables)
+    }
+}
+
+
+extension LegalNoticeBannerRowView: UIGestureRecognizerDelegate {
+
+    // 본체 탭 제스처가 closeButton 위 터치까지 받으면 두 액션이 동시에 발화한다
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch
+    ) -> Bool {
+        return touch.view !== self.closeButton
+    }
+}
+
+
+// MARK: - update
+
+extension LegalNoticeBannerRowView {
+
+    func update(_ model: LegalNoticeBannerModel) {
+        self.messageLabel.text = model.message
+        self.effectiveDateLabel.text = model.effectiveDateText
+    }
+
+    func setupStyling(
+        _ fontSet: any FontSet, _ colorSet: any ColorSet
+    ) {
+        self.iconImageView.tintColor = colorSet.accentInfo
+        self.messageLabel.font = fontSet.normal
+        self.messageLabel.textColor = colorSet.text0
+        self.effectiveDateLabel.font = fontSet.subNormal
+        self.effectiveDateLabel.textColor = colorSet.text2
+        self.closeButton.tintColor = colorSet.text2
+    }
+}
+
+
+// MARK: - layout
+
+extension LegalNoticeBannerRowView {
+
+    private func setupLayout() {
+
+        self.addSubview(contentStackView)
+        contentStackView.autoLayout.active(with: self) {
+            $0.leadingAnchor.constraint(equalTo: $1.leadingAnchor, constant: Constant.horizontalPadding)
+            $0.trailingAnchor.constraint(equalTo: $1.trailingAnchor, constant: -Constant.horizontalPadding)
+            $0.topAnchor.constraint(equalTo: $1.topAnchor, constant: Constant.verticalPadding)
+            $0.bottomAnchor.constraint(equalTo: $1.bottomAnchor, constant: -Constant.verticalPadding)
+        }
+        contentStackView.axis = .horizontal
+        contentStackView.alignment = .center
+        contentStackView.spacing = 8
+
+        contentStackView.addArrangedSubview(iconImageView)
+        iconImageView.autoLayout.active {
+            $0.widthAnchor.constraint(equalToConstant: Constant.iconSize)
+            $0.heightAnchor.constraint(equalToConstant: Constant.iconSize)
+        }
+        iconImageView.image = UIImage(systemName: "doc.text")
+        iconImageView.contentMode = .scaleAspectFit
+
+        contentStackView.addArrangedSubview(textStackView)
+        textStackView.axis = .vertical
+        textStackView.spacing = 2
+        textStackView.addArrangedSubview(messageLabel)
+        textStackView.addArrangedSubview(effectiveDateLabel)
+        messageLabel.numberOfLines = 0
+
+        contentStackView.addArrangedSubview(closeButton)
+        closeButton.autoLayout.active {
+            $0.widthAnchor.constraint(equalToConstant: Constant.closeButtonSize)
+            $0.heightAnchor.constraint(equalToConstant: Constant.closeButtonSize)
+        }
+        closeButton.setImage(UIImage(systemName: "xmark"), for: .normal)
+    }
+}
+
+
+// MARK: - LegalNoticeBannerView
+
+final class LegalNoticeBannerView: UIView {
+
+    private let stackView = UIStackView()
+    private var rows: [LegalNoticeBannerRowView] = []
+    private var separators: [UIView] = []
+    private var cancellables: Set<AnyCancellable> = []
+    private var currentFontSet: (any FontSet)?
+    private var currentColorSet: (any ColorSet)?
+
+    private let documentTappedSubject = PassthroughSubject<LegalDocumentType, Never>()
+    private let closeTappedSubject = PassthroughSubject<LegalDocumentType, Never>()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+
+// MARK: - update
+
+extension LegalNoticeBannerView {
+
+    var documentTapped: AnyPublisher<LegalDocumentType, Never> {
+        return self.documentTappedSubject.eraseToAnyPublisher()
+    }
+
+    var closeTapped: AnyPublisher<LegalDocumentType, Never> {
+        return self.closeTappedSubject.eraseToAnyPublisher()
+    }
+
+    func update(_ models: [LegalNoticeBannerModel]) {
+        self.stackView.arrangedSubviews.forEach {
+            self.stackView.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        }
+        self.cancellables = []
+        self.separators = []
+
+        self.rows = models.map { model -> LegalNoticeBannerRowView in
+            let row = LegalNoticeBannerRowView()
+            row.update(model)
+            self.applyStyleIfNeeded(to: row)
+            self.bind(row, documentType: model.documentType)
+            return row
+        }
+
+        self.rows.enumerated().forEach { index, row in
+            if index > 0 {
+                let separator = self.makeSeparatorView()
+                self.separators.append(separator)
+                self.stackView.addArrangedSubview(separator)
+            }
+            self.stackView.addArrangedSubview(row)
+        }
+
+        self.isHidden = models.isEmpty
+    }
+
+    private func bind(_ row: LegalNoticeBannerRowView, documentType: LegalDocumentType) {
+        row.tapped
+            .sink(receiveValue: { [weak self] in self?.documentTappedSubject.send(documentType) })
+            .store(in: &self.cancellables)
+        row.closeTapped
+            .sink(receiveValue: { [weak self] in self?.closeTappedSubject.send(documentType) })
+            .store(in: &self.cancellables)
+    }
+
+    private func applyStyleIfNeeded(to row: LegalNoticeBannerRowView) {
+        guard let fontSet = self.currentFontSet, let colorSet = self.currentColorSet else { return }
+        row.setupStyling(fontSet, colorSet)
+    }
+
+    private func makeSeparatorView() -> UIView {
+        let separator = UIView()
+        separator.autoLayout.active {
+            $0.heightAnchor.constraint(equalToConstant: 1)
+        }
+        separator.backgroundColor = self.currentColorSet?.line
+        return separator
+    }
+
+    func setupStyling(
+        _ fontSet: any FontSet, _ colorSet: any ColorSet
+    ) {
+        self.currentFontSet = fontSet
+        self.currentColorSet = colorSet
+        self.backgroundColor = colorSet.bg1
+        self.rows.forEach { $0.setupStyling(fontSet, colorSet) }
+        self.separators.forEach { $0.backgroundColor = colorSet.line }
+    }
+}
+
+
+// MARK: - layout
+
+extension LegalNoticeBannerView {
+
+    private func setupLayout() {
+
+        self.addSubview(stackView)
+        stackView.autoLayout.active(with: self) {
+            $0.leadingAnchor.constraint(equalTo: $1.leadingAnchor)
+            $0.trailingAnchor.constraint(equalTo: $1.trailingAnchor)
+            $0.topAnchor.constraint(equalTo: $1.topAnchor)
+            $0.bottomAnchor.constraint(equalTo: $1.bottomAnchor)
+        }
+        stackView.axis = .vertical
+        stackView.spacing = 0
+    }
+}

--- a/TodoCalendarApp/Sources/Main/MainBuilderImple.swift
+++ b/TodoCalendarApp/Sources/Main/MainBuilderImple.swift
@@ -60,7 +60,8 @@ extension MainSceneBuilerImple: MainSceneBuiler {
             billingUsecase: self.usecaseFactory.billingUsecase,
             aiAgentOrchestrationUsecase: self.usecaseFactory.aiAgentOrchestrationUsecase,
             eventLiveActivityUsecase: self.usecaseFactory.eventLiveActivityUsecase,
-            guideTodoUsecase: self.usecaseFactory.makeGuideTodoUsecase()
+            guideTodoUsecase: self.usecaseFactory.makeGuideTodoUsecase(),
+            legalNoticeUsecase: self.usecaseFactory.makeLegalNoticeUsecase()
         )
         
         let viewController = MainViewController(

--- a/TodoCalendarApp/Sources/Main/MainViewController.swift
+++ b/TodoCalendarApp/Sources/Main/MainViewController.swift
@@ -26,6 +26,7 @@ final class MainViewController: UIViewController, MainScene {
     private let calendarContainerView = UIView()
     private let bottomBannerView: UIView?
     private let loadingAllEventsLabel = UILabel()
+    private let legalNoticeBannerView = LegalNoticeBannerView()
     private let compositeLoadingBarView = CompositeLoadingBarView()
     
     private let viewModel: any MainViewModel
@@ -139,6 +140,29 @@ extension MainViewController {
             })
             .store(in: &self.cancellables)
 
+        self.viewModel.legalNoticeBanners
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self] models in
+                self?.legalNoticeBannerView.update(models)
+            })
+            .store(in: &self.cancellables)
+
+        self.legalNoticeBannerView.documentTapped
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self] documentType in
+                self?.viewAppearance.impactIfNeed()
+                self?.viewModel.openLegalNoticeDocument(documentType)
+            })
+            .store(in: &self.cancellables)
+
+        self.legalNoticeBannerView.closeTapped
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self] documentType in
+                self?.viewAppearance.impactIfNeed()
+                self?.viewModel.closeLegalNoticeBanner(documentType)
+            })
+            .store(in: &self.cancellables)
+
         self.headerView.returnTodayView.addTapGestureRecognizerPublisher()
             .sink(receiveValue: { [weak self] in
                 self?.viewModel.returnToToday()
@@ -216,6 +240,9 @@ extension MainViewController {
         loadingAllEventsLabel.textAlignment = .center
         loadingAllEventsLabel.isHidden = true
 
+        headerAreaStackView.addArrangedSubview(legalNoticeBannerView)
+        legalNoticeBannerView.isHidden = true
+
         headerAreaStackView.addArrangedSubview(compositeLoadingBarView)
         compositeLoadingBarView.autoLayout.active {
             $0.heightAnchor.constraint(equalToConstant: 3.2)
@@ -250,6 +277,7 @@ extension MainViewController {
         self.headerView.setupStyling(fontSet, colorSet)
         self.loadingAllEventsLabel.font = fontSet.subNormal
         self.loadingAllEventsLabel.textColor = colorSet.text2
+        self.legalNoticeBannerView.setupStyling(fontSet, colorSet)
         self.compositeLoadingBarView.setupStyling(fontSet, colorSet)
     }
 }

--- a/TodoCalendarApp/Sources/Main/MainViewModel.swift
+++ b/TodoCalendarApp/Sources/Main/MainViewModel.swift
@@ -28,6 +28,12 @@ public struct CurrentMonth: Equatable {
     var yearText: String?
 }
 
+struct LegalNoticeBannerModel: Equatable {
+    let documentType: LegalDocumentType
+    let message: String
+    let effectiveDateText: String
+}
+
 protocol MainViewModel: AnyObject, Sendable, MainSceneInteractor {
 
     // interactor
@@ -39,6 +45,8 @@ protocol MainViewModel: AnyObject, Sendable, MainSceneInteractor {
     func moveToEventTypeFilterSetting()
     func moveToSetting()
     func jumpDate()
+    func openLegalNoticeDocument(_ documentType: LegalDocumentType)
+    func closeLegalNoticeBanner(_ documentType: LegalDocumentType)
 
     // presenter
     var currentMonth: AnyPublisher<CurrentMonth, Never> { get }
@@ -46,6 +54,7 @@ protocol MainViewModel: AnyObject, Sendable, MainSceneInteractor {
     var temporaryUserDataMigrationStatus: AnyPublisher<TemporaryUserDataMigrationStatus?, Never> { get }
     var isLoadingCalendarEvents: AnyPublisher<Bool, Never> { get }
     var isLoadingAllEvents: AnyPublisher<Bool, Never> { get }
+    var legalNoticeBanners: AnyPublisher<[LegalNoticeBannerModel], Never> { get }
 }
 
 
@@ -65,6 +74,7 @@ final class MainViewModelImple: MainViewModel, @unchecked Sendable {
     private let aiAgentOrchestrationUsecase: any AIAgentOrchestrationUsecase
     private let eventLiveActivityUsecase: any EventLiveActivityUsecase
     private let guideTodoUsecase: any GuideTodoUsecase
+    private let legalNoticeUsecase: any LegalNoticeUsecase
     var router: (any MainRouting)?
 
     init(
@@ -79,7 +89,8 @@ final class MainViewModelImple: MainViewModel, @unchecked Sendable {
         billingUsecase: any BillingUsecase,
         aiAgentOrchestrationUsecase: any AIAgentOrchestrationUsecase,
         eventLiveActivityUsecase: any EventLiveActivityUsecase,
-        guideTodoUsecase: any GuideTodoUsecase
+        guideTodoUsecase: any GuideTodoUsecase,
+        legalNoticeUsecase: any LegalNoticeUsecase
     ) {
         self.uiSettingUsecase = uiSettingUsecase
         self.temporaryUserDataMigrationUsecase = temporaryUserDataMigrationUsecase
@@ -93,10 +104,11 @@ final class MainViewModelImple: MainViewModel, @unchecked Sendable {
         self.aiAgentOrchestrationUsecase = aiAgentOrchestrationUsecase
         self.eventLiveActivityUsecase = eventLiveActivityUsecase
         self.guideTodoUsecase = guideTodoUsecase
+        self.legalNoticeUsecase = legalNoticeUsecase
 
         self.internalBinding()
     }
-    
+
     private struct Subject {
         let focusedDayInfo = CurrentValueSubject<SelectDayInfo?, Never>(nil)
         let temporaryUserDataMigrationStatus = CurrentValueSubject<TemporaryUserDataMigrationStatus?, Never>(nil)
@@ -140,6 +152,7 @@ final class MainViewModelImple: MainViewModel, @unchecked Sendable {
                 self?.aiAgentOrchestrationUsecase.refreshProcessingJobIfNeeded()
                 self?.aiAgentOrchestrationUsecase.loadUsage()
                 self?.handleWillEnterForeground()
+                self?.legalNoticeUsecase.checkNoticeIsNeed()
             })
             .store(in: &self.cancellables)
     }
@@ -165,6 +178,7 @@ extension MainViewModelImple {
         self.billingUsecase.startObservingTransactions()
         self.billingUsecase.recoverUnfinishedTransactions()
         self.guideTodoUsecase.prepare()
+        self.legalNoticeUsecase.checkNoticeIsNeed()
         Task { [weak self] in
             await self?.eventLiveActivityUsecase.prepare()
         }
@@ -248,6 +262,14 @@ extension MainViewModelImple {
         else { return }
         self.calendarSceneInteractor?.moveDay(day.dayInfo)
     }
+
+    func openLegalNoticeDocument(_ documentType: LegalDocumentType) {
+        self.router?.showWebView(documentType.linkPath)
+    }
+
+    func closeLegalNoticeBanner(_ documentType: LegalDocumentType) {
+        self.legalNoticeUsecase.confirmNotice(documentType)
+    }
 }
 
 
@@ -300,6 +322,34 @@ extension MainViewModelImple {
         return self.eventSyncUsecase.syncStatus
             .map { $0 == .fullSyncing }
             .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
+
+    var legalNoticeBanners: AnyPublisher<[LegalNoticeBannerModel], Never> {
+
+        let message: (LegalDocumentType) -> String = { documentType in
+            switch documentType {
+            case .terms: return "legal_notice.message::terms".localized()
+            case .privacy: return "legal_notice.message::privacy".localized()
+            }
+        }
+        let dateFormatter = DateFormatter()
+            |> \.dateFormat .~ "date_form.yyyy_MM_dd".localized()
+            |> \.timeZone .~ TimeZone(secondsFromGMT: 0)
+
+        return self.legalNoticeUsecase.pendingNoticeUpdates
+            .map { updates -> [LegalNoticeBannerModel] in
+                return updates.map { info in
+                    let effectiveDateText = "legal_notice.effectiveDate".localized(
+                        with: dateFormatter.string(from: info.effectiveDate)
+                    )
+                    return LegalNoticeBannerModel(
+                        documentType: info.documentType,
+                        message: message(info.documentType),
+                        effectiveDateText: effectiveDateText
+                    )
+                }
+            }
             .eraseToAnyPublisher()
     }
 }

--- a/TodoCalendarApp/TodoCalendarAppTests/MainViewModelImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/MainViewModelImpleTests.swift
@@ -31,6 +31,7 @@ class MainViewModelImpleTests: BaseTestCase, PublisherWaitable {
     private var stubAIOrchestrationUsecase: StubAIAgentOrchestrationUsecase!
     private var spyEventLiveActivityUsecase: SpyEventLiveActivityUsecase!
     private var stubGuideTodoUsecase: StubGuideTodoUsecase!
+    private var stubLegalNoticeUsecase: StubLegalNoticeUsecase!
     var cancelBag: Set<AnyCancellable>!
 
     override func setUpWithError() throws {
@@ -47,6 +48,7 @@ class MainViewModelImpleTests: BaseTestCase, PublisherWaitable {
         self.stubAIOrchestrationUsecase = .init()
         self.spyEventLiveActivityUsecase = .init()
         self.stubGuideTodoUsecase = .init()
+        self.stubLegalNoticeUsecase = .init()
         self.cancelBag = .init()
         self.timeout = 0.01
     }
@@ -65,6 +67,7 @@ class MainViewModelImpleTests: BaseTestCase, PublisherWaitable {
         self.stubAIOrchestrationUsecase = nil
         self.spyEventLiveActivityUsecase = nil
         self.stubGuideTodoUsecase = nil
+        self.stubLegalNoticeUsecase = nil
         self.cancelBag = nil
     }
 
@@ -87,7 +90,8 @@ class MainViewModelImpleTests: BaseTestCase, PublisherWaitable {
             billingUsecase: self.spyBillingUsecase,
             aiAgentOrchestrationUsecase: self.stubAIOrchestrationUsecase,
             eventLiveActivityUsecase: self.spyEventLiveActivityUsecase,
-            guideTodoUsecase: self.stubGuideTodoUsecase
+            guideTodoUsecase: self.stubGuideTodoUsecase,
+            legalNoticeUsecase: self.stubLegalNoticeUsecase
         )
         viewModel.router = self.spyRouter
         self.spyRouter.didCalendarAttached = {
@@ -114,10 +118,26 @@ extension MainViewModelImpleTests {
             billingUsecase: self.spyBillingUsecase,
             aiAgentOrchestrationUsecase: self.stubAIOrchestrationUsecase,
             eventLiveActivityUsecase: self.spyEventLiveActivityUsecase,
-            guideTodoUsecase: self.stubGuideTodoUsecase
+            guideTodoUsecase: self.stubGuideTodoUsecase,
+            legalNoticeUsecase: self.stubLegalNoticeUsecase
         )
         viewModel.router = self.spyRouter
         return viewModel
+    }
+
+    private func makeUpdateInfo(
+        id: String = "notice_1",
+        documentType: LegalDocumentType,
+        effectiveDate: Date = Date(timeIntervalSince1970: 1_700_000_000)
+    ) -> LegalNoticeUpdateInfo {
+        return LegalNoticeUpdateInfo(id: id, documentType: documentType, effectiveDate: effectiveDate)
+    }
+
+    private func formattedEffectiveDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "date_form.yyyy_MM_dd".localized()
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter.string(from: date)
     }
 
     func testViewModel_whenPrepare_startObservingTransactionsAndRecoverUnfinished() {
@@ -561,6 +581,32 @@ extension MainViewModelImpleTests {
             return Empty().eraseToAnyPublisher()
         }
     }
+
+    private final class StubLegalNoticeUsecase: LegalNoticeUsecase, @unchecked Sendable {
+
+        private let updatesSubject = CurrentValueSubject<[LegalNoticeUpdateInfo], Never>([])
+        var didCheckNoticeIsNeed: Bool = false
+        var didConfirmNoticeWithDocumentType: LegalDocumentType?
+
+        func checkNoticeIsNeed() {
+            self.didCheckNoticeIsNeed = true
+        }
+
+        var pendingNoticeUpdates: AnyPublisher<[LegalNoticeUpdateInfo], Never> {
+            return self.updatesSubject.eraseToAnyPublisher()
+        }
+
+        func confirmNotice(_ documentType: LegalDocumentType) {
+            self.didConfirmNoticeWithDocumentType = documentType
+            self.updatesSubject.send(
+                self.updatesSubject.value.filter { $0.documentType != documentType }
+            )
+        }
+
+        func sendUpdates(_ updates: [LegalNoticeUpdateInfo]) {
+            self.updatesSubject.send(updates)
+        }
+    }
 }
 
 
@@ -683,5 +729,121 @@ extension MainViewModelImpleTests {
 
         // then
         XCTAssertEqual(self.stubGuideTodoUsecase.didPrepare, true)
+    }
+}
+
+
+// MARK: - 고지 배너
+
+extension MainViewModelImpleTests {
+
+    func testViewModel_whenTwoPendingUpdates_emitsTwoBannerModelsInOrder() {
+        // given
+        let expect = expectation(description: "미확인 문서 2건 -> 배너 모델 2건")
+        expect.expectedFulfillmentCount = 2
+        let viewModel = self.makeViewModelWithoutPrepare()
+
+        // when
+        let modelLists = self.waitOutputs(expect, for: viewModel.legalNoticeBanners) {
+            self.stubLegalNoticeUsecase.sendUpdates([
+                self.makeUpdateInfo(id: "terms_1", documentType: .terms),
+                self.makeUpdateInfo(id: "privacy_1", documentType: .privacy)
+            ])
+        }
+
+        // then
+        let models = modelLists.last
+        let expectedEffectiveDateText = "legal_notice.effectiveDate".localized(
+            with: self.formattedEffectiveDate(Date(timeIntervalSince1970: 1_700_000_000))
+        )
+        XCTAssertEqual(models?.map { $0.documentType }, [.terms, .privacy])
+        XCTAssertEqual(models?.map { $0.message }, [
+            "legal_notice.message::terms".localized(),
+            "legal_notice.message::privacy".localized()
+        ])
+        XCTAssertEqual(models?.map { $0.effectiveDateText }, [
+            expectedEffectiveDateText, expectedEffectiveDateText
+        ])
+    }
+
+    func testViewModel_whenOnePendingUpdate_emitsOneBannerModel() {
+        // given
+        let expect = expectation(description: "미확인 문서 1건 -> 배너 모델 1건")
+        expect.expectedFulfillmentCount = 2
+        let viewModel = self.makeViewModelWithoutPrepare()
+
+        // when
+        let modelLists = self.waitOutputs(expect, for: viewModel.legalNoticeBanners) {
+            self.stubLegalNoticeUsecase.sendUpdates([
+                self.makeUpdateInfo(documentType: .privacy)
+            ])
+        }
+
+        // then
+        let models = modelLists.last
+        XCTAssertEqual(models?.map { $0.documentType }, [.privacy])
+        XCTAssertEqual(models?.map { $0.message }, [
+            "legal_notice.message::privacy".localized()
+        ])
+    }
+
+    func testViewModel_whenNoPendingUpdates_emitsEmptyArray() {
+        // given
+        let expect = expectation(description: "미확인 문서가 없으면 빈 배열 방출")
+        let viewModel = self.makeViewModelWithoutPrepare()
+
+        // when
+        let models = self.waitFirstOutput(expect, for: viewModel.legalNoticeBanners)
+
+        // then
+        XCTAssertEqual(models, [])
+    }
+
+    func testViewModel_whenOpenDocument_showsWebViewForThatDocumentOnly() {
+        // given
+        let viewModel = self.makeViewModelWithoutPrepare()
+
+        // when
+        viewModel.openLegalNoticeDocument(.privacy)
+
+        // then
+        XCTAssertEqual(self.spyRouter.didShowWebViewPath, LegalDocumentType.privacy.linkPath)
+        XCTAssertNil(self.spyRouter.didShowActionSheetWith)
+    }
+
+    func testViewModel_whenCloseBanner_confirmsThatDocumentOnly() {
+        // given
+        let viewModel = self.makeViewModelWithoutPrepare()
+
+        // when
+        viewModel.closeLegalNoticeBanner(.terms)
+
+        // then
+        XCTAssertEqual(self.stubLegalNoticeUsecase.didConfirmNoticeWithDocumentType, .terms)
+    }
+
+    func testViewModel_whenPrepare_checkLegalNotice() {
+        // given
+        let viewModel = self.makeViewModelWithoutPrepare()
+
+        // when
+        viewModel.prepare()
+
+        // then
+        XCTAssertEqual(self.stubLegalNoticeUsecase.didCheckNoticeIsNeed, true)
+    }
+
+    func testViewModel_whenWillEnterForeground_checkLegalNotice() {
+        // given
+        let viewModel = self.makeViewModelWithoutPrepare()
+
+        // when
+        NotificationCenter.default.post(
+            name: UIApplication.willEnterForegroundNotification, object: nil
+        )
+
+        // then
+        XCTAssertEqual(self.stubLegalNoticeUsecase.didCheckNoticeIsNeed, true)
+        withExtendedLifetime(viewModel) { }
     }
 }

--- a/docs/spec/infrastructure.md
+++ b/docs/spec/infrastructure.md
@@ -459,6 +459,133 @@ private func runMigrationVersion6to7(_ database: any DataBase) throws {
 
 ---
 
+## 8. 약관·개인정보처리방침 개정 고지 (법적 배너)
+
+사용자에게 중요한 개정(요금·이용 한도 축소·책임 제한 확대·개인정보 수집 항목·제3자 제공처 추가)을 원격 설정으로 푸시하고, 메인 화면 배너로 고지한다. 약관과 방침은 각자 독립적으로 개정되고 확인되므로, 모델·저장·UI 전부 **문서 단위**로 분리돼 있다 — 배너는 미확인 문서 수만큼(0~2줄) 뜨고 줄마다 개별로 확인한다.
+
+### 8.1 원격 설정
+
+**위치**: `sudopark/TodoCalendar-Terms` 레포 `main` 브랜치의 `app-config/legal-notice.json`
+**서빙**: `https://raw.githubusercontent.com/sudopark/TodoCalendar-Terms/main/app-config/legal-notice.json` (GitHub raw URL, §7.1과 동일 prefix)
+**포맷**:
+```json
+{
+  "terms":   { "id": "2026-09-01-terms",   "effective_date": "2026-09-01" },
+  "privacy": { "id": "2026-09-15-privacy", "effective_date": "2026-09-15" }
+}
+```
+
+- 최상위 키가 `LegalDocumentType`(`terms` / `privacy`) raw value다.
+- 고지 없음은 `{}` (빈 객체).
+- 디코딩은 Repository 레이어의 `LegalNoticeMapper`(`Decodable`)가 담당하고, Domain 모델(`LegalDocumentType` / `LegalNoticeUpdateInfo` / `LegalNoticeUpdates = [LegalDocumentType: LegalNoticeUpdateInfo]`)은 Decodable 미채택. `LegalNoticeMapper.init(from:)`는 `LegalDocumentType.allCases`를 순회하며 문서별로 독립 디코딩해 **항목 단위로 흡수**한다 — 한 문서가 깨져도 나머지는 산다.
+- 시행일 파싱은 `dateFormat = "yyyy-MM-dd"`, `timeZone = TimeZone(secondsFromGMT: 0)`, `locale = Locale(identifier: "en_US_POSIX")` 고정.
+
+**항목 단위 흡수 — 엣지 케이스**:
+
+| 입력 | 결과 |
+|---|---|
+| `{}` | 빈 딕셔너리 |
+| `{"terms": {...}, "privacy": {...}}` | 두 항목 모두 반영 |
+| `{"unknown": {...}}` | 빈 딕셔너리 — 모르는 문서 종류는 무시 (forward compatibility) |
+| `{"terms": {...}, "unknown": {...}}` | `terms`만 반영 |
+| 항목의 `id` 누락 | 그 문서만 버림 |
+| 항목의 `effective_date` 파싱 실패 | 그 문서만 버림 |
+| 네트워크 실패 | `loadNoticeUpdates`가 throw — 삼키는 건 usecase 책임(§8.2) |
+
+### 8.2 판정 알고리즘
+
+```swift
+protocol LegalNoticeRepository: Sendable {
+    func loadNoticeUpdates() async throws -> LegalNoticeUpdates
+    func fetchConfirmedNoticeId(_ documentType: LegalDocumentType) -> String?
+    func updateConfirmedNoticeId(_ id: String, for documentType: LegalDocumentType)
+}
+```
+
+확인 이력은 `LegalNoticeRepositoryImple`이 `EnvironmentStorage`(UserDefaults 백엔드)에 문서별 키 `"confirmed_legal_notice_id_\(documentType.rawValue)"`로 저장·조회한다.
+
+`LegalNoticeUsecaseImple.checkNoticeIsNeed()` 호출 시:
+
+```
+1. checkTrigger 발생 → 원격 loadNoticeUpdates() 실행 (실패 시 빈 딕셔너리로 삼킴)
+2. LegalDocumentType.allCases 순서로 순회하며 각 문서의 원격 id와 fetchConfirmedNoticeId(documentType)를 비교
+3. 다르면 pending 목록에 포함, 같으면 제외
+4. pendingNoticeUpdates: AnyPublisher<[LegalNoticeUpdateInfo], Never>로 방출
+```
+
+- **정렬 근거**: `LegalNoticeUpdates`는 딕셔너리라 순서가 없다. `LegalDocumentType.allCases`(선언 순서 terms → privacy)로 순회해 배열을 만들기 때문에 방출 순서가 고정되고, 이 순회가 없으면 배너 줄 순서가 실행마다 흔들린다.
+- 초기값·조회 실패·고지 없음은 전부 **빈 배열**이다. `pendingUpdates`가 `CurrentValueSubject<[LegalNoticeUpdateInfo], Never>([])`라 무방출이나 empty completion이 아니라 명시적 빈 배열로 표현된다.
+- `confirmNotice(_ documentType:)` — pending 배열에서 그 문서의 항목을 찾아 `updateConfirmedNoticeId(info.id, for: documentType)`를 호출한 뒤, pending 에서 그 항목만 뺀 배열을 재방출한다. pending 에 없는 문서를 넘기면 아무 일도 하지 않는다.
+
+### 8.3 체크 트리거
+
+`LegalNoticeUsecase.checkNoticeIsNeed()` 호출 시점:
+
+| 시점 | 트리거 지점 |
+|---|---|
+| 앱 시작 | `MainViewModelImple.prepare()` |
+| 포그라운드 복귀 | `MainViewModelImple.internalBinding()`의 `UIApplication.willEnterForegroundNotification` 구독 |
+
+내부는 `Subject.checkTrigger: PassthroughSubject<Void, Never>`를 send. `flatMapLatest`로 원격 조회(§8.2 1번)에 연결하고, 문서별 비교를 거친 배열이 `Subject.pendingUpdates: CurrentValueSubject<[LegalNoticeUpdateInfo], Never>([])`에 저장되어 `pendingNoticeUpdates` Publisher로 노출된다. `PassthroughSubject`가 아니라 `CurrentValueSubject`인 이유 — `confirmNotice(_:)`가 갱신된 배열을 재방출해야 그 줄이 내려가기 때문이다.
+
+`MainViewModelImple.legalNoticeBanners`는 별도 상태로 미러링하지 않고, `legalNoticeUsecase.pendingNoticeUpdates`를 매번 직접 `map`해 `[LegalNoticeBannerModel]`로 변환한다.
+
+**Usecase 공급**: `SupportUsecaseFactory.makeLegalNoticeUsecase()` (`NonLoginUsecaseFactoryImple` / `LoginUsecaseFactoryImple` 둘 다 구현). 소비자가 `MainViewModel` 하나뿐이라 단일 인스턴스 공유 계약은 없다 — 호출마다 새 인스턴스를 만든다.
+
+### 8.4 노출 동작
+
+**위치**: `MainViewController.headerAreaStackView`의 `addArrangedSubview` 순서상 `loadingAllEventsLabel` 아래, `compositeLoadingBarView` 위 (`headerView` → `loadingAllEventsLabel` → `legalNoticeBannerView` → `compositeLoadingBarView`). 초기 `isHidden = true`.
+
+배너는 `LegalNoticeBannerView` — 세로 `UIStackView` 컨테이너다. `MainViewModel.legalNoticeBanners: AnyPublisher<[LegalNoticeBannerModel], Never>`가 방출하면 `update(_:)`가 행을 재구성한다:
+- 모델이 0개면 `isHidden = true`
+- 1개 이상이면 문서마다 행(`LegalNoticeBannerRowView`)을 하나씩 만들어 채운다
+- 행 사이에는 1px 구분선(`colorSet.line`)을 넣는다. 첫 행 위·마지막 행 아래에는 없다.
+
+`LegalNoticeBannerModel`(`documentType` / `message` / `effectiveDateText`)의 `message`는 문서 종류에 따라 `legal_notice.message::terms` 또는 `legal_notice.message::privacy`로 분기하고, `effectiveDateText`는 `legal_notice.effectiveDate`(en `Effective %@` / ko `시행일 %@`)에 `date_form.yyyy_MM_dd` 패턴(en `MM/dd/yyyy` / ko `yyyy.MM.dd`)으로 UTC 고정 포맷한 날짜를 채운다. 문서가 한 줄에 하나이므로 한 줄에 두 문서를 담는 문구는 없다.
+
+**행 구성**(`LegalNoticeBannerRowView`): 아이콘(`doc.text`, 18×18, `colorSet.accentInfo`) · 세로 스택(메시지 `fontSet.normal`/`colorSet.text0`, `numberOfLines = 0` · 시행일 `fontSet.subNormal`/`colorSet.text2`) · 닫기 버튼(`xmark`, 24×24, `colorSet.text2`). 좌우 16 / 상하 10 padding.
+
+**주요 설계**: 배너는 modal present가 아니라 `headerAreaStackView`에 포함된 subview다 — 업데이트 팝업(강제·권장 모달)·UMP 동의 폼·ATT 프롬프트·전면 광고와 노출 순서를 다투지 않는다.
+
+**사용자 액션**:
+- **행 탭** — `LegalNoticeBannerView.documentTapped: AnyPublisher<LegalDocumentType, Never>`를 거쳐 `MainViewModelImple.openLegalNoticeDocument(_:)` → `router?.showWebView(documentType.linkPath)`로 그 문서 웹뷰를 바로 연다. 문서가 한 줄에 하나뿐이라 액션시트 분기는 없다.
+  - 탭 제스처는 행(`LegalNoticeBannerRowView`)이 직접 소유하고 닫기 버튼 위 터치는 받지 않는다 — 상위 뷰의 제스처는 버튼 터치까지 받아 두 액션이 함께 발화하는 게 UIKit 기본 동작이다.
+- **닫기 버튼** — `LegalNoticeBannerView.closeTapped: AnyPublisher<LegalDocumentType, Never>` → `MainViewModelImple.closeLegalNoticeBanner(_:)` → `legalNoticeUsecase.confirmNotice(documentType)`. 그 문서의 확인 id가 `EnvironmentStorage`에 저장되고 `pendingNoticeUpdates`가 그 문서를 뺀 배열을 재방출한다 — 그 줄만 사라지고 나머지 줄은 유지된다.
+
+### 8.5 고지 등급 정책
+
+**원격에 올리는 것** (중요 변경만):
+- 요금 인상·변경 (플랜 전환, 신규 가격 정책)
+- 이용 한도 축소 (AI Agent 일일 한도 감소, 저장소 용량 제한 신설 등)
+- 책임 제한 확대 (서비스 중단 면책 조건 추가 등)
+- 개인정보 수집 항목 추가 (위치, 연락처 등 신규 항목)
+- 제3자 제공처 추가 (외부 서비스 통합 시)
+
+**원격에 안 올리는 것**: 오탈자·표현 정리 — 웹 게시 + 시행일 갱신만으로 끝낸다.
+
+**개인정보 수집 항목·제공처 추가 시 유의**:
+약관 또는 개인정보 수집 동의서 개정만으로는 부족할 수 있다 — 법령에 따라 별도 명시적 동의가 필요한 경우가 있다. 이 경우 배너 고지는 선언 목적이고, 실제 수집은 동의 폼으로 별도 처리한다.
+
+**시행 시점 정책**: 약관·개인정보처리방침 §12는 "중요한 변경은 시행 전에 앱에서 안내합니다"로 규정한다 — 시행 **전**에만 고지하면 되고 구체적인 일수는 박지 않는다. 시행일이 지나도 배너 줄은 자동으로 내려가지 않는다. 문서별 줄이 사라지는 경로는 (a) 유저가 그 줄의 닫기 버튼을 눌러 `confirmNotice(documentType)`가 그 문서의 확인 id를 저장하거나, (b) 원격 `legal-notice.json`에서 그 문서 항목을 내려 다음 체크에서 pending 목록에서 빠지는 두 가지뿐이다.
+
+### 8.6 관련 파일
+
+| 레이어 | 파일 |
+|---|---|
+| Domain Model | `Domain/Sources/Models/LegalNotice.swift` |
+| Domain Repo | `Domain/Sources/Repositories/LegalNoticeRepository.swift` |
+| Domain Usecase | `Domain/Sources/Usecases/Support/LegalNoticeUsecase.swift` |
+| Repository Impl | `Repository/Sources/Repository+Imple/Support/LegalNoticeRepositoryImple.swift` |
+| Mapper | `Repository/Sources/Repository+Imple/Support/LegalNotice+Mapping.swift` |
+| Endpoint | `Repository/Sources/Remote/Endpoint.swift` (`AppEndpoints.legalNotice`) |
+| Main View | `TodoCalendarApp/Sources/Main/LegalNoticeBannerView.swift` |
+| Main ViewController | `TodoCalendarApp/Sources/Main/MainViewController.swift` (배너 layout) |
+| Main VM | `TodoCalendarApp/Sources/Main/MainViewModel.swift` (`openLegalNoticeDocument` / `closeLegalNoticeBanner` / `legalNoticeBanners` publisher) |
+| Factory | `Presentations/Scenes/Sources/Factories.swift` / `TodoCalendarApp/Sources/Factories/Factories+Usecase.swift` (`SupportUsecaseFactory.makeLegalNoticeUsecase`) |
+| 원격 설정 | `sudopark/TodoCalendar-Terms` 레포의 `app-config/legal-notice.json` |
+
+---
+
 ## 상태 전이 다이어그램
 
 ### SharedDataStore 동시성 모델


### PR DESCRIPTION
이용약관·개인정보처리방침 §12 가 "중요한 변경은 시행 전에 앱에서 안내합니다" 라고 약속하는데 앱엔 그 수단이 없었다. 첫 개정 시점에 문서상 약속을 이행할 방법이 없는 상태다.

## 접근

`sudopark/TodoCalendar-Terms` 레포의 `app-config/legal-notice.json` 에 고지를 올리면 메인 화면 헤더 아래에 배너가 뜬다. 데이터 경로는 앱 버전 체크(`docs/spec/infrastructure.md §7`)를 복제했다 — GitHub raw 원격 설정 → Repository 매퍼 → Domain usecase 판정. 조회처는 #983 이 `AppEndpoints` prefix 를 옮긴 그 레포·브랜치를 그대로 탄다.

**약관과 방침은 한 덩어리가 아니라 각자 갱신되고 각자 확인되는 독립 문서로 다룬다.** 모델(`LegalNoticeUpdates = [LegalDocumentType: LegalNoticeUpdateInfo]`)·원격 포맷·확인 이력 저장·배너 UI 가 전부 문서 단위다. 배너는 미확인 문서 수만큼 줄이 쌓이고, 줄마다 닫기 버튼으로 그 문서만 확인 처리된다.

**노출 형태를 modal 이 아니라 배너로 잡았다.** 앱 시작 구간에서 `topPresentedViewController()` 위에 올라가려는 주체가 이미 넷이다 (UMP 동의 폼·ATT 프롬프트, 강제/권장 업데이트 팝업, 전면 광고). 서로를 모르는 상태라 여기에 모달을 하나 더 얹으면 각자에게 나머지를 아는 가드가 필요해지고, 주체가 늘 때마다 조합이 터진다. 배너는 `MainViewController` 뷰 계층 안에 있어 present 경쟁에 참가하지 않는다 — 모달이 뜨면 아래에 가려질 뿐이고 닫히면 그대로 남는다. 기존 팝업·광고 코드는 한 줄도 건드리지 않았다.

조회 트리거·표시·확인이 전부 `MainViewModelImple` 한 곳에 모인다. 배너가 메인 화면의 것이니 언제 갱신되는지도 메인 화면이 정한다. `Root/` 는 손대지 않았다 — 업데이트 팝업이 Root 에 트리거를 둔 건 팝업을 Root Router 가 present 하기 때문이고, 배너엔 그 이유가 없다.

## 동작

- 앱 시작(`prepare()`)·포그라운드 복귀 시 원격 고지를 조회한다. 문서별로 고지 id 가 그 문서의 마지막 확인 id 와 다를 때만 그 줄이 뜬다
- 줄 탭 → 그 문서 웹뷰. 줄마다 문서가 하나뿐이라 선택 단계가 없다
- **닫기 버튼을 눌러야 확인 처리된다.** 문서를 열어보기만 해선 안 내려간다. 방침 줄을 닫아도 약관 줄은 남는다
- 확인 이력은 App Group UserDefaults 에 문서별 키로 남는다. 재설치·롤백이면 다시 뜨고, 계정 전환에는 영향받지 않는다
- 배너 줄 순서는 `LegalDocumentType.allCases` 순회로 고정한다 — 딕셔너리는 순서가 없어 그냥 꺼내면 실행마다 줄이 뒤바뀐다
- 조회 실패·고지 없음·원격 포맷 깨짐은 전부 "그 줄 없음" 으로 흡수한다. 항목 하나가 깨져도 나머지 문서는 산다
- 모르는 최상위 키는 무시한다 — 나중에 문서 종류가 늘어도 구버전 앱이 죽지 않는다

## 고지 등급

중요 변경(요금·이용 한도 축소·책임 제한 확대·개인정보 수집 항목·제3자 제공처 추가)만 원격에 올린다. 오탈자·표현 정리는 웹 게시 + 시행일 갱신으로 끝낸다 — 앱에 별도 "경미한 변경" 등급을 만들지 않았다. 약관 §12 의 "시행 전" 문구는 그대로 두고 일수(30일 등)를 박지 않는다.

`TodoCalendar-Terms` 레포에는 고지 없음 상태(`{}`)로 파일을 올려뒀다. 실제 개정 시점엔 그 파일에 문서별 항목만 채우면 된다.

## 남은 과제

- 로컬라이즈는 en·ko 만 추가했다. 나머지 29개 언어는 #810 대기 목록에 등재
