### PR TITLE
[#998] AI 입력 사용 시 알림 권한 요청과 거부 안내

### DIFF
--- a/.claude/rules/testability.md
+++ b/.claude/rules/testability.md
@@ -149,7 +149,7 @@ final class MyTests: PublisherWaitable {
 
 | Method | 용도 |
 |---|---|
-| `expectConfirm(_:)` | `ConfirmationExpectation` 생성 (default count: 1, timeout: 100ms) |
+| `expectConfirm(_:)` | `ConfirmationExpectation` 생성 (default count: 1, timeout: 3s) |
 | `outputs(_:for:_:)` | async — 방출값 수집 |
 | `firstOutput(_:for:_:)` | async — 첫 방출만 |
 | `failure(_:for:_:)` | async — 실패 completion |
@@ -157,7 +157,7 @@ final class MyTests: PublisherWaitable {
 다중 방출/긴 대기 필요 시 `expect.count`, `expect.timeout` 조정.
 
 ### XCTest
-`BaseTestCase, PublisherWaitable` 채택, `setUpWithError`에서 `cancelBag = .init()`. 메서드는 `waitOutputs(_:for:timeout:_:)` / `waitFirstOutput(_:for:timeout:_:)` / `waitError(_:for:timeout:_:)` (XCTestExpectation 기반).
+`BaseTestCase, PublisherWaitable` 채택, `setUpWithError`에서 `cancelBag = .init()`. 메서드는 `waitOutputs(_:for:timeout:_:)` / `waitFirstOutput(_:for:timeout:_:)` / `waitError(_:for:timeout:_:)` (XCTestExpectation 기반, default timeout: 2s).
 
 ---
 

--- a/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
+++ b/Domain/Sources/Usecases/AI/AIAgentOrchestrationUsecase.swift
@@ -20,6 +20,7 @@ public protocol AIAgentOrchestrationUsecase: AnyObject, Sendable {
     var recognizingText: AnyPublisher<String, Never> { get }
     var voiceLevel: AnyPublisher<Float, Never> { get }
     var speechPermissionDenied: AnyPublisher<Void, Never> { get }
+    var isNotificationPermissionDenied: AnyPublisher<Bool, Never> { get }
     var isCreditExhausted: Bool { get }
 
     func prepare()
@@ -41,6 +42,7 @@ public protocol AIAgentOrchestrationUsecase: AnyObject, Sendable {
     func handleJobStatusChanged(_ jobId: String)
     func refreshProcessingJobIfNeeded()
 
+    func refreshNotificationPermissionStatus()
 }
 
 
@@ -52,17 +54,20 @@ public final class AIAgentOrchestrationUsecaseImple: AIAgentOrchestrationUsecase
     private let usageUsecase: any AIAgentUsageUsecase
     private let speechRecognizeUsecase: any SpeechRecognizeUsecase
     private let eventSyncUsecase: any EventSyncUsecase
+    private let notificationPermissionUsecase: any NotificationPermissionUsecase
 
     public init(
         commandUsecase: any AICommandUsecase,
         usageUsecase: any AIAgentUsageUsecase,
         speechRecognizeUsecase: any SpeechRecognizeUsecase,
-        eventSyncUsecase: any EventSyncUsecase
+        eventSyncUsecase: any EventSyncUsecase,
+        notificationPermissionUsecase: any NotificationPermissionUsecase
     ) {
         self.commandUsecase = commandUsecase
         self.usageUsecase = usageUsecase
         self.speechRecognizeUsecase = speechRecognizeUsecase
         self.eventSyncUsecase = eventSyncUsecase
+        self.notificationPermissionUsecase = notificationPermissionUsecase
     }
 
     private struct Subject {
@@ -70,6 +75,7 @@ public final class AIAgentOrchestrationUsecaseImple: AIAgentOrchestrationUsecase
         let recognizingText = PassthroughSubject<String, Never>()
         let voiceLevel = PassthroughSubject<Float, Never>()
         let speechPermissionDenied = PassthroughSubject<Void, Never>()
+        let isNotificationPermissionDenied = CurrentValueSubject<Bool, Never>(false)
     }
     private let subject = Subject()
     private var commandCancellable: AnyCancellable?
@@ -155,8 +161,13 @@ extension AIAgentOrchestrationUsecaseImple {
         guard self.canEnterVoiceInput else { return }
         guard !self.blockEntryIfCreditExhausted() else { return }
         self.bindSpeechRecognizing()
-        self.speechRecognizeUsecase.startListening()
         self.subject.state.send(.listening(.voice))
+        Task { [weak self] in
+            // 마이크 알럿은 조회 왕복 없이 첫 await 에서 바로 뜬다 — 여기서 기다려야 알림이 먼저 뜬다.
+            await self?.checkAndRequestNotificationPermissionIfNeeded()
+            guard self?.isVoiceListening == true else { return }
+            self?.speechRecognizeUsecase.startListening()
+        }
     }
 
     public func finishVoiceInput() {
@@ -328,6 +339,11 @@ extension AIAgentOrchestrationUsecaseImple {
         }
     }
 
+    private var isVoiceListening: Bool {
+        guard case .listening(.voice) = self.subject.state.value else { return false }
+        return true
+    }
+
     private var canEnterVoiceInput: Bool {
         switch self.subject.state.value {
         case .none, .idle, .listening(.keyboard), .listening(.image): return true
@@ -452,6 +468,44 @@ extension AIAgentOrchestrationUsecaseImple {
 }
 
 
+// MARK: - 알림 권한
+
+extension AIAgentOrchestrationUsecaseImple {
+
+    public func refreshNotificationPermissionStatus() {
+        Task { [weak self] in
+            await self?.updateNotificationPermissionDenied(shouldRequest: false)
+        }
+    }
+
+    private func checkAndRequestNotificationPermissionIfNeeded() async {
+        await self.updateNotificationPermissionDenied(shouldRequest: true)
+    }
+
+    private func updateNotificationPermissionDenied(shouldRequest: Bool) async {
+        let isDenied = await self.resolveNotificationPermissionDenied(shouldRequest: shouldRequest)
+        self.subject.isNotificationPermissionDenied.send(isDenied)
+    }
+
+    // throw는 fail-open(false) — 조회 실패로 안내를 띄우면 권한이 있는 사용자에게 오탐이 뜬다.
+    private func resolveNotificationPermissionDenied(shouldRequest: Bool) async -> Bool {
+        guard let status = try? await self.notificationPermissionUsecase.checkAuthorizationStatus()
+        else { return false }
+        switch status {
+        case .authorized:
+            return false
+        case .denied:
+            return true
+        case .notDetermined:
+            guard shouldRequest,
+                  let granted = try? await self.notificationPermissionUsecase.requestPermission()
+            else { return false }
+            return !granted
+        }
+    }
+}
+
+
 // MARK: - outputs
 
 extension AIAgentOrchestrationUsecaseImple {
@@ -474,6 +528,10 @@ extension AIAgentOrchestrationUsecaseImple {
 
     public var speechPermissionDenied: AnyPublisher<Void, Never> {
         return self.subject.speechPermissionDenied.eraseToAnyPublisher()
+    }
+
+    public var isNotificationPermissionDenied: AnyPublisher<Bool, Never> {
+        return self.subject.isNotificationPermissionDenied.removeDuplicates().eraseToAnyPublisher()
     }
 
     public var isCreditExhausted: Bool {
@@ -508,6 +566,10 @@ public final class NotNeedAIAgentOrchestrationUsecase: AIAgentOrchestrationUseca
         return Empty(completeImmediately: false).eraseToAnyPublisher()
     }
 
+    public var isNotificationPermissionDenied: AnyPublisher<Bool, Never> {
+        return Just(false).eraseToAnyPublisher()
+    }
+
     public var isCreditExhausted: Bool { false }
 
     public func prepare() { }
@@ -532,4 +594,5 @@ public final class NotNeedAIAgentOrchestrationUsecase: AIAgentOrchestrationUseca
     public func loadUsage() { }
     public func handleJobStatusChanged(_ jobId: String) { }
     public func refreshProcessingJobIfNeeded() { }
+    public func refreshNotificationPermissionStatus() { }
 }

--- a/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
+++ b/Domain/Tests/Usecases/AI/AIAgentOrchestrationUsecaseImpleTests.swift
@@ -18,17 +18,20 @@ import Extensions
 @testable import Domain
 
 
-class AIAgentOrchestrationUsecaseImpleTests: PublisherWaitable {
+class AIAgentOrchestrationUsecaseImpleTests: PublisherWaitable, AsyncEffectWaitable {
 
     var cancelBag: Set<AnyCancellable>! = []
     private var stubCommand: StubAICommandUsecase!
     private var stubUsage: StubAIAgentUsageUsecase!
     private var stubSpeech: StubSpeechRecognizeUsecase!
     private var stubSync: StubEventSyncUsecase!
+    private var stubNotificationPermission: StubNotificationPermissionUsecase!
 
     private func makeUsecase(
         shouldFail: Bool = false,
-        isCreditExhausted: Bool = false
+        isCreditExhausted: Bool = false,
+        notificationStatus: NotificationAuthorizationStatus = .authorized,
+        shouldGrantNotification: Bool = true
     ) -> AIAgentOrchestrationUsecaseImple {
         self.stubCommand = .init()
         self.stubCommand.shouldFail = shouldFail
@@ -36,12 +39,22 @@ class AIAgentOrchestrationUsecaseImpleTests: PublisherWaitable {
         self.stubUsage.stubIsCreditExhausted = isCreditExhausted
         self.stubSpeech = .init()
         self.stubSync = .init()
+        self.stubNotificationPermission = .init()
+        self.stubNotificationPermission.stubAuthorizationStatusCheckResult = .success(notificationStatus)
+        self.stubNotificationPermission.stubRequestPermissionResult = .success(shouldGrantNotification)
         return AIAgentOrchestrationUsecaseImple(
             commandUsecase: self.stubCommand,
             usageUsecase: self.stubUsage,
             speechRecognizeUsecase: self.stubSpeech,
-            eventSyncUsecase: self.stubSync
+            eventSyncUsecase: self.stubSync,
+            notificationPermissionUsecase: self.stubNotificationPermission
         )
+    }
+
+    private func makeUsecaseWithNotificationCheckFailure() -> AIAgentOrchestrationUsecaseImple {
+        let usecase = self.makeUsecase()
+        self.stubNotificationPermission.stubAuthorizationStatusCheckResult = .failure(RuntimeError("check fail"))
+        return usecase
     }
 
     private func makeUsecaseWithCommandJob(_ job: AIJob) -> AIAgentOrchestrationUsecaseImple {
@@ -849,6 +862,36 @@ private final class StubAIAgentUsageUsecase: AIAgentUsageUsecase, @unchecked Sen
     }
 }
 
+// 권한 응답 도착 시점을 테스트가 정하는 게이트 — 응답 전/후 동작을 결정적으로 가른다
+private final class PermissionGate: @unchecked Sendable {
+
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isOpened = false
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            self.lock.lock()
+            if self.isOpened {
+                self.lock.unlock()
+                continuation.resume()
+            } else {
+                self.continuation = continuation
+                self.lock.unlock()
+            }
+        }
+    }
+
+    func open() {
+        self.lock.lock()
+        let continuation = self.continuation
+        self.continuation = nil
+        self.isOpened = true
+        self.lock.unlock()
+        continuation?.resume()
+    }
+}
+
 private final class StubSpeechRecognizeUsecase: SpeechRecognizeUsecase, @unchecked Sendable {
 
     let recognizeResultSubject = PassthroughSubject<Result<SpeechRecognizeResult, any Error>, Never>()
@@ -890,7 +933,7 @@ extension AIAgentOrchestrationUsecaseImpleTests {
             usecase.enterVoiceInput()
         }
         // then
-        #expect(self.stubSpeech.didStartListening == true)
+        try await self.waitEffect("음성 인식이 시작됨") { self.stubSpeech.didStartListening }
         if case .listening(.voice) = state {} else {
             Issue.record("expected listening(.voice), got \(String(describing: state))")
         }
@@ -1151,20 +1194,23 @@ extension AIAgentOrchestrationUsecaseImpleTests {
             usecase.enterVoiceInput()
         }
         // then — .listening(.voice) 전환 + speech 시작
-        #expect(self.stubSpeech.didStartListening == true)
+        try await self.waitEffect("음성 인식이 시작됨") { self.stubSpeech.didStartListening }
         if case .listening(.voice) = state {} else {
             Issue.record("expected listening(.voice), got \(String(describing: state))")
         }
     }
 
     // 이미 .listening(.voice) 상태에서 enterVoiceInput → 조용히 무시, speech 재시작 없음
-    @Test func usecase_enterVoiceInput_alreadyVoice_doesNotRestartSpeech() {
+    @Test func usecase_enterVoiceInput_alreadyVoice_doesNotRestartSpeech() async throws {
         // given — idle에서 enterVoiceInput으로 .listening(.voice)
         let usecase = self.makeUsecaseInIdle()
         usecase.enterVoiceInput()
+        try await self.waitEffect("첫 인식 시작이 도달") { self.stubSpeech.startListeningCount == 1 }
         // when — 이미 voice-listening 상태에서 재호출
         usecase.enterVoiceInput()
-        // then — 재진입이 조용히 무시돼 startListening은 첫 번째 한 번만
+        // then — 재진입이 조용히 무시돼 startListening은 첫 번째 한 번만.
+        // 뒤늦은 두 번째 호출을 놓치지 않게 정착 시간을 두고 다시 본다
+        try await Task.sleep(for: .milliseconds(50))
         #expect(self.stubSpeech.startListeningCount == 1)
     }
 }
@@ -1199,6 +1245,7 @@ extension AIAgentOrchestrationUsecaseImpleTests {
         // given — 음성 입력 → 키보드 전환
         let usecase = self.makeUsecaseInIdle()
         usecase.enterVoiceInput()          // .listening(.voice), startListening 1회
+        try await self.waitEffect("첫 인식 시작이 도달") { self.stubSpeech.startListeningCount == 1 }
         usecase.enterKeyboardInput()       // .listening(.keyboard), stopListening
         let expect = expectConfirm("keyboard 닫기 → voice 복귀")
         // when — 키보드 시트 닫힘(dismissByGesture) → enterVoiceInput
@@ -1206,7 +1253,7 @@ extension AIAgentOrchestrationUsecaseImpleTests {
             usecase.enterVoiceInput()
         }
         // then — .listening(.voice) 복귀 + speech 재시작 (2번째 start)
-        #expect(self.stubSpeech.startListeningCount == 2)
+        try await self.waitEffect("음성 인식이 재시작됨") { self.stubSpeech.startListeningCount == 2 }
         if case .listening(.voice) = state {} else {
             Issue.record("expected listening(.voice), got \(String(describing: state))")
         }
@@ -1786,7 +1833,7 @@ extension AIAgentOrchestrationUsecaseImpleTests {
         guard case .listening(let inputMode) = state
         else { Issue.record("listening 상태가 아니다"); return }
         #expect(inputMode == .voice)
-        #expect(self.stubSpeech.didStartListening == true)
+        try await self.waitEffect("음성 인식이 시작됨") { self.stubSpeech.didStartListening }
     }
 }
 
@@ -1817,5 +1864,191 @@ extension AIAgentOrchestrationUsecaseImpleTests {
         let state = try await self.firstOutput(expect, for: usecase.state)
         guard case .processing = state
         else { Issue.record("processing 상태가 아니다: \(String(describing: state))"); return }
+    }
+}
+
+
+// MARK: - 알림 권한
+
+extension AIAgentOrchestrationUsecaseImpleTests {
+
+    // 마이크·음성인식 알럿보다 알림 알럿이 먼저 뜨려면, 권한 응답이 오기 전엔 인식이 시작되면 안 된다
+    @Test func usecase_whenEnterVoiceInput_notStartRecognizingUntilNotificationPermissionResolved() async throws {
+        // given — 권한 응답을 게이트로 잡아둔다
+        let gate = PermissionGate()
+        let usecase = self.makeUsecase(notificationStatus: .notDetermined)
+        self.stubNotificationPermission.requestPermissionGate = { await gate.wait() }
+        // when
+        usecase.enterVoiceInput()
+        try await self.waitEffect("알림 권한 요청이 도달") {
+            self.stubNotificationPermission.didRequestPermission == true
+        }
+        // then — 응답 전이라 인식은 아직 시작되지 않았다
+        #expect(self.stubSpeech.didStartListening == false)
+        // when — 권한 응답 도착
+        gate.open()
+        // then
+        try await self.waitEffect("응답 뒤에야 인식이 시작됨") { self.stubSpeech.didStartListening }
+    }
+
+    // 권한 응답을 기다리는 사이 취소하면 뒤늦은 응답이 인식을 시작시키지 않는다
+    @Test func usecase_whenStopInputBeforeNotificationPermissionResolved_notStartRecognizing() async throws {
+        // given
+        let gate = PermissionGate()
+        let usecase = self.makeUsecase(notificationStatus: .notDetermined)
+        self.stubNotificationPermission.requestPermissionGate = { await gate.wait() }
+        usecase.enterVoiceInput()
+        try await self.waitEffect("알림 권한 요청이 도달") {
+            self.stubNotificationPermission.didRequestPermission == true
+        }
+        // when — 응답 도착 전에 취소
+        usecase.stopInput()
+        gate.open()
+        // then — 뒤늦은 응답이 인식을 시작시키지 않는다
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(self.stubSpeech.didStartListening == false)
+    }
+
+    @Test func usecase_whenEnterKeyboardInput_notCheckNotificationPermission() async throws {
+        // given — 키보드 전환은 listening 진입 이후라 알림 권한을 다시 건드리지 않는다
+        let expect = expectConfirm("키보드 전환에는 값 변화 없음")
+        expect.count = 0
+        expect.timeout = .milliseconds(100)
+        let usecase = self.makeUsecase(notificationStatus: .notDetermined, shouldGrantNotification: false)
+        // when
+        let values = try await self.outputs(expect, for: usecase.isNotificationPermissionDenied.dropFirst()) {
+            usecase.enterKeyboardInput()
+        }
+        // then
+        #expect(values.isEmpty)
+        #expect(self.stubNotificationPermission.didCheckAuthorizationStatus == nil)
+    }
+
+    @Test func usecase_whenEnterImageInput_notCheckNotificationPermission() async throws {
+        // given — 이미지 전환도 listening 진입 이후라 알림 권한을 다시 건드리지 않는다
+        let expect = expectConfirm("이미지 전환에는 값 변화 없음")
+        expect.count = 0
+        expect.timeout = .milliseconds(100)
+        let usecase = self.makeUsecase(notificationStatus: .notDetermined, shouldGrantNotification: false)
+        // when
+        let values = try await self.outputs(expect, for: usecase.isNotificationPermissionDenied.dropFirst()) {
+            usecase.enterImageInput()
+        }
+        // then
+        #expect(values.isEmpty)
+        #expect(self.stubNotificationPermission.didCheckAuthorizationStatus == nil)
+    }
+
+    @Test func usecase_whenNotificationPermissionRequestDenied_emitDenied() async throws {
+        // given
+        let expect = expectConfirm("notDetermined + 거부 → isNotificationPermissionDenied true 방출")
+        expect.count = 2
+        let usecase = self.makeUsecase(notificationStatus: .notDetermined, shouldGrantNotification: false)
+        // when
+        let values = try await self.outputs(expect, for: usecase.isNotificationPermissionDenied) {
+            usecase.enterVoiceInput()
+        }
+        // then
+        #expect(values == [false, true])
+    }
+
+    @Test func usecase_whenNotificationPermissionAlreadyDenied_emitDeniedWithoutRequest() async throws {
+        // given
+        let expect = expectConfirm("이미 denied → 요청 없이 true 방출")
+        expect.count = 2
+        let usecase = self.makeUsecase(notificationStatus: .denied)
+        // when
+        let values = try await self.outputs(expect, for: usecase.isNotificationPermissionDenied) {
+            usecase.enterVoiceInput()
+        }
+        // then — true 방출이 도달한 시점 = 상태 판정이 끝난 시점이라 여기서 요청 여부를 단언해도 안전하다
+        #expect(values == [false, true])
+        #expect(self.stubNotificationPermission.didRequestPermission == nil)
+    }
+
+    @Test func usecase_whenNotificationPermissionAuthorized_notEmitDenied() async throws {
+        // given
+        let usecase = self.makeUsecase(notificationStatus: .authorized)
+        // when — authorized는 값이 바뀌지 않아 기다릴 조건이 없다. 조회 도달을 기다린 뒤 현재값을 본다
+        usecase.enterVoiceInput()
+        // then
+        try await self.waitEffect("알림 권한 조회가 도달") {
+            self.stubNotificationPermission.didCheckAuthorizationStatus == true
+        }
+        #expect(self.stubNotificationPermission.didRequestPermission == nil)
+        let expect = expectConfirm("false 유지")
+        let value = try await self.firstOutput(expect, for: usecase.isNotificationPermissionDenied)
+        #expect(value == false)
+    }
+
+    @Test func usecase_whenNotificationPermissionCheckFails_notEmitDenied() async throws {
+        // given
+        let usecase = self.makeUsecaseWithNotificationCheckFailure()
+        // when — throw 시 fail-open(false)이라 값이 바뀌지 않아 기다릴 조건이 없다. 조회 도달을 기다린 뒤 현재값을 본다
+        usecase.enterVoiceInput()
+        // then
+        try await self.waitEffect("알림 권한 조회가 도달") {
+            self.stubNotificationPermission.didCheckAuthorizationStatus == true
+        }
+        let expect = expectConfirm("체크 실패 → fail-open, false 유지")
+        let value = try await self.firstOutput(expect, for: usecase.isNotificationPermissionDenied)
+        #expect(value == false)
+    }
+
+    @Test func usecase_whenEnterVoiceInputBlockedByCreditExhausted_notCheckNotificationPermission() async throws {
+        // given — credit 가드가 알림 권한 호출보다 먼저 걸린다
+        let expect = expectConfirm("크레딧 소진 → failed 상태")
+        let usecase = self.makeUsecase(isCreditExhausted: true, notificationStatus: .notDetermined)
+        // when
+        let state = try await self.firstOutput(expect, for: usecase.state) {
+            usecase.enterVoiceInput()
+        }
+        // then — failed 도달 시점 = 가드가 이미 막은 뒤라 여기서 요청 여부를 단언해도 안전하다
+        guard case .failed(_, _, let errorCode) = state
+        else { Issue.record("failed 상태가 아니다: \(String(describing: state))"); return }
+        #expect(errorCode == .dailyLimitExceeded)
+        #expect(self.stubNotificationPermission.didRequestPermission == nil)
+    }
+
+    @Test func usecase_whenRefreshNotificationPermissionStatusWithDenied_emitDenied() async throws {
+        // given
+        let expect = expectConfirm("refresh + denied → true 방출")
+        expect.count = 2
+        let usecase = self.makeUsecase(notificationStatus: .denied)
+        // when
+        let values = try await self.outputs(expect, for: usecase.isNotificationPermissionDenied) {
+            usecase.refreshNotificationPermissionStatus()
+        }
+        // then
+        #expect(values == [false, true])
+    }
+
+    @Test func usecase_whenRefreshNotificationPermissionStatusWithNotDetermined_notRequestPermission() async throws {
+        // given
+        let usecase = self.makeUsecase(notificationStatus: .notDetermined)
+        // when — notDetermined는 refresh에서 요청하지 않아 값이 바뀌지 않는다. 조회 도달을 기다린 뒤 단언한다
+        usecase.refreshNotificationPermissionStatus()
+        // then
+        try await self.waitEffect("알림 권한 조회가 도달") {
+            self.stubNotificationPermission.didCheckAuthorizationStatus == true
+        }
+        #expect(self.stubNotificationPermission.didRequestPermission == nil)
+        let expect = expectConfirm("false 유지")
+        let value = try await self.firstOutput(expect, for: usecase.isNotificationPermissionDenied)
+        #expect(value == false)
+    }
+
+    @Test func usecase_whenEnterVoiceInputWithDeniedNotification_stillEnterListening() async throws {
+        // given
+        let usecase = self.makeUsecase(notificationStatus: .denied)
+        usecase.reset()
+        let expect = expectConfirm("권한 거부와 무관하게 listening 전이")
+        // when
+        let state = try await self.firstOutput(expect, for: usecase.state.dropFirst()) {
+            usecase.enterVoiceInput()
+        }
+        // then
+        guard case .listening(.voice) = state
+        else { Issue.record("listening(.voice) 상태가 아니다: \(String(describing: state))"); return }
     }
 }

--- a/Presentations/AIAgentScene/CLAUDE.md
+++ b/Presentations/AIAgentScene/CLAUDE.md
@@ -19,5 +19,6 @@ AI 어시스턴트 진입 시트들. 키보드 입력 시트(AIAgentKeyboardInpu
 | 컴포넌트 | 역할 |
 |---|---|
 | `Components/AIAgentUsageGaugeView` | 사용량/일일 한도 미니 게이지 + top-up 잔량·하향 예약 안내 (두 시트 공유, #713·#720). `dailyLimit > 0`일 때만 렌더하는 건 호출측 책임, 신규 요소 3종은 값 유무로 뷰 내부에서 분기. 플랜 칩은 `CommonPresentation`의 `BillingPlanChipView`를 그대로 사용(#739) — paywall과 공유하므로 이 프레임워크에 독자 구현을 두지 않는다. 하향 예약 안내도 같은 이유로 `BillingScheduledChangeView`(CommonPresentation)를 쓴다(#852) |
+| `Components/AIAgentNotificationPermissionNoticeView` | 알림 권한 거부 시 세 시트(KeyboardInput/Command/ImageCommand) 헤더 아래 공통 노출하는 설정 이동 안내 (#998). 노출 조건(`isNotificationPermissionDenied`)은 호출측이 감싼다 — 뷰는 표시·탭 위임만 |
 
 시트 헤더는 CommonPresentation `SheetHeaderView` 사용 (원래 이 프레임워크의 AIAgentSheetHeader였다가 #659에서 승격).

--- a/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandStageView.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandStageView.swift
@@ -23,6 +23,7 @@ import CommonPresentation
     var commandState: AIAgentCommandState?
     var usage: AIAgentUsage?
     var userPlan: BillingUserPlan?
+    var isNotificationPermissionDenied: Bool = false
 
     func bind(_ viewModel: any AIAgentCommandViewModel) {
         guard self.didBind == false else { return }
@@ -42,6 +43,11 @@ import CommonPresentation
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] in self?.userPlan = $0 })
             .store(in: self.cancellables)
+
+        viewModel.isNotificationPermissionDenied
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self] in self?.isNotificationPermissionDenied = $0 })
+            .store(in: self.cancellables)
     }
 }
 
@@ -57,6 +63,7 @@ final class AIAgentCommandViewEventHandler: Observable {
     var acknowledge: () -> Void = { }
     var close: () -> Void = { }
     var showPlans: () -> Void = { }
+    var openNotificationSetting: () -> Void = { }
 
     func bind(_ viewModel: any AIAgentCommandViewModel) {
         self.prepare = viewModel.prepare
@@ -66,6 +73,7 @@ final class AIAgentCommandViewEventHandler: Observable {
         self.acknowledge = viewModel.acknowledge
         self.close = viewModel.close
         self.showPlans = viewModel.showPlans
+        self.openNotificationSetting = viewModel.openNotificationSetting
     }
 }
 
@@ -153,6 +161,13 @@ struct AIAgentCommandStageView: View {
                         .eventHandler(\.onClose) {
                             self.eventHandlers.close()
                         }
+
+                    if self.state.isNotificationPermissionDenied {
+                        AIAgentNotificationPermissionNoticeView()
+                            .eventHandler(\.onTap) {
+                                self.eventHandlers.openNotificationSetting()
+                            }
+                    }
 
                     if let usage = state.usage, usage.dailyLimit > 0 {
                         AIAgentUsageGaugeView(usage: usage, userPlan: state.userPlan)

--- a/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandViewModel.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentCommandViewModel.swift
@@ -37,10 +37,12 @@ public protocol AIAgentCommandViewModel: AnyObject, Sendable {
     func acknowledge()
     func close()
     func showPlans()
+    func openNotificationSetting()
 
     var commandState: AnyPublisher<AIAgentCommandState?, Never> { get }
     var usage: AnyPublisher<AIAgentUsage, Never> { get }
     var currentUserPlan: AnyPublisher<BillingUserPlan?, Never> { get }
+    var isNotificationPermissionDenied: AnyPublisher<Bool, Never> { get }
 }
 
 
@@ -77,6 +79,7 @@ extension AIAgentCommandViewModelImple {
 
     func prepare() {
         self.orchestrationUsecase.loadUsage()
+        self.orchestrationUsecase.refreshNotificationPermissionStatus()
     }
 
     func sendCommand(_ text: String) {
@@ -117,6 +120,10 @@ extension AIAgentCommandViewModelImple {
         // reset 없이 idle로 안 돌아가면 다음 한도 초과 때 상위의 false→true 재전이 감지가 막혀 시트가 안 뜬다
         self.orchestrationUsecase.reset()
         self.listener?.aiAgentCommandDidRequestPaywall()
+    }
+
+    func openNotificationSetting() {
+        self.router?.openSystemSetting()
     }
 }
 
@@ -167,5 +174,9 @@ extension AIAgentCommandViewModelImple {
             .map { $0 as BillingUserPlan? }
             .prepend(nil)
             .eraseToAnyPublisher()
+    }
+
+    var isNotificationPermissionDenied: AnyPublisher<Bool, Never> {
+        return self.orchestrationUsecase.isNotificationPermissionDenied
     }
 }

--- a/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentRouter.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentCommand/AIAgentRouter.swift
@@ -6,29 +6,15 @@
 //  Copyright © 2026 com.sudo.park. All rights reserved.
 //
 
-import UIKit
+import Foundation
 import Scenes
 
 
 // MARK: - AIAgentRouting
 
-protocol AIAgentRouting: Routing, Sendable {
-    func openSystemSetting()
-}
+protocol AIAgentRouting: Routing, Sendable { }
 
 
 // MARK: - AIAgentRouter
 
 final class AIAgentRouter: BaseRouterImple, AIAgentRouting, @unchecked Sendable { }
-
-extension AIAgentRouter {
-
-    func openSystemSetting() {
-        Task { @MainActor in
-            guard let url = URL(string: UIApplication.openSettingsURLString),
-                  UIApplication.shared.canOpenURL(url)
-            else { return }
-            UIApplication.shared.open(url)
-        }
-    }
-}

--- a/Presentations/AIAgentScene/Sources/AIAgentImageCommand/AIAgentImageCommandView.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentImageCommand/AIAgentImageCommandView.swift
@@ -23,6 +23,7 @@ import CommonPresentation
     fileprivate var actionTaken: Bool = false
     var usage: AIAgentUsage?
     var userPlan: BillingUserPlan?
+    var isNotificationPermissionDenied: Bool = false
     @ObservationIgnored private var didBind = false
     @ObservationIgnored private var didSeedText = false
     @ObservationIgnored private let cancellables = CancelBag()
@@ -48,6 +49,11 @@ import CommonPresentation
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] in self?.userPlan = $0 })
             .store(in: self.cancellables)
+
+        viewModel.isNotificationPermissionDenied
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self] in self?.isNotificationPermissionDenied = $0 })
+            .store(in: self.cancellables)
     }
 
     private func seedTextIfNeeded(_ stage: AIAgentImageCommandStage) {
@@ -67,12 +73,14 @@ final class AIAgentImageCommandEventHandler: Observable {
     var send: (String, String) -> Void = { _, _ in }
     var close: () -> Void = { }
     var dismissByGesture: () -> Void = { }
+    var openNotificationSetting: () -> Void = { }
 
     func bind(_ viewModel: any AIAgentImageCommandViewModel) {
         self.prepare = viewModel.prepare
         self.send = viewModel.send(text:additionalInstruction:)
         self.close = viewModel.close
         self.dismissByGesture = viewModel.dismissByGesture
+        self.openNotificationSetting = viewModel.openNotificationSetting
     }
 }
 
@@ -128,6 +136,13 @@ private struct AIAgentImageCommandView: View {
                     .eventHandler(\.onClose) {
                         self.eventHandler.close()
                     }
+
+                if self.state.isNotificationPermissionDenied {
+                    AIAgentNotificationPermissionNoticeView()
+                        .eventHandler(\.onTap) {
+                            self.eventHandler.openNotificationSetting()
+                        }
+                }
 
                 if let usage = self.state.usage, usage.dailyLimit > 0 {
                     AIAgentUsageGaugeView(usage: usage, userPlan: self.state.userPlan)

--- a/Presentations/AIAgentScene/Sources/AIAgentImageCommand/AIAgentImageCommandViewModel.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentImageCommand/AIAgentImageCommandViewModel.swift
@@ -28,10 +28,12 @@ protocol AIAgentImageCommandViewModel: AnyObject, Sendable {
     func send(text: String, additionalInstruction: String)
     func close()
     func dismissByGesture()
+    func openNotificationSetting()
 
     var stage: AnyPublisher<AIAgentImageCommandStage, Never> { get }
     var usage: AnyPublisher<AIAgentUsage, Never> { get }
     var currentUserPlan: AnyPublisher<BillingUserPlan?, Never> { get }
+    var isNotificationPermissionDenied: AnyPublisher<Bool, Never> { get }
 }
 
 
@@ -75,6 +77,7 @@ extension AIAgentImageCommandViewModelImple {
 
     func prepare() {
         self.aiAgentOrchestrationUsecase.loadUsage()
+        self.aiAgentOrchestrationUsecase.refreshNotificationPermissionStatus()
         self.startRecognize()
     }
 
@@ -135,6 +138,10 @@ extension AIAgentImageCommandViewModelImple {
         self.recognizeTask = nil
         self.aiAgentOrchestrationUsecase.enterVoiceInput()
     }
+
+    func openNotificationSetting() {
+        self.router?.openSystemSetting()
+    }
 }
 
 
@@ -155,6 +162,10 @@ extension AIAgentImageCommandViewModelImple {
             .map { $0 as BillingUserPlan? }
             .prepend(nil)
             .eraseToAnyPublisher()
+    }
+
+    var isNotificationPermissionDenied: AnyPublisher<Bool, Never> {
+        return self.aiAgentOrchestrationUsecase.isNotificationPermissionDenied
     }
 }
 

--- a/Presentations/AIAgentScene/Sources/AIAgentKeyboardInput/AIAgentKeyboardInputView.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentKeyboardInput/AIAgentKeyboardInputView.swift
@@ -17,6 +17,7 @@ import CommonPresentation
     fileprivate var actionTaken: Bool = false
     var usage: AIAgentUsage?
     var userPlan: BillingUserPlan?
+    var isNotificationPermissionDenied: Bool = false
     @ObservationIgnored private var didBind = false
     @ObservationIgnored private let cancellables = CancelBag()
 
@@ -33,6 +34,11 @@ import CommonPresentation
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] in self?.userPlan = $0 })
             .store(in: self.cancellables)
