### PR TITLE
[#990] 테스트 스킴 플레이키 해소 — 크래시 4종 제거

### DIFF
--- a/.claude/rules/swift-style.md
+++ b/.claude/rules/swift-style.md
@@ -80,3 +80,33 @@ self.someFunction { [repository] in repository.load() }
 PR 올리기 전 `python3 .claude/scripts/check-comments.py`로 이번 브랜치가 추가한 주석을 훑는다 (pr 스킬 소관). 지적된 건은 기본이 삭제다.
 
 배경: #820 — AI 작업으로 유입된 서술형 주석 354줄을 사후 일괄 정리했다.
+
+## 6. 구독 보관함 — `Set<AnyCancellable>` 대신 `CancelBag`
+
+프로덕션 코드는 구독을 `Extensions` 의 `CancelBag` 에 담는다. `Set<AnyCancellable>` 프로퍼티를 직접 두지 않는다.
+
+```swift
+// ❌
+private var cancellables: Set<AnyCancellable> = []
+... .store(in: &self.cancellables)
+
+// ✅
+private let cancellables = CancelBag()
+... .store(in: self.cancellables)
+```
+
+**Why:** 뷰모델·유스케이스는 대개 `@unchecked Sendable` 이고, `Task` 본문 안에서 구독을 담는 순간 메인 스레드의 `store` 와 겹쳐 Set 저장소가 깨진다. 손상된 Set 은 `member:` unrecognized selector 로 프로세스를 죽이는데, 수신 클래스가 런마다 바뀌어 원인 추적이 어렵다 (`docs/troubleshooting/2026-08-24-cancelbag-data-race-crash.md`). `CancelBag` 은 잠금으로 그 경로를 막는다.
+
+- 비우기는 `cancelAll()`.
+- 예외는 `UnitTestHelpKit.PublisherWaitable` 뿐이다. 테스트마다 인스턴스가 새로 생겨 레이스가 없다.
+
+### 검증
+
+기계 강제 수단은 아직 없다. PR 전에 직접 확인한다 (pr 스킬 소관):
+
+```bash
+grep -rn "Set<AnyCancellable>" --include='*.swift' Domain Repository Presentations Services TodoCalendarApp Supports Template \
+  | grep -vE "Tests/|Snapshots/|CancelBag\.swift|Task\+Extensions\.swift|PublisherWaitable\.swift"
+```
+
+출력이 비어야 한다. Xcode Scene 템플릿(`Template/`)도 대상이다 — 거기 남으면 새 Scene 마다 위반이 복제된다.

--- a/.claude/rules/testability.md
+++ b/.claude/rules/testability.md
@@ -5,6 +5,8 @@ paths:
   - "Repository/**"
   - "Presentations/**"
   - "Services/**"
+  - "TodoCalendarApp/**"
+  - "Supports/**"
 ---
 
 # 테스트 작성 규칙
@@ -191,7 +193,7 @@ extension AppDataMigrationImpleTests {
 
 | Module | Contents |
 |---|---|
-| `UnitTestHelpKit` | `BaseTestCase`, `PublisherWaitable`, `BaseStub`, `TestError` |
+| `UnitTestHelpKit` | `BaseTestCase`, `PublisherWaitable`, `AsyncEffectWaitable`, `BaseStub`, `TestError` |
 | `TestDoubles` | 공유 Stub repositories / stub usecases |
 | `SnapshotTestHelpKit` | `captureSnapshotPair`·`SnapshotTheme`·`catalogSnapshotDirectory` — 스냅샷 캡처 (snapshot-check 스킬) |
 
@@ -203,3 +205,19 @@ extension AppDataMigrationImpleTests {
 - `Tests/`는 `Sources/`의 폴더 구조를 미러링한다 (예: `Sources/Usecases/…` → `Tests/Usecases/…`).
 - 구현체 테스트 파일명은 대상 타입명 + `Tests`: `XxxImpleTests.swift` (예: `EventTagDetailViewModelImpleTests.swift`).
 - 테스트 더블은 해당 프레임워크 `Tests/Doubles/`에. 여러 프레임워크가 공유하면 `TestDoubles` 모듈에 (§7).
+
+---
+
+## 9. 비동기 효과 대기 — 고정 sleep 금지
+
+`Task.sleep` 으로 효과 도착을 기다리지 않는다. `UnitTestHelpKit.AsyncEffectWaitable` 을 채택하고 조건이 참이 될 때까지 폴링한다 — 병렬 실행 부하로 효과가 늦어도 대기 시간만 늘고 판정은 안 흔들린다.
+
+```swift
+try await self.waitEffect("갱신된 이름이 반영됨") { stub.didUpdateWith?.eventName == "new" }
+#expect(stub.didUpdateWith?.eventName == "new")
+```
+
+- 조건이 끝내 참이 안 되면 `AsyncEffectWaitTimeout` 을 던진다. 설명 문자열은 필수 — 무엇을 기다리다 실패했는지가 메시지에 남는다.
+- **"안 일어남" 단언**(`#expect(stub.didEnd == false)`)은 기다릴 조건이 없어 정착 sleep 이 맞다. 짧아도 오탐이 아니라 오통과 방향이라 플레이키를 안 만든다.
+- **"정확히 N회" 단언**은 도달까지 폴링한 뒤 정착 시간을 두고 다시 본다 — 도달 즉시 단언하면 뒤늦은 중복 방출을 놓친다.
+- 정착 시간은 **50ms** 를 기본으로 쓴다. 사람마다 다른 매직넘버가 흩어지지 않게 이 값을 기준으로 두고, 벗어나면 이유를 한 줄 남긴다.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -15,6 +15,10 @@ description: Use when creating or merging a pull request in this project — PR 
 - 페이즈가 나뉘는 작업은 페이즈별 PR — 머지 후 다음 페이즈 착수.
 - WIP 정리는 PR 올리기 전에 (commit 스킬의 흡수 절차) — 리뷰어에게 보이는 커밋은 논리 단위 최종본이어야 한다.
 
+### 구독 보관함 검토 (필수)
+
+프로덕션에 `Set<AnyCancellable>` 이 남지 않았는지 본다 — 검증 명령과 배경은 `.claude/rules/swift-style.md` §6 `검증`. 출력이 비어야 통과다.
+
 ### 주석 검토 (필수)
 
 PR 생성 **전에** 이번 브랜치가 추가한 주석을 훑는다:

--- a/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
@@ -73,7 +73,7 @@ public final class AIAgentOrchestrationUsecaseImple: AIAgentOrchestrationUsecase
     }
     private let subject = Subject()
     private var commandCancellable: AnyCancellable?
-    private var voiceInputBindings = Set<AnyCancellable>()
+    private let voiceInputBindings = CancelBag()
     private var currentProcessingJobId: String?
 
     private func startProcessing(_ processing: AnyPublisher<AICommandProcessing, any Error>) {
@@ -198,20 +198,20 @@ extension AIAgentOrchestrationUsecaseImple {
             .sink { [weak self] result in
                 self?.handleRecognizeEnd(result)
             }
-            .store(in: &self.voiceInputBindings)
+            .store(in: self.voiceInputBindings)
 
         self.speechRecognizeUsecase.recognizingText
             .sink { [weak self] text in
                 self?.subject.recognizingText.send(text)
             }
-            .store(in: &self.voiceInputBindings)
+            .store(in: self.voiceInputBindings)
 
         self.speechRecognizeUsecase.isRecognizingWithLevel
             .compactMap { $0 }
             .sink { [weak self] level in
                 self?.subject.voiceLevel.send(level)
             }
-            .store(in: &self.voiceInputBindings)
+            .store(in: self.voiceInputBindings)
     }
 
     // 인식 종료는 텍스트 확보·무인식·실패를 가리지 않고 stopInput과 동등하게 접는다.
@@ -236,8 +236,7 @@ extension AIAgentOrchestrationUsecaseImple {
     }
 
     private func resetVoiceBinding() {
-        self.voiceInputBindings.forEach { $0.cancel() }
-        self.voiceInputBindings.removeAll()
+        self.voiceInputBindings.cancelAll()
     }
 }
 

--- a/Domain/Sources/Usecases/AI/AIAgentUsageUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentUsageUsecase.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Combine
+import Extensions
 import AsyncFlatMap
 
 
@@ -40,7 +41,7 @@ public final class AIAgentUsageUsecaseImple: AIAgentUsageUsecase, @unchecked Sen
         let refresh = PassthroughSubject<Void, Never>()
     }
     private let subject = Subject()
-    private var cancellables = Set<AnyCancellable>()
+    private let cancellables = CancelBag()
 }
 
 
@@ -63,7 +64,7 @@ extension AIAgentUsageUsecaseImple {
             .map(loadUsageWithoutError)
             .switchToLatest()
             .sink(receiveValue: { _ in })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     public func loadUsage() async throws -> AIAgentUsage {

--- a/Domain/Sources/Usecases/AI/AICommandUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AICommandUsecase.swift
@@ -72,14 +72,14 @@ public final class AICommandUsecaseImple: AICommandUsecase, @unchecked Sendable 
         let jobFinishEvent = PassthroughSubject<String, Never>()
     }
     private let subject = Subject()
-    private var cancelBag = Set<AnyCancellable>()
+    private let cancelBag = CancelBag()
 
     private func internalBind() {
         self.calendarSettingUsecase.currentTimeZone
             .sink(receiveValue: { [weak self] timeZone in
                 self?.subject.timeZone.send(timeZone)
             })
-            .store(in: &self.cancelBag)
+            .store(in: self.cancelBag)
     }
 }
 

--- a/Domain/Sources/Usecases/Common/PagingUsecase.swift
+++ b/Domain/Sources/Usecases/Common/PagingUsecase.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Combine
+import Extensions
 import AsyncFlatMap
 
 
@@ -57,7 +58,7 @@ public final class PagingUsecase<Repository: PagingRepository> {
         let occurredError = PassthroughSubject<any Error, Never>()
     }
     private let subject = Subject()
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     private func internalBinding() {
         
@@ -87,7 +88,7 @@ public final class PagingUsecase<Repository: PagingRepository> {
             .map(loadWithoutError)
             .switchToLatest()
             .sink(receiveValue: updatePagingResult)
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Domain/Sources/Usecases/Common/PlaceSuggestUsecase.swift
+++ b/Domain/Sources/Usecases/Common/PlaceSuggestUsecase.swift
@@ -54,7 +54,7 @@ public final class PlaceSuggestUsecaseImple: PlaceSuggestUsecase, @unchecked Sen
         let places = CurrentValueSubject<[Place], Never>([])
     }
     private let subject = Subject()
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 }
 
 extension PlaceSuggestUsecaseImple {
@@ -89,7 +89,7 @@ extension PlaceSuggestUsecaseImple {
             .sink(receiveValue: { [weak self] places in
                 self?.subject.places.send(places)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Domain/Sources/Usecases/Events/EventSyncMediator.swift
+++ b/Domain/Sources/Usecases/Events/EventSyncMediator.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Combine
+import Extensions
 
 public protocol EventSyncMediator: Sendable {
     
@@ -37,7 +38,7 @@ public final class EventSyncMediatorImple: EventSyncMediator, @unchecked Sendabl
         let isTemporaryUserDataMigration = CurrentValueSubject<Bool, Never>(false)
     }
     private let subject = Subject()
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     private func internalBinding() {
         
@@ -45,7 +46,7 @@ public final class EventSyncMediatorImple: EventSyncMediator, @unchecked Sendabl
             .sink(receiveValue: { [weak self] isMigrating in
                 self?.subject.isTemporaryUserDataMigration.send(isMigrating)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Domain/Sources/Usecases/Events/EventTagUsecase.swift
+++ b/Domain/Sources/Usecases/Events/EventTagUsecase.swift
@@ -58,7 +58,7 @@ public final class EventTagUsecaseImple: EventTagUsecase, @unchecked Sendable {
         self.refreshBindingQueue = refreshBindingQueue ?? DispatchQueue(label: "event-tag-binding")
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     private var shareKey: String { ShareDataKeys.tags.rawValue }
 }
@@ -143,7 +143,7 @@ extension EventTagUsecaseImple {
             .sink(receiveValue: { [weak self] ids in
                 self?.refreshCustomTags(ids)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         let offIds = self.tagRepository.loadOffTags()
         self.sharedDataStore.put(Set<EventTagId>.self, key: ShareDataKeys.offEventTagSet.rawValue, offIds)
@@ -161,7 +161,7 @@ extension EventTagUsecaseImple {
             .removeDuplicates()
             .map { $0.asDictionary { $0.tagId }}
             .sink(receiveValue: updateStore)
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     public func refreshCustomTags(_ ids: [String]) {
@@ -178,7 +178,7 @@ extension EventTagUsecaseImple {
         
         self.tagRepository.loadCustomTags(ids)
             .sink(receiveCompletion: { _ in }, receiveValue: updateCached)
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     public func eventTag(id: EventTagId) -> AnyPublisher<(any EventTag)?, Never> {

--- a/Domain/Sources/Usecases/Events/ExternalCalendar/AppleCalendarUsecase.swift
+++ b/Domain/Sources/Usecases/Events/ExternalCalendar/AppleCalendarUsecase.swift
@@ -76,12 +76,11 @@ public final class AppleCalendarUsecaseImple: AppleCalendarUsecase, @unchecked S
         self.sharedDataStore = sharedDataStore
     }
 
-    private var cancelBag: Set<AnyCancellable> = []
-    private var refreshEventBag: Set<AnyCancellable> = []
+    private let cancelBag = CancelBag()
+    private let refreshEventBag = CancelBag()
 
     private func clearCancelBag() {
-        cancelBag.forEach { $0.cancel() }
-        cancelBag = []
+        cancelBag.cancelAll()
     }
 }
 
@@ -106,7 +105,7 @@ extension AppleCalendarUsecaseImple {
                     self.clearCache()
                 }
             }
-            .store(in: &cancelBag)
+            .store(in: cancelBag)
     }
 
     private func refreshIfAlreadyIntegrated() {
@@ -149,7 +148,7 @@ extension AppleCalendarUsecaseImple {
                     self.appearanceStore.applyCalendarTags(tags)
                 }
             )
-            .store(in: &cancelBag)
+            .store(in: cancelBag)
     }
 
     public var calendarTags: AnyPublisher<[AppleCalendar.Tag], Never> {
@@ -168,8 +167,7 @@ extension AppleCalendarUsecaseImple {
 extension AppleCalendarUsecaseImple {
 
     public func refreshEvents(in period: Range<TimeInterval>) {
-        refreshEventBag.forEach { $0.cancel() }
-        refreshEventBag = []
+        refreshEventBag.cancelAll()
 
         integrationUsecase.currentOrNewIntegratedAccount(for: appleService.identifier)
             .flatMap { [weak self] _ -> AnyPublisher<[AppleCalendar.Event], Never> in
@@ -179,7 +177,7 @@ extension AppleCalendarUsecaseImple {
                     .eraseToAnyPublisher()
             }
             .sink { [weak self] events in self?.updateStoredEvents(events, in: period) }
-            .store(in: &refreshEventBag)
+            .store(in: refreshEventBag)
     }
 
     private func updateStoredEvents(_ refreshed: [AppleCalendar.Event], in period: Range<TimeInterval>) {

--- a/Domain/Sources/Usecases/Events/ExternalCalendar/GoogleCalendarUsecase.swift
+++ b/Domain/Sources/Usecases/Events/ExternalCalendar/GoogleCalendarUsecase.swift
@@ -128,12 +128,11 @@ public final class GoogleCalendarUsecaseImple: GoogleCalendarUsecase, @unchecked
         self.sharedDataStore = sharedDataStore
     }
 
-    private var cancelBag: Set<AnyCancellable> = []
-    private var refreshEventBag: Set<AnyCancellable> = []
+    private let cancelBag = CancelBag()
+    private let refreshEventBag = CancelBag()
 
     private func clearCancelBag() {
-        self.cancelBag.forEach { $0.cancel() }
-        self.cancelBag = []
+        self.cancelBag.cancelAll()
     }
 }
 
@@ -160,7 +159,7 @@ extension GoogleCalendarUsecaseImple {
                     self.clearAccountCache(email)
                 }
             }
-            .store(in: &cancelBag)
+            .store(in: cancelBag)
     }
 
     public func refreshGoogleCalendarEventTags() {
@@ -193,7 +192,7 @@ extension GoogleCalendarUsecaseImple {
                 }
                 self.appearanceStore.applyColors(colors, for: accountId)
             }
-            .store(in: &cancelBag)
+            .store(in: cancelBag)
     }
 
     private func refreshCalendarTags(_ accountId: String, isNew: Bool = false) {
@@ -214,7 +213,7 @@ extension GoogleCalendarUsecaseImple {
                 }
                 self.appearanceStore.applyCalendarTags(incoming, for: accountId)
             }
-            .store(in: &cancelBag)
+            .store(in: cancelBag)
     }
 
     private func clearAccountCache(_ accountId: String) {
@@ -303,8 +302,7 @@ extension GoogleCalendarUsecaseImple {
 extension GoogleCalendarUsecaseImple {
 
     private func cancelRefresh() {
-        refreshEventBag.forEach { $0.cancel() }
-        refreshEventBag = []
+        refreshEventBag.cancelAll()
     }
 
     public func refreshEvents(in period: Range<TimeInterval>) {
@@ -322,7 +320,7 @@ extension GoogleCalendarUsecaseImple {
                     self.refreshEvents(calendar.id, accountId: calendar.ownerId, in: period)
                 }
             })
-            .store(in: &self.refreshEventBag)
+            .store(in: self.refreshEventBag)
     }
 
     public func refreshRepeatingEvent(
@@ -342,7 +340,7 @@ extension GoogleCalendarUsecaseImple {
                     return instances.reduce(into: withoutStale) { $0[$1.eventId] = $1 }
                 }
             })
-            .store(in: &self.cancelBag)
+            .store(in: self.cancelBag)
     }
 
     private func refreshEvents(
@@ -368,7 +366,7 @@ extension GoogleCalendarUsecaseImple {
 
         repository.loadEvents(calendarId, in: period)
             .sink(receiveValue: updateEvents)
-            .store(in: &self.refreshEventBag)
+            .store(in: self.refreshEventBag)
     }
 
     public func events(

--- a/Domain/Sources/Usecases/Events/ForemostEventUsecase.swift
+++ b/Domain/Sources/Usecases/Events/ForemostEventUsecase.swift
@@ -50,7 +50,7 @@ public final class ForemostEventUsecaseImple: ForemostEventUsecase, @unchecked S
         self.eventNotifyService = eventNotifyService
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 }
 
 extension ForemostEventUsecaseImple {
@@ -74,7 +74,7 @@ extension ForemostEventUsecaseImple {
                 $0 ? RefreshingEvent.refreshForemostEvent(true) : .refreshForemostEvent(false)
             }
             .sink(receiveValue: handleRefreshed)
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     public func update(foremost eventId: ForemostEventId) async throws {

--- a/Domain/Sources/Usecases/Events/ScheduleEventUsecase.swift
+++ b/Domain/Sources/Usecases/Events/ScheduleEventUsecase.swift
@@ -48,7 +48,7 @@ public final class ScheduleEventUsecaseImple: ScheduleEventUsecase, @unchecked S
     }
     
     private let eventMemorizationQueue = DispatchQueue(label: "schedule-event-memorize")
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 }
 
 
@@ -184,7 +184,7 @@ extension ScheduleEventUsecaseImple {
             }
             .receive(on: self.eventMemorizationQueue)
             .sink(receiveCompletion: { _ in }, receiveValue: updateCache)
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     public func scheduleEvents(in period: Range<TimeInterval>)  -> AnyPublisher<[ScheduleEvent], Never> {

--- a/Domain/Sources/Usecases/Events/TodoEventUsecase.swift
+++ b/Domain/Sources/Usecases/Events/TodoEventUsecase.swift
@@ -56,7 +56,7 @@ public final class TodoEventUsecaseImple: TodoEventUsecase {
         self.eventNotifyService = eventNotifyService
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 }
 
 
@@ -206,7 +206,7 @@ extension TodoEventUsecaseImple {
                 $0 ? RefreshingEvent.refreshingCurrentTodo(true) : .refreshingCurrentTodo(false)
             }
             .sink(receiveCompletion: { _ in }, receiveValue: updateCached)
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     public var currentTodoEvents: AnyPublisher<[TodoEvent], Never> {
@@ -235,7 +235,7 @@ extension TodoEventUsecaseImple {
                 $0 ? RefreshingEvent.refreshingTodo(true) : .refreshingTodo(false)
             }
             .sink(receiveCompletion: { _ in }, receiveValue: updateCache)
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     public func todoEvents(in period: Range<TimeInterval>) -> AnyPublisher<[TodoEvent], Never> {
@@ -287,7 +287,7 @@ extension TodoEventUsecaseImple {
                 $0 ? RefreshingEvent.refreshingUncompletedTodo(true) : .refreshingUncompletedTodo(false)
             }
             .sink(receiveValue: refreshCached)
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     public var uncompletedTodos: AnyPublisher<[TodoEvent], Never> {

--- a/Domain/Sources/Usecases/Notification/EventNotificationUsecase.swift
+++ b/Domain/Sources/Usecases/Notification/EventNotificationUsecase.swift
@@ -25,7 +25,7 @@ public final class EventNotificationUsecaseImple: EventNotificationUsecase, @unc
     private let notificationRepository: any EventNotificationRepository
     private let notificationService: any LocalNotificationService
 
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private var todoSyncBinding: AnyCancellable?
     private var scheduleSyncBinding: AnyCancellable?
 
@@ -99,7 +99,7 @@ extension EventNotificationUsecaseImple {
                 self.cancelNotifications(notificationIds)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 
     private func runSyncScheduleEvents() {
@@ -149,7 +149,7 @@ extension EventNotificationUsecaseImple {
                 self.cancelNotifications(notificationIds)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 
     private func scheduleNotificationIfFuture(_ params: SingleEventNotificationMakeParams) async throws -> String? {

--- a/Domain/Sources/Usecases/Setting/TemporaryUserDataMigrationUescase.swift
+++ b/Domain/Sources/Usecases/Setting/TemporaryUserDataMigrationUescase.swift
@@ -43,7 +43,7 @@ public final class TemporaryUserDataMigrationUescaseImple: TemporaryUserDataMigr
         let migrationResult = PassthroughSubject<Result<Void, any Error>, Never>()
     }
     private let subject = Subject()
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 }
 
 
@@ -58,7 +58,7 @@ extension TemporaryUserDataMigrationUescaseImple {
                 logger.log(level: .error, "migration check fail: \(error)")
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     public func startMigration() {
@@ -80,7 +80,7 @@ extension TemporaryUserDataMigrationUescaseImple {
                 try await self?.updateMigrationNeedCount()
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func updateMigrationNeedCount() async throws {

--- a/Domain/Sources/Usecases/Speech/SpeechRecognizeUsecase.swift
+++ b/Domain/Sources/Usecases/Speech/SpeechRecognizeUsecase.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Combine
+import Extensions
 
 
 // MARK: - SpeechRecognizeResult
@@ -61,7 +62,7 @@ public final class SpeechRecognizeUsecaseImple: SpeechRecognizeUsecase, @uncheck
         let recognizingText = CurrentValueSubject<String, Never>("")
     }
     private let subject = Subject()
-    private var serviceBinding = Set<AnyCancellable>()
+    private let serviceBinding = CancelBag()
     private var startTask: Task<Void, Never>?
 }
 
@@ -82,13 +83,13 @@ extension SpeechRecognizeUsecaseImple {
                 try self.service.start()
                 guard !Task.isCancelled else {
                     self.service.stop()
-                    self.serviceBinding = []
+                    self.serviceBinding.cancelAll()
                     return
                 }
                 self.subject.isRecognizing.send(true)
 
             } catch {
-                self.serviceBinding = []
+                self.serviceBinding.cancelAll()
                 self.subject.isRecognizing.send(false)
                 self.subject.result.send(.failure(error))
             }
@@ -99,7 +100,7 @@ extension SpeechRecognizeUsecaseImple {
         self.startTask?.cancel()
         self.startTask = nil
         self.service.stop()
-        self.serviceBinding = []
+        self.serviceBinding.cancelAll()
         self.subject.isRecognizing.send(false)
     }
     
@@ -116,7 +117,7 @@ extension SpeechRecognizeUsecaseImple {
         }
 
         self.subject.recognizingText.send("")
-        self.serviceBinding = []
+        self.serviceBinding.cancelAll()
 
         let recognizedOrTimeout = Publishers.CombineLatest(
             self.service.recognized.mapAsOptional().prepend(nil),
@@ -136,7 +137,7 @@ extension SpeechRecognizeUsecaseImple {
                 receiveCompletion: self.handleCompletion(),
                 receiveValue: self.handleRecognized()
             )
-            .store(in: &self.serviceBinding)
+            .store(in: self.serviceBinding)
 
         self.service.recognized
             .map { $0.text }
@@ -146,7 +147,7 @@ extension SpeechRecognizeUsecaseImple {
                     self?.subject.recognizingText.send(text)
                 }
             )
-            .store(in: &self.serviceBinding)
+            .store(in: self.serviceBinding)
     }
     
     private func handleCompletion() -> (Subscribers.Completion<any Error>) -> Void  {

--- a/Domain/Sources/Usecases/Support/AppUpdateCheckUsecase.swift
+++ b/Domain/Sources/Usecases/Support/AppUpdateCheckUsecase.swift
@@ -44,7 +44,7 @@ public final class AppUpdateCheckUsecaseImple: AppUpdateCheckUsecase, @unchecked
         let currentUpdateInfo = CurrentValueSubject<AppUpdateInfo?, Never>(nil)
     }
     private let subject = Subject()
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 }
 
 
@@ -70,7 +70,7 @@ extension AppUpdateCheckUsecaseImple {
             .sink(receiveValue: { [weak self] requirement in
                 self?.subject.appUpdateRequirement.send(requirement)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 
     private func loadUpdateInfoWithoutError() -> AnyPublisher<AppUpdateInfo?, any Error> {

--- a/Domain/Sources/Usecases/Support/FeedbackUsecase.swift
+++ b/Domain/Sources/Usecases/Support/FeedbackUsecase.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Prelude
 import Optics
+import Extensions
 import Combine
 
 
@@ -30,7 +31,7 @@ public final class FeedbackUsecaseImple: FeedbackUsecase, @unchecked Sendable {
     private let deviceInfoFetchService: any DeviceInfoFetchService
     
     private let userId = CurrentValueSubject<String?, Never>(nil)
-    private var cancellables = Set<AnyCancellable>()
+    private let cancellables = CancelBag()
     
     public init(
         accountUsecase: any AccountUsecase,
@@ -50,7 +51,7 @@ public final class FeedbackUsecaseImple: FeedbackUsecase, @unchecked Sendable {
             .sink(receiveValue: { [weak self] account in
                 self?.userId.send(account?.userId)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Domain/Sources/Usecases/Support/LegalNoticeUsecase.swift
+++ b/Domain/Sources/Usecases/Support/LegalNoticeUsecase.swift
@@ -38,7 +38,7 @@ public final class LegalNoticeUsecaseImple: LegalNoticeUsecase, @unchecked Senda
         let pendingUpdates = CurrentValueSubject<[LegalNoticeUpdateInfo], Never>([])
     }
     private let subject = Subject()
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 }
 
 
@@ -62,7 +62,7 @@ extension LegalNoticeUsecaseImple {
             .sink(receiveValue: { [weak self] updates in
                 self?.subject.pendingUpdates.send(updates)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 
     private func loadUpdatesWithoutError() -> AnyPublisher<LegalNoticeUpdates, any Error> {

--- a/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandStageView.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandStageView.swift
@@ -18,7 +18,7 @@ import CommonPresentation
 @Observable final class AIAgentCommandViewState {
 
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
 
     var commandState: AIAgentCommandState?
     var usage: AIAgentUsage?
@@ -31,17 +31,17 @@ import CommonPresentation
         viewModel.commandState
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] in self?.commandState = $0 })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.usage
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] in self?.usage = $0 })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.currentUserPlan
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] in self?.userPlan = $0 })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandViewModel.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandViewModel.swift
@@ -53,7 +53,7 @@ final class AIAgentCommandViewModelImple: AIAgentCommandViewModel, @unchecked Se
     var router: (any AIAgentRouting)?
     weak var listener: (any AIAgentCommandSceneListener)?
 
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 
     init(
         orchestrationUsecase: any AIAgentOrchestrationUsecase,
@@ -66,7 +66,7 @@ final class AIAgentCommandViewModelImple: AIAgentCommandViewModel, @unchecked Se
             .removeDuplicates()
             .dropFirst()
             .sink { [weak self] _ in self?.orchestrationUsecase.loadUsage() }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/AIAgentScene/Sources/AIAgentImageCommand/AIAgentImageCommandView.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentImageCommand/AIAgentImageCommandView.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -24,7 +25,7 @@ import CommonPresentation
     var userPlan: BillingUserPlan?
     @ObservationIgnored private var didBind = false
     @ObservationIgnored private var didSeedText = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
 
     func bind(_ viewModel: any AIAgentImageCommandViewModel) {
         guard self.didBind == false else { return }
@@ -36,17 +37,17 @@ import CommonPresentation
                 self?.stage = stage
                 self?.seedTextIfNeeded(stage)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.usage
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] in self?.usage = $0 })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.currentUserPlan
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] in self?.userPlan = $0 })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 
     private func seedTextIfNeeded(_ stage: AIAgentImageCommandStage) {

--- a/Presentations/AIAgentScene/Sources/AIAgentKeyboardInput/AIAgentKeyboardInputView.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentKeyboardInput/AIAgentKeyboardInputView.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -17,7 +18,7 @@ import CommonPresentation
     var usage: AIAgentUsage?
     var userPlan: BillingUserPlan?
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
 
     func bind(_ viewModel: any AIAgentKeyboardInputViewModel) {
         guard self.didBind == false else { return }
@@ -26,12 +27,12 @@ import CommonPresentation
         viewModel.usage
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] in self?.usage = $0 })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.currentUserPlan
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] in self?.userPlan = $0 })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/BillingScenes/Sources/Paywall/PaywallView.swift
+++ b/Presentations/BillingScenes/Sources/Paywall/PaywallView.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -17,7 +18,7 @@ import CommonPresentation
 @Observable final class PaywallViewState {
 
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
 
     var currentPlan: BillingPlanId?
     var currentPlanDescription: String = ""
@@ -40,67 +41,67 @@ import CommonPresentation
         viewModel.currentPlan
             .receive(on: RunLoop.main)
             .sink { [weak self] in self?.currentPlan = $0 }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.currentPlanDescription
             .receive(on: RunLoop.main)
             .sink { [weak self] in self?.currentPlanDescription = $0 }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.scheduledChange
             .receive(on: RunLoop.main)
             .sink { [weak self] in self?.scheduledChange = $0 }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.screenState
             .receive(on: RunLoop.main)
             .sink { [weak self] in self?.screenState = $0 }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.catalogState
             .receive(on: RunLoop.main)
             .sink { [weak self] in self?.catalogState = $0 }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.cellModels
             .receive(on: RunLoop.main)
             .sink { [weak self] in self?.cellModels = $0 }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.topupCellModels
             .receive(on: RunLoop.main)
             .sink { [weak self] in self?.topupCellModels = $0 }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.topupTitle
             .receive(on: RunLoop.main)
             .sink { [weak self] in self?.topupTitle = $0 }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.selectedPlanId
             .receive(on: RunLoop.main)
             .sink { [weak self] in self?.selectedPlanId = $0 }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.selectedPlanDetail
             .receive(on: RunLoop.main)
             .sink { [weak self] in self?.selectedPlanDetail = $0 }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.isPurchasing
             .receive(on: RunLoop.main)
             .sink { [weak self] in self?.isPurchasing = $0 }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.hasUnfinishedTransactions
             .receive(on: RunLoop.main)
             .sink { [weak self] in self?.hasUnfinishedTransactions = $0 }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.showsManageSubscription
             .receive(on: RunLoop.main)
             .sink { [weak self] in self?.showsManageSubscription = $0 }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/BillingScenes/Sources/Paywall/PaywallViewModel.swift
+++ b/Presentations/BillingScenes/Sources/Paywall/PaywallViewModel.swift
@@ -128,7 +128,7 @@ final class PaywallViewModelImple: PaywallViewModel, @unchecked Sendable {
         let topupRemaining = CurrentValueSubject<Int?, Never>(nil)
     }
     private let subject = Subject()
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 
     private func currentOfferings(_ state: PaywallCatalogState) -> [BillingPlanOffering] {
         guard case .loaded(let offerings) = state else { return [] }
@@ -144,7 +144,7 @@ final class PaywallViewModelImple: PaywallViewModel, @unchecked Sendable {
                 self?.subject.scheduledChange.send(userPlan.scheduledChange)
                 self?.subject.topupRemaining.send(userPlan.topupRemaining)
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperView.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperView.swift
@@ -8,12 +8,13 @@
 
 import SwiftUI
 import Combine
+import Extensions
 import CommonPresentation
 
 @Observable final class CalendarPaperViewState {
 
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
 
     // 값 자체엔 의미가 없다 — 증가가 곧 스크롤 트리거다.
     fileprivate var scrollToVoiceInputTrigger: Int = 0
@@ -28,7 +29,7 @@ import CommonPresentation
             .sink { [weak self] _ in
                 self?.scrollToVoiceInputTrigger += 1
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperViewController.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperViewController.swift
@@ -10,6 +10,7 @@
 import SwiftUI
 import UIKit
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -21,7 +22,7 @@ final class CalendarPaperViewController: UIHostingController<CalenarPaperContain
     private let viewModel: any CalendarPaperViewModel
     let viewAppearance: ViewAppearance
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     @MainActor
     var interactor: (any CalendarPaperSceneInteractor)? { self.viewModel }

--- a/Presentations/CalendarScenes/Sources/CalendarViewController.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 import Combine
 import Domain
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -19,7 +20,7 @@ final class CalendarViewController: UIPageViewController, CalendarScene {
     @MainActor
     var interactor: (any CalendarSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any CalendarViewModel,
@@ -94,7 +95,7 @@ final class CalendarViewController: UIPageViewController, CalendarScene {
             .sink(receiveValue: { [weak self] tuple in
                 self?.setupStyling(tuple.1, tuple.2)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
@@ -97,7 +97,7 @@ final class CalendarViewModelImple: CalendarViewModel, @unchecked Sendable {
         let aiAgentState = CurrentValueSubject<AIAgentState?, Never>(nil)
         let isSignedIn = CurrentValueSubject<Bool, Never>(false)
     }
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
     // 슬라이드 도중 포커스가 통째로 바뀌면 뒤늦은 완료 콜백이 낡은 인덱스를 적용하지 않게 한다
     private var focusGeneration: Int = 0
@@ -118,7 +118,7 @@ final class CalendarViewModelImple: CalendarViewModel, @unchecked Sendable {
                     self?.calendarPaperInteractors?[safe: offset]?.updateMonthIfNeed(month)
                 }
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         self.bindEventUploadService()
         self.bindRefreshEvents()
@@ -129,13 +129,13 @@ final class CalendarViewModelImple: CalendarViewModel, @unchecked Sendable {
             .sink(receiveValue: { [weak self] isSignedIn in
                 self?.subject.isSignedIn.send(isSignedIn)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         self.aiAgentOrchestrationUsecase.state
             .sink(receiveValue: { [weak self] state in
                 self?.subject.aiAgentState.send(state)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     private func bindRefreshEvents() {
@@ -155,7 +155,7 @@ final class CalendarViewModelImple: CalendarViewModel, @unchecked Sendable {
             .sink(receiveValue: { [weak self] ranges in
                 self?.refreshEvents(ranges)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         let refreshAfterEnterForeground = NotificationCenter.default.publisher(
             for: UIApplication.willEnterForegroundNotification
@@ -172,13 +172,13 @@ final class CalendarViewModelImple: CalendarViewModel, @unchecked Sendable {
             self?.refreshEvents([total])
             self?.todoEventUsecase.refreshCurentTodoEvents()
         })
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
         
         refreshAfterEnterForeground
             .sink(receiveValue: { [weak self] in
                 self?.eventSyncUsecase.sync()
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     private func bindFocusedMonthChanged() {
@@ -217,7 +217,7 @@ final class CalendarViewModelImple: CalendarViewModel, @unchecked Sendable {
             logger.log(level: .debug, "select day changed: \(selected)")
             self?.listener?.calendarScene(focusChangedTo: selected)
         })
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func bindRefreshHoliday() {
@@ -230,7 +230,7 @@ final class CalendarViewModelImple: CalendarViewModel, @unchecked Sendable {
             .sink(receiveValue: { [weak self] newYears in
                 self?.refreshHolidays(for: newYears)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     private func refreshHolidays(for newYears: [Int]) {
@@ -239,7 +239,7 @@ final class CalendarViewModelImple: CalendarViewModel, @unchecked Sendable {
                 try? await self?.holidayUsecase.refreshHolidays(year)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func refreshEvents(_ ranges: [Range<TimeInterval>]) {
@@ -266,7 +266,7 @@ final class CalendarViewModelImple: CalendarViewModel, @unchecked Sendable {
                 }
             }
         })
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 
     private func bindVoiceInputLifecycle() {
@@ -278,13 +278,13 @@ final class CalendarViewModelImple: CalendarViewModel, @unchecked Sendable {
             .sink(receiveValue: { [weak self] _ in
                 self?.aiAgentOrchestrationUsecase.stopInput()
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         self.aiAgentOrchestrationUsecase.speechPermissionDenied
             .sink(receiveValue: { [weak self] _ in
                 self?.showSpeechPermissionSettingGuide()
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 
     private func showSpeechPermissionSettingGuide() {
@@ -310,7 +310,7 @@ extension CalendarViewModelImple {
             .sink(receiveValue: { [weak self] today in
                 self?.prepareInitialMonths(around: today)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.calendarSettingUsecase.prepare()
         Task { [weak self] in
@@ -378,7 +378,7 @@ extension CalendarViewModelImple {
                     thisMonthInteractor?.selectToday()
                 }
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     func moveDay(_ day: CalendarDay, withClearPresented: Bool) {
@@ -479,7 +479,7 @@ extension CalendarViewModelImple {
         .sink(receiveValue: { [weak self] _, _ in
             self?.todoEventUsecase.refreshUncompletedTodos()
         })
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 }
 
@@ -518,7 +518,7 @@ extension CalendarViewModelImple {
                 guard let self else { return }
                 self.router?.routeToAICommand(listener: self)
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 
     // 음성 입력 '진입 순간'에만 스크롤한다 — 같은 상태의 반복 방출로는 재스크롤하지 않는다.
@@ -533,7 +533,7 @@ extension CalendarViewModelImple {
                 else { return }
                 self?.calendarPaperInteractors?[safe: focusedIndex]?.scrollToVoiceInput()
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 
     private static func isAICommandPhase(_ state: AIAgentState) -> Bool {
@@ -559,7 +559,7 @@ extension CalendarViewModelImple {
         .sink(receiveValue: { [weak self] _, _ in
             self?.performAIEntry()
         })
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 
     private func performAIEntry() {

--- a/Presentations/CalendarScenes/Sources/Common/CalendarEvents/CalendarEventListhUsecase.swift
+++ b/Presentations/CalendarScenes/Sources/Common/CalendarEvents/CalendarEventListhUsecase.swift
@@ -79,7 +79,7 @@ final class CalendarEventListhUsecaseImple: CalendarEventListhUsecase, @unchecke
         let writableCalendarIds = CurrentValueSubject<WritableCalendarIds, Never>(.init())
     }
     private let subject = Subject()
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     private func internalBind() {
         
@@ -87,19 +87,19 @@ final class CalendarEventListhUsecaseImple: CalendarEventListhUsecase, @unchecke
             .sink(receiveValue: { [weak self] event in
                 self?.subject.foremostEvent.send(event)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.calendarSettingUsecase.currentTimeZone
             .sink(receiveValue: { [weak self] timeZone in
                 self?.subject.timeZone.send(timeZone)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.eventTagUsecase.offEventTagIdsOnCalendar()
             .sink(receiveValue: { [weak self] ids in
                 self?.subject.offTagIds.send(ids)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         Publishers.CombineLatest(
             self.googleCalendarUsecase.calendarTags,
@@ -117,7 +117,7 @@ final class CalendarEventListhUsecaseImple: CalendarEventListhUsecase, @unchecke
         .sink(receiveValue: { [weak self] ids in
             self?.subject.writableCalendarIds.send(ids)
         })
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellEventHanleViewModel.swift
@@ -89,7 +89,7 @@ final class EventListCellEventHanleViewModelImple: EventListCellEventHanleViewMo
         let doneTodoResult = PassthroughSubject<DoneTodoResult, Never>()
         let registeredLiveActivityTarget = CurrentValueSubject<LiveActivityTarget?, Never>(nil)
     }
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private var todoCompleteTaskMap: [String: Task<Void, any Error>] = [:]
     private let subject = Subject()
 
@@ -98,7 +98,7 @@ final class EventListCellEventHanleViewModelImple: EventListCellEventHanleViewMo
             .sink { [weak self] target in
                 self?.subject.registeredLiveActivityTarget.send(target)
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 
@@ -215,7 +215,7 @@ extension EventListCellEventHanleViewModelImple {
                     break
                 }
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 
     private func confirmReauthenticateThenRemove(
@@ -249,7 +249,7 @@ extension EventListCellEventHanleViewModelImple {
                 self.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 
     private func showWriteScopeNotGrantedGuide(_ reason: GoogleCalendarWriteScopeFailReason) {
@@ -277,7 +277,7 @@ extension EventListCellEventHanleViewModelImple {
                     self?.router?.showError(error)
                 }
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         }
     }
 
@@ -405,7 +405,7 @@ extension EventListCellEventHanleViewModelImple {
                     self?.router?.showError(error)
                 }
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         }
     }
     
@@ -452,7 +452,7 @@ extension EventListCellEventHanleViewModelImple {
                 self?.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func copyEvent(_ cellViewModel: any EventCellViewModel) {
@@ -496,7 +496,7 @@ extension EventListCellEventHanleViewModelImple {
                     eventTagId: todo.eventTagId ?? .default, detailId: todo.uuid
                 )
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 
     private func shareScheduleEvent(_ cellViewModel: ScheduleEventCellViewModel) {
@@ -513,7 +513,7 @@ extension EventListCellEventHanleViewModelImple {
                     eventTagId: schedule.eventTagId ?? .default, detailId: schedule.uuid
                 )
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 
     private func assembleAndShareText(
@@ -550,7 +550,7 @@ extension EventListCellEventHanleViewModelImple {
             )
             self?.showShareSheetIfNeeded(model, builder)
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 
     private func shareGoogleEvent(_ cellViewModel: GoogleCalendarEventCellViewModel) {
@@ -576,7 +576,7 @@ extension EventListCellEventHanleViewModelImple {
             }, receiveValue: { [weak self] origin, tags, timeZone in
                 self?.shareGoogleEventText(origin, calendarId: calendarId, tags: tags, timeZone: timeZone)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 
     private func shareGoogleEventText(
@@ -615,7 +615,7 @@ extension EventListCellEventHanleViewModelImple {
             guard let origin else { return }
             self?.shareAppleEventText(origin, calendarId: calendarId, tags: tags, timeZone: timeZone)
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 
     private func shareAppleEventText(

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellView.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellView.swift
@@ -21,7 +21,7 @@ import CommonPresentation
 @Observable final class PendingCompleteTodoState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     var ids: Set<String> = []
     
     func bind(_ viewModel: EventListCellEventHanleViewModel, _ appearance: ViewAppearance) {
@@ -37,7 +37,7 @@ import CommonPresentation
                     self.ids.remove(result.id)
                 }
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListView.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListView.swift
@@ -39,7 +39,7 @@ enum DayEventListScrollAnchor {
 @Observable final class DayEventListViewState {
 
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
 
     fileprivate var foremostModel: (any EventCellViewModel)?
     fileprivate var uncompletedTodos: [TodoEventCellViewModel] = []
@@ -83,7 +83,7 @@ enum DayEventListScrollAnchor {
                     self?.foremostModel = model
                 }
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.uncompletedTodoEventModels
             .receive(on: RunLoop.main)
@@ -92,14 +92,14 @@ enum DayEventListScrollAnchor {
                     self?.uncompletedTodos = models
                 }
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.selectedDay
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] model in
                 self?.dayModel = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.cellViewModels
             .receive(on: RunLoop.main)
@@ -108,7 +108,7 @@ enum DayEventListScrollAnchor {
                     self?.cellViewModels = cellViewModels
                 }
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.foremostEventMarkingStatus
             .receive(on: RunLoop.main)
@@ -117,24 +117,24 @@ enum DayEventListScrollAnchor {
                     self?.foremostEventMarkingStatus = status
                 }
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.aiAgentState
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] state in
                 self?.aiAgentState = state
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.recognizingText
             .receive(on: RunLoop.main)
             .sink { [weak self] text in self?.recognizingText = text }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.voiceLevel
             .receive(on: RunLoop.main)
             .sink { [weak self] level in self?.voiceLevel = level }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListViewModel.swift
@@ -138,7 +138,7 @@ final class DayEventListViewModelImple: DayEventListViewModel, @unchecked Sendab
         let aiAgentState = CurrentValueSubject<AIAgentState?, Never>(nil)
     }
 
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
     private let cvmCombineScheduler = DispatchQueue(label: "serial-combine")
 
@@ -148,13 +148,13 @@ final class DayEventListViewModelImple: DayEventListViewModel, @unchecked Sendab
             .sink { [weak self] signedIn in
                 self?.subject.isSignedIn.send(signedIn)
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         self.aiAgentOrchestrationUsecase.state
             .sink { [weak self] state in
                 self?.subject.aiAgentState.send(state)
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 
@@ -189,7 +189,7 @@ extension DayEventListViewModelImple {
                 $0.filter { $0.eventIdentifier != newPendingTodo.eventIdentifier }
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 
     private func updatePendingTodos(

--- a/Presentations/CalendarScenes/Sources/Month/MonthView.swift
+++ b/Presentations/CalendarScenes/Sources/Month/MonthView.swift
@@ -10,6 +10,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import CommonPresentation
 
 @Observable final class MonthViewState {
@@ -26,7 +27,7 @@ import CommonPresentation
     }
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     func bind(_ viewModel: any MonthViewModel) {
         guard self.didBind == false else { return }
@@ -40,28 +41,28 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] days in
                 self?.weekDays = days
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.weekModels
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] models in
                 self?.weeks = models
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.currentSelectDayIdentifier
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] identifier in
                 self?.selectedDay = identifier
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.todayIdentifier
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] identifier in
                 self?.today = identifier
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/CalendarScenes/Sources/Month/MonthViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/Month/MonthViewModel.swift
@@ -233,7 +233,7 @@ final class MonthViewModelImple: MonthViewModel, @unchecked Sendable {
         let eventStackMap = CurrentValueSubject<[String: WeekEventStack], Never>([:])
     }
     private let subject = Subject()
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private var currentMonthComponentsBinding: AnyCancellable?
     private let eventStackBuildingQueue = DispatchQueue(label: "event-stack-builder")
     
@@ -254,7 +254,7 @@ final class MonthViewModelImple: MonthViewModel, @unchecked Sendable {
             let totalComponent = CurrentMonthInfo(timeZone: timeZone, component: component, range: range)
             self?.subject.currentMonthInfo.send(totalComponent)
         })
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func bindEventsInCurrentMonth() {
@@ -286,7 +286,7 @@ final class MonthViewModelImple: MonthViewModel, @unchecked Sendable {
             .sink(receiveValue: { [weak self] stackMap in
                 self?.subject.eventStackMap.send(stackMap)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     private func bindCurerntSelectedDayNotifying() {
@@ -307,7 +307,7 @@ final class MonthViewModelImple: MonthViewModel, @unchecked Sendable {
             .sink(receiveValue: { [weak self] pair in
                 self?.listener?.monthScene(didChange: pair.0, and: pair.1)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/CalendarScenes/Sources/SelectDay/SelectDayDialogViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/SelectDay/SelectDayDialogViewModel.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Combine
 import Domain
+import Extensions
 import Scenes
 
 
@@ -43,7 +44,7 @@ final class SelectDayDialogViewModelImple: SelectDayDialogViewModel, @unchecked 
         let today = CurrentValueSubject<CalendarComponent.Day?, Never>(nil)
     }
     private let subject = Subject()
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     private func internalBinding() {
         
@@ -51,7 +52,7 @@ final class SelectDayDialogViewModelImple: SelectDayDialogViewModel, @unchecked 
             .sink(receiveValue: { [weak self] today in
                 self?.subject.today.send(today)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/CalendarScenes/Sources/SharePreview/SharePreviewView.swift
+++ b/Presentations/CalendarScenes/Sources/SharePreview/SharePreviewView.swift
@@ -19,7 +19,7 @@ import Extensions
 @Observable final class SharePreviewViewState {
 
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
 
     fileprivate var isTagFilterExpanded: Bool = false
     fileprivate var tagCellViewModels: [SharePreviewTagCellViewModel] = []
@@ -40,52 +40,52 @@ import Extensions
         viewModel.isTagFilterExpanded
             .receive(on: RunLoop.main)
             .sink { [weak self] isExpanded in self?.isTagFilterExpanded = isExpanded }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.tagCellViewModels
             .receive(on: RunLoop.main)
             .sink { [weak self] models in self?.tagCellViewModels = models }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.sectionModels
             .receive(on: RunLoop.main)
             .sink { [weak self] sections in self?.sectionModels = sections }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.dateHeaderText
             .receive(on: RunLoop.main)
             .sink { [weak self] text in self?.dateHeaderText = text }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.includeTagName
             .receive(on: RunLoop.main)
             .sink { [weak self] isOn in self?.includeTagName = isOn }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.isShareEnabled
             .receive(on: RunLoop.main)
             .sink { [weak self] isEnable in self?.isShareEnabled = isEnable }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.format
             .receive(on: RunLoop.main)
             .sink { [weak self] format in self?.format = format }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.imageContentModel
             .receive(on: RunLoop.main)
             .sink { [weak self] content in self?.imageContentModel = content }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.imageHeaderText
             .receive(on: RunLoop.main)
             .sink { [weak self] text in self?.imageHeaderText = text }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.isIncludeTagNameOptionVisible
             .receive(on: RunLoop.main)
             .sink { [weak self] isVisible in self?.isIncludeTagNameOptionVisible = isVisible }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/CalendarScenes/Sources/SharePreview/SharePreviewViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/SharePreview/SharePreviewViewModel.swift
@@ -107,7 +107,7 @@ final class SharePreviewViewModelImple: SharePreviewViewModel, @unchecked Sendab
         let format = CurrentValueSubject<SharePreviewFormat, Never>(.text)
     }
     private let subject = Subject()
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 }
 
 
@@ -122,7 +122,7 @@ extension SharePreviewViewModelImple {
                 self?.subject.rawLines.send(lines)
                 self?.subject.knownTagIds.send(Set(lines.compactMap { $0.tagId }))
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         self.subject.includeTagName.send(
             self.eventShareSettingUsecase.loadEventShareSetting().includeTagName
@@ -144,7 +144,7 @@ extension SharePreviewViewModelImple {
                 overrides[tagId] = !isCurrentlyOn
                 self.subject.userTagOverrides.send(overrides)
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 
     func selectAllTags() {
@@ -200,7 +200,7 @@ extension SharePreviewViewModelImple {
                 guard !text.isEmpty else { return }
                 self.router?.shareText(text)
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 
     private func shareImage() {
@@ -217,7 +217,7 @@ extension SharePreviewViewModelImple {
             guard !self.isEmptyContent(filtered) else { return }
             self.router?.shareImage(filtered, headerText: headerText)
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 
     func close() {

--- a/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
@@ -18,7 +18,7 @@ import UnitTestHelpKit
 @testable import CalendarScenes
 
 
-class CalendarViewModelImpleTests: BaseTestCase, PublisherWaitable {
+class CalendarViewModelImpleTests: BaseTestCase, PublisherWaitable, AsyncEffectWaitable {
     
     var cancelBag: Set<AnyCancellable>!
     private var spyRouter: SpyRouter!
@@ -1144,50 +1144,54 @@ extension CalendarViewModelImpleTests {
     func testViewModel_whenVoiceInputStarts_scrollsOnlyFocusedMonthPaper() async throws {
         // given
         let viewModel = self.makeViewModel()
-        viewModel.prepare()
-        try await Task.sleep(for: .milliseconds(50))
+        try await self.prepareInitialMonths(viewModel)
 
         // when
         self.stubOrchestration.stateSubject.send(.listening(.voice))
-        try await Task.sleep(for: .milliseconds(50))
 
         // then — 초기 포커스는 가운데(index 1) 달
-        let counts = self.spyRouter.spyInteractors.map { $0.didScrollToVoiceInputCount }
-        XCTAssertEqual(counts, [0, 1, 0])
+        try await self.assertScrollToVoiceInputCounts([0, 1, 0])
+        withExtendedLifetime(viewModel) { }
     }
 
     func testViewModel_whenFocusMovedToOtherMonth_scrollsThatMonthPaper() async throws {
         // given
         let viewModel = self.makeViewModel()
-        viewModel.prepare()
-        try await Task.sleep(for: .milliseconds(50))
+        try await self.prepareInitialMonths(viewModel)
 
         // when
         viewModel.focusChanged(from: 1, to: 2)
         self.stubOrchestration.stateSubject.send(.listening(.voice))
-        try await Task.sleep(for: .milliseconds(50))
 
         // then
-        let counts = self.spyRouter.spyInteractors.map { $0.didScrollToVoiceInputCount }
-        XCTAssertEqual(counts, [0, 0, 1])
+        try await self.assertScrollToVoiceInputCounts([0, 0, 1])
+        withExtendedLifetime(viewModel) { }
     }
 
     func testViewModel_whenStayInVoiceListening_scrollsOnlyOncePerEntry() async throws {
         // given
         let viewModel = self.makeViewModel()
-        viewModel.prepare()
-        try await Task.sleep(for: .milliseconds(50))
+        try await self.prepareInitialMonths(viewModel)
 
         // when — 같은 상태가 반복 방출돼도 진입 edge는 1회
         self.stubOrchestration.stateSubject.send(.listening(.voice))
         self.stubOrchestration.stateSubject.send(.listening(.voice))
-        try await Task.sleep(for: .milliseconds(50))
 
         // then
-        let counts = self.spyRouter.spyInteractors.map { $0.didScrollToVoiceInputCount }
-        XCTAssertEqual(counts, [0, 1, 0])
+        try await self.assertScrollToVoiceInputCounts([0, 1, 0])
+        withExtendedLifetime(viewModel) { }
     }
 
+    private var scrollToVoiceInputCounts: [Int] {
+        return self.spyRouter.spyInteractors.map { $0.didScrollToVoiceInputCount }
+    }
+
+    // 스크롤이 도착할 때까지 기다린 뒤, 뒤늦은 추가 방출이 없는지 정착 시간을 두고 다시 본다
+    private func assertScrollToVoiceInputCounts(_ expected: [Int]) async throws {
+        try await self.waitEffect("스크롤 횟수 \(expected) 도달") { self.scrollToVoiceInputCounts == expected }
+        try await Task.sleep(for: .milliseconds(50))
+        XCTAssertEqual(self.scrollToVoiceInputCounts, expected)
+    }
 }
 
 // MARK: - 외부 진입점의 AI 입력 요청 (requestAIEntry)
@@ -1549,65 +1553,73 @@ private extension CalendarViewModelImpleTests {
 
 extension CalendarViewModelImpleTests {
 
+    // VM이 해제되면 구독도 끊겨 단언이 무의미해지므로 호출측이 받아 살려둔다
     private func postAppLifecycleAfterPrepared(
         _ notificationName: Notification.Name,
         state: AIAgentState?
-    ) async throws {
+    ) async throws -> CalendarViewModelImple {
         let viewModel = self.makeViewModel()
-        viewModel.prepare()
-        try await Task.sleep(for: .milliseconds(50))
+        try await self.prepareInitialMonths(viewModel)
         state.map { self.stubOrchestration.stateSubject.send($0) }
 
         NotificationCenter.default.post(name: notificationName, object: nil)
-        try await Task.sleep(for: .milliseconds(50))
-        // VM이 해제되면 구독도 끊겨 단언이 무의미해진다
-        withExtendedLifetime(viewModel) { }
+        return viewModel
     }
 
-    private func enterBackgroundAfterPrepared(state: AIAgentState?) async throws {
-        try await self.postAppLifecycleAfterPrepared(
+    private func enterBackgroundAfterPrepared(state: AIAgentState?) async throws -> CalendarViewModelImple {
+        return try await self.postAppLifecycleAfterPrepared(
             UIApplication.didEnterBackgroundNotification, state: state
         )
     }
 
+    // 중지가 일어나지 '않음'을 보는 케이스는 기다릴 조건이 없어 정착 시간만 둔다
+    private func assertKeepsInputAfterSettling() async throws {
+        try await Task.sleep(for: .milliseconds(50))
+        XCTAssertNil(self.stubOrchestration.didStopInput)
+    }
+
     func testViewModel_whenAppEntersBackgroundWhileVoiceListening_stopsInput() async throws {
         // given, when
-        try await self.enterBackgroundAfterPrepared(state: .listening(.voice))
+        let viewModel = try await self.enterBackgroundAfterPrepared(state: .listening(.voice))
 
         // then
+        try await self.waitEffect("백그라운드 전환으로 입력 중지") { self.stubOrchestration.didStopInput == true }
         XCTAssertEqual(self.stubOrchestration.didStopInput, true)
+        withExtendedLifetime(viewModel) { }
     }
 
     func testViewModel_whenAppEntersBackgroundWhileKeyboardListening_keepsInput() async throws {
         // given, when
-        try await self.enterBackgroundAfterPrepared(state: .listening(.keyboard))
+        let viewModel = try await self.enterBackgroundAfterPrepared(state: .listening(.keyboard))
 
         // then
-        XCTAssertNil(self.stubOrchestration.didStopInput)
+        try await self.assertKeepsInputAfterSettling()
+        withExtendedLifetime(viewModel) { }
     }
 
     func testViewModel_whenAppEntersBackgroundWhileIdle_keepsInput() async throws {
         // given, when
-        try await self.enterBackgroundAfterPrepared(state: .idle)
+        let viewModel = try await self.enterBackgroundAfterPrepared(state: .idle)
 
         // then
-        XCTAssertNil(self.stubOrchestration.didStopInput)
+        try await self.assertKeepsInputAfterSettling()
+        withExtendedLifetime(viewModel) { }
     }
 
     func testViewModel_whenAppResignsActiveWhileVoiceListening_keepsInput() async throws {
         // given, when
-        try await self.postAppLifecycleAfterPrepared(
+        let viewModel = try await self.postAppLifecycleAfterPrepared(
             UIApplication.willResignActiveNotification, state: .listening(.voice)
         )
 
         // then
-        XCTAssertNil(self.stubOrchestration.didStopInput)
+        try await self.assertKeepsInputAfterSettling()
+        withExtendedLifetime(viewModel) { }
     }
 
     private func makePreparedViewModel() async throws -> CalendarViewModelImple {
         let viewModel = self.makeViewModel()
-        viewModel.prepare()
-        try await Task.sleep(for: .milliseconds(50))
+        try await self.prepareInitialMonths(viewModel)
         return viewModel
     }
 

--- a/Presentations/EventDetailScene/Sources/DoneTodoDetail/DoneTodoDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/DoneTodoDetail/DoneTodoDetailView.swift
@@ -12,6 +12,7 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -20,7 +21,7 @@ import CommonPresentation
 @Observable final class DoneTodoDetailViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     var name: String?
     var tag: SelectedTag?
@@ -43,56 +44,56 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] name in
                 self?.name = name
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.eventTag
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] tag in
                 self?.tag = tag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.timeModel
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] model in
                 self?.timeModel = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.notificationTimeText
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] text in
                 self?.notificationOptions = text
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.url
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] url in
                 self?.url = url
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.memo
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] memo in
                 self?.memo = memo
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.placeModel
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] place in
                 self?.placeModel = place
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isReverting
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] flag in
                 self?.isReverting = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/EventDetailScene/Sources/DoneTodoDetail/DoneTodoDetailViewController.swift
+++ b/Presentations/EventDetailScene/Sources/DoneTodoDetail/DoneTodoDetailViewController.swift
@@ -11,6 +11,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -25,7 +26,7 @@ final class DoneTodoDetailViewController: UIHostingController<DoneTodoDetailCont
     @MainActor
     var interactor: (any DoneTodoDetailSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any DoneTodoDetailViewModel,
@@ -62,6 +63,6 @@ final class DoneTodoDetailViewController: UIHostingController<DoneTodoDetailCont
             .sink(receiveValue: { [weak self] isReverting in
                 self?.isModalInPresentation = isReverting
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }

--- a/Presentations/EventDetailScene/Sources/DoneTodoDetail/DoneTodoDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/DoneTodoDetail/DoneTodoDetailViewModel.swift
@@ -13,6 +13,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -83,7 +84,7 @@ final class DoneTodoDetailViewModelImple: DoneTodoDetailViewModel, @unchecked Se
         let isReverting = CurrentValueSubject<Bool, Never>(false)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 }
 
@@ -98,7 +99,7 @@ extension DoneTodoDetailViewModelImple {
             .sink(receiveValue: { [weak self] done in
                 self?.subject.doneToddo.send(done)
             }, receiveError: self.handleError())
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.doneDetailUsecase.loadDetail(self.uuid)
             .mapAsOptional()
@@ -106,7 +107,7 @@ extension DoneTodoDetailViewModelImple {
             .sink(receiveValue: { [weak self] detail in
                 self?.subject.doneTodoDetail.send(detail)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     func openMap() {
@@ -145,7 +146,7 @@ extension DoneTodoDetailViewModelImple {
                 self?.handleError()(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func handleReverted(_ todo: TodoEvent) {

--- a/Presentations/EventDetailScene/Sources/EventDetailInput/EventDetailInputViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailInput/EventDetailInputViewModel.swift
@@ -196,7 +196,7 @@ final class EventDetailInputViewModelImple: EventDetailInputViewModel, @unchecke
         }
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 }
 
@@ -213,7 +213,7 @@ extension EventDetailInputViewModelImple {
         .sink(receiveValue: { [weak self] (basic, additional) in
             self?.listener?.eventDetail(didInput: basic, additional: additional)
         })
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
         
         let setting = self.eventSettingUsecase.loadEventSetting()
         self.subject.eventSetting.send(setting)
@@ -240,7 +240,7 @@ extension EventDetailInputViewModelImple {
             .sink(receiveValue: { [weak self] preview in
                 self?.subject.linkPreview.send(preview)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     func prepared(basic: EventDetailBasicData, additional: EventDetailData) {
@@ -254,7 +254,7 @@ extension EventDetailInputViewModelImple {
             .compactMap { $0 }
             .first()
             .sink(receiveValue: update)
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     func enter(name: String) {

--- a/Presentations/EventDetailScene/Sources/EventDetailInput/SelectMapApp/SelectMapAppDialogView.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailInput/SelectMapApp/SelectMapAppDialogView.swift
@@ -12,6 +12,7 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -20,7 +21,7 @@ import CommonPresentation
 @Observable final class SelectMapAppDialogViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     var supportMapApps: [SupportMapApps] = []
     var openMapWithThisSelection: Bool = false
@@ -37,7 +38,7 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] option in
                 self?.openMapWithThisSelection = option
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/EventDetailScene/Sources/EventDetailInput/SelectMapApp/SelectMapAppDialogViewController.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailInput/SelectMapApp/SelectMapAppDialogViewController.swift
@@ -11,6 +11,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -25,7 +26,7 @@ final class SelectMapAppDialogViewController: UIHostingController<SelectMapAppDi
     @MainActor
     var interactor: (any SelectMapAppDialogSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any SelectMapAppDialogViewModel,

--- a/Presentations/EventDetailScene/Sources/EventDetailInput/SelectMapApp/SelectMapAppDialogViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailInput/SelectMapApp/SelectMapAppDialogViewModel.swift
@@ -13,6 +13,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 
@@ -55,7 +56,7 @@ final class SelectMapAppDialogViewModelImple: SelectMapAppDialogViewModel, @unch
         let alwaysSelectThisMapOption = CurrentValueSubject<Bool, Never>(false)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 }
 

--- a/Presentations/EventDetailScene/Sources/EventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailView.swift
@@ -21,7 +21,7 @@ import Scenes
 @Observable final class EventDetailViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     var selectedTag: SelectedTag?
     var enterName: String = ""
@@ -69,42 +69,42 @@ import Scenes
             .sink(receiveValue: { [weak self] model in
                 self?.eventDetailTypeModel = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         inputViewModel.initialName
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] name in
                 self?.enterName = name ?? ""
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         inputViewModel.initailURL
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] value in
                 self?.url = value ?? ""
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         inputViewModel.isValidURLEntered
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] isValid in
                 self?.isValidURLEntered = isValid
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         inputViewModel.linkPreview
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] model in
                 self?.linkPreviewModel = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         inputViewModel.initialMemo
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] value in
                 self?.memo = value ?? ""
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         inputViewModel.selectedTime
             .receive(on: RunLoop.main)
@@ -112,84 +112,84 @@ import Scenes
                 self?.selectedTime = time
                 self?.isAllDay = time?.isAllDay ?? false
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         inputViewModel.selectedTimeDDay
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] text in
                 self?.ddayText = text
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         inputViewModel.repeatOption
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] option in
                 self?.selectedRepeat = option
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         inputViewModel.repeatOptionPeriod
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] period in
                 self?.selectedRepeatPeriod = period
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         inputViewModel.selectedTag
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] tag in
                 self?.selectedTag = tag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         inputViewModel.selectedNotificationTimeText
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] text in
                 self?.selectedNotificationTimeText = text
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         inputViewModel.suggestPlaces
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] places in
                 self?.suggestPlaces = places
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         inputViewModel.selectedPlace
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] place in
                 self?.selectedPlace = place
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isForemost
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] isForemost in
                 self?.isForemost = isForemost
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isSaving
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] isSaving in
                 self?.isSaving = isSaving
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isSavable
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] isSavable in
                 self?.isSavable = isSavable
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.moreActions
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] actions in
                 self?.availableMoreActions = actions
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/EventDetailScene/Sources/EventDetailViewController.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailViewController.swift
@@ -10,6 +10,7 @@
 import UIKit
 import Prelude
 import Optics
+import Extensions
 import SwiftUI
 import Combine
 import Scenes
@@ -31,7 +32,7 @@ final class EventDetailViewController: UIHostingController<EventDetailContainerV
     @MainActor
     var interactor: EmptyInteractor?
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any EventDetailViewModel,
@@ -80,7 +81,7 @@ extension EventDetailViewController: UIAdaptivePresentationControllerDelegate {
             self?.isSaving = isSaving
             self?.isModalInPresentation = hasChanges || isSaving
         })
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     func presentationControllerDidAttemptToDismiss(

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailView.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -18,7 +19,7 @@ import CommonPresentation
 @Observable final class AppleCalendarEventDetailViewState {
 
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
 
     var isEditable: Bool = false
     var readOnlyCalendarMessage: String?
@@ -45,98 +46,98 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] isEditable in
                 self?.isEditable = isEditable
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.readOnlyCalendarMessage
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] message in
                 self?.readOnlyCalendarMessage = message
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.eventName
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] name in
                 self?.eventName = name
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.timeText
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] text in
                 self?.timeText = text
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.ddayText
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] text in
                 self?.ddayText = text
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.repeatText
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] text in
                 self?.repeatText = text
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.location
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] text in
                 self?.location = text ?? ""
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.url
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] text in
                 self?.url = text ?? ""
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.notes
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] text in
                 self?.notes = text ?? ""
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.attendees
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] list in
                 self?.attendees = list
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.tagModel
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] model in
                 self?.tagModel = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.isSavable
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] isSavable in
                 self?.isSavable = isSavable
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.isSaving
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] isSaving in
                 self?.isSaving = isSaving
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.liveActivityActionModel
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] model in
                 self?.liveActivityActionModel = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewController.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewController.swift
@@ -9,6 +9,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -23,7 +24,7 @@ final class AppleCalendarEventDetailViewController: UIHostingController<AppleCal
     @MainActor
     var interactor: (any AppleCalendarEventDetailSceneInteractor)? { self.viewModel }
 
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 
     init(
         viewModel: any AppleCalendarEventDetailViewModel,

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailViewModel.swift
@@ -115,7 +115,7 @@ final class AppleCalendarEventDetailViewModelImple: AppleCalendarEventDetailView
         let isWritable = CurrentValueSubject<Bool?, Never>(nil)
     }
 
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 
     private func internalBind() {
@@ -124,7 +124,7 @@ final class AppleCalendarEventDetailViewModelImple: AppleCalendarEventDetailView
             .sink { [weak self] timeZone in
                 self?.subject.timeZone.send(timeZone)
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         let calendarId = self.calendarId
         self.appleCalendarUsecase.calendarTags
@@ -132,13 +132,13 @@ final class AppleCalendarEventDetailViewModelImple: AppleCalendarEventDetailView
             .sink { [weak self] tag in
                 self?.subject.calendarTag.send(tag)
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         self.appleCalendarUsecase.isCalendarWritable(calendarId)
             .sink { [weak self] isWritable in
                 self?.subject.isWritable.send(isWritable)
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 
@@ -153,7 +153,7 @@ extension AppleCalendarEventDetailViewModelImple {
             .sink { [weak self] origin in
                 self?.applyLoaded(origin)
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 
     private func applyLoaded(_ origin: AppleCalendar.EventOrigin) {
@@ -367,7 +367,7 @@ extension AppleCalendarEventDetailViewModelImple {
                 self.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 }
 
@@ -441,7 +441,7 @@ extension AppleCalendarEventDetailViewModelImple {
                 self.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 }
 
@@ -474,7 +474,7 @@ extension AppleCalendarEventDetailViewModelImple {
                 guard !text.isEmpty else { return }
                 self?.router?.showShareSheet(text: text)
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailView.swift
@@ -15,6 +15,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -24,7 +25,7 @@ import CommonPresentation
 @Observable final class GoogleCalendarEventDetailViewState {
 
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
 
     var isEditable: Bool = false
     var readOnlyCalendarMessage: String?
@@ -55,70 +56,70 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] isEditable in
                 self?.isEditable = isEditable
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.readOnlyCalendarMessage
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] message in
                 self?.readOnlyCalendarMessage = message
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.hasDetailLink
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] has in
                 self?.hasDetailLink = has
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.eventColorModel
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] model in
                 self?.eventColor = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.eventName
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] name in
                 self?.eventName = name
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.timeText
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] text in
                 self?.timeText = text
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.ddayText
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] text in
                 self?.ddayText = text
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.repeatOption
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] option in
                 self?.repeatOptionText = option
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.calendarModel
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] model in
                 self?.calendarModel = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.location
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] text in
                 self?.location = text ?? ""
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.descriptionModel
             .receive(on: RunLoop.main)
@@ -132,49 +133,49 @@ import CommonPresentation
                     self?.memo = raw
                 }
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.attachments
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] models in
                 self?.attachments = models
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.attendees
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] model in
                 self?.attendees = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.conferenceModel
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] model in
                 self?.conferenceData = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.isSavable
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] isSavable in
                 self?.isSavable = isSavable
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.isSaving
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] isSaving in
                 self?.isSaving = isSaving
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.liveActivityActionModel
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] model in
                 self?.liveActivityActionModel = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewController.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewController.swift
@@ -13,6 +13,7 @@ import SwiftUI
 import Combine
 import Prelude
 import Optics
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -30,7 +31,7 @@ final class GoogleCalendarEventDetailViewController: UIHostingController<GoogleC
 
     private var hasChanges: Bool = false
     private var isSaving: Bool = false
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 
     init(
         viewModel: any GoogleCalendarEventDetailViewModel,
@@ -79,7 +80,7 @@ extension GoogleCalendarEventDetailViewController: UIAdaptivePresentationControl
             self?.isSaving = isSaving
             self?.isModalInPresentation = hasChanges || isSaving
         })
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 
     func presentationControllerDidAttemptToDismiss(

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailViewModel.swift
@@ -227,7 +227,7 @@ final class GoogleCalendarEventDetailViewModelImple: GoogleCalendarEventDetailVi
         let isDescriptionPlainEditing = CurrentValueSubject<Bool, Never>(false)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
     
     private func internalBind() {
@@ -236,7 +236,7 @@ final class GoogleCalendarEventDetailViewModelImple: GoogleCalendarEventDetailVi
             .sink(receiveValue: { [weak self] timeZone in
                 self?.subject.timeZone.send(timeZone)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         let calendarId = self.calendarId
         self.googleCalendarUsecase.calendarTags
@@ -244,7 +244,7 @@ final class GoogleCalendarEventDetailViewModelImple: GoogleCalendarEventDetailVi
             .sink(receiveValue: { [weak self] tag in
                 self?.subject.calendarTag.send(tag)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         self.googleCalendarUsecase.eventWritePermission(
             accountId: self.accountId, calendarId: self.calendarId
@@ -252,7 +252,7 @@ final class GoogleCalendarEventDetailViewModelImple: GoogleCalendarEventDetailVi
         .sink(receiveValue: { [weak self] permission in
             self?.subject.writePermission.send(permission)
         })
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 }
 
@@ -281,7 +281,7 @@ extension GoogleCalendarEventDetailViewModelImple {
             }, receiveError: { [weak self] error in
                 self?.router?.showError(error)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 
     private func alertEventCanceled() {
@@ -466,7 +466,7 @@ extension GoogleCalendarEventDetailViewModelImple {
                 self.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 
     private func showWriteScopeNotGrantedGuide(_ reason: GoogleCalendarWriteScopeFailReason) {
@@ -574,7 +574,7 @@ extension GoogleCalendarEventDetailViewModelImple {
                 self.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 
 }
@@ -656,7 +656,7 @@ extension GoogleCalendarEventDetailViewModelImple {
                 self.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 }
 
@@ -708,7 +708,7 @@ extension GoogleCalendarEventDetailViewModelImple {
                 guard !text.isEmpty else { return }
                 self?.router?.showShareSheet(text: text)
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailView.swift
@@ -22,7 +22,7 @@ import Scenes
 @Observable final class HolidayEventDetailViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     var name: String = ""
     var dateText: String = ""
@@ -40,35 +40,35 @@ import Scenes
             .sink(receiveValue: { [weak self] name in
                 self?.name = name
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.dateText
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] text in
                 self?.dateText = text
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.ddayText
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] text in
                 self?.ddayText = text
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.countryModel
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] model in
                 self?.countryModel = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.liveActivityActionModel
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] model in
                 self?.liveActivityActionModel = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailViewController.swift
+++ b/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailViewController.swift
@@ -11,6 +11,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -25,7 +26,7 @@ final class HolidayEventDetailViewController: UIHostingController<HolidayEventDe
     @MainActor
     var interactor: (any HolidayEventDetailSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any HolidayEventDetailViewModel,

--- a/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailViewModel.swift
@@ -70,7 +70,7 @@ final class HolidayEventDetailViewModelImple: HolidayEventDetailViewModel, @unch
         let holiday = CurrentValueSubject<Holiday?, Never>(nil)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 }
 
@@ -85,13 +85,13 @@ extension HolidayEventDetailViewModelImple {
             .sink(receiveValue: { [weak self] holiday in
                 self?.subject.holiday.send(holiday)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.holidayUsecase.currentSelectedCountry
             .sink(receiveValue: { [weak self] country in
                 self?.subject.country.send(country)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     func close() {

--- a/Presentations/EventDetailScene/Sources/Selections/SelectEventNotificationTime/SelectEventNotificationTimeView.swift
+++ b/Presentations/EventDetailScene/Sources/Selections/SelectEventNotificationTime/SelectEventNotificationTimeView.swift
@@ -20,7 +20,7 @@ import CommonPresentation
 @Observable final class SelectEventNotificationTimeViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     var defaultTimeOptions: [NotificationTimeOptionModel] = []
     var customTimeOptions: [CustomTimeOptionModel] = []
@@ -49,28 +49,28 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] models in
                 self?.defaultTimeOptions = models
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.customTimeOptions
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] models in
                 self?.customTimeOptions = models
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.selectedDefaultTimeOptions
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] options in
                 self?.selectedDefaultTimeOptions = options
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isNeedNotificaitonPermission
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] in
                 self?.notificaitonPermissionDenied = true
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/EventDetailScene/Sources/Selections/SelectEventNotificationTime/SelectEventNotificationTimeViewController.swift
+++ b/Presentations/EventDetailScene/Sources/Selections/SelectEventNotificationTime/SelectEventNotificationTimeViewController.swift
@@ -11,6 +11,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -25,7 +26,7 @@ final class SelectEventNotificationTimeViewController: UIHostingController<Selec
     @MainActor
     var interactor: (any SelectEventNotificationTimeSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any SelectEventNotificationTimeViewModel,

--- a/Presentations/EventDetailScene/Sources/Selections/SelectEventNotificationTime/SelectEventNotificationTimeViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/Selections/SelectEventNotificationTime/SelectEventNotificationTimeViewModel.swift
@@ -13,6 +13,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -97,7 +98,7 @@ final class SelectEventNotificationTimeViewModelImple: SelectEventNotificationTi
         let notificationPermissionDenied = PassthroughSubject<Void, Never>()
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
     
     private func bindChangedOptionChanged() {
@@ -108,7 +109,7 @@ final class SelectEventNotificationTimeViewModelImple: SelectEventNotificationTi
             .sink(receiveValue: { [weak self] options in
                 self?.listener?.selectEventNotificationTime(didUpdate: options)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 
@@ -142,7 +143,7 @@ extension SelectEventNotificationTimeViewModelImple {
             default: break
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     func toggleSelectDefaultOption(_ option: EventNotificationTimeOption?) {

--- a/Presentations/EventDetailScene/Sources/Selections/SelectEventRepeatOption/SelectEventRepeatOptionView.swift
+++ b/Presentations/EventDetailScene/Sources/Selections/SelectEventRepeatOption/SelectEventRepeatOptionView.swift
@@ -34,7 +34,7 @@ enum SelectEndOptionType: Int {
 @Observable final class SelectEventRepeatOptionViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     var optionList: [[SelectRepeatingOptionModel]] = []
     var selectedOptionId: String?
@@ -55,28 +55,28 @@ enum SelectEndOptionType: Int {
             .sink(receiveValue: { [weak self] text in
                 self?.repeatStartTimeText = text
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.options
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] list in
                 self?.optionList = list
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.selectedOptionId
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] id in
                 self?.selectedOptionId = id
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.defaultRepeatEndDate
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] date in
                 self?.selectedEndDate = date
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.repeatEndOption
             .receive(on: RunLoop.main)
@@ -94,14 +94,14 @@ enum SelectEndOptionType: Int {
                     self?.selectEndOptionType = .after
                 }
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isNoRepeatOption
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] flag in
                 self?.isNoRepeatOption = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/EventDetailScene/Sources/Selections/SelectEventRepeatOption/SelectEventRepeatOptionViewController.swift
+++ b/Presentations/EventDetailScene/Sources/Selections/SelectEventRepeatOption/SelectEventRepeatOptionViewController.swift
@@ -10,6 +10,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -24,7 +25,7 @@ final class SelectEventRepeatOptionViewController: UIHostingController<SelectEve
     @MainActor
     var interactor: (any SelectEventRepeatOptionSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any SelectEventRepeatOptionViewModel,

--- a/Presentations/EventDetailScene/Sources/Selections/SelectEventRepeatOption/SelectEventRepeatOptionViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/Selections/SelectEventRepeatOption/SelectEventRepeatOptionViewModel.swift
@@ -164,7 +164,7 @@ final class SelectEventRepeatOptionViewModelImple: SelectEventRepeatOptionViewMo
         let endOption = CurrentValueSubject<RepeatEndOptionModel?, Never>(nil)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 }
 
@@ -184,7 +184,7 @@ extension SelectEventRepeatOptionViewModelImple {
         self.calendarSettingUsecase.currentTimeZone
             .first()
             .sink(receiveValue: setupValue)
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     private func setupOptionModels(

--- a/Presentations/EventDetailScene/Sources/Selections/SelectEventTag/SelectEventTagView.swift
+++ b/Presentations/EventDetailScene/Sources/Selections/SelectEventTag/SelectEventTagView.swift
@@ -20,7 +20,7 @@ import CommonPresentation
 @Observable final class SelectEventTagViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     var tags: [TagCellViewModel] = []
     var selectedTagId: EventTagId?
@@ -36,14 +36,14 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] tags in
                 self?.tags = tags
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.selectedTagId
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] id in
                 self?.selectedTagId = id
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/EventDetailScene/Sources/Selections/SelectEventTag/SelectEventTagViewController.swift
+++ b/Presentations/EventDetailScene/Sources/Selections/SelectEventTag/SelectEventTagViewController.swift
@@ -10,6 +10,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -24,7 +25,7 @@ final class SelectEventTagViewController: UIHostingController<SelectEventTagCont
     @MainActor
     var interactor: (any SelectEventTagSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any SelectEventTagViewModel,

--- a/Presentations/EventDetailScene/Sources/Selections/SelectEventTag/SelectEventTagViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/Selections/SelectEventTag/SelectEventTagViewModel.swift
@@ -12,6 +12,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 
@@ -76,7 +77,7 @@ final class SelectEventTagViewModelImple: SelectEventTagViewModel, @unchecked Se
         let tags = CurrentValueSubject<[any EventTag]?, Never>(nil)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
     
     private func bindSelectedTagNotify() {
@@ -86,7 +87,7 @@ final class SelectEventTagViewModelImple: SelectEventTagViewModel, @unchecked Se
             .sink(receiveValue: { [weak self] tag in
                 self?.listener?.selectEventTag(didSelected: tag)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 
@@ -111,7 +112,7 @@ extension SelectEventTagViewModelImple {
         
         self.tagUsecase.loadAllEventTags()
             .sink(receiveValue: loaded, receiveError: handleError)
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     func selectTag(_ id: EventTagId) {

--- a/Presentations/EventDetailScene/Sources/ViewModels/AddEventViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/AddEventViewModel.swift
@@ -63,7 +63,7 @@ final class AddEventViewModelImple: EventDetailViewModel, @unchecked Sendable {
         let isSaving = CurrentValueSubject<Bool, Never>(false)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private var inputInteractor: (any EventDetailInputInteractor)?
     private let subject = Subject()
     
@@ -72,7 +72,7 @@ final class AddEventViewModelImple: EventDetailViewModel, @unchecked Sendable {
             .sink(receiveValue: { [weak self] timeZone in
                 self?.subject.timeZone.send(timeZone)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 
@@ -106,7 +106,7 @@ extension AddEventViewModelImple: EventDetailInputListener {
                 self?.inputInteractor?.prepared(basic: pair.0, additional: pair.1)
                 self?.subject.isTodo.send(params.isTodoCase)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     private func prepareBasicData(
@@ -250,7 +250,7 @@ extension AddEventViewModelImple: EventDetailInputListener {
             }
             self?.subject.isSaving.send(false)
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func saveNewScheduleEvent() {
@@ -279,7 +279,7 @@ extension AddEventViewModelImple: EventDetailInputListener {
             }
             self?.subject.isSaving.send(false)
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func saveEventDetailWithoutError(_ eventId: String?) async {

--- a/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
@@ -66,7 +66,7 @@ final class EditScheduleEventDetailViewModelImple: EventDetailViewModel, @unchec
         let timeZone = CurrentValueSubject<TimeZone?, Never>(nil)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
     private weak var inputInteractor: (any EventDetailInputInteractor)?
     
@@ -76,7 +76,7 @@ final class EditScheduleEventDetailViewModelImple: EventDetailViewModel, @unchec
             .sink(receiveValue: { [weak self] timeZone in
                 self?.subject.timeZone.send(timeZone)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 
@@ -121,7 +121,7 @@ extension EditScheduleEventDetailViewModelImple: EventDetailInputListener {
             self.additionDataWithoutError().mapNever()
         )
         .sink(receiveCompletion: handleCompleted, receiveValue: handlePrepared)
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func prepareBasicData() -> AnyPublisher<EventDetailBasicData, any Error> {
@@ -203,7 +203,7 @@ extension EditScheduleEventDetailViewModelImple: EventDetailInputListener {
                 guard !text.isEmpty else { return }
                 self?.router?.showShareSheet(text: text)
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     private func removeEventAfterConfirm(onlyThisTime: Bool) {
@@ -238,7 +238,7 @@ extension EditScheduleEventDetailViewModelImple: EventDetailInputListener {
                     self?.router?.showError(error)
                 }
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         }
     }
     
@@ -272,7 +272,7 @@ extension EditScheduleEventDetailViewModelImple: EventDetailInputListener {
                     self?.router?.showError(error)
                 }
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         }
     }
 
@@ -371,7 +371,7 @@ extension EditScheduleEventDetailViewModelImple: EventDetailInputListener {
                 self.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func replaceEventDetailToTodo(_ scheduleId: String, _ newTodoId: String) async {
@@ -517,7 +517,7 @@ extension EditScheduleEventDetailViewModelImple: EventDetailInputListener {
             }
             self?.subject.isSaving.send(false)
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func scheduleEditParams(from basic: EventDetailBasicData, _ timeZone: TimeZone) -> SchedulePutParams {

--- a/Presentations/EventDetailScene/Sources/ViewModels/EditTodoEventDetailViewModelImple.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/EditTodoEventDetailViewModelImple.swift
@@ -60,7 +60,7 @@ final class EditTodoEventDetailViewModelImple: EventDetailViewModel, @unchecked 
         let timeZone = CurrentValueSubject<TimeZone?, Never>(nil)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
     private weak var inputInteractor: (any EventDetailInputInteractor)?
     
@@ -70,7 +70,7 @@ final class EditTodoEventDetailViewModelImple: EventDetailViewModel, @unchecked 
             .sink(receiveValue: { [weak self] timeZone in
                 self?.subject.timeZone.send(timeZone)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 
@@ -113,7 +113,7 @@ extension EditTodoEventDetailViewModelImple: EventDetailInputListener {
             self.additionDataWithoutError().mapNever()
         )
         .sink(receiveCompletion: handleComplete, receiveValue: handlePrepared)
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func prepareBasicData() -> AnyPublisher<EventDetailBasicData, any Error> {
@@ -189,7 +189,7 @@ extension EditTodoEventDetailViewModelImple: EventDetailInputListener {
                 guard !text.isEmpty else { return }
                 self?.router?.showShareSheet(text: text)
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     private func removeEventAfterConfirm(onlyThisTime: Bool) {
@@ -218,7 +218,7 @@ extension EditTodoEventDetailViewModelImple: EventDetailInputListener {
                     self?.router?.showError(error)
                 }
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         }
     }
     
@@ -265,7 +265,7 @@ extension EditTodoEventDetailViewModelImple: EventDetailInputListener {
                     self?.router?.showError(error)
                 }
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         }
     }
     
@@ -327,7 +327,7 @@ extension EditTodoEventDetailViewModelImple: EventDetailInputListener {
                 self.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func replaceEventDetailToSchedule(
@@ -439,7 +439,7 @@ extension EditTodoEventDetailViewModelImple: EventDetailInputListener {
             }
             self?.subject.isSaving.send(false)
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func todoEditParams(from basic: EventDetailBasicData, _ timeZone: TimeZone) -> TodoEditParams {

--- a/Presentations/EventListScenes/Sources/DoneTodoList/DoneTodoEventListView.swift
+++ b/Presentations/EventListScenes/Sources/DoneTodoList/DoneTodoEventListView.swift
@@ -14,6 +14,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -22,7 +23,7 @@ import CommonPresentation
 @Observable final class DoneTodoEventListViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     var isRemovingDoneTodos = false
     var sections: [DoneTodoListSectionModel] = []
@@ -39,14 +40,14 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] flag in
                 self?.isRemovingDoneTodos = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.sectionModels
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] sections in
                 self?.sections = sections
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/EventListScenes/Sources/DoneTodoList/DoneTodoEventListViewController.swift
+++ b/Presentations/EventListScenes/Sources/DoneTodoList/DoneTodoEventListViewController.swift
@@ -11,6 +11,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -25,7 +26,7 @@ final class DoneTodoEventListViewController: UIHostingController<DoneTodoEventLi
     @MainActor
     var interactor: (any DoneTodoEventListSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any DoneTodoEventListViewModel,

--- a/Presentations/EventListScenes/Sources/DoneTodoList/DoneTodoEventListViewModel.swift
+++ b/Presentations/EventListScenes/Sources/DoneTodoList/DoneTodoEventListViewModel.swift
@@ -13,6 +13,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 
@@ -242,7 +243,7 @@ final class DoneTodoEventListViewModelImple: DoneTodoEventListViewModel, @unchec
         let revertedIdSet = CurrentValueSubject<Set<String>, Never>([])
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
     private var todoRevertingTasks: [String: Task<Void, any Error>] = [:]
     
@@ -251,7 +252,7 @@ final class DoneTodoEventListViewModelImple: DoneTodoEventListViewModel, @unchec
             .sink(receiveValue: { [weak self] zone in
                 self?.subject.currentTimeZone.send(zone)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 
@@ -320,7 +321,7 @@ extension DoneTodoEventListViewModelImple {
                 self?.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     func close() {

--- a/Presentations/MemberScenes/Sources/ManageAccount/ManageAccountView.swift
+++ b/Presentations/MemberScenes/Sources/ManageAccount/ManageAccountView.swift
@@ -12,6 +12,7 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -20,7 +21,7 @@ import CommonPresentation
 @Observable final class ManageAccountViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     var isMigrating = false
     var accountInfo: AccountInfoModel?
@@ -39,35 +40,35 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] flag in
                 self?.isMigrating = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.currentAccountInfo
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] info in
                 self?.accountInfo = info
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isNeedMigrationEventCount
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] count in
                 self?.migrationNeedEventCount = count
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isSigningOut
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] flag in
                 self?.isSignOuts = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isDeletingAccount
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] flag in
                 self?.isDeletingAccount = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/MemberScenes/Sources/ManageAccount/ManageAccountViewController.swift
+++ b/Presentations/MemberScenes/Sources/ManageAccount/ManageAccountViewController.swift
@@ -11,6 +11,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -25,7 +26,7 @@ final class ManageAccountViewController: UIHostingController<ManageAccountContai
     @MainActor
     var interactor: (any ManageAccountSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any ManageAccountViewModel,

--- a/Presentations/MemberScenes/Sources/ManageAccount/ManageAccountViewModel.swift
+++ b/Presentations/MemberScenes/Sources/ManageAccount/ManageAccountViewModel.swift
@@ -13,6 +13,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 
@@ -76,7 +77,7 @@ final class ManageAccountViewModelImple: ManageAccountViewModel, @unchecked Send
         let isDeletingAccount = CurrentValueSubject<Bool, Never>(false)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
     
     private func internalBinding() {
@@ -85,19 +86,19 @@ final class ManageAccountViewModelImple: ManageAccountViewModel, @unchecked Send
             .sink(receiveValue: { [weak self] info in
                 self?.subject.accountInfo.send(info)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.migrationUsecase.migrationNeedEventCount
             .sink(receiveValue: { [weak self] count in
                 self?.subject.migrationNeedEventCount.send(count)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.migrationUsecase.isMigrating
             .sink(receiveValue: { [weak self] flag in
                 self?.subject.isMigrating.send(flag)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.migrationUsecase.migrationResult
             .sink(receiveValue: { [weak self] result in
@@ -108,7 +109,7 @@ final class ManageAccountViewModelImple: ManageAccountViewModel, @unchecked Send
                     self?.router?.showError(error)
                 }
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 
@@ -159,7 +160,7 @@ extension ManageAccountViewModelImple {
                 self?.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     func deleteAccount() {
@@ -189,7 +190,7 @@ extension ManageAccountViewModelImple {
                 self?.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/MemberScenes/Sources/SignIn/SignInView.swift
+++ b/Presentations/MemberScenes/Sources/SignIn/SignInView.swift
@@ -12,6 +12,7 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -20,7 +21,7 @@ import CommonPresentation
 @Observable final class SignInViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     var isSigning = false
     var supportOAuthServices: [any OAuth2ServiceProvider] = []
@@ -35,7 +36,7 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] flag in
                 self?.isSigning = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.supportOAuthServices = viewModel.supportSignInOAuthService
     }

--- a/Presentations/MemberScenes/Sources/SignIn/SignInViewController.swift
+++ b/Presentations/MemberScenes/Sources/SignIn/SignInViewController.swift
@@ -11,6 +11,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -25,7 +26,7 @@ final class SignInViewController: UIHostingController<SignInContainerView>, Sign
     @MainActor
     var interactor: (any SignInSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any SignInViewModel,

--- a/Presentations/MemberScenes/Sources/SignIn/SignInViewModel.swift
+++ b/Presentations/MemberScenes/Sources/SignIn/SignInViewModel.swift
@@ -11,6 +11,7 @@
 import Foundation
 import Combine
 import Domain
+import Extensions
 import Scenes
 
 
@@ -46,7 +47,7 @@ final class SignInViewModelImple: SignInViewModel, @unchecked Sendable {
         let isSigningIn = CurrentValueSubject<Bool, Never>(false)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 }
 
@@ -68,7 +69,7 @@ extension SignInViewModelImple {
                 self?.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     func close() {

--- a/Presentations/SettingScene/Sources/Event/EventDefaultMapApp/EventDefaultMapAppView.swift
+++ b/Presentations/SettingScene/Sources/Event/EventDefaultMapApp/EventDefaultMapAppView.swift
@@ -12,6 +12,7 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -20,7 +21,7 @@ import CommonPresentation
 @Observable final class EventDefaultMapAppViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     var models: [SupportMapAppModel] = []
     
@@ -34,7 +35,7 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] models in
                 self?.models = models
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/Event/EventDefaultMapApp/EventDefaultMapAppViewController.swift
+++ b/Presentations/SettingScene/Sources/Event/EventDefaultMapApp/EventDefaultMapAppViewController.swift
@@ -11,6 +11,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -25,7 +26,7 @@ final class EventDefaultMapAppViewController: UIHostingController<EventDefaultMa
     @MainActor
     var interactor: (any EventDefaultMapAppSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any EventDefaultMapAppViewModel,

--- a/Presentations/SettingScene/Sources/Event/EventDefaultMapApp/EventDefaultMapAppViewModel.swift
+++ b/Presentations/SettingScene/Sources/Event/EventDefaultMapApp/EventDefaultMapAppViewModel.swift
@@ -13,6 +13,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 
@@ -49,7 +50,7 @@ final class EventDefaultMapAppViewModelImple: EventDefaultMapAppViewModel, @unch
     
     private struct Subject {}
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 }
 

--- a/Presentations/SettingScene/Sources/Event/EventNotificationDefaultTimeOption/EventNotificationDefaultTimeOptionView.swift
+++ b/Presentations/SettingScene/Sources/Event/EventNotificationDefaultTimeOption/EventNotificationDefaultTimeOptionView.swift
@@ -12,6 +12,7 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -20,7 +21,7 @@ import CommonPresentation
 @Observable final class EventNotificationDefaultTimeOptionViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     var isNeedNotificationPermission: Bool = false
     var options: [DefaultTimeOptionModel] = []
@@ -37,21 +38,21 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] flag in
                 self?.isNeedNotificationPermission = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.options
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] options in
                 self?.options = options
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.selectedOption
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] option in
                 self?.selectedOption = option
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/Event/EventNotificationDefaultTimeOption/EventNotificationDefaultTimeOptionViewController.swift
+++ b/Presentations/SettingScene/Sources/Event/EventNotificationDefaultTimeOption/EventNotificationDefaultTimeOptionViewController.swift
@@ -11,6 +11,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -25,7 +26,7 @@ final class EventNotificationDefaultTimeOptionViewController: UIHostingControlle
     @MainActor
     var interactor: (any EventNotificationDefaultTimeOptionSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any EventNotificationDefaultTimeOptionViewModel,

--- a/Presentations/SettingScene/Sources/Event/EventNotificationDefaultTimeOption/EventNotificationDefaultTimeOptionViewModel.swift
+++ b/Presentations/SettingScene/Sources/Event/EventNotificationDefaultTimeOption/EventNotificationDefaultTimeOptionViewModel.swift
@@ -13,6 +13,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -71,7 +72,7 @@ final class EventNotificationDefaultTimeOptionViewModelImple: EventNotificationD
         let selecedOption = CurrentValueSubject<EventNotificationTimeOption??, Never>(nil)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 }
 
@@ -106,7 +107,7 @@ extension EventNotificationDefaultTimeOptionViewModelImple {
                 self.subject.notificationPermissionStatus.send(.denied)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     func requestPermission() {
@@ -127,7 +128,7 @@ extension EventNotificationDefaultTimeOptionViewModelImple {
                 self.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func showNotificationPermissionDenied() {

--- a/Presentations/SettingScene/Sources/Event/EventSettingView.swift
+++ b/Presentations/SettingScene/Sources/Event/EventSettingView.swift
@@ -12,6 +12,7 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -20,7 +21,7 @@ import CommonPresentation
 @Observable final class EventSettingViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     var tagModel: BaseCalendarEventTagCellViewModel?
     var selectedEventNotificationTimeText: String?
@@ -41,56 +42,56 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] model in
                 self?.tagModel = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.selectedEventNotificationTimeText
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] text in
                 self?.selectedEventNotificationTimeText = text
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.selectedAllDayEventNotificationTimeText
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] text in
                 self?.selectedAllDayEventNotificationTimeText = text
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.selectedPeriod
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] model in
                 self?.periodModel = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.defaultMapApp
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] app in
                 self?.defaultMapApp = app
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.eventSyncModel
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] model in
                 self?.eventSyncModel = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.integratedExternalCalendars
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] models in
                 self?.externalCalendarServiceModels = models
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isConnectOrDisconnectExternalCalednar
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] flag in
                 self?.isConnectOrDisconnectingExternalService = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/Event/EventSettingViewController.swift
+++ b/Presentations/SettingScene/Sources/Event/EventSettingViewController.swift
@@ -11,6 +11,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -25,7 +26,7 @@ final class EventSettingViewController: UIHostingController<EventSettingContaine
     @MainActor
     var interactor: (any EventSettingSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any EventSettingViewModel,

--- a/Presentations/SettingScene/Sources/Event/EventSettingViewModel.swift
+++ b/Presentations/SettingScene/Sources/Event/EventSettingViewModel.swift
@@ -13,6 +13,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 
@@ -155,7 +156,7 @@ final class EventSettingViewModelImple: EventSettingViewModel, @unchecked Sendab
         let isConnectOrDisconnectExternalCalednar = CurrentValueSubject<Bool, Never>(false)
     }
 
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 
     private func internalBinding() {
@@ -164,7 +165,7 @@ final class EventSettingViewModelImple: EventSettingViewModel, @unchecked Sendab
             .sink(receiveValue: { [weak self] setting in
                 self?.subject.setting.send(setting)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 
@@ -237,7 +238,7 @@ extension EventSettingViewModelImple {
                 self?.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func handleAppleCalendarPermissionFail(_ reason: AppleCalendarPermissionFailReason) {
@@ -277,7 +278,7 @@ extension EventSettingViewModelImple {
                 self?.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     func close() {

--- a/Presentations/SettingScene/Sources/EventTag/EventDefaultTagSelect/EventDefaultTagSelectView.swift
+++ b/Presentations/SettingScene/Sources/EventTag/EventDefaultTagSelect/EventDefaultTagSelectView.swift
@@ -14,6 +14,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -22,7 +23,7 @@ import CommonPresentation
 @Observable final class EventDefaultTagSelectViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     var cellViewModels: [BaseCalendarEventTagCellViewModel] = []
     var selectedId: EventTagId?
     
@@ -37,14 +38,14 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] cvms in
                 self?.cellViewModels = cvms
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.selectedId
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] id in
                 self?.selectedId = id
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/EventTag/EventDefaultTagSelect/EventDefaultTagSelectViewController.swift
+++ b/Presentations/SettingScene/Sources/EventTag/EventDefaultTagSelect/EventDefaultTagSelectViewController.swift
@@ -11,6 +11,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -25,7 +26,7 @@ final class EventDefaultTagSelectViewController: UIHostingController<EventDefaul
     @MainActor
     var interactor: (any EventDefaultTagSelectSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any EventDefaultTagSelectViewModel,

--- a/Presentations/SettingScene/Sources/EventTag/EventDefaultTagSelect/EventDefaultTagSelectViewModel.swift
+++ b/Presentations/SettingScene/Sources/EventTag/EventDefaultTagSelect/EventDefaultTagSelectViewModel.swift
@@ -13,6 +13,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 
@@ -58,7 +59,7 @@ final class EventDefaultTagSelectViewModelImple: EventDefaultTagSelectViewModel,
         let selectedId = CurrentValueSubject<EventTagId?, Never>(nil)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 }
 

--- a/Presentations/SettingScene/Sources/EventTag/EventTagDetail/EventTagDetailView.swift
+++ b/Presentations/SettingScene/Sources/EventTag/EventTagDetail/EventTagDetailView.swift
@@ -11,6 +11,7 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -20,7 +21,7 @@ import CommonPresentation
 @Observable final class EventTagDetailViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     fileprivate var suggestColorHexes: [String] = []
     fileprivate var newTagName: String = ""
@@ -46,28 +47,28 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] hex in
                 self?.originalColorHex = hex
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isSavable
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] flag in
                 self?.isSavable = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.selectedColorHex
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] color in
                 self?.selectedColorHex = color
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isProcessing
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] flag in
                 self?.isProcessing = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/EventTag/EventTagDetail/EventTagDetailViewController.swift
+++ b/Presentations/SettingScene/Sources/EventTag/EventTagDetail/EventTagDetailViewController.swift
@@ -10,6 +10,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -24,7 +25,7 @@ final class EventTagDetailViewController: UIHostingController<EventTagDetailCont
     @MainActor
     var interactor: (any EventTagDetailSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any EventTagDetailViewModel,
@@ -61,6 +62,6 @@ final class EventTagDetailViewController: UIHostingController<EventTagDetailCont
             .sink(receiveValue: { [weak self] isProcessing in
                 self?.isModalInPresentation = isProcessing
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }

--- a/Presentations/SettingScene/Sources/EventTag/EventTagDetail/EventTagDetailViewModel.swift
+++ b/Presentations/SettingScene/Sources/EventTag/EventTagDetail/EventTagDetailViewModel.swift
@@ -12,6 +12,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 
@@ -72,7 +73,7 @@ final class EventTagDetailViewModelImple: EventTagDetailViewModel, @unchecked Se
         let isProcessing = CurrentValueSubject<Bool, Never>(false)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 }
 
@@ -117,7 +118,7 @@ extension EventTagDetailViewModelImple {
             }
             self?.subject.isProcessing.send(false)
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func deleteTagWithEvents(_ tagId: String) {
@@ -133,7 +134,7 @@ extension EventTagDetailViewModelImple {
             }
             self?.subject.isProcessing.send(false)
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     func save() {
@@ -173,7 +174,7 @@ extension EventTagDetailViewModelImple {
             }
             self?.subject.isProcessing.send(false)
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func editTag(_ id: String) {
@@ -195,7 +196,7 @@ extension EventTagDetailViewModelImple {
             }
             self.subject.isProcessing.send(false)
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func saveNewTag() {
@@ -217,7 +218,7 @@ extension EventTagDetailViewModelImple {
             }
             self.subject.isProcessing.send(false)
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func show(

--- a/Presentations/SettingScene/Sources/EventTag/EventTagList/EventTagListView.swift
+++ b/Presentations/SettingScene/Sources/EventTag/EventTagList/EventTagListView.swift
@@ -22,7 +22,7 @@ import Extensions
 @Observable final class EventTagListViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     var cellviewModels: [BaseCalendarEventTagCellViewModel] = []
     var externalCalendarTagSections: [ExternalCalendarEventTagListSectionModel] = []
@@ -40,7 +40,7 @@ import Extensions
                     self?.cellviewModels = cellViewModels
                 }
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.externalCalendarSections
             .receive(on: RunLoop.main)
@@ -49,7 +49,7 @@ import Extensions
                     self?.externalCalendarTagSections = sections
                 }
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/EventTag/EventTagList/EventTagListViewController.swift
+++ b/Presentations/SettingScene/Sources/EventTag/EventTagList/EventTagListViewController.swift
@@ -10,6 +10,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -24,7 +25,7 @@ final class EventTagListViewController: UIHostingController<EventTagListContaine
     @MainActor
     var interactor: (any EventTagListSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         isRootNavigation: Bool,

--- a/Presentations/SettingScene/Sources/EventTag/EventTagList/EventTagListViewModel.swift
+++ b/Presentations/SettingScene/Sources/EventTag/EventTagList/EventTagListViewModel.swift
@@ -12,6 +12,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 
@@ -63,7 +64,7 @@ final class EventTagListViewModelImple: EventTagListViewModel, @unchecked Sendab
         let cvms = CurrentValueSubject<[BaseCalendarEventTagCellViewModel]?, Never>(nil)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
     
     private func internalBinding() {
@@ -72,13 +73,13 @@ final class EventTagListViewModelImple: EventTagListViewModel, @unchecked Sendab
             .sink(receiveValue: { [weak self] cvms in
                 self?.subject.cvms.send(cvms)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.eventTagListUsecase.reloadFailed
             .sink(receiveValue: { [weak self] error in
                 self?.router?.showError(error)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/EventTag/EventTagList/EventTagListViewUsecase.swift
+++ b/Presentations/SettingScene/Sources/EventTag/EventTagList/EventTagListViewUsecase.swift
@@ -11,6 +11,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 
 
 // MARK: - base calednar event tag
@@ -90,7 +91,7 @@ final class EventTagListViewUsecase {
     
     private let allTags = CurrentValueSubject<[any EventTag]?, Never>(nil)
     private let occuredError = PassthroughSubject<any Error, Never>()
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 }
 
 extension EventTagListViewUsecase {
@@ -107,7 +108,7 @@ extension EventTagListViewUsecase {
         
         self.tagUsecase.loadAllEventTags()
             .sink(receiveValue: loaded, receiveError: handleError)
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     func reloadExternalCalendarIfNeed() {

--- a/Presentations/SettingScene/Sources/Setting/Appearance/AppearanceSettingView.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/AppearanceSettingView.swift
@@ -10,6 +10,7 @@
 
 import SwiftUI
 import Domain
+import Extensions
 import Combine
 import CommonPresentation
 
@@ -58,7 +59,7 @@ struct AppearanceRow< Content: View>: View {
 @Observable final class AppearanceSettingViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     var timeZoneName: String?
     var hapticOn: Bool = false
@@ -79,21 +80,21 @@ struct AppearanceRow< Content: View>: View {
             .sink(receiveValue: { [weak self] name in
                 self?.timeZoneName = name
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.hapticIsOn
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] flag in
                 self?.hapticOn = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.animationIsOn
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] flag in
                 self?.animationOn = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/Setting/Appearance/AppearanceSettingViewController.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/AppearanceSettingViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -28,7 +29,7 @@ final class AppearanceSettingViewController: UIHostingController<AppearanceSetti
     @MainActor
     var interactor: (any AppearanceSettingSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         initial setting: CalendarAppearanceSettings,

--- a/Presentations/SettingScene/Sources/Setting/Appearance/AppearanceSettingViewModel.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/AppearanceSettingViewModel.swift
@@ -12,6 +12,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 
@@ -55,7 +56,7 @@ final class AppearanceSettingViewModelImple: AppearanceSettingViewModel, @unchec
         let uiSetting = CurrentValueSubject<CalendarAppearanceSettings?, Never>(nil)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 }
 

--- a/Presentations/SettingScene/Sources/Setting/Appearance/CalendarSection/CalendarAppearancePreviewView.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/CalendarSection/CalendarAppearancePreviewView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import Domain
+import Extensions
 import Combine
 import CommonPresentation
 
@@ -14,7 +15,7 @@ import CommonPresentation
 @Observable final class CalendarSectionAppearanceSettingViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     var calendarModel: CalendarAppearanceModel = .init([], [])
     var accentDays: [AccentDays: Bool] = [:]
     var showUnderLine: Bool = false
@@ -37,7 +38,7 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] day in
                 self?.selectedWeekDay = day
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.calendarAppearanceModel
             .receive(on: RunLoop.main)
@@ -51,28 +52,28 @@ import CommonPresentation
                     self?.didFirstCalendarModelUpdated = true
                 }
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.accentDaysActivatedMap
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] map in
                 self?.accentDays = map
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isShowUnderLineOnEventDay
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] flag in
                 self?.showUnderLine = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.selectedColorTheme
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] model in
                 self?.selectedColorTheme = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/Setting/Appearance/CalendarSection/CalendarSectionAppearnaceSettingViewModel.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/CalendarSection/CalendarSectionAppearnaceSettingViewModel.swift
@@ -10,6 +10,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 struct CalendarSectionAppearanceSetting {
@@ -145,7 +146,7 @@ final class CalendarSectionViewModelImple: CalendarSectionAppearnaceSettingViewM
         let setting = CurrentValueSubject<CalendarSectionAppearanceSetting?, Never>(nil)
     }
     private let subject = Subject()
-    private var cancelables: Set<AnyCancellable> = []
+    private let cancelables = CancelBag()
     
     private func internalBind() {
         
@@ -153,7 +154,7 @@ final class CalendarSectionViewModelImple: CalendarSectionAppearnaceSettingViewM
             .sink(receiveValue: { [weak self] day in
                 self?.subject.startWeekDay.send(day)
             })
-            .store(in: &self.cancelables)
+            .store(in: self.cancelables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/Setting/Appearance/ColorTheme/ColorThemeSelectView.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/ColorTheme/ColorThemeSelectView.swift
@@ -14,6 +14,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -22,7 +23,7 @@ import CommonPresentation
 @Observable final class ColorThemeSelectViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     fileprivate var sampleModel: CalendarAppearanceModel = .init(.sunday)
     fileprivate var themeModels: [ColorThemeModel] = []
@@ -38,14 +39,14 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] model in
                 self?.sampleModel = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.colorThemeModels
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] models in
                 self?.themeModels = models
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/Setting/Appearance/ColorTheme/ColorThemeSelectViewController.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/ColorTheme/ColorThemeSelectViewController.swift
@@ -11,6 +11,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -25,7 +26,7 @@ final class ColorThemeSelectViewController: UIHostingController<ColorThemeSelect
     @MainActor
     var interactor: (any ColorThemeSelectSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any ColorThemeSelectViewModel,

--- a/Presentations/SettingScene/Sources/Setting/Appearance/ColorTheme/ColorThemeSelectViewModel.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/ColorTheme/ColorThemeSelectViewModel.swift
@@ -13,6 +13,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 
@@ -67,7 +68,7 @@ final class ColorThemeSelectViewModelImple: ColorThemeSelectViewModel, @unchecke
         let availableTheme = CurrentValueSubject<[ColorSetKeys]?, Never>(nil)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 }
 
@@ -85,7 +86,7 @@ extension ColorThemeSelectViewModelImple {
                 self?.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     func selectTheme(_ model: ColorThemeModel) {

--- a/Presentations/SettingScene/Sources/Setting/Appearance/EventList/EventListAppearanceSettingView.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/EventList/EventListAppearanceSettingView.swift
@@ -8,13 +8,14 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
 @Observable final class EventListAppearanceSettingViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     var sampleModel: EventListAppearanceSampleModel?
     var additionalFontSizeModel: EventTextAdditionalSizeModel = .init(0)
     var showHolidayName: Bool = false
@@ -40,42 +41,42 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] model in
                 self?.sampleModel = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.eventFontIncreasedSizeModel
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] model in
                 self?.additionalFontSizeModel = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isShowHolidayName
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] flag in
                 self?.showHolidayName = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isShowLunarCalendarDate
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] flag in
                 self?.showLunarCalendarDate = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isShowTimeWith24HourForm
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] flag in
                 self?.is24hourTimeForm = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.showUncompletedTodo
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] show in
                 self?.showUncompletedTodos = show
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/Setting/Appearance/EventList/EventListAppearnaceSettingViewModel.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/EventList/EventListAppearnaceSettingViewModel.swift
@@ -10,6 +10,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 
 
 struct EventListAppearanceSetting {
@@ -110,7 +111,7 @@ final class EventListAppearnaceSettingViewModelImple: EventListAppearnaceSetting
         let setting = CurrentValueSubject<EventListAppearanceSetting?, Never>(nil)
     }
     private let subject = Subject()
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 }
 
 

--- a/Presentations/SettingScene/Sources/Setting/Appearance/EventOnCalendar/EventOnCalendarView.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/EventOnCalendar/EventOnCalendarView.swift
@@ -8,13 +8,14 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
 @Observable final class EventOnCalendarViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     @ObservationIgnored let allRowHeights: [RowHeightOnCalendarViewModel] = [
         .init(.small), .init(.medium), .init(.large)
     ]
@@ -39,28 +40,28 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] height in
                 self?.selectedRowHeight = height
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.textIncreasedSizeText
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] model in
                 self?.additionalFontSizeModel = model
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isBoldTextOnCalendar
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] isBold in
                 self?.isBold = isBold
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.showEvnetTagColor
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] isShow in
                 self?.isShowEventTagColor = isShow
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/Setting/Appearance/EventOnCalendar/EventOnCalendarViewModel.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/EventOnCalendar/EventOnCalendarViewModel.swift
@@ -10,6 +10,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 struct EventOnCalendarAppearanceSetting {
@@ -108,7 +109,7 @@ final class EventOnCalendarViewModelImple: EventOnCalendarViewModel, @unchecked 
         let setting = CurrentValueSubject<EventOnCalendarAppearanceSetting?, Never>(nil)
     }
     private let subject = Subject()
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 }
 
 extension EventOnCalendarViewModelImple {

--- a/Presentations/SettingScene/Sources/Setting/Appearance/TimeZone/TimeZoneSelectView.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/TimeZone/TimeZoneSelectView.swift
@@ -14,6 +14,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -22,7 +23,7 @@ import CommonPresentation
 @Observable final class TimeZoneSelectViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     var searchKeyword: String = ""
     var systemTimeZone: TimeZoneModel?
@@ -42,14 +43,14 @@ import CommonPresentation
                 self?.systemTimeZone = list.systemTimeZone
                 self?.timeZones = list.timeZones
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.selectedTimeZoneIdentifier
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] identifier in
                 self?.selectedIdentifier = identifier
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/Setting/Appearance/TimeZone/TimeZoneSelectViewController.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/TimeZone/TimeZoneSelectViewController.swift
@@ -11,6 +11,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -25,7 +26,7 @@ final class TimeZoneSelectViewController: UIHostingController<TimeZoneSelectCont
     @MainActor
     var interactor: (any TimeZoneSelectSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any TimeZoneSelectViewModel,

--- a/Presentations/SettingScene/Sources/Setting/Appearance/TimeZone/TimeZoneSelectViewModel.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/TimeZone/TimeZoneSelectViewModel.swift
@@ -11,6 +11,7 @@
 import Foundation
 import Combine
 import Domain
+import Extensions
 import Scenes
 
 
@@ -106,7 +107,7 @@ final class TimeZoneSelectViewModelImple: TimeZoneSelectViewModel, @unchecked Se
         let searchKeyword = CurrentValueSubject<String?, Never>(nil)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 }
 

--- a/Presentations/SettingScene/Sources/Setting/Appearance/Widget/WidgetAppearanceSettingView.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/Widget/WidgetAppearanceSettingView.swift
@@ -9,13 +9,14 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
 @Observable final class WidgetAppearanceSettingViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     var background: WidgetAppearanceSettings.Background = .system
     var isSystemTheme = true
@@ -37,7 +38,7 @@ import CommonPresentation
                     self?.customBackground = UIColor.from(hex: hex)?.asColor
                 }
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/Setting/Appearance/Widget/WidgetAppearanceSettingViewController.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/Widget/WidgetAppearanceSettingViewController.swift
@@ -9,6 +9,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -21,7 +22,7 @@ final class WidgetAppearanceSettingViewController: UIHostingController<WidgetApp
     @MainActor
     var interactor: (any WidgetAppearanceSettingSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any WidgetAppearanceSettingViewModel,

--- a/Presentations/SettingScene/Sources/Setting/Appearance/Widget/WidgetAppearanceSettingViewModel.swift
+++ b/Presentations/SettingScene/Sources/Setting/Appearance/Widget/WidgetAppearanceSettingViewModel.swift
@@ -11,6 +11,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 
@@ -40,7 +41,7 @@ final class WidgetAppearanceSettingViewModelImple: WidgetAppearanceSettingViewMo
         let setting = CurrentValueSubject<WidgetAppearanceSettings?, Never>(nil)
     }
     private let subject = Subject()
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 }
 
 extension WidgetAppearanceSettingViewModelImple {

--- a/Presentations/SettingScene/Sources/Setting/Holiday/CountrySelectView.swift
+++ b/Presentations/SettingScene/Sources/Setting/Holiday/CountrySelectView.swift
@@ -11,6 +11,7 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -19,7 +20,7 @@ import CommonPresentation
 @Observable final class CountrySelectViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     var countries: [HolidaySupportCountry] = []
     var selectedCountryCode: String? = nil
     var isSavable: Bool = false
@@ -36,28 +37,28 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] countries in
                 self?.countries = countries
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.selectedCountryCode
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] code in
                 self?.selectedCountryCode = code
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isSaving
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] flag in
                 self?.isSaving = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isConfirmable
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] flag in
                 self?.isSavable = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/Setting/Holiday/CountrySelectViewController.swift
+++ b/Presentations/SettingScene/Sources/Setting/Holiday/CountrySelectViewController.swift
@@ -10,6 +10,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -24,7 +25,7 @@ final class CountrySelectViewController: UIHostingController<CountrySelectContai
     @MainActor
     var interactor: (any CountrySelectSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any CountrySelectViewModel,

--- a/Presentations/SettingScene/Sources/Setting/Holiday/CountrySelectViewModel.swift
+++ b/Presentations/SettingScene/Sources/Setting/Holiday/CountrySelectViewModel.swift
@@ -12,6 +12,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 
@@ -53,7 +54,7 @@ final class CountrySelectViewModelImple: CountrySelectViewModel, @unchecked Send
         let isSaving = CurrentValueSubject<Bool, Never>(false)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 }
 
@@ -69,18 +70,18 @@ extension CountrySelectViewModelImple {
             .sink(receiveValue: { [weak self] country in
                 self?.subject.selectedCode.send(country?.code)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.holidayUsecase.availableCountries
             .sink(receiveValue: { [weak self] countries in
                 self?.subject.countries.send(countries)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         Task { [weak self] in
             try? await self?.holidayUsecase.refreshAvailableCountries()
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     func selectCountry(_ code: String) {
@@ -119,7 +120,7 @@ extension CountrySelectViewModelImple {
                 self?.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     func close() {

--- a/Presentations/SettingScene/Sources/Setting/Holiday/HolidayListView.swift
+++ b/Presentations/SettingScene/Sources/Setting/Holiday/HolidayListView.swift
@@ -11,6 +11,7 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -19,7 +20,7 @@ import CommonPresentation
 @Observable final class HolidayListViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     var countryName: String = ""
     var holidays: [HolidayItemModel] = []
@@ -36,28 +37,28 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] isRefreshing in
                 self?.isRefreshing = isRefreshing
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.currentCountryName
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] name in
                 self?.countryName = name
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.currentYearHolidays
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] items in
                 self?.holidays = items
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.hiddenHolidayNames
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] names in
                 self?.hiddenHolidayNames = names
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/Setting/Holiday/HolidayListViewController.swift
+++ b/Presentations/SettingScene/Sources/Setting/Holiday/HolidayListViewController.swift
@@ -10,6 +10,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -24,7 +25,7 @@ final class HolidayListViewController: UIHostingController<HolidayListContainerV
     @MainActor
     var interactor: (any HolidayListSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any HolidayListViewModel,

--- a/Presentations/SettingScene/Sources/Setting/Holiday/HolidayListViewModel.swift
+++ b/Presentations/SettingScene/Sources/Setting/Holiday/HolidayListViewModel.swift
@@ -12,6 +12,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 
@@ -73,7 +74,7 @@ final class HolidayListViewModelImple: HolidayListViewModel, @unchecked Sendable
         let isRefreshingHolidays = CurrentValueSubject<Bool, Never>(false)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 }
 
@@ -88,7 +89,7 @@ extension HolidayListViewModelImple {
             .sink(receiveValue: { [weak self] timeZone in
                 self?.setupCurrentYear(timeZone)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     func refresh() {
@@ -103,7 +104,7 @@ extension HolidayListViewModelImple {
                 self?.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func setupCurrentYear(_ timeZone: TimeZone) {
@@ -114,7 +115,7 @@ extension HolidayListViewModelImple {
         Task { [weak self] in
             try await self?.holidayUsecase.refreshHolidays(year)
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     func selectCountry() {
@@ -129,7 +130,7 @@ extension HolidayListViewModelImple {
                 self?.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 
     func close() {

--- a/Presentations/SettingScene/Sources/Setting/OpenSourceLicense/OpenSourceLicenseView.swift
+++ b/Presentations/SettingScene/Sources/Setting/OpenSourceLicense/OpenSourceLicenseView.swift
@@ -10,6 +10,7 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -18,7 +19,7 @@ import CommonPresentation
 @Observable final class OpenSourceLicenseViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     var libraries: [OpenSourceLibrary] = []
     var licenses: [OpenSourceLicenseText] = []
     
@@ -32,14 +33,14 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] libraries in
                 self?.libraries = libraries
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.licenses
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] licenses in
                 self?.licenses = licenses
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/Setting/SettingItemListView.swift
+++ b/Presentations/SettingScene/Sources/Setting/SettingItemListView.swift
@@ -11,6 +11,7 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -19,7 +20,7 @@ import CommonPresentation
 @Observable final class SettingItemListViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     var sections: [any SettingSectionModelType] = []
     
     func bind(_ viewModel: any SettingItemListViewModel) {
@@ -33,7 +34,7 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] sections in
                 self?.sections = sections
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/Setting/SettingItemListViewController.swift
+++ b/Presentations/SettingScene/Sources/Setting/SettingItemListViewController.swift
@@ -10,6 +10,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -24,7 +25,7 @@ final class SettingItemListViewController: UIHostingController<SettingItemListCo
     @MainActor
     var interactor: (any SettingItemListSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any SettingItemListViewModel,

--- a/Presentations/SettingScene/Sources/Setting/SettingItemListViewModel.swift
+++ b/Presentations/SettingScene/Sources/Setting/SettingItemListViewModel.swift
@@ -10,6 +10,7 @@
 import Foundation
 import Combine
 import Domain
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -204,7 +205,7 @@ final class SettingItemListViewModelImple: SettingItemListViewModel, @unchecked 
         let isAdPrivacyOptionsRequired = CurrentValueSubject<Bool, Never>(false)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 }
 
@@ -223,7 +224,7 @@ extension SettingItemListViewModelImple {
             let info = await self?.deviceInfoFetchService.fetchDeviceInfo()
             self?.subject.deviceInfo.send(info)
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func prepareAdPrivacyOptionsRequirement() {
@@ -231,7 +232,7 @@ extension SettingItemListViewModelImple {
             let isRequired = self?.privacyOptionsFormRouter?.isPrivacyOptionsRequired()
             self?.subject.isAdPrivacyOptionsRequired.send(isRequired ?? false)
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     func selectItem(_ model: any SettingItemModelType) {

--- a/Presentations/SettingScene/Sources/Support/Feedback/FeedbackPostView.swift
+++ b/Presentations/SettingScene/Sources/Support/Feedback/FeedbackPostView.swift
@@ -12,6 +12,7 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -20,7 +21,7 @@ import CommonPresentation
 @Observable final class FeedbackPostViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     var isPosting: Bool = false
     var isPostable: Bool = false
@@ -37,14 +38,14 @@ import CommonPresentation
             .sink(receiveValue: { [weak self] flag in
                 self?.isPostable = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         viewModel.isPosting
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] flag in
                 self?.isPosting = flag
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Presentations/SettingScene/Sources/Support/Feedback/FeedbackPostViewController.swift
+++ b/Presentations/SettingScene/Sources/Support/Feedback/FeedbackPostViewController.swift
@@ -11,6 +11,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -25,7 +26,7 @@ final class FeedbackPostViewController: UIHostingController<FeedbackPostContaine
     @MainActor
     var interactor: (any FeedbackPostSceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any FeedbackPostViewModel,

--- a/Presentations/SettingScene/Sources/Support/Feedback/FeedbackPostViewModel.swift
+++ b/Presentations/SettingScene/Sources/Support/Feedback/FeedbackPostViewModel.swift
@@ -13,6 +13,7 @@ import Prelude
 import Optics
 import Combine
 import Domain
+import Extensions
 import Scenes
 
 
@@ -50,7 +51,7 @@ final class FeedbackPostViewModelImple: FeedbackPostViewModel, @unchecked Sendab
         let isPosting = CurrentValueSubject<Bool, Never>(false)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 }
 
@@ -84,7 +85,7 @@ extension FeedbackPostViewModelImple {
                 self?.router?.showError(error)
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func showPostedAndClose() {

--- a/Repository/CLAUDE.md
+++ b/Repository/CLAUDE.md
@@ -159,21 +159,12 @@ sequenceDiagram
 
 ### 테스트 인프라 (`Tests/Common/`)
 
-- **`BaseLocalTests: BaseTestCase`** — 테스트용 SQLite DB를 캐시 디렉터리에 별도 파일로 생성하고, 테스트 종료 시 삭제. 실제 앱의 DB에는 영향을 주지 않음.
+- **`BaseLocalTests: BaseTestCase`** — 테스트용 SQLite DB를 캐시 디렉터리에 별도 파일로 생성하고, 테스트 종료 시 닫은 뒤 삭제. 실제 앱의 DB에는 영향을 주지 않음.
 - **`LocalTestable` 프로토콜** — `runTestWithOpenClose(_:_:)` 헬퍼로 DB 생성→테스트→삭제를 자동화. Swift Testing (`@Suite`) 사용 시 채택.
 
-```swift
-// BaseLocalTests: 캐시 디렉터리에 테스트 전용 DB 파일 생성
-func testDBPath() -> String {
-    return FileManager.default
-        .url(for: .cachesDirectory, ...)
-        .appendingPathComponent("\(self.fileName).db").path
-}
-// tearDown 시 DB 파일 삭제 → 앱 데이터와 완전 격리
-override func tearDownWithError() throws {
-    try? FileManager.default.removeItem(atPath: self.testDBPath())
-}
-```
+**DB 파일명은 `fileName`에 테스트마다 다른 UUID를 붙이고, tearDown은 커넥션을 닫은 뒤 파일을 지운다.** 고정 파일명 + 미close 조합이면 앞 테스트의 커넥션이 살아 있는 채로 뒤 테스트가 같은 vnode를 열어 프로세스가 죽는다 (원인·측정치는 `docs/troubleshooting/2026-08-24-local-db-tests-random-crash.md`).
+
+`fileName` 지정은 `super.setUpWithError()` **앞**에 둔다 — 뒤에 두면 파일명이 기본값으로 남아 로그에서 어느 테스트의 DB인지 추적이 안 된다 (UUID 덕에 충돌 자체는 안 난다).
 
 ### Local Repository 테스트
 
@@ -186,9 +177,9 @@ override func tearDownWithError() throws {
 ```swift
 // 예: TodoLocalRepositoryImpleTests
 class TodoLocalRepositoryImpleTests: BaseLocalTests {
-    // setUp: 캐시 디렉터리에 test.db 생성
+    // setUp: 캐시 디렉터리에 todos_<UUID>.db 생성
     // 실제 SQLite에 TodoEvent 저장 → 조회하여 검증
-    // tearDown: test.db 파일 삭제
+    // tearDown: 커넥션 close 후 그 파일 삭제
 }
 ```
 

--- a/Repository/Sources/Repository+Imple/Event/Todo/TodoRemoteRepositoryImple.swift
+++ b/Repository/Sources/Repository+Imple/Event/Todo/TodoRemoteRepositoryImple.swift
@@ -19,7 +19,7 @@ public final class TodoRemoteRepositoryImple: TodoEventRepository, @unchecked Se
     
     private let remote: any TodoRemote
     private let cacheStorage: any TodoLocalStorage
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     public init(
         remote: any TodoRemote,

--- a/Repository/Tests/AI/AICommandRepositoryImpleTests.swift
+++ b/Repository/Tests/AI/AICommandRepositoryImpleTests.swift
@@ -19,8 +19,8 @@ class AICommandRepositoryImpleTests: BaseLocalTests {
     private var stubRemote: StubRemoteAPI!
 
     override func setUpWithError() throws {
-        try super.setUpWithError()
         self.fileName = "ai_command_test"
+        try super.setUpWithError()
         self.stubRemote = .init(responses: DummyResponse().responses)
     }
 

--- a/Repository/Tests/Common/BaseLocalTests.swift
+++ b/Repository/Tests/Common/BaseLocalTests.swift
@@ -15,11 +15,12 @@ import UnitTestHelpKit
 class BaseLocalTests: BaseTestCase {
     
     var fileName: String = "test"
+    private var dbFileName: String = "test"
     
     func testDBPath() -> String {
         return try! FileManager.default
             .url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
-            .appendingPathComponent("\(self.fileName).db")
+            .appendingPathComponent("\(self.dbFileName).db")
             .path
     }
     
@@ -27,15 +28,19 @@ class BaseLocalTests: BaseTestCase {
     
     override func setUpWithError() throws {
         self.timeout = 1.0
+        // 앞 테스트의 커넥션이 아직 살아 있어도 같은 vnode 를 물지 않도록 테스트마다 다른 파일을 연다
+        self.dbFileName = "\(self.fileName)_\(UUID().uuidString)"
         let path = self.testDBPath()
         print("will open => \(path)")
         self.sqliteService = SQLiteService()
         _ = self.sqliteService.open(path: path)
     }
     
-    override func tearDownWithError() throws {
+    override func tearDown() async throws {
+        let path = self.testDBPath()
+        try? await self.sqliteService?.async.close()
         self.sqliteService = nil
-        try? FileManager.default.removeItem(atPath: self.testDBPath())
+        try? FileManager.default.removeItem(atPath: path)
     }
 }
 

--- a/Repository/Tests/Event/EventDetailData/EventDetailDataLocalRepostioryImpleTests.swift
+++ b/Repository/Tests/Event/EventDetailData/EventDetailDataLocalRepostioryImpleTests.swift
@@ -53,7 +53,7 @@ extension EventDetailDataLocalRepostioryImpleTests {
         
         // when
         let _ = try await repository.saveDetail(detail)
-        let loadedDetail = try await repository.loadDetail("some").firstValue(with: 100)
+        let loadedDetail = try await repository.loadDetail("some").firstValue(with: 1000)
         
         // then
         XCTAssertEqual(loadedDetail?.eventId, detail.eventId)

--- a/Repository/Tests/Event/EventTag/EventTagLocalRepositoryImpleTests.swift
+++ b/Repository/Tests/Event/EventTag/EventTagLocalRepositoryImpleTests.swift
@@ -154,7 +154,7 @@ extension EventTagLocalRepositoryImpleTests {
         
         // when
         try await repository.deleteTag(origin.uuid)
-        let tagAfterDelete = try await repository.loadCustomTags([origin.uuid]).firstValue(with: 100)
+        let tagAfterDelete = try await repository.loadCustomTags([origin.uuid]).firstValue(with: 1000)
         let offIdsAfterDelete = repository.loadOffTags()
         
         // then
@@ -265,7 +265,7 @@ extension EventTagLocalRepositoryImpleTests {
         let repository = try await self.makeRepositoryWithStubSaveTags(totalTags)
         
         // when
-        let tags = try await repository.loadAllCustomTags().firstValue(with: 10)
+        let tags = try await repository.loadAllCustomTags().firstValue(with: 1000)
         
         // then
         XCTAssertEqual(tags?.map { $0.uuid }, totalTags.map { $0.uuid })

--- a/Repository/Tests/Event/ExternalCalendar/ExternalCalendarDBConnectionPoolImpleTests.swift
+++ b/Repository/Tests/Event/ExternalCalendar/ExternalCalendarDBConnectionPoolImpleTests.swift
@@ -19,11 +19,13 @@ final class ExternalCalendarSQLiteConnectionPoolImpleTests {
 
     private let serviceId1 = "google"
     private let serviceId2 = "apple"
+    // 앞 테스트의 커넥션이 아직 살아 있어도 같은 vnode 를 물지 않도록 테스트마다 다른 파일을 연다
+    private let dbFileSuffix = UUID().uuidString
 
     private func testDBPath(name: String) -> String {
         (try! FileManager.default
             .url(for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
-            .appendingPathComponent("\(name).db"))
+            .appendingPathComponent("\(name)_\(dbFileSuffix).db"))
             .path
     }
 

--- a/Repository/Tests/Event/Todo/TodoLocalRepositoryImpleTests.swift
+++ b/Repository/Tests/Event/Todo/TodoLocalRepositoryImpleTests.swift
@@ -235,7 +235,7 @@ extension TodoLocalRepositoryImpleTests {
         let _ = try await repository.updateTodoEvent(old.uuid, params)
         
         // when
-        let events = try await repository.loadTodoEvents(in: self.dummyRange(0..<10)).firstValue(with: 10)
+        let events = try await repository.loadTodoEvents(in: self.dummyRange(0..<10)).firstValue(with: 1000)
         
         // then
         XCTAssertEqual(events?.count, 1)
@@ -265,7 +265,7 @@ extension TodoLocalRepositoryImpleTests {
         try await stubTodos()
         
         // when
-        let uncompletedTodos = try await repository.loadUncompletedTodos().firstValue(with: 100)
+        let uncompletedTodos = try await repository.loadUncompletedTodos().firstValue(with: 1000)
         
         
         // then
@@ -705,7 +705,7 @@ extension TodoLocalRepositoryImpleTests {
         let repository = try await self.makeRepositoryWithStubTodo(todo)
         
         // when
-        let loadedTodo = try await repository.todoEvent(todo.uuid).firstValue(with: 100)
+        let loadedTodo = try await repository.todoEvent(todo.uuid).firstValue(with: 1000)
         
         // then
         XCTAssertNotNil(loadedTodo)

--- a/Services/AdService/Sources/AdBannerUIView.swift
+++ b/Services/AdService/Sources/AdBannerUIView.swift
@@ -21,7 +21,7 @@ public final class AdBannerUIView: UIView {
     private var isLoaded: Bool = false
     private var isAllowed: Bool = false
     private var didRequestLoad: Bool = false
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 
     public init(
         adUnitId: String,
@@ -55,7 +55,7 @@ public final class AdBannerUIView: UIView {
             .sink(receiveValue: { [weak self] isAllowed in
                 self?.apply(isAllowed: isAllowed)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 
     private func apply(isAllowed: Bool) {

--- a/Services/SpeechService/Sources/SpeechRecognizeServiceImple.swift
+++ b/Services/SpeechService/Sources/SpeechRecognizeServiceImple.swift
@@ -30,7 +30,7 @@ public final class SpeechRecognizeServiceImple: SpeechRecognizeService, @uncheck
         let audioInputDisrupted = PassthroughSubject<Void, Never>()
     }
     private let subject = Subject()
-    private var audioSessionObserving = Set<AnyCancellable>()
+    private let audioSessionObserving = CancelBag()
 
     // 이 dBFS 이하를 0(무음)으로, 0dBFS를 1로 매핑하는 노이즈 플로어
     private let noiseFloor: Float = -50.0
@@ -75,7 +75,7 @@ extension SpeechRecognizeServiceImple {
     }
 
     private func observeAudioDisruption() {
-        self.audioSessionObserving = []
+        self.audioSessionObserving.cancelAll()
 
         let interruptionBegan = NotificationCenter.default
             .publisher(for: AVAudioSession.interruptionNotification)
@@ -96,7 +96,7 @@ extension SpeechRecognizeServiceImple {
             .sink { [weak self] _ in
                 self?.subject.audioInputDisrupted.send(())
             }
-            .store(in: &self.audioSessionObserving)
+            .store(in: self.audioSessionObserving)
     }
 
     private func isInterruptionBegan() -> (Notification) -> Bool {
@@ -173,7 +173,7 @@ extension SpeechRecognizeServiceImple {
     // 무조건 호출해도 안전(idempotent): stop/cancel/removeTap 모두 미동작·미설치 상태에서 호출해도 무해.
     // start 실패 cleanup, 중복 stop, 에러 분기 self-teardown 모두 이 한 경로로 처리.
     private func teardownAudio() {
-        self.audioSessionObserving = []
+        self.audioSessionObserving.cancelAll()
         self.task?.cancel()
         self.audioEngine.stop()
         self.audioEngine.inputNode.removeTap(onBus: 0)

--- a/Supports/Extensions/Sources/Type+Extensions/CancelBag.swift
+++ b/Supports/Extensions/Sources/Type+Extensions/CancelBag.swift
@@ -1,0 +1,43 @@
+//
+//  CancelBag.swift
+//  Extensions
+//
+//  Created by sudo.park on 8/24/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+
+/// 구독 보관함. `Set<AnyCancellable>` 을 직접 두면 백그라운드 Task 에서 store 하는 순간
+/// 메인 스레드 store 와 겹쳐 Set 저장소가 깨진다 — 잠금으로 그 경로 자체를 막는다.
+public final class CancelBag: @unchecked Sendable {
+    
+    private let lock = NSLock()
+    private var cancellables: Set<AnyCancellable> = []
+    
+    public init() { }
+    
+    public func insert(_ cancellable: AnyCancellable) {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        self.cancellables.insert(cancellable)
+    }
+    
+    public func cancelAll() {
+        self.lock.lock()
+        let stored = self.cancellables
+        self.cancellables.removeAll()
+        self.lock.unlock()
+        stored.forEach { $0.cancel() }
+    }
+}
+
+
+extension AnyCancellable {
+    
+    public func store(in bag: CancelBag) {
+        bag.insert(self)
+    }
+}

--- a/Supports/Extensions/Sources/Type+Extensions/Task+Extensions.swift
+++ b/Supports/Extensions/Sources/Type+Extensions/Task+Extensions.swift
@@ -17,4 +17,8 @@ extension Task {
         let anyCancellable = AnyCancellable(self)
         set.insert(anyCancellable)
     }
+    
+    public func store(in bag: CancelBag) {
+        bag.insert(AnyCancellable(self))
+    }
 }

--- a/Supports/UnitTestHelpKit/Sources/AsyncEffectWaitable.swift
+++ b/Supports/UnitTestHelpKit/Sources/AsyncEffectWaitable.swift
@@ -1,0 +1,48 @@
+//
+//  AsyncEffectWaitable.swift
+//  UnitTestHelpKit
+//
+//  Created by sudo.park on 8/24/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+
+public struct AsyncEffectWaitTimeout: Error, CustomStringConvertible {
+    
+    public let timeoutMillis: Int
+    public let description: String
+    
+    init(timeoutMillis: Int, description: String) {
+        self.timeoutMillis = timeoutMillis
+        self.description = description
+    }
+}
+
+
+public protocol AsyncEffectWaitable: AnyObject { }
+
+extension AsyncEffectWaitable {
+    
+    /// 고정 sleep 대신 조건이 참이 될 때까지 폴링한다. 병렬 실행 부하로 효과가 늦게 도착해도
+    /// 기다리는 시간만 늘어날 뿐 판정이 흔들리지 않는다. 끝내 참이 되지 않으면 던져서
+    /// 뒤따르는 단언이 엉뚱한 메시지로 실패하는 대신 대기 실패임을 드러낸다.
+    public func waitEffect(
+        _ description: String,
+        timeoutMillis: Int = 3000,
+        until condition: () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(TimeInterval(timeoutMillis) / 1000)
+        while Date() < deadline {
+            if condition() { return }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        guard condition() else {
+            throw AsyncEffectWaitTimeout(
+                timeoutMillis: timeoutMillis,
+                description: "\(timeoutMillis)ms 안에 조건이 참이 되지 않았다 — \(description)"
+            )
+        }
+    }
+}

--- a/Template/Todo-Calendar-Scene.xctemplate/Default/___FILEBASENAME___ViewController.swift
+++ b/Template/Todo-Calendar-Scene.xctemplate/Default/___FILEBASENAME___ViewController.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -18,7 +19,7 @@ final class ___VARIABLE_sceneName___ViewController: UIViewController, ___VARIABL
     @MainActor
     var interactor: (any ___VARIABLE_sceneName___SceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any ___VARIABLE_sceneName___ViewModel,
@@ -55,7 +56,7 @@ extension ___VARIABLE_sceneName___ViewController {
             .sink(receiveValue: { [weak self] tuple in
                 self?.setupStyling(tuple.1, tuple.2)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/Template/Todo-Calendar-Scene.xctemplate/Default/___FILEBASENAME___ViewModel.swift
+++ b/Template/Todo-Calendar-Scene.xctemplate/Default/___FILEBASENAME___ViewModel.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Combine
 import Domain
+import Extensions
 import Scenes
 
 
@@ -33,7 +34,7 @@ final class ___VARIABLE_sceneName___ViewModelImple: ___VARIABLE_sceneName___View
         
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 }
 

--- a/Template/Todo-Calendar-Scene.xctemplate/SwiftUI/___FILEBASENAME___View.swift
+++ b/Template/Todo-Calendar-Scene.xctemplate/SwiftUI/___FILEBASENAME___View.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -14,7 +15,7 @@ import CommonPresentation
 @Observable final class ___VARIABLE_sceneName___ViewState {
     
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
     
     func bind(_ viewModel: any ___VARIABLE_sceneName___ViewModel) {
         

--- a/Template/Todo-Calendar-Scene.xctemplate/SwiftUI/___FILEBASENAME___ViewController.swift
+++ b/Template/Todo-Calendar-Scene.xctemplate/SwiftUI/___FILEBASENAME___ViewController.swift
@@ -5,6 +5,7 @@
 import UIKit
 import SwiftUI
 import Combine
+import Extensions
 import Scenes
 import CommonPresentation
 
@@ -19,7 +20,7 @@ final class ___VARIABLE_sceneName___ViewController: UIHostingController<___VARIA
     @MainActor
     var interactor: (any ___VARIABLE_sceneName___SceneInteractor)? { self.viewModel }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     
     init(
         viewModel: any ___VARIABLE_sceneName___ViewModel,

--- a/Template/Todo-Calendar-Scene.xctemplate/SwiftUI/___FILEBASENAME___ViewModel.swift
+++ b/Template/Todo-Calendar-Scene.xctemplate/SwiftUI/___FILEBASENAME___ViewModel.swift
@@ -5,6 +5,7 @@
 import Foundation
 import Combine
 import Domain
+import Extensions
 import Scenes
 
 
@@ -33,7 +34,7 @@ final class ___VARIABLE_sceneName___ViewModelImple: ___VARIABLE_sceneName___View
         
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
 }
 

--- a/TodoCalendarApp/AppExtensions/Share/Sources/ShareCommandView.swift
+++ b/TodoCalendarApp/AppExtensions/Share/Sources/ShareCommandView.swift
@@ -18,7 +18,7 @@ import CommonPresentation
 @Observable final class ShareCommandViewState {
 
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
 
     // 공유 원문은 viewModel이 1회 실어주고, 이후엔 유저가 직접 편집한다
     var sharedText: String = ""
@@ -66,37 +66,37 @@ import CommonPresentation
         viewModel.sharedText
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] in self?.sharedText = $0 })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.source
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] in self?.source = $0 })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.isPreparing
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] in self?.isPreparing = $0 })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.blockedMessage
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] in self?.blockedMessage = $0 })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.isSending
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] in self?.isSending = $0 })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.sentMessage
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] in self?.sentMessage = $0 })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         viewModel.failureMessage
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] in self?.failureMessage = $0 })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/TodoCalendarApp/Sources/Main/LegalNoticeBannerView.swift
+++ b/TodoCalendarApp/Sources/Main/LegalNoticeBannerView.swift
@@ -9,6 +9,7 @@
 import UIKit
 import Combine
 import Domain
+import Extensions
 import CommonPresentation
 
 
@@ -32,7 +33,7 @@ final class LegalNoticeBannerRowView: UIView {
 
     private let tapSubject = PassthroughSubject<Void, Never>()
     private let closeSubject = PassthroughSubject<Void, Never>()
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -64,11 +65,11 @@ extension LegalNoticeBannerRowView {
 
         rowTapPublisher
             .sink(receiveValue: { [weak self] in self?.tapSubject.send(()) })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         self.closeButton.addTapGestureRecognizerPublisher()
             .sink(receiveValue: { [weak self] in self?.closeSubject.send(()) })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 
@@ -155,7 +156,7 @@ final class LegalNoticeBannerView: UIView {
     private let stackView = UIStackView()
     private var rows: [LegalNoticeBannerRowView] = []
     private var separators: [UIView] = []
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private var currentFontSet: (any FontSet)?
     private var currentColorSet: (any ColorSet)?
 
@@ -190,7 +191,7 @@ extension LegalNoticeBannerView {
             self.stackView.removeArrangedSubview($0)
             $0.removeFromSuperview()
         }
-        self.cancellables = []
+        self.cancellables.cancelAll()
         self.separators = []
 
         self.rows = models.map { model -> LegalNoticeBannerRowView in
@@ -216,10 +217,10 @@ extension LegalNoticeBannerView {
     private func bind(_ row: LegalNoticeBannerRowView, documentType: LegalDocumentType) {
         row.tapped
             .sink(receiveValue: { [weak self] in self?.documentTappedSubject.send(documentType) })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         row.closeTapped
             .sink(receiveValue: { [weak self] in self?.closeTappedSubject.send(documentType) })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 
     private func applyStyleIfNeeded(to row: LegalNoticeBannerRowView) {

--- a/TodoCalendarApp/Sources/Main/MainViewController.swift
+++ b/TodoCalendarApp/Sources/Main/MainViewController.swift
@@ -38,7 +38,7 @@ final class MainViewController: UIViewController, MainScene {
     @MainActor
     var interactor: (any MainSceneInteractor)? { self.viewModel }
 
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 
     init(
         viewModel: any MainViewModel,
@@ -115,7 +115,7 @@ extension MainViewController {
             .sink(receiveValue: { [weak self] tuple in
                 self?.setupStyling(tuple.1, tuple.2)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.viewModel.currentMonth
             .receive(on: RunLoop.main)
@@ -124,42 +124,42 @@ extension MainViewController {
                 self?.headerView.yearLabel.text = month.yearText
                 self?.headerView.yearLabel.isHidden = month.yearText == nil
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.viewModel.isShowReturnToToday
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] show in
                 self?.headerView.returnTodayView.isHidden = !show
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.viewModel.temporaryUserDataMigrationStatus
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] status in
                 self?.headerView.updateMigrationStatus(status)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.viewModel.isLoadingCalendarEvents
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] isLoading in
                 self?.compositeLoadingBarView.updateIsLoading(isLoading)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         self.viewModel.isLoadingAllEvents
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] isLoading in
                 self?.loadingAllEventsLabel.isHidden = !isLoading
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         self.viewModel.legalNoticeBanners
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] models in
                 self?.legalNoticeBannerView.update(models)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         self.legalNoticeBannerView.documentTapped
             .receive(on: RunLoop.main)
@@ -167,7 +167,7 @@ extension MainViewController {
                 self?.viewAppearance.impactIfNeed()
                 self?.viewModel.openLegalNoticeDocument(documentType)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         self.legalNoticeBannerView.closeTapped
             .receive(on: RunLoop.main)
@@ -175,20 +175,20 @@ extension MainViewController {
                 self?.viewAppearance.impactIfNeed()
                 self?.viewModel.closeLegalNoticeBanner(documentType)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         self.headerView.returnTodayView.addTapGestureRecognizerPublisher()
             .sink(receiveValue: { [weak self] in
                 self?.viewModel.returnToToday()
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.headerView.migrationButton.addTapGestureRecognizerPublisher()
             .sink(receiveValue: { [weak self] in
                 self?.viewAppearance.impactIfNeed()
                 self?.viewModel.handleMigration()
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.headerView.eventTypeFilterButton
             .addTapGestureRecognizerPublisher()
@@ -196,35 +196,35 @@ extension MainViewController {
                 self?.viewAppearance.impactIfNeed()
                 self?.viewModel.moveToEventTypeFilterSetting()
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.headerView.settingButton.addTapGestureRecognizerPublisher()
             .sink { [weak self] in
                 self?.viewAppearance.impactIfNeed()
                 self?.viewModel.moveToSetting()
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.headerView.jumpButton.addTapGestureRecognizerPublisher()
             .sink { [weak self] in
                 self?.viewAppearance.impactIfNeed()
                 self?.viewModel.jumpDate()
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         self.headerView.previousMonthButton.addTapGestureRecognizerPublisher()
             .sink { [weak self] in
                 self?.viewAppearance.impactIfNeed()
                 self?.viewModel.moveToPreviousMonth()
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         self.headerView.nextMonthButton.addTapGestureRecognizerPublisher()
             .sink { [weak self] in
                 self?.viewAppearance.impactIfNeed()
                 self?.viewModel.moveToNextMonth()
             }
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 

--- a/TodoCalendarApp/Sources/Main/MainViewModel.swift
+++ b/TodoCalendarApp/Sources/Main/MainViewModel.swift
@@ -13,6 +13,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import Scenes
 
 
@@ -114,7 +115,7 @@ final class MainViewModelImple: MainViewModel, @unchecked Sendable {
         let temporaryUserDataMigrationStatus = CurrentValueSubject<TemporaryUserDataMigrationStatus?, Never>(nil)
     }
     
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
     private let subject = Subject()
     private var calendarSceneInteractor: (any CalendarSceneInteractor)?
     
@@ -125,14 +126,14 @@ final class MainViewModelImple: MainViewModel, @unchecked Sendable {
             .sink(receiveValue: { [weak self] _ in
                 self?.subject.temporaryUserDataMigrationStatus.send(.migrating)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.temporaryUserDataMigrationUsecase.migrationNeedEventCount
             .filter { $0 > 0 }
             .sink(receiveValue: { [weak self] count in
                 self?.subject.temporaryUserDataMigrationStatus.send(.need(count))
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
         
         self.temporaryUserDataMigrationUsecase.migrationResult
             .sink(receiveValue: { [weak self] result in
@@ -144,7 +145,7 @@ final class MainViewModelImple: MainViewModel, @unchecked Sendable {
                     self?.router?.showError(error)
                 }
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
             .sink(receiveValue: { [weak self] _ in
@@ -154,7 +155,7 @@ final class MainViewModelImple: MainViewModel, @unchecked Sendable {
                 self?.handleWillEnterForeground()
                 self?.legalNoticeUsecase.checkNoticeIsNeed()
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 
 }
@@ -194,7 +195,7 @@ extension MainViewModelImple {
         Task { [weak self] in
             _ = try await self?.uiSettingUsecase.refreshAppearanceSetting()
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func bindEventTagColorMap() {
@@ -204,7 +205,7 @@ extension MainViewModelImple {
             .sink(receiveValue: { [weak self] tags in
                 self?.uiSettingUsecase.applyEventTagColors(Array(tags.values))
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     func returnToToday() {

--- a/TodoCalendarApp/Sources/Root/ApplicationPrepareUsecase.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationPrepareUsecase.swift
@@ -49,7 +49,7 @@ final class ApplicationPrepareUsecaseImple: ApplicationPrepareUsecase {
     private let appDataMigration: AppDataMigrationImple
     private let databasePathFinding: (String?) -> String
 
-    private var cancelBag: Set<AnyCancellable> = []
+    private let cancelBag = CancelBag()
 
     init(
         accountUsecase: any AccountUsecase,

--- a/TodoCalendarApp/Sources/Root/ApplicationRootViewModel.swift
+++ b/TodoCalendarApp/Sources/Root/ApplicationRootViewModel.swift
@@ -59,7 +59,7 @@ final class ApplicationRootViewModelImple: @unchecked Sendable {
         let isSignIn = CurrentValueSubject<Bool, Never>(false)
     }
     private let subject = Subject()
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 }
 
 
@@ -100,7 +100,7 @@ extension ApplicationRootViewModelImple: AutenticatorTokenRefreshListener {
                     self?.handleUserSignedOut()
                 }
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     private func bindExternalCalenarIntegratedStatus() {
@@ -114,7 +114,7 @@ extension ApplicationRootViewModelImple: AutenticatorTokenRefreshListener {
                     self?.prepareUsecase.prepareExternalCalendarStopIntegrated(status.serviceId)
                 }
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
     
     private func handleUserSignedIn(_ account: Account) {
@@ -127,7 +127,7 @@ extension ApplicationRootViewModelImple: AutenticatorTokenRefreshListener {
             await self?.attach(mainSceneInteractor: interactor)
             self?.registerTokenIfNeed()
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
     
     private func handleUserSignedOut() {
@@ -183,13 +183,13 @@ extension ApplicationRootViewModelImple {
             .sink(receiveValue: { [weak self] _ in
                 self?.handleDidEnterBackground()
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
 
         NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)
             .sink(receiveValue: { [weak self] _ in
                 self?.handleWillEnterForeground()
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 
     private func handleDidEnterBackground() {
@@ -208,7 +208,7 @@ extension ApplicationRootViewModelImple {
             .sink(receiveValue: { [weak self] requirement in
                 self?.router?.showUpdatePopup(requirement)
             })
-            .store(in: &self.cancellables)
+            .store(in: self.cancellables)
     }
 }
 
@@ -257,7 +257,7 @@ extension ApplicationRootViewModelImple {
                 logger.log(level: .error, "register fcm token fail: \(error.localizedDescription)")
             }
         }
-        .store(in: &self.cancellables)
+        .store(in: self.cancellables)
     }
 }
 

--- a/TodoCalendarApp/Sources/Root/EventLiveActivityUsecaseImple.swift
+++ b/TodoCalendarApp/Sources/Root/EventLiveActivityUsecaseImple.swift
@@ -75,7 +75,9 @@ extension EventLiveActivityUsecaseImple {
     private func eventDetail(for target: LiveActivityTarget) async -> EventDetailData? {
         guard let id = target.eventDetailDataId else { return nil }
         return try? await self.eventDetailDataUsecase.loadDetail(id)
-            .timeout(.seconds(Constant.detailLoadTimeout), scheduler: DispatchQueue.global())
+            // Publishers.Timeout 은 concurrent 큐를 스케줄러로 받으면 구독 즉시 온 값을 흘린다 —
+            // Just 기준 global() 은 5000회 중 777회 유실, 메인 큐는 0회다
+            .timeout(.seconds(Constant.detailLoadTimeout), scheduler: DispatchQueue.main)
             .values
             .first(where: { _ in true })
     }

--- a/TodoCalendarApp/TodoCalendarAppTests/EventLiveActivityUsecaseImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/EventLiveActivityUsecaseImpleTests.swift
@@ -20,7 +20,7 @@ import Domain
 @testable import TodoCalendarApp
 
 
-final class EventLiveActivityUsecaseImpleTests: PublisherWaitable {
+final class EventLiveActivityUsecaseImpleTests: PublisherWaitable, AsyncEffectWaitable {
 
     var cancelBag: Set<AnyCancellable>! = .init()
 
@@ -115,8 +115,15 @@ final class EventLiveActivityUsecaseImpleTests: PublisherWaitable {
         return formatter.string(from: date)
     }
 
+    // 효과가 '안 일어남'을 보는 케이스는 기다릴 조건이 없어 정착 시간만 둔다
     private func waitForEffects() async throws {
         try await Task.sleep(for: .milliseconds(100))
+    }
+
+    private func waitForEffects(
+        _ description: String, until condition: () -> Bool
+    ) async throws {
+        try await self.waitEffect(description, until: condition)
     }
 
     /// 실행 시각과 무관하게 항상 `(now, now+8h)` 안에 들어오는 공휴일 시나리오를 만든다 —
@@ -521,7 +528,7 @@ extension EventLiveActivityUsecaseImpleTests {
             [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
             ["t1": self.makeTodo(id: "t1", name: "new", eventDate: future)]
         )
-        try await self.waitForEffects()
+        try await self.waitForEffects("stub.didUpdateWith?.eventName == 'new'") { stub.didUpdateWith?.eventName == "new" }
 
         // then
         #expect(stub.didUpdateWith?.eventName == "new")
@@ -543,7 +550,7 @@ extension EventLiveActivityUsecaseImpleTests {
             [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
             ["t1": self.makeTodo(id: "t1", eventDate: nextTime)]
         )
-        try await self.waitForEffects()
+        try await self.waitForEffects("stub.didUpdateWith?.eventDate == Date(timeIntervalSince1970: nextTime.timeIntervalSince1970)") { stub.didUpdateWith?.eventDate == Date(timeIntervalSince1970: nextTime.timeIntervalSince1970) }
 
         // then
         #expect(stub.didUpdateWith?.eventDate == Date(timeIntervalSince1970: nextTime.timeIntervalSince1970))
@@ -567,12 +574,12 @@ extension EventLiveActivityUsecaseImpleTests {
             [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
             ["t1": self.makeTodo(id: "t1", eventDate: nextTime)]
         )
-        try await self.waitForEffects()
-
-        // then
         let expectedText = self.expectedTimeText(
             for: Date(timeIntervalSince1970: nextTime.timeIntervalSince1970)
         )
+        try await self.waitForEffects("stub.didUpdateWith?.eventTimeText == expectedText") { stub.didUpdateWith?.eventTimeText == expectedText }
+
+        // then
         #expect(stub.didUpdateWith?.eventTimeText == expectedText)
     }
 
@@ -591,7 +598,7 @@ extension EventLiveActivityUsecaseImpleTests {
             [String: GoogleCalendar.Event].self, key: ShareDataKeys.googleCalendarEvents.rawValue,
             ["g1": self.makeGoogleEvent(id: "g1", eventDate: future, location: "new place")]
         )
-        try await self.waitForEffects()
+        try await self.waitForEffects("stub.didUpdateWith?.placeName == 'new place'") { stub.didUpdateWith?.placeName == "new place" }
 
         // then
         #expect(stub.didUpdateWith?.placeName == "new place")
@@ -630,7 +637,7 @@ extension EventLiveActivityUsecaseImpleTests {
             [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
             ["t1": self.makeTodo(id: "t1", name: "changed", eventDate: future)]
         )
-        try await self.waitForEffects()
+        try await self.waitForEffects("stub.didUpdateWith?.startDate == startDate") { stub.didUpdateWith?.startDate == startDate }
 
         // then
         #expect(stub.didUpdateWith?.startDate == startDate)
@@ -728,12 +735,12 @@ extension EventLiveActivityUsecaseImpleTests {
             [String: TodoEvent].self, key: ShareDataKeys.todos.rawValue,
             ["t1": self.makeTodo(id: "t1", name: "changed", eventDate: future)]
         )
-        try await self.waitForEffects()
-
-        // then
         let expectedTimeText = self.expectedTimeText(
             for: Date(timeIntervalSince1970: future.timeIntervalSince1970)
         )
+        try await self.waitForEffects("stub.didUpdateWith?.eventTimeText == expectedTimeText") { stub.didUpdateWith?.eventTimeText == expectedTimeText }
+
+        // then
         #expect(stub.didUpdateWith?.eventTimeText == expectedTimeText)
         #expect(stub.didUpdateWith?.tagColorHex == "#ABCDEF")
         #expect(stub.didUpdateWith?.startDate == restoredContent.startDate)
@@ -786,10 +793,10 @@ extension EventLiveActivityUsecaseImpleTests {
             MemorizedEventsContainer<ScheduleEvent>()
                 .append(self.makeSchedule(id: "s1", name: "changed", eventDate: newTime))
         )
-        try await self.waitForEffects()
+        let expectedQuery = EventTime.at(newTime.timeIntervalSince1970).queryParams
+        try await self.waitForEffects("stub.didUpdateWith?.scheduleTimeQuery == expectedQuery") { stub.didUpdateWith?.scheduleTimeQuery == expectedQuery }
 
         // then
-        let expectedQuery = EventTime.at(newTime.timeIntervalSince1970).queryParams
         #expect(stub.didUpdateWith?.scheduleTimeQuery == expectedQuery)
     }
 
@@ -801,7 +808,7 @@ extension EventLiveActivityUsecaseImpleTests {
         )
         let (usecase, stub, _) = self.makeUsecase(stubRestoredRegistration: registration)
         await usecase.prepare()
-        try await self.waitForEffects()
+        try await self.waitForEffects("stub.didEnd == true") { stub.didEnd == true }
 
         // when
         await usecase.handleWillEnterForeground()
@@ -973,7 +980,7 @@ extension EventLiveActivityUsecaseImpleTests {
 
         // when
         self.putTodos(store, [self.makeTodo(id: "t1", name: "changed", eventDate: future)])
-        try await self.waitForEffects()
+        try await self.waitForEffects("stub.didUpdateWith?.eventName == 'changed'") { stub.didUpdateWith?.eventName == "changed" }
 
         // then
         #expect(stub.didUpdateWith?.eventName == "changed")
@@ -1013,7 +1020,7 @@ extension EventLiveActivityUsecaseImpleTests {
         // when
         await usecase.handleWillEnterForeground()
         self.putTodos(store, [self.makeTodo(id: "t1", eventDate: future, turn: 3)])
-        try await self.waitForEffects()
+        try await self.waitForEffects("stub.didEnd == true") { stub.didEnd == true }
 
         // then
         #expect(stub.didEnd == true)
@@ -1078,7 +1085,7 @@ extension EventLiveActivityUsecaseImpleTests {
 
         // when
         self.putTodos(store, [self.makeTodo(id: "t1", eventDate: future, turn: 4)])
-        try await self.waitForEffects()
+        try await self.waitForEffects("stub.didEnd == true") { stub.didEnd == true }
 
         // then
         #expect(stub.didEnd == true)
@@ -1207,7 +1214,7 @@ extension EventLiveActivityUsecaseImpleTests {
             [String: [Int: [Holiday]]].self, key: ShareDataKeys.holidays.rawValue,
             ["KR": [2026: [Holiday(uuid: "hz", dateString: scenario.dateString, name: "new")]]]
         )
-        try await self.waitForEffects()
+        try await self.waitForEffects("stub.didUpdateWith?.eventName == 'new'") { stub.didUpdateWith?.eventName == "new" }
 
         // then
         #expect(stub.didEnd == false)
@@ -1730,7 +1737,7 @@ extension EventLiveActivityUsecaseImpleTests {
 
         // when
         self.putTodos(store, [self.makeTodo(id: "t1", name: "new", eventDate: future)])
-        try await self.waitForEffects()
+        try await self.waitForEffects("stub.didUpdateWith?.eventName == 'new'") { stub.didUpdateWith?.eventName == "new" }
 
         // then
         let content = try #require(stub.didUpdateWith)

--- a/TodoCalendarApp/TodoCalendarAppTests/MainViewModelImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/MainViewModelImpleTests.swift
@@ -99,6 +99,9 @@ class MainViewModelImpleTests: BaseTestCase, PublisherWaitable {
         }
         viewModel.prepare()
         self.wait(for: [expect], timeout: self.timeout)
+        // 앞 테스트의 VM 이 아직 살아 있으면 전역 NotificationCenter 방출에 반응해 이미 채워진
+        // expectation 을 다시 때린다. XCTest 는 그걸 API violation 어서션으로 처리해 프로세스를 죽인다
+        self.spyRouter.didCalendarAttached = nil
         return viewModel
     }
 }
@@ -216,6 +219,7 @@ extension MainViewModelImpleTests {
         
         // then
         self.wait(for: [expect], timeout: self.timeout)
+        self.spyUISettingUsecase.didAppluEventTagColorCallback = nil
     }
     
     func testViewModel_whenPrepare_prepareGoogleCalendar() {
@@ -694,6 +698,7 @@ extension MainViewModelImpleTests {
 
         // then
         self.wait(for: [expect], timeout: 0.1)
+        self.spyEventLiveActivityUsecase.whenDidPrepare = nil
         XCTAssertEqual(self.spyEventLiveActivityUsecase.didPrepare, true)
     }
 
@@ -711,6 +716,7 @@ extension MainViewModelImpleTests {
 
         // then
         self.wait(for: [expect], timeout: 0.1)
+        self.spyEventLiveActivityUsecase.whenDidHandleWillEnterForeground = nil
         XCTAssertEqual(self.spyEventLiveActivityUsecase.didHandleWillEnterForeground, true)
     }
 }

--- a/docs/coding-style-and-philosophy.md
+++ b/docs/coding-style-and-philosophy.md
@@ -191,7 +191,7 @@ let userDefaults = suiteName.flatMap { UserDefaults(suiteName: $0) } ?? .standar
 // Trailing closure
 self.todoRepository.loadCurrentTodoEvents()
     .sink(receiveCompletion: { _ in }, receiveValue: updateCached)
-    .store(in: &self.cancellables)
+    .store(in: self.cancellables)
 
 // [weak self] capture
 let updateCached: ([TodoEvent]) -> Void = { [weak self] currents in

--- a/docs/scene-spec.md
+++ b/docs/scene-spec.md
@@ -97,7 +97,7 @@ final class XXXViewModelImple: XXXViewModel, @unchecked Sendable {
         let someState = CurrentValueSubject<SomeType?, Never>(nil)
     }
     private let subject = Subject()
-    private var cancellables: Set<AnyCancellable> = []
+    private let cancellables = CancelBag()
 
     init(someUsecase: any SomeUsecase) { ... }
 }
@@ -159,7 +159,7 @@ graph LR
 // ViewState — ViewModel Publisher를 구독하여 View용 상태로 변환
 @Observable final class XXXViewState {
     @ObservationIgnored private var didBind = false
-    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    @ObservationIgnored private let cancellables = CancelBag()
 
     var someValue: String = ""
 
@@ -169,7 +169,7 @@ graph LR
         viewModel.someState
             .receive(on: RunLoop.main)
             .sink { [weak self] in self?.someValue = $0 }
-            .store(in: &cancellables)
+            .store(in: cancellables)
     }
 }
 

--- a/docs/troubleshooting/2026-08-24-cancelbag-data-race-crash.md
+++ b/docs/troubleshooting/2026-08-24-cancelbag-data-race-crash.md
@@ -1,0 +1,32 @@
+---
+issue: "#990"
+subdomain: Infra
+symptoms: [unrecognized selector sent to instance 0x8000000000000000, member:, NSInvalidArgumentException, CalendarScenes 랜덤 크래시, Set AnyCancellable 동시 변이]
+resolution: fixed
+---
+
+# 백그라운드 Task 에서 구독을 담다 Set 저장소가 깨진다
+
+- **증상**: `CalendarScenes` 를 통째로 돌리면 랜덤한 테스트에서 프로세스가 죽는다 (3회 중 2회). `TodoCalendarApp` 도 매 회 죽었다. `Executed N tests, with 0 failures` 인데 `exit 65` 이고 실행 개수가 매번 다르다.
+
+  ```
+  -[__NSTaggedDate member:]: unrecognized selector sent to instance 0x8000000000000000
+  -[NSTaggedPointerString member:]: unrecognized selector sent to instance 0x8000000000000000
+  ```
+
+  **수신 클래스가 런마다 바뀌는데 주소는 같다.** 태그드 포인터 난독화가 프로세스마다 달라서 그런 것이고, 같은 쓰레기 포인터를 읽고 있다는 뜻이다 — 로직 버그가 아니라 메모리 손상 신호다.
+
+- **근본 원인**: 뷰모델·유스케이스가 `@unchecked Sendable` 인데 구독을 `Set<AnyCancellable>` 프로퍼티에 담는다. `Task` 본문 안에서 그 Set 을 변이하는 자리가 네 곳 있어, 메인 스레드의 `store(in:)` 과 겹치면 Set 저장소가 깨진다. 크래시 지점은 `viewModel.prepare()` 였고, 그 안에서 `Task { ... self?.bindRefreshHoliday() }` 가 백그라운드에서 같은 Set 을 건드렸다.
+
+  | 위치 | 경로 |
+  |---|---|
+  | `CalendarViewModelImple.prepare` | `bindRefreshHoliday()` |
+  | `EventListCellEventHanleViewModelImple` | `confirmAndRemoveEvent()` |
+  | `ApplicationRootViewModelImple.prepareInitialScene` | `registerTokenIfNeed()` |
+  | `ApplicationRootViewModelImple.handleUserSignedIn` | `registerTokenIfNeed()` |
+
+- **해결**: `Extensions` 에 잠금으로 보호되는 `CancelBag` 을 두고 프로덕션 보관함을 전부 교체 (선언 138곳·호출 392곳). 담을 그릇 자체를 스레드 안전하게 만들어 네 곳을 개별로 고치는 대신 이 부류 자체를 없앴다.
+
+- **기각 방향**: 네 곳만 MainActor 로 홉시킨다 — 새로 `Task { self.bindX() }` 를 쓰는 순간 재발한다. 잡을 자리가 계속 늘어난다.
+
+- **재발 시 판별**: `member:` unrecognized selector 나 `0x8000000000000000` 이 보이면 Set 저장소 손상이다. 새 코드가 `Set<AnyCancellable>` 을 직접 두고 있지 않은지 본다 — 프로덕션은 `CancelBag` 만 쓴다.

--- a/docs/troubleshooting/2026-08-24-combine-timeout-drops-value-on-concurrent-queue.md
+++ b/docs/troubleshooting/2026-08-24-combine-timeout-drops-value-on-concurrent-queue.md
@@ -1,0 +1,42 @@
+---
+issue: "#990"
+subdomain: Event
+symptoms: [라이브액티비티 placeName nil, memo nil, EventLiveActivityUsecaseImpleTests 간헐 실패, Publishers.Timeout, DispatchQueue.global, 동기 방출 유실]
+resolution: fixed
+---
+
+# `.timeout` 이 concurrent 큐에서 동기 방출값을 흘린다
+
+- **증상**: `EventLiveActivityUsecaseImpleTests` 의 "상세에서 place·memo 를 채운다" 계열 4개가 전체 실행에서 간헐 실패한다. 상세가 통째로 안 들어온다.
+
+  ```
+  Expectation failed: (content.placeName → nil) == "회의실 A"
+  Expectation failed: (content.placeName → nil) == "3층 라운지"
+  Expectation failed: (content.memo → nil) == "준비물"
+  ```
+
+  전체 스킴 6회 중 4회, 스위트 단독 5회 중 2회. **단일 테스트 단독 실행은 10회 전부 통과** 한다.
+
+- **근본 원인**: `EventLiveActivityUsecaseImple.eventDetail(for:)` 이 `.timeout(.seconds(1), scheduler: DispatchQueue.global())` 을 탄다. `Publishers.Timeout` 은 **concurrent 큐**를 스케줄러로 받으면 구독 즉시 도착한 값을 흘린다.
+
+  측정 (`Just(1)` 기준, 시뮬레이터에서 5000회):
+
+  | 구성 | 유실 |
+  |---|---|
+  | `.timeout(30s, DispatchQueue.global()) → .values.first` | 389 / 5000 |
+  | `.timeout(30s, DispatchQueue.global()) → .first().sink` | 1046 / 5000 |
+  | `.timeout(30s, DispatchQueue(label:)) → .values.first` | 0 / 5000 |
+  | `.timeout(30s, DispatchQueue.main) → .values.first` | 0 / 5000 |
+  | `.timeout(30s, RunLoop.main) → .values.first` | 0 / 2000 |
+  | timeout 없이 `.values.first` | 0 / 5000 |
+
+  소비 방식(`values` vs `sink`)과 무관하고 스케줄러 종류만 가른다. 타임아웃 값과도 무관하다 — 30초로 늘려도 유실률이 그대로다.
+
+- **해결**: 타임아웃 스케줄러를 `DispatchQueue.main` 으로 교체. `AICommandUsecase.notFinishJobTimeout` 이 이미 쓰던 것과 같은 스케줄러라 코드베이스 안에서 일관된다. 프로덕션 결함이기도 하다 — 상세가 캐시에서 즉시 오면 그 확률로 라이브액티비티가 place·memo 없이 등록된다.
+
+- **기각 방향**:
+  - 병렬 부하로 1초 타임아웃을 넘긴다 — 타임아웃을 30초로 주입해도 유실률이 안 변해 기각. 1초 블로킹 테스트의 소요 시간도 매 회차 1.002초로 일정해 풀 포화 근거가 없었다
+  - `@Suite(.serialized)` 로 병렬을 줄인다 — 동시 실행 깊이를 4에서 3으로 낮췄을 뿐 실패가 계속됐다
+  - `.values` 브리지의 demand 레이스 — 단독 실행 10/10 통과로 한 번 기각했다가, timeout 을 뺀 구성이 0/5000 인 것으로 `.timeout` 쪽이 원인임이 확정됐다
+
+- **재발 시 판별**: `.timeout(_:scheduler:)` 에 넘기는 스케줄러가 concurrent 큐면 의심한다. 프로덕션에서 `DispatchQueue.global()` 을 쓰던 자리는 여기 하나였고, `AICommandUsecase.notFinishJobTimeout` 은 `DispatchQueue.main` 이라 무관하다.

--- a/docs/troubleshooting/2026-08-24-local-db-tests-random-crash.md
+++ b/docs/troubleshooting/2026-08-24-local-db-tests-random-crash.md
@@ -1,0 +1,28 @@
+---
+issue: "#990"
+subdomain: Infra
+symptoms: [Repository 스킴 랜덤 실패, illegal multi-threaded access to database connection, vnode unlinked while in use, Restarting after unexpected exit, BaseLocalTests, 플레이키]
+resolution: fixed
+---
+
+# 로컬 DB 테스트가 런마다 다른 지점에서 크래시
+
+- **증상**: `Repository` 스킴을 통째로 돌리면 매번 다른 테스트가 깨진다. 같은 커밋 3회 실행에서 1회 FAILED. 로그에 sqlite API 위반이 런당 132~142건 찍히고 `Restarting after unexpected exit` 로 프로세스가 재시작된다.
+
+  ```
+  BUG IN CLIENT OF libsqlite3.dylib: illegal multi-threaded access to database connection
+  BUG IN CLIENT OF libsqlite3.dylib: database integrity compromised by API violation:
+    vnode unlinked while in use: .../Caches/temps.db
+  ```
+
+- **근본 원인**: `BaseLocalTests` 가 두 조건을 동시에 만족시켰다.
+  1. DB 파일명이 **클래스당 고정**(`temps.db`·`todos.db` 등)이라 클래스 안 모든 테스트가 같은 vnode 를 쓴다.
+  2. `tearDownWithError` 가 `sqliteService = nil` 로 참조만 끊고 곧바로 파일을 지운다. 커넥션은 `SQLiteDataBase.deinit` 이 임의 스레드에서 닫는데, 그 시점에 이전 테스트의 쿼리가 아직 serial access queue 에서 돌고 있으면 `sqlite3_close` 와 겹친다.
+
+- **해결**: `fileName` 에 테스트마다 다른 UUID 를 붙여 vnode 공유를 없애고, `tearDown() async` 에서 `async.close()` 로 pending 작업을 배수한 뒤 파일을 지운다. `AICommandRepositoryImpleTests` 는 `fileName` 지정이 `super.setUpWithError()` 뒤에 있어 반영되지 않았던 것도 함께 고쳤다.
+
+  실측: 수정 후 5회 전부 통과, sqlite 위반 23~26건, 런 시간 34s → 17s.
+
+- **기각 방향**: open 을 완료 콜백 API 로 바꿔 쿼리와 같은 serial access queue 에서 연다 — `illegal multi-threaded access` 진단이 **크래시 난 회차에만** 뜨고 통과 회차엔 0건이었다. open 은 매 테스트 항상 메인에서 했으므로 그게 원인이면 상시 떴어야 한다. setUp 의 open 과 테스트 본문의 쿼리는 시간상 순차라 동시 접근이 아니고, 그 진단은 동시 접근에서 뜬다. 실제 원인은 tearDown 의 close 가 다른 스레드의 쿼리와 겹친 것이라 close 조항이 흡수한다. 세마포어로 콜백을 동기화하면 콜백이 안 올 때 타임아웃 없이 매다는 경로만 새로 생긴다.
+
+- **재발 시 판별**: `Executed N tests, with 0 failures` 인데 `exit 65` 이거나 실행 개수가 런마다 다르면 크래시다. 로그에서 `vnode unlinked while in use` 뒤의 파일명을 보면 어느 테스트 클래스인지 바로 나온다.

--- a/docs/troubleshooting/2026-08-24-paywall-screenstate-emission-count-flaky.md
+++ b/docs/troubleshooting/2026-08-24-paywall-screenstate-emission-count-flaky.md
@@ -1,0 +1,28 @@
+---
+issue: "#991"
+subdomain: Billing
+symptoms: [PaywallViewModelImpleTests, Confirmation was confirmed, screenState 방출 개수, BillingScenes 간헐 실패, outputs 창]
+resolution: deferred
+---
+
+# Paywall `screenState` 테스트가 방출 개수로 흔들린다
+
+- **증상**: `BillingScenes` 의 `PaywallViewModelImpleTests` 중 `screenState` 를 관찰하는 테스트가 간헐 실패한다. 깨지는 테스트가 회차마다 바뀌고 방출이 모자라기도 넘치기도 한다.
+
+  ```
+  viewModel_retryAfterUserPlanLoadFailed_reentersLoadingBeforeFailingAgain
+    Confirmation was confirmed 4 times, but expected to be confirmed 3 times
+    Confirmation was confirmed 2 times, but expected to be confirmed 3 times
+  viewModel_whenUserPlanLoadFails_screenStateIsUserPlanLoadFailed
+    Confirmation was confirmed 3 times, but expected to be confirmed 2 times
+  ```
+
+- **귀속**: #990 브랜치 5회 중 2회, **develop 5회 중 1회**. 같은 테스트·같은 시그니처라 #990 의 회귀가 아니다.
+
+- **근본 원인**: 미확정. 테스트가 `outputs(_:for:)` 창을 개수로만 끊는 게 직접 원인으로 보인다. `retryAfter...` 는 창을 두 번 여는데, 첫 창이 닫히는 시점에 첫 `prepare()` 의 로드가 아직 방출 중이면 잔여가 두 번째 창에 섞인다. 두 번째 구독이 CombineLatest 직전 정착 상태를 리플레이하는 타이밍도 얽혀 있다.
+
+- **해결**: 보류. 확정된 방향은 개수 기반 창을 걷어내는 것 — 한 구독으로 두 `prepare()` 를 모두 관찰하거나, `screenState` 가 중간 상태를 몇 번 방출하는지를 계약으로 확정한다. 후속은 #991.
+
+- **기각 방향**: 첫 창 뒤 100ms 정착 대기 — 실패 지점이 형제 테스트로 옮겨갈 뿐이라 해소로 볼 수 없다. 되돌렸다.
+
+- **재발 시 판별**: `Confirmation was confirmed` (뒤에 붙는 숫자는 회차마다 다르다) 가 `PublisherWaitable.swift` 를 가리키면 이 건이다. `BillingScenes` 가 이 문구로 빨개지면 재실행하고, 계속 깨져도 브랜치 실패로 판정하지 않는다.

--- a/docs/troubleshooting/INDEX.md
+++ b/docs/troubleshooting/INDEX.md
@@ -26,3 +26,4 @@
 - [2026-08-22 DayEventList 라이브액티비티 해제 표시 테스트 간헐 타임아웃](2026-08-22-dayeventlist-live-activity-clear-mark-flaky.md) — Event / deferred / whenLiveActivityUnregistered_cellViewModelsClearMark·Exceeded timeout of 2 seconds·간헐 실패
 - [2026-08-22 구글 이벤트 개별 색상이 라이브액티비티에서 무시됨](2026-08-22-google-event-custom-color-ignored-in-live-activity.md) — ExternalCalendar / fixed / 구글 이벤트 색상·커스텀 색상 무시·라이브액티비티 색·colorId
 - [2026-08-22 캘린더 하단 배너를 붙이자 플랜 구독 합성에서 격리 어서션 크래시](2026-08-22-ad-banner-plan-binding-main-actor-crash.md) — Billing / fixed / 배너 광고 크래시·_swift_task_checkIsolatedSwift·dispatch_assert_queue_fail·MainActor 격리 위반
+- [2026-08-24 로컬 DB 테스트가 런마다 다른 지점에서 크래시](2026-08-24-local-db-tests-random-crash.md) — Infra / fixed / illegal multi-threaded access·vnode unlinked while in use·Repository 스킴 랜덤 실패

--- a/docs/troubleshooting/INDEX.md
+++ b/docs/troubleshooting/INDEX.md
@@ -27,3 +27,5 @@
 - [2026-08-22 구글 이벤트 개별 색상이 라이브액티비티에서 무시됨](2026-08-22-google-event-custom-color-ignored-in-live-activity.md) — ExternalCalendar / fixed / 구글 이벤트 색상·커스텀 색상 무시·라이브액티비티 색·colorId
 - [2026-08-22 캘린더 하단 배너를 붙이자 플랜 구독 합성에서 격리 어서션 크래시](2026-08-22-ad-banner-plan-binding-main-actor-crash.md) — Billing / fixed / 배너 광고 크래시·_swift_task_checkIsolatedSwift·dispatch_assert_queue_fail·MainActor 격리 위반
 - [2026-08-24 로컬 DB 테스트가 런마다 다른 지점에서 크래시](2026-08-24-local-db-tests-random-crash.md) — Infra / fixed / illegal multi-threaded access·vnode unlinked while in use·Repository 스킴 랜덤 실패
+- [2026-08-24 `.timeout` 이 concurrent 큐에서 동기 방출값을 흘린다](2026-08-24-combine-timeout-drops-value-on-concurrent-queue.md) — Event / fixed / 라이브액티비티 placeName·memo nil·Publishers.Timeout·DispatchQueue.global
+- [2026-08-24 백그라운드 Task 에서 구독을 담다 Set 저장소가 깨진다](2026-08-24-cancelbag-data-race-crash.md) — Infra / fixed / unrecognized selector 0x8000000000000000·member:·CalendarScenes 랜덤 크래시

--- a/docs/troubleshooting/INDEX.md
+++ b/docs/troubleshooting/INDEX.md
@@ -29,3 +29,4 @@
 - [2026-08-24 로컬 DB 테스트가 런마다 다른 지점에서 크래시](2026-08-24-local-db-tests-random-crash.md) — Infra / fixed / illegal multi-threaded access·vnode unlinked while in use·Repository 스킴 랜덤 실패
 - [2026-08-24 `.timeout` 이 concurrent 큐에서 동기 방출값을 흘린다](2026-08-24-combine-timeout-drops-value-on-concurrent-queue.md) — Event / fixed / 라이브액티비티 placeName·memo nil·Publishers.Timeout·DispatchQueue.global
 - [2026-08-24 백그라운드 Task 에서 구독을 담다 Set 저장소가 깨진다](2026-08-24-cancelbag-data-race-crash.md) — Infra / fixed / unrecognized selector 0x8000000000000000·member:·CalendarScenes 랜덤 크래시
+- [2026-08-24 Paywall screenState 테스트가 방출 개수로 흔들린다](2026-08-24-paywall-screenstate-emission-count-flaky.md) — Billing / deferred / Confirmation was confirmed·PaywallViewModelImpleTests·BillingScenes 간헐 실패


### PR DESCRIPTION
같은 커밋에서 돌려도 통과·실패가 갈리던 원인을 규명해 없앴다. 빨간불이 회귀인지 플레이키인지 판정하느라 빌드 사이클을 태우던 문제다.

closes #990

## 결함 3종

규명해보니 **둘은 테스트 인프라, 하나는 앱 결함**이었다.

### 1. sqlite vnode 공유 — Repository 랜덤 크래시

`BaseLocalTests` 가 클래스당 고정 DB 파일명을 쓰는데 tearDown 이 커넥션을 닫지 않고 파일만 지웠다. 앞 테스트의 살아 있는 커넥션과 뒤 테스트의 새 커넥션이 같은 vnode 를 물어 프로세스가 죽었다.

```
BUG IN CLIENT OF libsqlite3.dylib: illegal multi-threaded access to database connection
BUG IN CLIENT OF libsqlite3.dylib: vnode unlinked while in use: .../Caches/temps.db
```

테스트마다 다른 파일명(UUID)을 쓰고, `tearDown() async` 에서 close 로 pending 작업을 배수한 뒤 파일을 지운다.

### 2. `Set<AnyCancellable>` 동시 변이 — CalendarScenes·TodoCalendarApp 랜덤 크래시

뷰모델이 `@unchecked Sendable` 인데 구독을 `Set<AnyCancellable>` 에 담고, `Task` 본문 안에서 그 Set 을 변이하는 자리가 네 곳 있었다. 메인 스레드 `store(in:)` 과 겹치면 Set 저장소가 깨진다.

```
-[__NSTaggedDate member:]: unrecognized selector sent to instance 0x8000000000000000
-[NSTaggedPointerString member:]: unrecognized selector sent to instance 0x8000000000000000
```

수신 클래스가 런마다 바뀌는데 주소는 같다 — 태그드 포인터 난독화가 프로세스마다 달라서고, 같은 쓰레기 포인터를 읽는다는 뜻이다.

네 곳을 개별로 홉시키면 새로 `Task { self.bindX() }` 를 쓰는 순간 재발한다. 그래서 담을 그릇 자체를 스레드 안전하게 만들었다 — 잠금으로 보호되는 `CancelBag` 을 `Extensions` 에 두고 프로덕션 보관함을 전부 교체했다 (선언 138곳·호출 392곳).

**관례가 코드에만 남지 않도록 하네스·템플릿도 함께 갱신했다** — `swift-style` rules §6(예외·PR 전 확인 grep 포함, `pr` 스킬 관문에 배선), Xcode Scene 템플릿 5파일, `scene-spec`·`coding-style` 예시. 템플릿을 안 고치면 다음 Scene 부터 같은 크래시 패턴이 그대로 복제된다.

### 3. `.timeout` 이 concurrent 큐에서 동기 방출값을 흘린다 — **앱 결함**

`EventLiveActivityUsecaseImple.eventDetail(for:)` 이 `.timeout(_:scheduler: DispatchQueue.global())` 을 탄다. `Publishers.Timeout` 은 concurrent 큐를 스케줄러로 받으면 구독 즉시 도착한 값을 흘린다.

`Just(1)` 로 5000회 측정:

| 스케줄러 | 유실 |
|---|---|
| `DispatchQueue.global()` (concurrent) | 777 / 5000 |
| `DispatchQueue(label:)` (serial) | 0 / 5000 |
| `DispatchQueue.main` | 0 / 5000 |
| `RunLoop.main` | 0 / 2000 |
| timeout 없이 | 0 / 5000 |

소비 방식(`values` vs `sink`)과 무관하고 스케줄러 종류만 가른다. 타임아웃 값과도 무관하다 — 30초로 늘려도 유실률이 그대로다. 상세가 캐시에서 즉시 오면 그 확률로 **라이브액티비티가 place·memo 없이 등록됐다.**

스케줄러를 `DispatchQueue.main` 으로 바꿨다. `AICommandUsecase.notFinishJobTimeout` 이 이미 쓰던 것과 같아 코드베이스 안에서 일관된다. 타임아웃 값(1초)과 나머지 흐름은 그대로다.

## 그 밖 — 벽시계에 기대던 테스트

- **`AsyncEffectWaitable.waitEffect`** 도입 — 조건이 참이 될 때까지 폴링하고, 끝내 참이 안 되면 던진다. 설명 문자열이 필수라 무엇을 기다리다 실패했는지가 남는다. `testability` rules §9 에 고정 sleep 금지와 두 예외("안 일어남" 단언·"정확히 N회" 단언), 정착 시간 기본값 50ms 등재
- `firstValue(with:)` 인자가 초가 아니라 **밀리초**라 DB 읽기에 10ms·100ms 가 걸려 있던 6곳 → 1000ms
- `CalendarViewModelImpleTests` 스크롤 3종·라이프사이클 4종 — 같은 파일에 이미 있던 결정적 대기 헬퍼(`prepareInitialMonths`)를 쓰도록 교체
- `EventLiveActivityUsecaseImpleTests` — `waitForEffects()` 32곳 중 stub 값 도착을 보는 13곳을 조건 폴링으로 승격. '안 일어남'을 보거나 관찰할 값이 없는 자리는 정착 대기로 유지
- `MainViewModelImpleTests` — expectation 을 채우는 콜백 4곳을 대기 직후 해제. 앞 테스트의 VM 이 살아 있으면 전역 NotificationCenter 방출에 반응해 죽은 expectation 을 때렸다

## 실측

| 스킴 | 수정 전 | 수정 후 |
|---|---|---|
| Repository | 3회 중 1회 크래시 | 4/4 통과 |
| CalendarScenes | 3회 중 2회 크래시 | 5/5 통과 |
| TodoCalendarApp | 유효 2회 모두 크래시 | 5/5 통과 |
| 전체 14스킴 | — | 14/14 통과 |

Repository 스킴은 런 시간도 34s → 17s 로 줄었다 (크래시 후 재시작이 없어져서).

## 남은 과제

`BillingScenes` 의 `PaywallViewModelImpleTests` 계열이 방출 개수로 흔들린다. **develop 에서도 재현돼(5회 중 1회) 이번 브랜치 회귀가 아니다.** 개수 기반 창을 걷어내야 하는데 paywall 상태 파이프라인까지 들어가야 해서 #991 로 분리했다.

규명 결과는 `docs/troubleshooting/` 에 4건 남겼다 (fixed 3 · deferred 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwttEcCB9zPS9CoLEuFf1Q