+
+        viewModel.isNotificationPermissionDenied
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self] in self?.isNotificationPermissionDenied = $0 })
+            .store(in: self.cancellables)
     }
 }
 
@@ -46,6 +52,7 @@ final class AIAgentKeyboardInputEventHandler: Observable {
     var stop: () -> Void = { }
     var close: () -> Void = { }
     var dismissByGesture: () -> Void = { }
+    var openNotificationSetting: () -> Void = { }
 
     func bind(_ viewModel: any AIAgentKeyboardInputViewModel) {
         self.prepare = viewModel.prepare
@@ -53,6 +60,7 @@ final class AIAgentKeyboardInputEventHandler: Observable {
         self.stop = viewModel.stop
         self.close = viewModel.close
         self.dismissByGesture = viewModel.dismissByGesture
+        self.openNotificationSetting = viewModel.openNotificationSetting
     }
 }
 
@@ -112,6 +120,13 @@ private struct AIAgentKeyboardInputView: View {
                     .eventHandler(\.onClose) {
                         self.eventHandler.close()
                     }
+
+                if self.state.isNotificationPermissionDenied {
+                    AIAgentNotificationPermissionNoticeView()
+                        .eventHandler(\.onTap) {
+                            self.eventHandler.openNotificationSetting()
+                        }
+                }
 
                 if let usage = state.usage, usage.dailyLimit > 0 {
                     AIAgentUsageGaugeView(usage: usage, userPlan: state.userPlan)

--- a/Presentations/AIAgentScene/Sources/AIAgentKeyboardInput/AIAgentKeyboardInputViewModel.swift
+++ b/Presentations/AIAgentScene/Sources/AIAgentKeyboardInput/AIAgentKeyboardInputViewModel.swift
@@ -16,9 +16,11 @@ protocol AIAgentKeyboardInputViewModel: AnyObject, Sendable {
     func stop()
     func close()
     func dismissByGesture()
+    func openNotificationSetting()
 
     var usage: AnyPublisher<AIAgentUsage, Never> { get }
     var currentUserPlan: AnyPublisher<BillingUserPlan?, Never> { get }
+    var isNotificationPermissionDenied: AnyPublisher<Bool, Never> { get }
 }
 
 
@@ -40,6 +42,7 @@ final class AIAgentKeyboardInputViewModelImple: AIAgentKeyboardInputViewModel, @
 
     func prepare() {
         self.aiAgentOrchestrationUsecase.loadUsage()
+        self.aiAgentOrchestrationUsecase.refreshNotificationPermissionStatus()
     }
 
     func send(_ text: String) {
@@ -64,6 +67,10 @@ final class AIAgentKeyboardInputViewModelImple: AIAgentKeyboardInputViewModel, @
     func dismissByGesture() {
         self.aiAgentOrchestrationUsecase.enterVoiceInput()
     }
+
+    func openNotificationSetting() {
+        self.router?.openSystemSetting()
+    }
 }
 
 
@@ -82,5 +89,9 @@ extension AIAgentKeyboardInputViewModelImple {
             .map { $0 as BillingUserPlan? }
             .prepend(nil)
             .eraseToAnyPublisher()
+    }
+
+    var isNotificationPermissionDenied: AnyPublisher<Bool, Never> {
+        return self.aiAgentOrchestrationUsecase.isNotificationPermissionDenied
     }
 }

--- a/Presentations/AIAgentScene/Sources/Components/AIAgentNotificationPermissionNoticeView.swift
+++ b/Presentations/AIAgentScene/Sources/Components/AIAgentNotificationPermissionNoticeView.swift
@@ -1,0 +1,43 @@
+//
+//  AIAgentNotificationPermissionNoticeView.swift
+//  AIAgentScene
+//
+//  Created by sudo.park on 8/25/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import SwiftUI
+import Extensions
+import CommonPresentation
+
+
+struct AIAgentNotificationPermissionNoticeView: View {
+
+    @Environment(ViewAppearance.self) private var appearance
+    var onTap: () -> Void = { }
+
+    var body: some View {
+        HStack(spacing: Metric.Spacing.xsmall) {
+            Image(systemName: "bell.slash.fill")
+                .foregroundStyle(self.appearance.colorSet.accentWarn.asColor)
+
+            Text("aiAgent::notificationPermissionDenied::message".localized())
+                .font(self.appearance.fontSet.size(12).asFont)
+                .foregroundStyle(self.appearance.colorSet.text2.asColor)
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .foregroundStyle(self.appearance.colorSet.text2.asColor)
+        }
+        .padding(spacing: .small)
+        .background(
+            RoundedRectangle(cornerRadius: Metric.Radius.regular)
+                .fill(self.appearance.colorSet.bg1.asColor)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            self.onTap()
+        }
+    }
+}

--- a/Presentations/AIAgentScene/Tests/AIAgentCommandViewModelImpleTests.swift
+++ b/Presentations/AIAgentScene/Tests/AIAgentCommandViewModelImpleTests.swift
@@ -308,6 +308,42 @@ extension AIAgentCommandViewModelImpleTests {
 }
 
 
+// MARK: - 알림 권한 거부 안내 (#998)
+
+extension AIAgentCommandViewModelImpleTests {
+
+    func testViewModel_whenPrepare_refreshNotificationPermissionStatus() {
+        // given
+        let viewModel = self.makeViewModel()
+        // when
+        viewModel.prepare()
+        // then
+        XCTAssertEqual(self.stubAgent.didRefreshNotificationPermissionStatus, true)
+    }
+
+    func testViewModel_relayNotificationPermissionDenied() {
+        // given
+        let viewModel = self.makeViewModel()
+        let expect = expectation(description: "알림 권한 거부 상태를 릴레이한다")
+        // when
+        let denied = self.waitFirstOutput(expect, for: viewModel.isNotificationPermissionDenied.dropFirst()) {
+            self.stubAgent.isNotificationPermissionDeniedSubject.send(true)
+        }
+        // then
+        XCTAssertEqual(denied, true)
+    }
+
+    func testViewModel_whenOpenNotificationSetting_routeToSystemSetting() {
+        // given
+        let viewModel = self.makeViewModel()
+        // when
+        viewModel.openNotificationSetting()
+        // then
+        XCTAssertEqual(self.spyRouter.didOpenSystemSetting, true)
+    }
+}
+
+
 // MARK: - 구매 후 usage 재조회 릴레이 (#739)
 
 extension AIAgentCommandViewModelImpleTests {

--- a/Presentations/AIAgentScene/Tests/AIAgentImageCommand/AIAgentImageCommandViewModelImpleTests.swift
+++ b/Presentations/AIAgentScene/Tests/AIAgentImageCommand/AIAgentImageCommandViewModelImpleTests.swift
@@ -145,3 +145,39 @@ extension AIAgentImageCommandViewModelImpleTests {
         #expect(self.spyRouter.didClosed != true)
     }
 }
+
+
+// MARK: - 알림 권한 거부 안내 (#998)
+
+extension AIAgentImageCommandViewModelImpleTests {
+
+    @Test func viewModel_whenPrepare_refreshNotificationPermissionStatus() {
+        // given
+        let viewModel = self.makeViewModel()
+        // when
+        viewModel.prepare()
+        // then
+        #expect(self.stubOrchestration.didRefreshNotificationPermissionStatus == true)
+    }
+
+    @Test func viewModel_relayNotificationPermissionDenied() async throws {
+        // given
+        let expect = expectConfirm("알림 권한 거부 상태를 릴레이한다")
+        let viewModel = self.makeViewModel()
+        // when
+        let denied = try await self.firstOutput(expect, for: viewModel.isNotificationPermissionDenied.dropFirst()) {
+            self.stubOrchestration.isNotificationPermissionDeniedSubject.send(true)
+        }
+        // then
+        #expect(denied == true)
+    }
+
+    @Test func viewModel_whenOpenNotificationSetting_routeToSystemSetting() {
+        // given
+        let viewModel = self.makeViewModel()
+        // when
+        viewModel.openNotificationSetting()
+        // then
+        #expect(self.spyRouter.didOpenSystemSetting == true)
+    }
+}

--- a/Presentations/AIAgentScene/Tests/AIAgentKeyboardInputViewModelImpleTests.swift
+++ b/Presentations/AIAgentScene/Tests/AIAgentKeyboardInputViewModelImpleTests.swift
@@ -20,12 +20,15 @@ final class AIAgentKeyboardInputViewModelImpleTests: PublisherWaitable {
 
     var cancelBag: Set<AnyCancellable>! = .init()
     private let stubAgent: StubAIAgentOrchestrationUsecase = .init()
+    private let spyRouter = SpyAIAgentKeyboardInputRouter()
 
     private func makeViewModel(userPlan: BillingUserPlan? = nil) -> AIAgentKeyboardInputViewModelImple {
-        return AIAgentKeyboardInputViewModelImple(
+        let viewModel = AIAgentKeyboardInputViewModelImple(
             aiAgentOrchestrationUsecase: self.stubAgent,
             billingUsecase: StubBillingUsecase(stubUserPlan: userPlan)
         )
+        viewModel.router = self.spyRouter
+        return viewModel
     }
 }
 
@@ -72,5 +75,41 @@ extension AIAgentKeyboardInputViewModelImpleTests {
         let plans = try await self.outputs(expect, for: viewModel.currentUserPlan)
         // then
         #expect(plans.map { $0?.planId } == [nil, .standard])
+    }
+}
+
+
+// MARK: - 알림 권한 거부 안내 (#998)
+
+extension AIAgentKeyboardInputViewModelImpleTests {
+
+    @Test func viewModel_whenPrepare_refreshNotificationPermissionStatus() {
+        // given
+        let viewModel = self.makeViewModel()
+        // when
+        viewModel.prepare()
+        // then
+        #expect(self.stubAgent.didRefreshNotificationPermissionStatus == true)
+    }
+
+    @Test func viewModel_relayNotificationPermissionDenied() async throws {
+        // given
+        let expect = expectConfirm("알림 권한 거부 상태를 릴레이한다")
+        let viewModel = self.makeViewModel()
+        // when
+        let denied = try await self.firstOutput(expect, for: viewModel.isNotificationPermissionDenied.dropFirst()) {
+            self.stubAgent.isNotificationPermissionDeniedSubject.send(true)
+        }
+        // then
+        #expect(denied == true)
+    }
+
+    @Test func viewModel_whenOpenNotificationSetting_routeToSystemSetting() {
+        // given
+        let viewModel = self.makeViewModel()
+        // when
+        viewModel.openNotificationSetting()
+        // then
+        #expect(self.spyRouter.didOpenSystemSetting == true)
     }
 }

--- a/Presentations/AIAgentScene/Tests/Doubles/SpyAIAgentKeyboardInputRouter.swift
+++ b/Presentations/AIAgentScene/Tests/Doubles/SpyAIAgentKeyboardInputRouter.swift
@@ -1,0 +1,16 @@
+//
+//  SpyAIAgentKeyboardInputRouter.swift
+//  AIAgentSceneTests
+//
+//  Created by sudo.park on 8/25/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Scenes
+import TestDoubles
+
+@testable import AIAgentScene
+
+
+final class SpyAIAgentKeyboardInputRouter: BaseSpyRouter, AIAgentKeyboardInputRouting, @unchecked Sendable { }

--- a/Presentations/AIAgentScene/Tests/Doubles/SpyAIAgentRouter.swift
+++ b/Presentations/AIAgentScene/Tests/Doubles/SpyAIAgentRouter.swift
@@ -13,10 +13,4 @@ import TestDoubles
 @testable import AIAgentScene
 
 
-final class SpyAIAgentRouter: BaseSpyRouter, AIAgentRouting, @unchecked Sendable {
-
-    var didOpenSystemSetting = false
-    func openSystemSetting() {
-        self.didOpenSystemSetting = true
-    }
-}
+final class SpyAIAgentRouter: BaseSpyRouter, AIAgentRouting, @unchecked Sendable { }

--- a/Presentations/AIAgentScene/Tests/Doubles/StubAIAgentOrchestrationUsecase.swift
+++ b/Presentations/AIAgentScene/Tests/Doubles/StubAIAgentOrchestrationUsecase.swift
@@ -19,6 +19,7 @@ final class StubAIAgentOrchestrationUsecase: AIAgentOrchestrationUsecase, @unche
     let recognizingTextSubject = PassthroughSubject<String, Never>()
     let voiceLevelSubject = PassthroughSubject<Float, Never>()
     let speechPermissionDeniedSubject = PassthroughSubject<Void, Never>()
+    let isNotificationPermissionDeniedSubject = CurrentValueSubject<Bool, Never>(false)
     private(set) var didPrepare = false
     private(set) var didEnterVoiceInput = false
     private(set) var didFinishVoiceInput = false
@@ -76,6 +77,11 @@ final class StubAIAgentOrchestrationUsecase: AIAgentOrchestrationUsecase, @unche
         self.didRefreshProcessingJob = true
     }
 
+    private(set) var didRefreshNotificationPermissionStatus: Bool?
+    func refreshNotificationPermissionStatus() {
+        self.didRefreshNotificationPermissionStatus = true
+    }
+
     var state: AnyPublisher<AIAgentState, Never> {
         self.stateSubject.compactMap { $0 }.eraseToAnyPublisher()
     }
@@ -90,5 +96,8 @@ final class StubAIAgentOrchestrationUsecase: AIAgentOrchestrationUsecase, @unche
     }
     var speechPermissionDenied: AnyPublisher<Void, Never> {
         self.speechPermissionDeniedSubject.eraseToAnyPublisher()
+    }
+    var isNotificationPermissionDenied: AnyPublisher<Bool, Never> {
+        self.isNotificationPermissionDeniedSubject.eraseToAnyPublisher()
     }
 }

--- a/Presentations/CalendarScenes/Sources/CalendarViewRouter.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewRouter.swift
@@ -25,8 +25,6 @@ protocol CalendarViewRouting: Routing, Sendable {
     func routeToPaywall()
 
     func routeToSignIn()
-
-    func openSystemSetting()
 }
 
 final class CalendarViewRouterImple: BaseRouterImple, CalendarViewRouting, @unchecked Sendable {
@@ -106,15 +104,6 @@ final class CalendarViewRouterImple: BaseRouterImple, CalendarViewRouting, @unch
         Task { @MainActor in
             let next = self.memberSceneBuilder.makeSignInScene()
             self.showBottomSlide(next)
-        }
-    }
-
-    func openSystemSetting() {
-        Task { @MainActor in
-            guard let url = URL(string: UIApplication.openSettingsURLString),
-                  UIApplication.shared.canOpenURL(url)
-            else { return }
-            UIApplication.shared.open(url)
         }
     }
 }

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListRouter.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListRouter.swift
@@ -162,14 +162,6 @@ extension DayEventListRouter {
         self.showConfirm(dialog: info)
     }
 
-    private func openSystemSetting() {
-        Task { @MainActor in
-            guard let url = URL(string: UIApplication.openSettingsURLString)
-            else { return }
-            UIApplication.shared.open(url)
-        }
-    }
-
     private func routeToImageCommand(imageData: Data) {
         Task { @MainActor in
             let next = self.aiImageCommandSceneBuilder.makeImageCommandScene(imageData: imageData)

--- a/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
@@ -1357,11 +1357,6 @@ private extension CalendarViewModelImpleTests {
         func routeToSignIn() {
             self.didRouteToSignIn = true
         }
-
-        var didOpenSystemSetting: Bool?
-        func openSystemSetting() {
-            self.didOpenSystemSetting = true
-        }
     }
     
     class SpyPaperInteractor: CalendarPaperSceneInteractor, @unchecked Sendable {

--- a/Presentations/EventDetailScene/Sources/Selections/SelectEventNotificationTime/SelectEventNotificationTimeRouter.swift
+++ b/Presentations/EventDetailScene/Sources/Selections/SelectEventNotificationTime/SelectEventNotificationTimeRouter.swift
@@ -8,34 +8,15 @@
 //
 //
 
-import UIKit
+import Foundation
 import Scenes
 import CommonPresentation
 
 
 // MARK: - Routing
 
-protocol SelectEventNotificationTimeRouting: Routing, Sendable { 
-    
-    func openSystemNotificationSetting()
-}
+protocol SelectEventNotificationTimeRouting: Routing, Sendable { }
 
 // MARK: - Router
 
 final class SelectEventNotificationTimeRouter: BaseRouterImple, SelectEventNotificationTimeRouting, @unchecked Sendable { }
-
-
-extension SelectEventNotificationTimeRouter {
-    
-    private var currentScene: (any SelectEventNotificationTimeScene)? {
-        self.scene as? (any SelectEventNotificationTimeScene)
-    }
-    
-    func openSystemNotificationSetting() {
-        Task { @MainActor in
-            guard let url = URL(string: UIApplication.openSettingsURLString)
-            else { return }
-            UIApplication.shared.open(url)
-        }
-    }
-}

--- a/Presentations/EventDetailScene/Sources/Selections/SelectEventNotificationTime/SelectEventNotificationTimeViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/Selections/SelectEventNotificationTime/SelectEventNotificationTimeViewModel.swift
@@ -188,7 +188,7 @@ extension SelectEventNotificationTimeViewModelImple {
     }
     
     func moveSystemNotificationSetting() {
-        self.router?.openSystemNotificationSetting()
+        self.router?.openSystemSetting()
     }
     
     func close() {

--- a/Presentations/EventDetailScene/Tests/SelectEventNotificationTimeViewModelTests.swift
+++ b/Presentations/EventDetailScene/Tests/SelectEventNotificationTimeViewModelTests.swift
@@ -303,18 +303,12 @@ extension SelectEventNotificationTimeViewModelTests {
         viewModel.moveSystemNotificationSetting()
         
         // then
-        XCTAssertEqual(self.spyRouter.didOpenSystemNotificationSetting, true)
+        XCTAssertEqual(self.spyRouter.didOpenSystemSetting, true)
     }
 }
 
 
-private class SpyRouter: BaseSpyRouter, SelectEventNotificationTimeRouting, @unchecked Sendable {
-    
-    var didOpenSystemNotificationSetting: Bool?
-    func openSystemNotificationSetting() {
-        self.didOpenSystemNotificationSetting = true
-    }
-}
+private class SpyRouter: BaseSpyRouter, SelectEventNotificationTimeRouting, @unchecked Sendable { }
 
 private class SpyListener: SelectEventNotificationTimeSceneListener {
     

--- a/Presentations/Scenes/Sources/BaseComponents.swift
+++ b/Presentations/Scenes/Sources/BaseComponents.swift
@@ -109,13 +109,23 @@ public protocol Routing: AnyObject {
     func showActionSheet(_ form: ActionSheetForm)
     func openSafari(_ path: String)
     func showWebView(_ path: String)
+    func openSystemSetting()
     func dismissPresented(animated: Bool, _ completed: (@Sendable () -> Void)?)
 }
 
 extension Routing {
-    
+
     public func closeScene(_ dismissed: (@Sendable () -> Void)? = nil) {
         self.closeScene(animate: true, dismissed)
+    }
+
+    public func openSystemSetting() {
+        Task { @MainActor in
+            guard let url = URL(string: UIApplication.openSettingsURLString),
+                  UIApplication.shared.canOpenURL(url)
+            else { return }
+            UIApplication.shared.open(url)
+        }
     }
 }
 

--- a/Presentations/SettingScene/Sources/Event/EventNotificationDefaultTimeOption/EventNotificationDefaultTimeOptionRouter.swift
+++ b/Presentations/SettingScene/Sources/Event/EventNotificationDefaultTimeOption/EventNotificationDefaultTimeOptionRouter.swift
@@ -15,10 +15,7 @@ import CommonPresentation
 
 // MARK: - Routing
 
-protocol EventNotificationDefaultTimeOptionRouting: Routing, Sendable { 
-    
-    func openSystemNotificationSetting()
-}
+protocol EventNotificationDefaultTimeOptionRouting: Routing, Sendable { }
 
 // MARK: - Router
 
@@ -36,13 +33,5 @@ extension EventNotificationDefaultTimeOptionRouter {
     
     private var currentScene: (any EventNotificationDefaultTimeOptionScene)? {
         self.scene as? (any EventNotificationDefaultTimeOptionScene)
-    }
-    
-    func openSystemNotificationSetting() {
-        Task { @MainActor in
-            guard let url = URL(string: UIApplication.openSettingsURLString)
-            else { return }
-            UIApplication.shared.open(url)
-        }
     }
 }

--- a/Presentations/SettingScene/Sources/Event/EventNotificationDefaultTimeOption/EventNotificationDefaultTimeOptionViewModel.swift
+++ b/Presentations/SettingScene/Sources/Event/EventNotificationDefaultTimeOption/EventNotificationDefaultTimeOptionViewModel.swift
@@ -111,7 +111,7 @@ extension EventNotificationDefaultTimeOptionViewModelImple {
     }
     
     func requestPermission() {
-        self.router?.openSystemNotificationSetting()
+        self.router?.openSystemSetting()
     }
     
     private func requestNotificationPermission() {

--- a/Presentations/SettingScene/Sources/Event/EventSettingRouter.swift
+++ b/Presentations/SettingScene/Sources/Event/EventSettingRouter.swift
@@ -20,7 +20,6 @@ protocol EventSettingRouting: Routing, Sendable {
     func routeToSelectTag()
     func routeToEventNotificationTime(forAllDay: Bool)
     func routeToSelectDefaultMapApp()
-    func openSystemSetting()
 }
 
 // MARK: - Router
@@ -74,13 +73,6 @@ extension EventSettingRouter {
         Task { @MainActor in
             let next = self.eventDefaultMapAppSceneBuilder.makeEventDefaultMapAppScene()
             self.currentScene?.navigationController?.pushViewController(next, animated: true)
-        }
-    }
-
-    func openSystemSetting() {
-        Task { @MainActor in
-            guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
-            UIApplication.shared.open(url)
         }
     }
 }

--- a/Presentations/SettingScene/Tests/Event/EventNotificationDefaultTimeOptionViewModelImpleTests.swift
+++ b/Presentations/SettingScene/Tests/Event/EventNotificationDefaultTimeOptionViewModelImpleTests.swift
@@ -92,7 +92,7 @@ extension EventNotificationDefaultTimeOptionViewModelImpleTests {
         viewModel.requestPermission()
         
         // then
-        XCTAssertEqual(self.spyRouter.didOpenSystemNotificationSetting, true)
+        XCTAssertEqual(self.spyRouter.didOpenSystemSetting, true)
     }
 }
 
@@ -161,10 +161,4 @@ extension EventNotificationDefaultTimeOptionViewModelImpleTests {
 }
 
 
-private final class SpyRouter: BaseSpyRouter, EventNotificationDefaultTimeOptionRouting, @unchecked Sendable {
-    
-    var didOpenSystemNotificationSetting: Bool?
-    func openSystemNotificationSetting() {
-        self.didOpenSystemNotificationSetting = true
-    }
-}
+private final class SpyRouter: BaseSpyRouter, EventNotificationDefaultTimeOptionRouting, @unchecked Sendable { }

--- a/Presentations/SettingScene/Tests/Event/EventSettingViewModelImpleTests.swift
+++ b/Presentations/SettingScene/Tests/Event/EventSettingViewModelImpleTests.swift
@@ -567,9 +567,4 @@ private class SpyRouter: BaseSpyRouter, EventSettingRouting, @unchecked Sendable
     func routeToSelectDefaultMapApp() {
         self.didRouteToSelectDefaultMapApp = true
     }
-
-    var didOpenSystemSetting: Bool?
-    func openSystemSetting() {
-        self.didOpenSystemSetting = true
-    }
 }

--- a/Repository/Tests/Event/Schedule/ScheduleEventLocalRepositoryImpleTests.swift
+++ b/Repository/Tests/Event/Schedule/ScheduleEventLocalRepositoryImpleTests.swift
@@ -228,7 +228,7 @@ extension ScheduleEventLocalRepositoryImpleTests {
         let saving: AsyncFlatMapPublisher<Void, Error, Void> = Publishers.create {
             return try await self.localStorage.updateScheduleEvents(events)
         }
-        let _ = self.waitFirstOutput(expect, for: saving, timeout: 1)
+        let _ = self.waitFirstOutput(expect, for: saving)
     }
     
     func testReposiotry_loadEventsInRange() {

--- a/Repository/Tests/Event/Todo/TodoLocalRepositoryImpleTests.swift
+++ b/Repository/Tests/Event/Todo/TodoLocalRepositoryImpleTests.swift
@@ -156,7 +156,7 @@ extension TodoLocalRepositoryImpleTests {
                 try db.insert(Detail.self, entities: details)
             }
         }
-        let _ = self.waitFirstOutput(expect, for: saving, timeout: 1)
+        let _ = self.waitFirstOutput(expect, for: saving)
     }
     
     // make and load/

--- a/Supports/Extensions/Resources/ca.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ca.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "Queden %@ crèdits addicionals";
 "aiAgent::usage::planChangeScheduled" = "Canvi al pla %2$@ el %1$@";
 "aiAgent::usage::resetsIn" = "Disponible de nou d'aquí a %@";
+"aiAgent::notificationPermissionDenied::message" = "Activeu les notificacions a Configuració per rebre els resultats de la IA.";
 "aiAgent::stop::confirm::title" = "Voleu aturar el processament?";
 "aiAgent::stop::confirm::message" = "En aturar-lo es descartarà l'ordre en curs i no es podrà reprendre.";
 "aiAgent::confirm::countdown" = "restant per aprovar";

--- a/Supports/Extensions/Resources/cs.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/cs.lproj/Localizable.strings
@@ -637,6 +637,7 @@
 "aiAgent::usage::topupRemaining" = "Zbývá %@ dalších kreditů";
 "aiAgent::usage::planChangeScheduled" = "Přechod na plán %2$@ dne %1$@";
 "aiAgent::usage::resetsIn" = "Znovu k dispozici za %@";
+"aiAgent::notificationPermissionDenied::message" = "Zapněte oznámení v Nastavení, abyste dostávali výsledky AI.";
 "aiAgent::stop::confirm::title" = "Zastavit zpracování?";
 "aiAgent::stop::confirm::message" = "Zastavení zruší probíhající příkaz a nebude možné jej obnovit.";
 "aiAgent::confirm::countdown" = "zbývá na potvrzení";

--- a/Supports/Extensions/Resources/da.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/da.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "%@ ekstra kreditter tilbage";
 "aiAgent::usage::planChangeScheduled" = "Skift til planen %2$@ den %1$@";
 "aiAgent::usage::resetsIn" = "Tilgængelig igen om %@";
+"aiAgent::notificationPermissionDenied::message" = "Slå notifikationer til i Indstillinger for at modtage AI-resultater.";
 "aiAgent::stop::confirm::title" = "Stop behandling?";
 "aiAgent::stop::confirm::message" = "Hvis du stopper, kasseres den igangværende kommando, og den kan ikke genoptages.";
 "aiAgent::confirm::countdown" = "tilbage til at godkende";

--- a/Supports/Extensions/Resources/de.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/de.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "Noch %@ zusätzliches Guthaben";
 "aiAgent::usage::planChangeScheduled" = "Wechsel zum Tarif %2$@ am %1$@";
 "aiAgent::usage::resetsIn" = "In %@ wieder verfügbar";
+"aiAgent::notificationPermissionDenied::message" = "Aktivieren Sie in den Einstellungen Benachrichtigungen, um KI-Ergebnisse zu erhalten.";
 "aiAgent::stop::confirm::title" = "Verarbeitung stoppen?";
 "aiAgent::stop::confirm::message" = "Durch das Stoppen wird der laufende Befehl verworfen und kann nicht fortgesetzt werden.";
 "aiAgent::confirm::countdown" = "verbleibend zur Bestätigung";

--- a/Supports/Extensions/Resources/el.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/el.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "Απομένουν %@ επιπλέον μονάδες";
 "aiAgent::usage::planChangeScheduled" = "Μετάβαση στο πρόγραμμα %2$@ στις %1$@";
 "aiAgent::usage::resetsIn" = "Διαθέσιμο ξανά σε %@";
+"aiAgent::notificationPermissionDenied::message" = "Ενεργοποιήστε τις ειδοποιήσεις από τις Ρυθμίσεις για να λαμβάνετε τα αποτελέσματα του AI.";
 "aiAgent::stop::confirm::title" = "Διακοπή επεξεργασίας;";
 "aiAgent::stop::confirm::message" = "Η διακοπή απορρίπτει την εντολή που εκτελείται και δεν θα μπορεί να συνεχιστεί.";
 "aiAgent::confirm::countdown" = "απομένουν για έγκριση";

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "%@ extra credits left";
 "aiAgent::usage::planChangeScheduled" = "Switching to the %2$@ plan on %1$@";
 "aiAgent::usage::resetsIn" = "Available again in %@";
+"aiAgent::notificationPermissionDenied::message" = "Turn on notifications in Settings to receive AI results.";
 "aiAgent::stop::confirm::title" = "Stop processing?";
 "aiAgent::stop::confirm::message" = "Stopping discards the task in progress, and it can't be resumed.";
 "aiAgent::confirm::countdown" = "left to approve";

--- a/Supports/Extensions/Resources/es.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/es.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "%@ créditos adicionales restantes";
 "aiAgent::usage::planChangeScheduled" = "Cambiarás al plan %2$@ el %1$@";
 "aiAgent::usage::resetsIn" = "Disponible de nuevo en %@";
+"aiAgent::notificationPermissionDenied::message" = "Activa las notificaciones en Ajustes para recibir los resultados de la IA.";
 "aiAgent::stop::confirm::title" = "¿Detener el procesamiento?";
 "aiAgent::stop::confirm::message" = "Al detener se descarta el comando en curso y no se puede reanudar.";
 "aiAgent::confirm::countdown" = "restante para aprobar";

--- a/Supports/Extensions/Resources/fi.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/fi.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "%@ lisäkrediittiä jäljellä";
 "aiAgent::usage::planChangeScheduled" = "Vaihto %2$@-pakettiin %1$@";
 "aiAgent::usage::resetsIn" = "Käytettävissä taas %@ kuluttua";
+"aiAgent::notificationPermissionDenied::message" = "Ota ilmoitukset käyttöön Asetuksissa, jotta saat AI:n tulokset.";
 "aiAgent::stop::confirm::title" = "Pysäytetäänkö käsittely?";
 "aiAgent::stop::confirm::message" = "Pysäyttäminen hylkää käynnissä olevan komennon, eikä sitä voi jatkaa.";
 "aiAgent::confirm::countdown" = "aikaa hyväksyä";

--- a/Supports/Extensions/Resources/fr.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/fr.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "%@ crédits supplémentaires restants";
 "aiAgent::usage::planChangeScheduled" = "Passage au forfait %2$@ le %1$@";
 "aiAgent::usage::resetsIn" = "De nouveau disponible dans %@";
+"aiAgent::notificationPermissionDenied::message" = "Activez les notifications dans Réglages pour recevoir les résultats de l’IA.";
 "aiAgent::stop::confirm::title" = "Arrêter le traitement ?";
 "aiAgent::stop::confirm::message" = "L'arrêt annule la commande en cours et elle ne pourra pas être reprise.";
 "aiAgent::confirm::countdown" = "restant pour approuver";

--- a/Supports/Extensions/Resources/hi.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/hi.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "%@ अतिरिक्त क्रेडिट बचे हैं";
 "aiAgent::usage::planChangeScheduled" = "%1$@ को %2$@ प्लान में बदलाव होगा";
 "aiAgent::usage::resetsIn" = "%@ में फिर से उपलब्ध";
+"aiAgent::notificationPermissionDenied::message" = "AI के परिणाम पाने के लिए सेटिंग्स में सूचनाएँ चालू करें।";
 "aiAgent::stop::confirm::title" = "प्रोसेसिंग रोकें?";
 "aiAgent::stop::confirm::message" = "रोकने से जारी निर्देश छोड़ दिया जाएगा, और इसे फिर से शुरू नहीं किया जा सकेगा।";
 "aiAgent::confirm::countdown" = "स्वीकृति के लिए शेष";

--- a/Supports/Extensions/Resources/hr.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/hr.lproj/Localizable.strings
@@ -637,6 +637,7 @@
 "aiAgent::usage::topupRemaining" = "Preostalo %@ dodatnih kredita";
 "aiAgent::usage::planChangeScheduled" = "Prelazak na plan %2$@ %1$@";
 "aiAgent::usage::resetsIn" = "Ponovno dostupno za %@";
+"aiAgent::notificationPermissionDenied::message" = "Uključite obavijesti u Postavkama kako biste primali AI rezultate.";
 "aiAgent::stop::confirm::title" = "Zaustaviti obradu?";
 "aiAgent::stop::confirm::message" = "Zaustavljanje odbacuje naredbu u tijeku i ona se neće moći nastaviti.";
 "aiAgent::confirm::countdown" = "preostalo za odobrenje";

--- a/Supports/Extensions/Resources/hu.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/hu.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "%@ extra kredit maradt";
 "aiAgent::usage::planChangeScheduled" = "%1$@-tól a(z) %2$@ csomagra vált";
 "aiAgent::usage::resetsIn" = "%@ múlva újra használható";
+"aiAgent::notificationPermissionDenied::message" = "Az AI-eredmények fogadásához kapcsolja be az értesítéseket a Beállításokban.";
 "aiAgent::stop::confirm::title" = "Leállítja a feldolgozást?";
 "aiAgent::stop::confirm::message" = "A leállítás elveti a folyamatban lévő parancsot, és az nem folytatható.";
 "aiAgent::confirm::countdown" = "van hátra a jóváhagyáshoz";

--- a/Supports/Extensions/Resources/id.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/id.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "Sisa %@ kredit tambahan";
 "aiAgent::usage::planChangeScheduled" = "Beralih ke paket %2$@ pada %1$@";
 "aiAgent::usage::resetsIn" = "Tersedia lagi dalam %@";
+"aiAgent::notificationPermissionDenied::message" = "Aktifkan notifikasi di Pengaturan untuk menerima hasil AI.";
 "aiAgent::stop::confirm::title" = "Hentikan proses?";
 "aiAgent::stop::confirm::message" = "Menghentikan akan membatalkan perintah yang sedang berjalan, dan tidak dapat dilanjutkan.";
 "aiAgent::confirm::countdown" = "tersisa untuk menyetujui";

--- a/Supports/Extensions/Resources/it.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/it.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "%@ crediti extra rimanenti";
 "aiAgent::usage::planChangeScheduled" = "Passaggio al piano %2$@ il %1$@";
 "aiAgent::usage::resetsIn" = "Di nuovo disponibile tra %@";
+"aiAgent::notificationPermissionDenied::message" = "Attiva le notifiche nelle Impostazioni per ricevere i risultati AI.";
 "aiAgent::stop::confirm::title" = "Interrompere l'elaborazione?";
 "aiAgent::stop::confirm::message" = "L'interruzione scarta l'attività in corso e non potrà essere ripresa.";
 "aiAgent::confirm::countdown" = "rimasti per approvare";

--- a/Supports/Extensions/Resources/ja.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ja.lproj/Localizable.strings
@@ -637,6 +637,7 @@
 "aiAgent::usage::topupRemaining" = "追加クレジット残り%@";
 "aiAgent::usage::planChangeScheduled" = "%1$@に%2$@プランへ切り替わります";
 "aiAgent::usage::resetsIn" = "%@後にまた使えます";
+"aiAgent::notificationPermissionDenied::message" = "AIの結果を受け取るには、設定で通知をオンにしてください。";
 "aiAgent::stop::confirm::title" = "処理を中止しますか？";
 "aiAgent::stop::confirm::message" = "中止すると進行中のコマンドは破棄され、再開できません。";
 "aiAgent::confirm::countdown" = "以内に承認してください";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "추가 크레딧 %@ 남음";
 "aiAgent::usage::planChangeScheduled" = "%1$@부터 %2$@ 플랜으로 바뀌어요";
 "aiAgent::usage::resetsIn" = "%@ 뒤에 다시 쓸 수 있어요";
+"aiAgent::notificationPermissionDenied::message" = "AI 결과를 받으려면 설정에서 알림을 켜 주세요.";
 "aiAgent::stop::confirm::title" = "처리를 중지할까요?";
 "aiAgent::stop::confirm::message" = "중지하면 진행 중인 작업이 사라지고 다시 시작할 수 없어요.";
 "aiAgent::confirm::countdown" = "안에 승인해 주세요";

--- a/Supports/Extensions/Resources/ms.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ms.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "Baki %@ kredit tambahan";
 "aiAgent::usage::planChangeScheduled" = "Bertukar ke pelan %2$@ pada %1$@";
 "aiAgent::usage::resetsIn" = "Tersedia semula dalam %@";
+"aiAgent::notificationPermissionDenied::message" = "Hidupkan pemberitahuan dalam Tetapan untuk menerima hasil AI.";
 "aiAgent::stop::confirm::title" = "Hentikan pemprosesan?";
 "aiAgent::stop::confirm::message" = "Menghentikan akan membuang arahan yang sedang berjalan, dan ia tidak boleh disambung semula.";
 "aiAgent::confirm::countdown" = "berbaki untuk meluluskan";

--- a/Supports/Extensions/Resources/nb.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/nb.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "%@ ekstra kreditter igjen";
 "aiAgent::usage::planChangeScheduled" = "Bytte til planen %2$@ den %1$@";
 "aiAgent::usage::resetsIn" = "Tilgjengelig igjen om %@";
+"aiAgent::notificationPermissionDenied::message" = "Slå på varsler i Innstillinger for å motta AI-resultater.";
 "aiAgent::stop::confirm::title" = "Stoppe behandlingen?";
 "aiAgent::stop::confirm::message" = "Å stoppe forkaster den pågående kommandoen, og den kan ikke gjenopptas.";
 "aiAgent::confirm::countdown" = "igjen til godkjenning";

--- a/Supports/Extensions/Resources/nl.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/nl.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "Nog %@ extra credits over";
 "aiAgent::usage::planChangeScheduled" = "Overstap naar het %2$@-plan op %1$@";
 "aiAgent::usage::resetsIn" = "Over %@ weer beschikbaar";
+"aiAgent::notificationPermissionDenied::message" = "Schakel meldingen in bij Instellingen om AI-resultaten te ontvangen.";
 "aiAgent::stop::confirm::title" = "Verwerking stoppen?";
 "aiAgent::stop::confirm::message" = "Stoppen verwerpt de lopende opdracht, en deze kan niet worden hervat.";
 "aiAgent::confirm::countdown" = "resterend om goed te keuren";

--- a/Supports/Extensions/Resources/pl.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/pl.lproj/Localizable.strings
@@ -637,6 +637,7 @@
 "aiAgent::usage::topupRemaining" = "Pozostało %@ dodatkowych kredytów";
 "aiAgent::usage::planChangeScheduled" = "Zmiana na plan %2$@ dnia %1$@";
 "aiAgent::usage::resetsIn" = "Znów dostępne za %@";
+"aiAgent::notificationPermissionDenied::message" = "Włącz powiadomienia w Ustawieniach, aby otrzymywać wyniki AI.";
 "aiAgent::stop::confirm::title" = "Zatrzymać przetwarzanie?";
 "aiAgent::stop::confirm::message" = "Zatrzymanie odrzuci bieżące polecenie i nie będzie można go wznowić.";
 "aiAgent::confirm::countdown" = "pozostało na zatwierdzenie";

--- a/Supports/Extensions/Resources/pt-BR.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/pt-BR.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "%@ créditos extras restantes";
 "aiAgent::usage::planChangeScheduled" = "Mudança para o plano %2$@ em %1$@";
 "aiAgent::usage::resetsIn" = "Disponível novamente em %@";
+"aiAgent::notificationPermissionDenied::message" = "Ative as notificações em Ajustes para receber os resultados da IA.";
 "aiAgent::stop::confirm::title" = "Interromper o processamento?";
 "aiAgent::stop::confirm::message" = "Interromper descarta o comando em andamento, e ele não pode ser retomado.";
 "aiAgent::confirm::countdown" = "restante para aprovar";

--- a/Supports/Extensions/Resources/ro.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ro.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "Mai ai %@ credite suplimentare";
 "aiAgent::usage::planChangeScheduled" = "Treci la planul %2$@ pe %1$@";
 "aiAgent::usage::resetsIn" = "Disponibil din nou în %@";
+"aiAgent::notificationPermissionDenied::message" = "Activați notificările din Setări pentru a primi rezultatele AI.";
 "aiAgent::stop::confirm::title" = "Oprești procesarea?";
 "aiAgent::stop::confirm::message" = "Oprirea anulează comanda în desfășurare, iar aceasta nu va putea fi reluată.";
 "aiAgent::confirm::countdown" = "rămas pentru aprobare";

--- a/Supports/Extensions/Resources/ru.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ru.lproj/Localizable.strings
@@ -637,6 +637,7 @@
 "aiAgent::usage::topupRemaining" = "Осталось %@ доп. кредитов";
 "aiAgent::usage::planChangeScheduled" = "Переход на план «%2$@» %1$@";
 "aiAgent::usage::resetsIn" = "Снова доступно через %@";
+"aiAgent::notificationPermissionDenied::message" = "Включите уведомления в настройках, чтобы получать результаты ИИ.";
 "aiAgent::stop::confirm::title" = "Остановить обработку?";
 "aiAgent::stop::confirm::message" = "Остановка отменяет выполняемую команду, и её нельзя будет возобновить.";
 "aiAgent::confirm::countdown" = "осталось на подтверждение";

--- a/Supports/Extensions/Resources/sk.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/sk.lproj/Localizable.strings
@@ -637,6 +637,7 @@
 "aiAgent::usage::topupRemaining" = "Zostáva %@ ďalších kreditov";
 "aiAgent::usage::planChangeScheduled" = "Prechod na plán %2$@ dňa %1$@";
 "aiAgent::usage::resetsIn" = "Znova k dispozícii o %@";
+"aiAgent::notificationPermissionDenied::message" = "Zapnite upozornenia v Nastaveniach, aby ste dostávali výsledky AI.";
 "aiAgent::stop::confirm::title" = "Zastaviť spracovanie?";
 "aiAgent::stop::confirm::message" = "Zastavením sa zruší prebiehajúci príkaz a nebude ho možné obnoviť.";
 "aiAgent::confirm::countdown" = "zostáva na potvrdenie";

--- a/Supports/Extensions/Resources/sv.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/sv.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "%@ extra krediter kvar";
 "aiAgent::usage::planChangeScheduled" = "Byte till planen %2$@ den %1$@";
 "aiAgent::usage::resetsIn" = "Tillgängligt igen om %@";
+"aiAgent::notificationPermissionDenied::message" = "Slå på notiser i Inställningar för att få AI-resultat.";
 "aiAgent::stop::confirm::title" = "Avbryta bearbetningen?";
 "aiAgent::stop::confirm::message" = "Om du avbryter kasseras den pågående åtgärden, och den kan inte återupptas.";
 "aiAgent::confirm::countdown" = "kvar för att godkänna";

--- a/Supports/Extensions/Resources/th.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/th.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "เครดิตเสริมเหลือ %@";
 "aiAgent::usage::planChangeScheduled" = "จะเปลี่ยนเป็นแพ็กเกจ %2$@ ในวันที่ %1$@";
 "aiAgent::usage::resetsIn" = "ใช้ได้อีกครั้งใน %@";
+"aiAgent::notificationPermissionDenied::message" = "เปิดการแจ้งเตือนในการตั้งค่าเพื่อรับผลลัพธ์จาก AI";
 "aiAgent::stop::confirm::title" = "ต้องการหยุดประมวลผลหรือไม่?";
 "aiAgent::stop::confirm::message" = "การหยุดจะทำให้งานที่กำลังทำอยู่หายไปและไม่สามารถกู้คืนได้";
 "aiAgent::confirm::countdown" = "เหลือเวลาอนุมัติ";

--- a/Supports/Extensions/Resources/tr.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/tr.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "%@ ek kredi kaldı";
 "aiAgent::usage::planChangeScheduled" = "%1$@ tarihinde %2$@ planına geçiş";
 "aiAgent::usage::resetsIn" = "%@ sonra tekrar kullanılabilir";
+"aiAgent::notificationPermissionDenied::message" = "AI sonuçlarını almak için Ayarlar’dan bildirimlere izin verin.";
 "aiAgent::stop::confirm::title" = "İşlem durdurulsun mu?";
 "aiAgent::stop::confirm::message" = "Durdurmak, devam eden işlemi iptal eder ve geri alınamaz.";
 "aiAgent::confirm::countdown" = "onaylamak için kaldı";

--- a/Supports/Extensions/Resources/uk.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/uk.lproj/Localizable.strings
@@ -637,6 +637,7 @@
 "aiAgent::usage::topupRemaining" = "Залишилось %@ додаткових кредитів";
 "aiAgent::usage::planChangeScheduled" = "Перехід на план «%2$@» %1$@";
 "aiAgent::usage::resetsIn" = "Знову доступно через %@";
+"aiAgent::notificationPermissionDenied::message" = "Увімкніть сповіщення в налаштуваннях, щоб отримувати результати ШІ.";
 "aiAgent::stop::confirm::title" = "Зупинити обробку?";
 "aiAgent::stop::confirm::message" = "Зупинення скасовує команду, що виконується, і її не можна буде відновити.";
 "aiAgent::confirm::countdown" = "залишилося на підтвердження";

--- a/Supports/Extensions/Resources/vi.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/vi.lproj/Localizable.strings
@@ -638,6 +638,7 @@
 "aiAgent::usage::topupRemaining" = "Còn lại %@ credit bổ sung";
 "aiAgent::usage::planChangeScheduled" = "Sẽ chuyển sang gói %2$@ vào %1$@";
 "aiAgent::usage::resetsIn" = "Có thể dùng lại sau %@";
+"aiAgent::notificationPermissionDenied::message" = "Bật thông báo trong Cài đặt để nhận kết quả AI.";
 "aiAgent::stop::confirm::title" = "Dừng xử lý?";
 "aiAgent::stop::confirm::message" = "Dừng lại sẽ hủy bỏ tác vụ đang thực hiện và không thể tiếp tục.";
 "aiAgent::confirm::countdown" = "để xác nhận";

--- a/Supports/Extensions/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/zh-Hans.lproj/Localizable.strings
@@ -637,6 +637,7 @@
 "aiAgent::usage::topupRemaining" = "还剩%@附加额度";
 "aiAgent::usage::planChangeScheduled" = "将于%1$@切换至%2$@套餐";
 "aiAgent::usage::resetsIn" = "%@后可再次使用";
+"aiAgent::notificationPermissionDenied::message" = "请在设置中开启通知，以接收 AI 结果。";
 "aiAgent::stop::confirm::title" = "是否停止处理？";
 "aiAgent::stop::confirm::message" = "停止后将放弃正在进行的任务，且无法恢复。";
 "aiAgent::confirm::countdown" = "内确认";

--- a/Supports/Extensions/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/zh-Hant.lproj/Localizable.strings
@@ -637,6 +637,7 @@
 "aiAgent::usage::topupRemaining" = "還剩%@額外點數";
 "aiAgent::usage::planChangeScheduled" = "將於%1$@切換至%2$@方案";
 "aiAgent::usage::resetsIn" = "%@後可再次使用";
+"aiAgent::notificationPermissionDenied::message" = "請至設定開啟通知，才能接收 AI 結果。";
 "aiAgent::stop::confirm::title" = "是否要停止處理？";
 "aiAgent::stop::confirm::message" = "停止後將會捨棄正在進行的工作，且無法繼續。";
 "aiAgent::confirm::countdown" = "內請核准";

--- a/Supports/TestDoubles/Sources/Scenes/BaseSpyRouter.swift
+++ b/Supports/TestDoubles/Sources/Scenes/BaseSpyRouter.swift
@@ -66,6 +66,11 @@ open class BaseSpyRouter: Routing {
         self.didShowWebViewPath = path
     }
 
+    public var didOpenSystemSetting: Bool?
+    open func openSystemSetting() {
+        self.didOpenSystemSetting = true
+    }
+
     public var didDismissPresented: Bool?
     public func dismissPresented(animated: Bool, _ completed: (() -> Void)?) {
         

--- a/Supports/TestDoubles/Sources/Usecases/StubAIAgentOrchestrationUsecase.swift
+++ b/Supports/TestDoubles/Sources/Usecases/StubAIAgentOrchestrationUsecase.swift
@@ -15,6 +15,7 @@ public final class StubAIAgentOrchestrationUsecase: AIAgentOrchestrationUsecase,
     public let recognizingTextSubject = PassthroughSubject<String, Never>()
     public let voiceLevelSubject = PassthroughSubject<Float, Never>()
     public let speechPermissionDeniedSubject = PassthroughSubject<Void, Never>()
+    public let isNotificationPermissionDeniedSubject = CurrentValueSubject<Bool, Never>(false)
     public private(set) var didPrepare: Bool?
     public private(set) var didEnterVoiceInput: Bool?
     public private(set) var didFinishVoiceInput: Bool?
@@ -64,6 +65,11 @@ public final class StubAIAgentOrchestrationUsecase: AIAgentOrchestrationUsecase,
         self.didRefreshProcessingJob = true
     }
 
+    public private(set) var didRefreshNotificationPermissionStatus: Bool?
+    public func refreshNotificationPermissionStatus() {
+        self.didRefreshNotificationPermissionStatus = true
+    }
+
     public var state: AnyPublisher<AIAgentState, Never> {
         self.stateSubject.compactMap { $0 }.eraseToAnyPublisher()
     }
@@ -78,6 +84,9 @@ public final class StubAIAgentOrchestrationUsecase: AIAgentOrchestrationUsecase,
     }
     public var speechPermissionDenied: AnyPublisher<Void, Never> {
         self.speechPermissionDeniedSubject.eraseToAnyPublisher()
+    }
+    public var isNotificationPermissionDenied: AnyPublisher<Bool, Never> {
+        self.isNotificationPermissionDeniedSubject.eraseToAnyPublisher()
     }
     public var isCreditExhausted: Bool {
         self.stubIsCreditExhausted

--- a/Supports/TestDoubles/Sources/Usecases/StubNotificationPermissionUsecase.swift
+++ b/Supports/TestDoubles/Sources/Usecases/StubNotificationPermissionUsecase.swift
@@ -14,7 +14,9 @@ open class StubNotificationPermissionUsecase: NotificationPermissionUsecase, @un
     public init() { }
     
     public var stubAuthorizationStatusCheckResult: Result<NotificationAuthorizationStatus, any Error> = .success(.authorized)
+    public private(set) var didCheckAuthorizationStatus: Bool?
     open func checkAuthorizationStatus() async throws -> NotificationAuthorizationStatus {
+        self.didCheckAuthorizationStatus = true
         switch self.stubAuthorizationStatusCheckResult {
         case .success(let success):
             return success
@@ -25,7 +27,12 @@ open class StubNotificationPermissionUsecase: NotificationPermissionUsecase, @un
     
     public var stubRequestPermissionResult: Result<Bool, any Error> = .success(true)
     public var didPermissionChanged: ((NotificationAuthorizationStatus) -> Void)?
+    public private(set) var didRequestPermission: Bool?
+    // 응답 도착 시점을 테스트가 잡아둘 수 있게 하는 게이트 — 요청 이후 동작의 순서를 검증할 때 쓴다.
+    public var requestPermissionGate: (@Sendable () async -> Void)?
     open func requestPermission() async throws -> Bool {
+        self.didRequestPermission = true
+        await self.requestPermissionGate?()
         switch self.stubRequestPermissionResult {
         case .success(let success):
             self.didPermissionChanged?(success ? .authorized : .denied)

--- a/Supports/UnitTestHelpKit/Sources/PublisherWaitable.swift
+++ b/Supports/UnitTestHelpKit/Sources/PublisherWaitable.swift
@@ -21,7 +21,7 @@ extension PublisherWaitable where Self: XCTestCase {
     public func waitOutputs<P: Publisher>(
         _ expect: XCTestExpectation,
         for source: P,
-        timeout: TimeInterval = 0.5,
+        timeout: TimeInterval = 2.0,
         _ action: (() -> Void)? = nil
     ) -> [P.Output] {
         // given
@@ -44,7 +44,7 @@ extension PublisherWaitable where Self: XCTestCase {
     public func waitError<P: Publisher>(
         _ expect: XCTestExpectation,
         for source: P,
-        timeout: TimeInterval = 0.5,
+        timeout: TimeInterval = 2.0,
         _ action: (() -> Void)? = nil
     ) -> P.Failure? {
         // given
@@ -68,7 +68,7 @@ extension PublisherWaitable where Self: XCTestCase {
     public func waitFirstOutput<P: Publisher>(
         _ expect: XCTestExpectation,
         for source: P,
-        timeout: TimeInterval = 0.5,
+        timeout: TimeInterval = 2.0,
         _ action: (() -> Void)? = nil
     ) -> P.Output? {
         return self.waitOutputs(expect, for: source, timeout: timeout, action).first
@@ -111,7 +111,7 @@ extension PublisherWaitable {
     public func expectConfirm(
         _ description: String
     ) -> ConfirmationExpectation {
-        return .init(comment: .init(stringLiteral: description), count: 1, timeout: .seconds(1))
+        return .init(comment: .init(stringLiteral: description), count: 1, timeout: .seconds(3))
     }
 
     @available(iOS 16.0, *)

--- a/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
+++ b/TodoCalendarApp/Sources/Factories/Factories+Usecase.swift
@@ -515,7 +515,10 @@ struct LoginUsecaseFactoryImple: UsecaseFactory {
             commandUsecase: aiCommandUsecase,
             usageUsecase: aiUsageUsecase,
             speechRecognizeUsecase: speech,
-            eventSyncUsecase: self.eventSyncUsecase
+            eventSyncUsecase: self.eventSyncUsecase,
+            notificationPermissionUsecase: NotificationPermissionUsecaseImple(
+                notificationService: UNLocalNotificationServiceImple()
+            )
         )
 
         self.billingUsecase = BillingUsecaseImple(

--- a/TodoCalendarApp/Sources/Main/MainViewModel.swift
+++ b/TodoCalendarApp/Sources/Main/MainViewModel.swift
@@ -152,6 +152,7 @@ final class MainViewModelImple: MainViewModel, @unchecked Sendable {
                 self?.billingUsecase.recoverUnfinishedTransactions()
                 self?.aiAgentOrchestrationUsecase.refreshProcessingJobIfNeeded()
                 self?.aiAgentOrchestrationUsecase.loadUsage()
+                self?.aiAgentOrchestrationUsecase.refreshNotificationPermissionStatus()
                 self?.handleWillEnterForeground()
                 self?.legalNoticeUsecase.checkNoticeIsNeed()
             })

--- a/TodoCalendarApp/TodoCalendarAppTests/MainViewModelImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/MainViewModelImpleTests.swift
@@ -680,6 +680,31 @@ extension MainViewModelImpleTests {
         XCTAssertNil(self.stubAIOrchestrationUsecase.didLoadUsage)
         withExtendedLifetime(viewModel) { }
     }
+
+    func testViewModel_whenEnterForeground_refreshNotificationPermissionStatus() {
+        // given
+        let viewModel = self.makeViewModelWithoutPrepare()
+
+        // when
+        NotificationCenter.default.post(
+            name: UIApplication.willEnterForegroundNotification, object: nil
+        )
+
+        // then
+        XCTAssertEqual(self.stubAIOrchestrationUsecase.didRefreshNotificationPermissionStatus, true)
+        withExtendedLifetime(viewModel) { }
+    }
+
+    func testViewModel_whenNotEnterForeground_notRefreshNotificationPermissionStatus() {
+        // given
+        let viewModel = self.makeViewModelWithoutPrepare()
+
+        // when
+
+        // then
+        XCTAssertNil(self.stubAIOrchestrationUsecase.didRefreshNotificationPermissionStatus)
+        withExtendedLifetime(viewModel) { }
+    }
 }
 
 

--- a/docs/troubleshooting/2026-08-25-ci-wallclock-timeout-flaky.md
+++ b/docs/troubleshooting/2026-08-25-ci-wallclock-timeout-flaky.md
@@ -1,0 +1,30 @@
+---
+issue: "#1003"
+subdomain: Infra
+symptoms: [CI 반복 실패, Exceeded timeout of, 매번 다른 테스트가 깨짐, 로컬은 통과 CI만 실패, PublisherWaitable, 플레이키]
+resolution: workaround
+---
+
+# CI 가 브랜치와 무관하게 매번 다른 테스트에서 타임아웃으로 깨진다
+
+- **증상**: PR CI 가 반복 실패하는데 깨지는 테스트가 런마다 다르다. 실패 메시지는 전부 `Exceeded timeout of N seconds` 형태로, 로직 단언이 틀린 게 아니라 시간이 모자라 깨진다. 같은 커밋이 로컬에서는 14/14 통과한다. 특정 브랜치 문제가 아니라 여러 PR(#981·#982·#881·#998)에서 동일하게 났다.
+
+- **근본 원인**: 테스트 스위트 전체가 벽시계 고정 타임아웃에 결합돼 있다. wait 호출 1113건이 전부 "정해진 시간 안에 방출이 오는가"로 판정한다. CI 는 self-hosted 러너(`Maggie-m1`)에서 매번 `rm -rf ./DerivedData` 후 클린 빌드로 도는데(`.github/workflows/pr_test.yml` `Reset DerivedData`), 로컬 증분 실행보다 느리고 부하 변동이 크다. 부하가 튀는 순간 실행 중이던 테스트가 상한을 넘고, 어느 테스트가 걸릴지는 매번 달라 다른 게 깨진다.
+
+  판별 근거: 같은 커밋의 두 CI run 이 서로 다른 스킴에서 실패했다 — run 32794396178 은 `SettingItemListViewModelImpleTests.test_selectAdPrivacyOptions_routesToAdPrivacyOptionsForm`(타임아웃 미지정 = 기본 0.5초), run 32806771882 는 `TodoLocalRepositoryImpleTests.testRepository_whenSkipRepeatingTodo_consumeTurn`(`stubSaveTodo` 의 명시 `timeout: 1`). 코드 결함이면 같은 지점에서 깨져야 한다.
+
+  Repository 쪽에 함께 찍힌 `prepare("bad parameter or other API misuse")` 는 별개 원인이 아니라 후속 증상이다. `stubSaveTodo` 가 저장 완료를 기다리다 상한을 넘으면 저장이 안 끝난 채 테스트 본문이 진행돼 DB 상태가 어긋난다.
+
+- **해결**: 국소 방편으로 `PublisherWaitable` 기본 타임아웃을 올렸다 — XCTest `0.5s → 2.0s`, Swift Testing `expectConfirm` `1s → 3s`. CI 에서 실제로 깨졌던 `stubSaveTodo`·`stubSaveSchedule` 의 명시 `timeout: 1` 은 제거해 기본값을 타게 했다.
+
+  positive 대기는 값이 오면 즉시 반환하므로 상한만 올라가고 실행 시간은 늘지 않는다 (SettingScene 5.38s → 4.97s 실측).
+
+  **한계·재발 조건**: 근본은 그대로다. 부하가 더 튀면 다시 깨진다. 짧은 명시 타임아웃(`timeout: 0.1` 82건 등)은 손대지 않아 그쪽이 먼저 걸릴 수 있다. 진짜 무한대기 회귀도 상한이 올라간 만큼 늦게 잡힌다.
+
+  **후속**: #1003 — 벽시계 대기를 조건 폴링(`AsyncEffectWaitable.waitEffect`, #990 도입)으로 점진 전환. 현재 채택 파일이 3개뿐이다.
+
+- **기각 방향**:
+  - CI `-retry-tests-on-failure` 로 실패분만 재실행 — 플레이키를 숨기는 쪽이라 진짜 간헐 버그도 같이 묻힌다. 원인이 환경 의존임을 이미 확정한 상태에서 신호를 지우는 선택은 이득이 없다.
+  - 짧은 명시 타임아웃(`0.1` 82건)까지 일괄 상향 — 그중 상당수가 "방출이 없어야 한다"를 검증하는 negative 대기다. 그건 상한까지 기다렸다가 부재를 확인하는 구조라 올리면 테스트 시간만 그만큼 늘고 판정은 그대로다. positive/negative 구분이 선행돼야 해서 #1003 으로 미뤘다.
+
+- **재발 시 판별**: 실패 메시지가 `Exceeded timeout of` 이고 로컬에서 같은 커밋이 통과하면 이 건이다. 깨진 테스트가 런마다 바뀌는지 확인하면 확정된다 — 고정이면 진짜 회귀다.

--- a/docs/troubleshooting/INDEX.md
+++ b/docs/troubleshooting/INDEX.md
@@ -30,3 +30,4 @@
 - [2026-08-24 `.timeout` 이 concurrent 큐에서 동기 방출값을 흘린다](2026-08-24-combine-timeout-drops-value-on-concurrent-queue.md) — Event / fixed / 라이브액티비티 placeName·memo nil·Publishers.Timeout·DispatchQueue.global
 - [2026-08-24 백그라운드 Task 에서 구독을 담다 Set 저장소가 깨진다](2026-08-24-cancelbag-data-race-crash.md) — Infra / fixed / unrecognized selector 0x8000000000000000·member:·CalendarScenes 랜덤 크래시
 - [2026-08-24 Paywall screenState 테스트가 방출 개수로 흔들린다](2026-08-24-paywall-screenstate-emission-count-flaky.md) — Billing / deferred / Confirmation was confirmed·PaywallViewModelImpleTests·BillingScenes 간헐 실패
+- [2026-08-25 CI 가 브랜치와 무관하게 매번 다른 테스트에서 타임아웃으로 깨진다](2026-08-25-ci-wallclock-timeout-flaky.md) — Infra / workaround / CI 반복 실패·Exceeded timeout of·매번 다른 테스트·로컬은 통과


### PR DESCRIPTION
## 문제

AI 입력으로 만든 커맨드는 서버가 처리한 뒤 push 로 결과를 알린다. 그런데 앱은 AI 입력을 쓰려는 시점에 알림 권한을 확인하지 않았다. 권한이 없는 사용자는 앱을 벗어나는 순간 결과를 영영 못 받는데, 왜 안 오는지 알 방법도 없었다.

이슈가 함께 짚은 `device_id` 전달과 push token 등록 타이밍은 조사 결과 **이미 성립한다** — `RemoteAPIImple.defaultHeader()` 가 모든 요청에 `device_id` 를 싣고(App Group 공유 `install_id`), APNs/FCM 토큰 발급은 알림 권한과 무관하게 launch 시점에 끝나 있어 권한 획득 직후 커맨드를 보내도 갭이 없다. 그래서 이번 작업은 권한 확인 하나로 좁혔다.

## 접근

**권한 확인은 usecase 계층에 둔다.** 음성·키보드·이미지 세 진입이 모두 `AIAgentOrchestrationUsecase` 를 거치므로 화면 진입점(DayEventList·CalendarViewModel) 중복 없이 한 곳에서 커버되고, 마이크·음성인식 권한이 `SpeechRecognizeUsecase` 에서 처리되는 계층 배치와도 대칭이다.

**권한은 진입을 막지 않는다.** foreground 에선 `AICommandUsecaseImple` 의 폴링이 결과를 받으므로 권한 없이도 앱 안에서는 성립한다. 대신 거부 상태면 AIAgentScene 시트 3개에 "설정에서 알림을 켜 달라" 안내를 공통으로 띄우고, 탭하면 시스템 설정으로 보낸다. 설정에서 켜고 돌아오면 포그라운드 복귀 시 재조회가 돌아 안내가 사라진다.

**요청 지점은 `enterVoiceInput` 하나다.** 키보드·이미지 전환 버튼은 `DayEventListView.listeningContent()` 안에만 있어 `enterVoiceInput` 을 거치지 않고는 도달할 수 없다. 그래서 세 진입에 흩뿌리지 않고 여기서만 확인한다.

**알럿 순서는 await 로 강제한다.** 마이크 알럿은 조회 왕복 없이 첫 `await` 에서 바로 뜨는 반면(`AVAudioApplication.shared.recordPermission` 은 동기 프로퍼티), 알림은 `checkAuthorizationStatus()` 왕복을 거친 뒤에야 요청에 도달한다. 요청만 먼저 걸어두면 마이크 알럿이 앞선다. 알림 권한 판정을 `await` 한 뒤에야 `startListening()` 을 부르고, 기다리는 사이 `stopInput()`·키보드 전환이 들어온 경우는 `isVoiceListening` 가드로 뒤늦은 인식 시작을 막는다. `.listening(.voice)` 방출은 동기로 남겨 재진입 가드가 즉시 무장되게 했다.

부수적으로, 안내가 쓰는 "시스템 설정 열기" 구현이 코드베이스에 8벌 복제돼 있었다(`openSystemSetting` 6벌 + 이름만 다른 `openSystemNotificationSetting` 2벌). 이번 변경이 그중 2벌을 더 늘리게 돼, `Routing` 프로토콜의 요구사항 + extension 기본 구현으로 올려 전부 소거했다. `BaseRouterImple` 이 아니라 `Routing` 에 둔 이유는 `ApplicationRootRouter` 가 `BaseRouterImple` 을 상속하지 않고 `Routing` 을 직접 채택하기 때문이다.

## 유저 검증 대기

시뮬레이터·유닛 테스트로 덮이지 않아 **실기기 확인이 필요한 항목**:

- **권한 알럿 표시 순서** — 신규 설치 상태에서 마이크 버튼을 처음 눌렀을 때 알림 알럿이 먼저 뜨고, 응답한 뒤에 마이크 → 음성인식 알럿이 이어지는지. 코드에서 `await` 로 순서를 강제했고 유닛 테스트도 그 순서를 검증하지만, iOS 가 알럿을 실제로 어떻게 큐잉하는지는 실측이 필요하다.
- **음성 리스닝 중 키보드 토글** — `canEnterKeyboardInput` 이 `.listening` 상태에서 진입을 허용하므로 두 번째 알림 권한 요청이 in-flight 가 될 수 있다. `UNUserNotificationCenter` 가 두 continuation 을 어떻게 처리하는지는 코드로 확정 불가. 알럿이 떠 있으면 앱 터치가 막혀 실제 도달 가능성은 낮다고 보나 확인이 필요하다.
- **`.provisional` / `.ephemeral` 권한 상태** — `UNLocalNotificationServiceImple.checkAuthorizationStatus()` 가 이 둘에서 throw 하고, 새 코드는 fail-open 으로 안내를 띄우지 않는다. provisional 은 조용히 배달되는 상태라 안내를 안 띄우는 게 맞아 보이지만 앱이 이 상태에 도달하는 경로가 있는지는 미확인.


