### PR TITLE
서비스 이용 가이드 스크린샷을 언어별로 촬영한다

### DIFF
--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -49,7 +49,15 @@ paths:
   역추적된다 — 같은 키를 대상 언어 lproj 에서 찾으면 그게 정답 문구다.
 - 링크 대상 파일·이미지 URL·헤딩 구조는 en 과 같게 두고, **헤딩 앵커만 번역된 헤딩을 따라간다**
   (`#foremost-event` → ko `#제일-중요한-이벤트`).
-- 스크린샷은 `guide/images/` 영문 1벌을 절대 URL 로 전 언어가 공유한다 — 언어별로 다시 찍지 않는다.
+- **스크린샷은 언어별로 찍는다.** `scripts/capture-guide-screenshots.sh <언어>...` 로 촬영해
+  (언어당 약 1분 40초, 백그라운드로 돌리면 시간 제한에 걸리니 **4개씩 포그라운드**로 끊는다)
+  `guide/images/<언어>/` 에 넣고, `scripts/rewrite-guide-image-lang.py <terms-repo> --write` 로
+  본문 URL 을 그 언어 경로로 돌린다. **en 만은 `en/` 을 만들지 말고 루트 `guide/images/` 를 덮어쓴다** —
+  거기가 en 겸 폴백 자리다. md 는 정적이라 폴백이 없어서, 촬영이 밀린 언어는 루트를 계속 가리켜야
+  이미지가 안 깨진다.
+  화면 속 더미 텍스트의 번역은 `SnapshotTestHelpKit` 의 `CatalogStrings.strings` 소관 (app-catalog 스킬 §2).
+- **AI 명령·응답문의 정본은 그 언어 가이드 본문이다.** `02-ai-input.md` 가 같은 예시 문장을 인용하고
+  있어서, 스샷과 본문이 어긋나면 독자가 같은 예시로 못 읽는다.
 - 검증: `python3 scripts/check-guide-parity.py <terms-repo-경로>` (언어 생략 = 전 언어) 0 위반.
 
 ## 2. 번역 원칙

--- a/.claude/skills/app-catalog/SKILL.md
+++ b/.claude/skills/app-catalog/SKILL.md
@@ -17,7 +17,10 @@ description: Use when producing full-screen snapshot images of app scenes for ex
 
 - 화면당 대표 상태 1개(정보가 풍부한 상태)로 구성. 상태 조합 나열 금지 — 그건 snapshot-check의 검증 영역.
 - 구성 소스 우선순위: ① 대상 뷰 파일의 #Preview/PreviewProvider (더미 구성 그대로 재사용) ② TestDoubles의 Dummies·Stub ③ 직접 구성.
-- 라이트·다크 pair 자동(captureSnapshotPair), 언어 en 고정. layout은 풀스크린 화면이면 `.fullScreen`, 위젯·부분 컴포넌트면 `.fixed`.
+- 라이트·다크 pair 자동(captureSnapshotPair). layout은 풀스크린 화면이면 `.fullScreen`, 위젯·부분 컴포넌트면 `.fixed`.
+- **더미 텍스트는 하드코딩하지 않는다.** 화면에 뜨는 문구는 두 갈래다:
+  - 실제 화면에서 로컬라이즈된 값이 들어가는 자리(반복 주기·알림 시각·태그명·`Todo` 배지)는 **프로덕션 경로로 만든다** — 키를 `.localized()` 로 부르거나, 도메인 모델을 세워 프로덕션 이니셜라이저(`TodoEventCellViewModel(_:in:_:_:)` 등)에 넘긴다. 손으로 적은 문자열은 프로덕션이 실제로 그리는 값과 어긋나기 쉽다.
+  - 유저가 입력했을 법한 콘텐츠(이벤트 이름·메모·AI 명령문)는 `SnapshotTestHelpKit` 의 `Resources/<lang>.lproj/CatalogStrings.strings` 에 넣고 `"키".catalogLocalized()` 로 부른다. **앱 lproj 에 넣지 않는다** — 프로덕션에 안 뜨는 문구가 앱 번들과 파리티 검사에 섞인다.
 - **캡처 호출에 `snapshotDirectory: catalogSnapshotDirectory()` 필수** — 검증용 기본 경로(`__Snapshots__/`)와 격리해 `snapshot-catalog/<Framework>/<스위트>/`에 기록한다.
 
 ## 3. 촬영·수집
@@ -26,9 +29,14 @@ description: Use when producing full-screen snapshot images of app scenes for ex
 
 ```bash
 xcodebuild test -workspace TodoCalendar.xcworkspace -scheme <Name>Snapshots \
+  -only-testing:<Name>Snapshots/<Name>CatalogSnapshots \
   -destination 'platform=iOS Simulator,name=iPhone 17 - snapshot_ref,OS=26.2' \
-  -testLanguage en -testRegion en_US | xcpretty
+  -testLanguage <언어> -testRegion <언어>_<지역> | xcpretty
 ```
+
+- **`-only-testing` 은 필수다.** 같은 스킴에 검증 스위트(`__Snapshots__/`, 커밋 대상)가 함께 살아서, 한정하지 않으면 그쪽이 이 언어·이 시점으로 재기록돼 워킹트리가 오염된다. 실행 후 `git status --short -- '*__Snapshots__*'` 가 비어 있어야 한다.
+- **언어는 요청받은 것으로 바꾼다.** 지정이 없으면 en/en_US.
+- 서비스 이용 가이드용 전 언어 촬영은 `scripts/capture-guide-screenshots.sh` 가 위 절차와 파일명 매핑을 감싼다 (`.claude/rules/localization.md` §1 가이드 절).
 
 - **기기 변경 가능**: 유저가 다른 기기·OS로 요청하면 `-destination`의 name/OS 교체 (`xcrun simctl list devices available`로 가용 확인). 여러 기기 세트 요청이면 destination만 바꿔 반복 실행.
 - 기본 시뮬레이터가 없으면 생성: `xcrun simctl create 'iPhone 17 - snapshot_ref' 'iPhone 17' iOS26.2`.

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ snapshot-catalog/
 
 ### Service guide 원고 — 산출물은 sudopark/TodoCalendar-Terms 의 guide/ 로 올라간다 ###
 docs/service-guide/
+snapshot-guide/

--- a/Presentations/AIAgentScene/Snapshots/AIAgentSceneCatalogSnapshots.swift
+++ b/Presentations/AIAgentScene/Snapshots/AIAgentSceneCatalogSnapshots.swift
@@ -54,8 +54,8 @@ final class AIAgentSceneCatalogSnapshots: XCTestCase {
         ) { theme in
             let state = AIAgentCommandViewState()
             state.commandState = .done(
-                command: "Lunch with Sara on Friday at noon",
-                message: "Added “Lunch with Sara” to Friday, March 13 at 12:00 PM."
+                command: "catalog.ai::command".catalogLocalized(),
+                message: "catalog.ai::result".catalogLocalized()
             )
             state.usage = AIAgentUsage(input: 3200, output: 0, limit: 20000)
                 |> \.creditsUsed .~ 3200

--- a/Presentations/CalendarScenes/Snapshots/CalendarScenesCatalogSnapshots.swift
+++ b/Presentations/CalendarScenes/Snapshots/CalendarScenesCatalogSnapshots.swift
@@ -12,6 +12,7 @@ import Combine
 import Prelude
 import Optics
 import Domain
+import Extensions
 import CommonPresentation
 import SnapshotTestHelpKit
 
@@ -84,16 +85,7 @@ private final class CatalogMonthViewModel: MonthViewModel, @unchecked Sendable {
     private let selectedDay = CurrentValueSubject<String?, Never>("2026-3-12")
 
     var weekDays: AnyPublisher<[WeekDayModel], Never> {
-        return Just([
-            .init(symbol: "SUN", "SUN", isSunday: true),
-            .init(symbol: "MON", "MON"),
-            .init(symbol: "TUE", "TUE"),
-            .init(symbol: "WED", "WED"),
-            .init(symbol: "THU", "THU"),
-            .init(symbol: "FRI", "FRI"),
-            .init(symbol: "SAT", "SAT", isSaturday: true)
-        ])
-        .eraseToAnyPublisher()
+        return Just(WeekDayModel.allModels()).eraseToAnyPublisher()
     }
 
     var weekModels: AnyPublisher<[WeekRowModel], Never> {
@@ -141,24 +133,24 @@ private final class CatalogMonthViewModel: MonthViewModel, @unchecked Sendable {
         switch weekId {
         case "week:0":
             lines = [
-                [self.event("holiday", "Independence Movement Day", days: [1], seq: 1...1, ids: ["2026-3-1"])],
-                [self.event("kickoff", "Project kickoff", days: [3, 4], seq: 3...4, ids: ["2026-3-3", "2026-3-4"])],
-                [self.event("dentist", "Dentist", days: [5], seq: 5...5, ids: ["2026-3-5"], hasPeriod: false)]
+                [self.event("holiday", "catalog.event::holiday".catalogLocalized(), days: [1], seq: 1...1, ids: ["2026-3-1"])],
+                [self.event("kickoff", "catalog.event::project_kickoff".catalogLocalized(), days: [3, 4], seq: 3...4, ids: ["2026-3-3", "2026-3-4"])],
+                [self.event("dentist", "catalog.event::dentist".catalogLocalized(), days: [5], seq: 5...5, ids: ["2026-3-5"], hasPeriod: false)]
             ]
         case "week:1":
             lines = [
-                [self.event("trip", "Jeju trip", days: [2, 3, 4], seq: 2...4, ids: ["2026-3-9", "2026-3-10", "2026-3-11"])],
-                [self.event("review", "Design review", days: [5], seq: 5...5, ids: ["2026-3-12"], hasPeriod: false)],
-                [self.event("dinner", "Dinner with Sara", days: [6], seq: 6...6, ids: ["2026-3-13"], hasPeriod: false)]
+                [self.event("trip", "catalog.event::trip".catalogLocalized(), days: [2, 3, 4], seq: 2...4, ids: ["2026-3-9", "2026-3-10", "2026-3-11"])],
+                [self.event("review", "catalog.event::design_review".catalogLocalized(), days: [5], seq: 5...5, ids: ["2026-3-12"], hasPeriod: false)],
+                [self.event("dinner", "catalog.event::dinner".catalogLocalized(), days: [6], seq: 6...6, ids: ["2026-3-13"], hasPeriod: false)]
             ]
         case "week:2":
             lines = [
-                [self.event("sprint", "Sprint planning", days: [2], seq: 2...2, ids: ["2026-3-16"], hasPeriod: false)],
-                [self.event("workshop", "Team workshop", days: [5, 6], seq: 5...6, ids: ["2026-3-19", "2026-3-20"])]
+                [self.event("sprint", "catalog.event::sprint_planning".catalogLocalized(), days: [2], seq: 2...2, ids: ["2026-3-16"], hasPeriod: false)],
+                [self.event("workshop", "catalog.event::team_workshop".catalogLocalized(), days: [5, 6], seq: 5...6, ids: ["2026-3-19", "2026-3-20"])]
             ]
         case "week:3":
             lines = [
-                [self.event("release", "Release day", days: [3], seq: 3...3, ids: ["2026-3-24"], hasPeriod: false)]
+                [self.event("release", "catalog.event::release_day".catalogLocalized(), days: [3], seq: 3...3, ids: ["2026-3-24"], hasPeriod: false)]
             ]
         default:
             lines = []
@@ -217,39 +209,59 @@ private struct CatalogCalendarEvent: CalendarEvent {
 /// DayEventListViewState 의 필드가 fileprivate 라 bind(viewModel:appearance:) 경로로만 채울 수 있다.
 private final class CatalogDayEventListViewModel: DayEventListViewModel, @unchecked Sendable {
 
-    private let foremost = TodoEventCellViewModel("foremost", name: "Submit the tax return")
-        |> \.periodText .~ .singleText(.init(text: "Todo"))
+    private enum Constant {
+        /// 2026-03-12(목) 00:00 ~ 03-13 00:00 KST
+        static let todayRange: Range<TimeInterval> = 1_773_241_200..<1_773_327_600
+        static let uncompletedTodoTime: TimeInterval = 1_773_279_000     // 10:30
+        static let designReviewTime: TimeInterval = 1_773_275_400        // 09:30
+        static let lunchPeriod: Range<TimeInterval> = 1_773_284_400..<1_773_288_000  // 12:00~13:00
+        /// 03-09 ~ 03-11 종일 — upperBound 가 03-11 00:00 이라 3일로 표시된다
+        static let tripPeriod: Range<TimeInterval> = 1_772_982_000..<1_773_154_800
+    }
 
-    private let uncompleteds: [TodoEventCellViewModel] = [
-        TodoEventCellViewModel("uncompleted", name: "Reply to the landlord")
-            |> \.periodText .~ .doubleText(.init(text: "Todo"), .init(text: "10:30", pmOram: "AM"))
-    ]
+    private let timeZone = TimeZone(identifier: "Asia/Seoul")!
 
-    private let cells: [any EventCellViewModel] = {
+    private lazy var foremost: TodoEventCellViewModel = self.currentTodoCell(
+        "foremost", "catalog.todo::tax_return".catalogLocalized(), isForemost: true
+    )
+
+    private lazy var uncompleteds: [TodoEventCellViewModel] = {
+        let todo = TodoEvent(uuid: "uncompleted", name: "catalog.todo::reply_landlord".catalogLocalized())
+            |> \.time .~ .at(Constant.uncompletedTodoTime)
+        let event = TodoCalendarEvent(todo, in: self.timeZone)
+        return TodoEventCellViewModel(event, in: Constant.todayRange, self.timeZone, false)
+            .map { [$0] } ?? []
+    }()
+
+    private lazy var cells: [any EventCellViewModel] = {
         let todos: [TodoEventCellViewModel] = [
-            TodoEventCellViewModel("todo1", name: "Water the plants")
-                |> \.periodText .~ .singleText(.init(text: "Todo")),
-            TodoEventCellViewModel("todo2", name: "Book the flight")
-                |> \.periodText .~ .singleText(.init(text: "Todo"))
+            self.currentTodoCell("todo1", "catalog.todo::water_plants".catalogLocalized()),
+            self.currentTodoCell("todo2", "catalog.todo::book_flight".catalogLocalized())
         ]
         let schedules: [ScheduleEventCellViewModel] = [
-            ScheduleEventCellViewModel("sc1", name: "Design review")
-                |> \.periodText .~ .singleText(.init(text: "9:30", pmOram: "AM")),
-            ScheduleEventCellViewModel("sc2", name: "Lunch with Sara")
-                |> \.periodText .~ .doubleText(
-                    .init(text: "12:00", pmOram: "PM"),
-                    .init(text: "1:00", pmOram: "PM")
-                )
-                |> \.periodDescription .~ "Mar 12 12:00 ~ Mar 12 13:00 (1 hour)",
-            ScheduleEventCellViewModel("sc3", name: "Jeju trip")
-                |> \.periodText .~ .doubleText(
-                    .init(text: "Mar 9"),
-                    .init(text: "Mar 11")
-                )
-                |> \.periodDescription .~ "Mar 9 ~ Mar 11 (3 days)"
+            ScheduleEvent(uuid: "sc1", name: "catalog.event::design_review".catalogLocalized(), time: .at(Constant.designReviewTime)),
+            ScheduleEvent(uuid: "sc2", name: "catalog.event::lunch".catalogLocalized(), time: .period(Constant.lunchPeriod)),
+            ScheduleEvent(
+                uuid: "sc3", name: "catalog.event::trip".catalogLocalized(),
+                time: .allDay(Constant.tripPeriod, secondsFromGMT: TimeInterval(self.timeZone.secondsFromGMT()))
+            )
         ]
+        .flatMap { ScheduleCalendarEvent.events(from: $0, in: self.timeZone) }
+        .compactMap {
+            ScheduleEventCellViewModel($0, in: Constant.todayRange, timeZone: self.timeZone, false)
+        }
         return todos + schedules
     }()
+
+    private func currentTodoCell(
+        _ id: String, _ name: String, isForemost: Bool = false
+    ) -> TodoEventCellViewModel {
+        return TodoEventCellViewModel(
+            currentTodo: TodoCalendarEvent(
+                current: TodoEvent(uuid: id, name: name), isForemost: isForemost
+            )
+        )
+    }
 
     var foremostEventModel: AnyPublisher<(any EventCellViewModel)?, Never> {
         Just(self.foremost).eraseToAnyPublisher()
@@ -258,7 +270,11 @@ private final class CatalogDayEventListViewModel: DayEventListViewModel, @unchec
         Just(self.uncompleteds).eraseToAnyPublisher()
     }
     var selectedDay: AnyPublisher<SelectedDayModel, Never> {
-        Just(SelectedDayModel(dateText: "Thursday, March 12, 2026", lunarDateText: "")).eraseToAnyPublisher()
+        let currentDay = CurrentSelectDayModel(
+            2026, 3, 12, weekId: "week:1", range: Constant.todayRange
+        )
+        return Just(SelectedDayModel(self.timeZone, currentModel: currentDay))
+            .eraseToAnyPublisher()
     }
     var cellViewModels: AnyPublisher<[any EventCellViewModel], Never> {
         Just(self.cells).eraseToAnyPublisher()

--- a/Presentations/EventDetailScene/Snapshots/EventDetailSceneCatalogSnapshots.swift
+++ b/Presentations/EventDetailScene/Snapshots/EventDetailSceneCatalogSnapshots.swift
@@ -40,16 +40,16 @@ final class EventDetailSceneCatalogSnapshots: XCTestCase {
         ) { theme in
             let state = EventDetailViewState()
             state.eventDetailTypeModel = .todoCase()
-            state.enterName = "Design review"
-            state.selectedTag = .init(.default, "Default", "#088CDA")
+            state.enterName = "catalog.event::design_review".catalogLocalized()
+            state.selectedTag = .init(.default, "eventTag.defaults.default::name".localized(), "#088CDA")
             state.selectedTime = .period(
                 .init(self.start, .current), .init(self.end, .current)
             )
-            state.selectedRepeat = "Every 2 Weeks Thursday"
-            state.selectedNotificationTimeText = "10 minute(s) before the event"
-            state.enterPlaceName = "Seoul Startup Hub"
-            state.selectedPlace = .customPlace("Seoul Startup Hub")
-            state.memo = "Bring the printed wireframes."
+            state.selectedRepeat = "eventDetail.repeating.everySomeWeek:title".localized(with: 2)
+            state.selectedNotificationTimeText = "event_notification_setting::option_title::before_minutes".localized(with: 10)
+            state.enterPlaceName = "catalog.place::startup_hub".catalogLocalized()
+            state.selectedPlace = .customPlace("catalog.place::startup_hub".catalogLocalized())
+            state.memo = "catalog.memo::wireframes".catalogLocalized()
             state.isSavable = true
             return EventDetailView()
                 .environment(state)

--- a/Presentations/EventListScenes/Snapshots/EventListScenesCatalogSnapshots.swift
+++ b/Presentations/EventListScenes/Snapshots/EventListScenesCatalogSnapshots.swift
@@ -41,9 +41,9 @@ final class EventListScenesCatalogSnapshots: XCTestCase {
             let lastMonth: TimeInterval = 1_770_690_600 // 2026-02-10 09:30 KST
             let lastYear: TimeInterval = 1_752_452_000  // 2025-07-14 KST
 
-            let recentNames = ["Water the plants", "Reply to the landlord", "Book the flight"]
-            let lastMonthNames = ["Renew the passport", "Send the invoice"]
-            let lastYearNames = ["Cancel the old subscription", "Return the library books"]
+            let recentNames = ["catalog.todo::water_plants".catalogLocalized(), "catalog.todo::reply_landlord".catalogLocalized(), "catalog.todo::book_flight".catalogLocalized()]
+            let lastMonthNames = ["catalog.todo::renew_passport".catalogLocalized(), "catalog.todo::send_invoice".catalogLocalized()]
+            let lastYearNames = ["catalog.todo::cancel_subscription".catalogLocalized(), "catalog.todo::return_books".catalogLocalized()]
 
             let recentEvents = recentNames.enumerated().map { idx, name in
                 DoneTodoEvent(

--- a/Presentations/SettingScene/Snapshots/SettingSceneCatalogSnapshots.swift
+++ b/Presentations/SettingScene/Snapshots/SettingSceneCatalogSnapshots.swift
@@ -110,10 +110,10 @@ extension SettingSceneCatalogSnapshots {
         ) { theme in
             let state = EventTagListViewState()
             let tags: [(String, String)] = [
-                ("Work", "#088CDA"),
-                ("Family", "#F9316D"),
-                ("Health", "#3CB371"),
-                ("Study", "#FFA02E")
+                ("catalog.tag::work".catalogLocalized(), "#088CDA"),
+                ("catalog.tag::family".catalogLocalized(), "#F9316D"),
+                ("catalog.tag::health".catalogLocalized(), "#3CB371"),
+                ("catalog.tag::study".catalogLocalized(), "#FFA02E")
             ]
             let customTags = tags.enumerated().map { idx, pair in
                 CustomEventTag(uuid: "tag:\(idx)", name: pair.0, colorHex: pair.1)

--- a/Supports/SnapshotTestHelpKit/Project.swift
+++ b/Supports/SnapshotTestHelpKit/Project.swift
@@ -5,6 +5,7 @@ let project = Project.framework(
     name: "SnapshotTestHelpKit",
     destinations: [.iPhone],
     iOSTargetVersion: "17.0",
+    resources: ["Resources/**"],
     dependencies: [
         .external(name: "SnapshotTesting"),
         .xctest

--- a/Supports/SnapshotTestHelpKit/Resources/ca.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/ca.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Dia del Moviment d'Independència";
+"catalog.event::project_kickoff" = "Inici del projecte";
+"catalog.event::dentist" = "Dentista";
+"catalog.event::trip" = "Viatge a Jeju";
+"catalog.event::design_review" = "Revisió de disseny";
+"catalog.event::dinner" = "Sopar amb la Sara";
+"catalog.event::sprint_planning" = "Planificació de l'sprint";
+"catalog.event::team_workshop" = "Taller d'equip";
+"catalog.event::release_day" = "Dia del llançament";
+"catalog.event::lunch" = "Dinar amb la Sara";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Presentar la declaració";
+"catalog.todo::reply_landlord" = "Respondre al propietari";
+"catalog.todo::water_plants" = "Regar les plantes";
+"catalog.todo::book_flight" = "Reservar el vol";
+"catalog.todo::renew_passport" = "Renovar el passaport";
+"catalog.todo::send_invoice" = "Enviar la factura";
+"catalog.todo::cancel_subscription" = "Cancel·lar la subscripció que no faig servir";
+"catalog.todo::return_books" = "Tornar els llibres de la biblioteca";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Portar els wireframes impresos.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Feina";
+"catalog.tag::family" = "Família";
+"catalog.tag::health" = "Salut";
+"catalog.tag::study" = "Estudis";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "dinar amb la Sara divendres al migdia";
+"catalog.ai::result" = "«Dinar amb la Sara» afegit al divendres 13 de març a les 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/cs.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/cs.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Den hnutí za nezávislost";
+"catalog.event::project_kickoff" = "Zahájení projektu";
+"catalog.event::dentist" = "Zubař";
+"catalog.event::trip" = "Cesta na Čedžu";
+"catalog.event::design_review" = "Design review";
+"catalog.event::dinner" = "Večeře se Sárou";
+"catalog.event::sprint_planning" = "Plánování sprintu";
+"catalog.event::team_workshop" = "Týmový workshop";
+"catalog.event::release_day" = "Den vydání";
+"catalog.event::lunch" = "Oběd se Sárou";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Podat daňové přiznání";
+"catalog.todo::reply_landlord" = "Odpovědět majiteli bytu";
+"catalog.todo::water_plants" = "Zalít květiny";
+"catalog.todo::book_flight" = "Rezervovat let";
+"catalog.todo::renew_passport" = "Obnovit pas";
+"catalog.todo::send_invoice" = "Poslat fakturu";
+"catalog.todo::cancel_subscription" = "Zrušit nepoužívané předplatné";
+"catalog.todo::return_books" = "Vrátit knihy do knihovny";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Vzít vytištěné drátěné modely.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Práce";
+"catalog.tag::family" = "Rodina";
+"catalog.tag::health" = "Zdraví";
+"catalog.tag::study" = "Studium";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "oběd se Sárou v pátek v poledne";
+"catalog.ai::result" = "„Oběd se Sárou“ byl přidán na pátek 13. března ve 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/da.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/da.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Uafhængighedsbevægelsens dag";
+"catalog.event::project_kickoff" = "Projektopstart";
+"catalog.event::dentist" = "Tandlæge";
+"catalog.event::trip" = "Rejse til Jeju";
+"catalog.event::design_review" = "Designgennemgang";
+"catalog.event::dinner" = "Middag med Sara";
+"catalog.event::sprint_planning" = "Sprintplanlægning";
+"catalog.event::team_workshop" = "Teamworkshop";
+"catalog.event::release_day" = "Releasedag";
+"catalog.event::lunch" = "Frokost med Sara";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Indsend selvangivelsen";
+"catalog.todo::reply_landlord" = "Svar udlejeren";
+"catalog.todo::water_plants" = "Vand planterne";
+"catalog.todo::book_flight" = "Book flybilletten";
+"catalog.todo::renew_passport" = "Forny passet";
+"catalog.todo::send_invoice" = "Send fakturaen";
+"catalog.todo::cancel_subscription" = "Opsig det abonnement jeg ikke bruger";
+"catalog.todo::return_books" = "Aflever biblioteksbøgerne";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Tag de printede wireframes med.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Arbejde";
+"catalog.tag::family" = "Familie";
+"catalog.tag::health" = "Sundhed";
+"catalog.tag::study" = "Studie";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "frokost med Sara fredag kl. 12";
+"catalog.ai::result" = "“Frokost med Sara” er tilføjet fredag den 13. marts kl. 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/de.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/de.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Tag der Unabhängigkeitsbewegung";
+"catalog.event::project_kickoff" = "Projekt-Kickoff";
+"catalog.event::dentist" = "Zahnarzt";
+"catalog.event::trip" = "Reise nach Jeju";
+"catalog.event::design_review" = "Design-Review";
+"catalog.event::dinner" = "Abendessen mit Sara";
+"catalog.event::sprint_planning" = "Sprint-Planung";
+"catalog.event::team_workshop" = "Team-Workshop";
+"catalog.event::release_day" = "Release-Tag";
+"catalog.event::lunch" = "Mittagessen mit Sara";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Steuererklärung abgeben";
+"catalog.todo::reply_landlord" = "Dem Vermieter antworten";
+"catalog.todo::water_plants" = "Pflanzen gießen";
+"catalog.todo::book_flight" = "Flug buchen";
+"catalog.todo::renew_passport" = "Reisepass verlängern";
+"catalog.todo::send_invoice" = "Rechnung verschicken";
+"catalog.todo::cancel_subscription" = "Ungenutztes Abo kündigen";
+"catalog.todo::return_books" = "Bibliotheksbücher zurückgeben";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Ausgedruckte Wireframes mitnehmen.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Arbeit";
+"catalog.tag::family" = "Familie";
+"catalog.tag::health" = "Gesundheit";
+"catalog.tag::study" = "Lernen";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "Mittagessen mit Sara am Freitag um 12 Uhr";
+"catalog.ai::result" = "„Mittagessen mit Sara“ wurde für Freitag, 13. März, 12:00 Uhr hinzugefügt.";

--- a/Supports/SnapshotTestHelpKit/Resources/el.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/el.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Ημέρα του Κινήματος Ανεξαρτησίας";
+"catalog.event::project_kickoff" = "Εκκίνηση έργου";
+"catalog.event::dentist" = "Οδοντίατρος";
+"catalog.event::trip" = "Ταξίδι στο Τζέτζου";
+"catalog.event::design_review" = "Επισκόπηση σχεδιασμού";
+"catalog.event::dinner" = "Δείπνο με τη Σάρα";
+"catalog.event::sprint_planning" = "Σχεδιασμός sprint";
+"catalog.event::team_workshop" = "Εργαστήριο ομάδας";
+"catalog.event::release_day" = "Ημέρα κυκλοφορίας";
+"catalog.event::lunch" = "Μεσημεριανό με τη Σάρα";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Υποβολή φορολογικής δήλωσης";
+"catalog.todo::reply_landlord" = "Απάντηση στον ιδιοκτήτη";
+"catalog.todo::water_plants" = "Πότισμα των φυτών";
+"catalog.todo::book_flight" = "Κράτηση πτήσης";
+"catalog.todo::renew_passport" = "Ανανέωση διαβατηρίου";
+"catalog.todo::send_invoice" = "Αποστολή τιμολογίου";
+"catalog.todo::cancel_subscription" = "Ακύρωση αχρησιμοποίητης συνδρομής";
+"catalog.todo::return_books" = "Επιστροφή βιβλίων στη βιβλιοθήκη";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Να πάρω τα εκτυπωμένα wireframes.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Δουλειά";
+"catalog.tag::family" = "Οικογένεια";
+"catalog.tag::health" = "Υγεία";
+"catalog.tag::study" = "Μελέτη";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "μεσημεριανό με τη Σάρα την Παρασκευή στις 12";
+"catalog.ai::result" = "Το «Μεσημεριανό με τη Σάρα» προστέθηκε την Παρασκευή 13 Μαρτίου στις 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/en.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/en.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Independence Movement Day";
+"catalog.event::project_kickoff" = "Project kickoff";
+"catalog.event::dentist" = "Dentist";
+"catalog.event::trip" = "Jeju trip";
+"catalog.event::design_review" = "Design review";
+"catalog.event::dinner" = "Dinner with Sara";
+"catalog.event::sprint_planning" = "Sprint planning";
+"catalog.event::team_workshop" = "Team workshop";
+"catalog.event::release_day" = "Release day";
+"catalog.event::lunch" = "Lunch with Sara";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Submit the tax return";
+"catalog.todo::reply_landlord" = "Reply to the landlord";
+"catalog.todo::water_plants" = "Water the plants";
+"catalog.todo::book_flight" = "Book the flight";
+"catalog.todo::renew_passport" = "Renew the passport";
+"catalog.todo::send_invoice" = "Send the invoice";
+"catalog.todo::cancel_subscription" = "Cancel the old subscription";
+"catalog.todo::return_books" = "Return the library books";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Bring the printed wireframes.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Work";
+"catalog.tag::family" = "Family";
+"catalog.tag::health" = "Health";
+"catalog.tag::study" = "Study";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "Lunch with Sara on Friday at noon";
+"catalog.ai::result" = "Added “Lunch with Sara” to Friday, March 13 at 12:00 PM.";

--- a/Supports/SnapshotTestHelpKit/Resources/es.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/es.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Día del Movimiento de Independencia";
+"catalog.event::project_kickoff" = "Inicio del proyecto";
+"catalog.event::dentist" = "Dentista";
+"catalog.event::trip" = "Viaje a Jeju";
+"catalog.event::design_review" = "Revisión de diseño";
+"catalog.event::dinner" = "Cena con Sara";
+"catalog.event::sprint_planning" = "Planificación del sprint";
+"catalog.event::team_workshop" = "Taller de equipo";
+"catalog.event::release_day" = "Día de lanzamiento";
+"catalog.event::lunch" = "Comida con Sara";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Presentar la declaración";
+"catalog.todo::reply_landlord" = "Responder al casero";
+"catalog.todo::water_plants" = "Regar las plantas";
+"catalog.todo::book_flight" = "Reservar el vuelo";
+"catalog.todo::renew_passport" = "Renovar el pasaporte";
+"catalog.todo::send_invoice" = "Enviar la factura";
+"catalog.todo::cancel_subscription" = "Cancelar la suscripción que no uso";
+"catalog.todo::return_books" = "Devolver los libros de la biblioteca";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Llevar los wireframes impresos.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Trabajo";
+"catalog.tag::family" = "Familia";
+"catalog.tag::health" = "Salud";
+"catalog.tag::study" = "Estudio";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "comida con Sara el viernes a mediodía";
+"catalog.ai::result" = "Se ha añadido «Comida con Sara» al viernes 13 de marzo a las 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/fi.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/fi.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Itsenäisyysliikkeen päivä";
+"catalog.event::project_kickoff" = "Projektin aloitus";
+"catalog.event::dentist" = "Hammaslääkäri";
+"catalog.event::trip" = "Matka Jejulle";
+"catalog.event::design_review" = "Designkatselmus";
+"catalog.event::dinner" = "Illallinen Saran kanssa";
+"catalog.event::sprint_planning" = "Sprintin suunnittelu";
+"catalog.event::team_workshop" = "Tiimityöpaja";
+"catalog.event::release_day" = "Julkaisupäivä";
+"catalog.event::lunch" = "Lounas Saran kanssa";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Lähetä veroilmoitus";
+"catalog.todo::reply_landlord" = "Vastaa vuokranantajalle";
+"catalog.todo::water_plants" = "Kastele kasvit";
+"catalog.todo::book_flight" = "Varaa lento";
+"catalog.todo::renew_passport" = "Uusi passi";
+"catalog.todo::send_invoice" = "Lähetä lasku";
+"catalog.todo::cancel_subscription" = "Irtisano käyttämätön tilaus";
+"catalog.todo::return_books" = "Palauta kirjastokirjat";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Ota tulostetut rautalankamallit mukaan.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Työ";
+"catalog.tag::family" = "Perhe";
+"catalog.tag::health" = "Terveys";
+"catalog.tag::study" = "Opiskelu";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "lounas Saran kanssa perjantaina keskipäivällä";
+"catalog.ai::result" = "”Lounas Saran kanssa” lisättiin perjantaille 13. maaliskuuta klo 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/fr.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/fr.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Jour du Mouvement d'indépendance";
+"catalog.event::project_kickoff" = "Lancement du projet";
+"catalog.event::dentist" = "Dentiste";
+"catalog.event::trip" = "Voyage à Jeju";
+"catalog.event::design_review" = "Revue de design";
+"catalog.event::dinner" = "Dîner avec Sara";
+"catalog.event::sprint_planning" = "Planification du sprint";
+"catalog.event::team_workshop" = "Atelier d'équipe";
+"catalog.event::release_day" = "Jour de la release";
+"catalog.event::lunch" = "Déjeuner avec Sara";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Envoyer la déclaration d'impôts";
+"catalog.todo::reply_landlord" = "Répondre au propriétaire";
+"catalog.todo::water_plants" = "Arroser les plantes";
+"catalog.todo::book_flight" = "Réserver le vol";
+"catalog.todo::renew_passport" = "Renouveler le passeport";
+"catalog.todo::send_invoice" = "Envoyer la facture";
+"catalog.todo::cancel_subscription" = "Résilier l'abonnement inutilisé";
+"catalog.todo::return_books" = "Rendre les livres de la bibliothèque";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Apporter les wireframes imprimés.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Travail";
+"catalog.tag::family" = "Famille";
+"catalog.tag::health" = "Santé";
+"catalog.tag::study" = "Études";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "déjeuner avec Sara vendredi à midi";
+"catalog.ai::result" = "« Déjeuner avec Sara » ajouté au vendredi 13 mars à 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/hi.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/hi.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "स्वतंत्रता आंदोलन दिवस";
+"catalog.event::project_kickoff" = "प्रोजेक्ट किकऑफ़";
+"catalog.event::dentist" = "डेंटिस्ट";
+"catalog.event::trip" = "जेजू की यात्रा";
+"catalog.event::design_review" = "डिज़ाइन रिव्यू";
+"catalog.event::dinner" = "सारा के साथ डिनर";
+"catalog.event::sprint_planning" = "स्प्रिंट प्लानिंग";
+"catalog.event::team_workshop" = "टीम वर्कशॉप";
+"catalog.event::release_day" = "रिलीज़ का दिन";
+"catalog.event::lunch" = "सारा के साथ लंच";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "टैक्स रिटर्न भरना";
+"catalog.todo::reply_landlord" = "मकान मालिक को जवाब देना";
+"catalog.todo::water_plants" = "पौधों में पानी देना";
+"catalog.todo::book_flight" = "फ़्लाइट बुक करना";
+"catalog.todo::renew_passport" = "पासपोर्ट रिन्यू कराना";
+"catalog.todo::send_invoice" = "इनवॉइस भेजना";
+"catalog.todo::cancel_subscription" = "बेकार पड़ा सब्सक्रिप्शन बंद करना";
+"catalog.todo::return_books" = "लाइब्रेरी की किताबें लौटाना";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "प्रिंट किए हुए वायरफ़्रेम साथ ले जाना।";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "काम";
+"catalog.tag::family" = "परिवार";
+"catalog.tag::health" = "सेहत";
+"catalog.tag::study" = "पढ़ाई";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "शुक्रवार दोपहर सारा के साथ लंच";
+"catalog.ai::result" = "“सारा के साथ लंच” शुक्रवार, 13 मार्च दोपहर 12:00 बजे जोड़ दिया गया।";

--- a/Supports/SnapshotTestHelpKit/Resources/hr.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/hr.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Dan pokreta za nezavisnost";
+"catalog.event::project_kickoff" = "Početak projekta";
+"catalog.event::dentist" = "Zubar";
+"catalog.event::trip" = "Putovanje na Jeju";
+"catalog.event::design_review" = "Pregled dizajna";
+"catalog.event::dinner" = "Večera sa Sarom";
+"catalog.event::sprint_planning" = "Planiranje sprinta";
+"catalog.event::team_workshop" = "Timska radionica";
+"catalog.event::release_day" = "Dan izdanja";
+"catalog.event::lunch" = "Ručak sa Sarom";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Predati poreznu prijavu";
+"catalog.todo::reply_landlord" = "Odgovoriti stanodavcu";
+"catalog.todo::water_plants" = "Zaliti biljke";
+"catalog.todo::book_flight" = "Rezervirati let";
+"catalog.todo::renew_passport" = "Obnoviti putovnicu";
+"catalog.todo::send_invoice" = "Poslati račun";
+"catalog.todo::cancel_subscription" = "Otkazati pretplatu koju ne koristim";
+"catalog.todo::return_books" = "Vratiti knjige u knjižnicu";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Ponijeti isprintane žičane modele.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Posao";
+"catalog.tag::family" = "Obitelj";
+"catalog.tag::health" = "Zdravlje";
+"catalog.tag::study" = "Učenje";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "ručak sa Sarom u petak u podne";
+"catalog.ai::result" = "„Ručak sa Sarom” dodan je u petak 13. ožujka u 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/hu.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/hu.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "A függetlenségi mozgalom napja";
+"catalog.event::project_kickoff" = "Projektindító";
+"catalog.event::dentist" = "Fogorvos";
+"catalog.event::trip" = "Csedzsu-i utazás";
+"catalog.event::design_review" = "Design review";
+"catalog.event::dinner" = "Vacsora Sárával";
+"catalog.event::sprint_planning" = "Sprinttervezés";
+"catalog.event::team_workshop" = "Csapatworkshop";
+"catalog.event::release_day" = "Kiadás napja";
+"catalog.event::lunch" = "Ebéd Sárával";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Adóbevallás beadása";
+"catalog.todo::reply_landlord" = "Válasz a főbérlőnek";
+"catalog.todo::water_plants" = "Növények meglocsolása";
+"catalog.todo::book_flight" = "Repülőjegy foglalása";
+"catalog.todo::renew_passport" = "Útlevél megújítása";
+"catalog.todo::send_invoice" = "Számla elküldése";
+"catalog.todo::cancel_subscription" = "Nem használt előfizetés lemondása";
+"catalog.todo::return_books" = "Könyvtári könyvek visszavitele";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Vidd magaddal a kinyomtatott drótvázakat.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Munka";
+"catalog.tag::family" = "Család";
+"catalog.tag::health" = "Egészség";
+"catalog.tag::study" = "Tanulás";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "ebéd Sárával pénteken délben";
+"catalog.ai::result" = "Az „Ebéd Sárával” hozzáadva péntekre, március 13-ra, 12:00-ra.";

--- a/Supports/SnapshotTestHelpKit/Resources/id.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/id.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Hari Gerakan Kemerdekaan";
+"catalog.event::project_kickoff" = "Kickoff proyek";
+"catalog.event::dentist" = "Dokter gigi";
+"catalog.event::trip" = "Liburan ke Jeju";
+"catalog.event::design_review" = "Review desain";
+"catalog.event::dinner" = "Makan malam dengan Sara";
+"catalog.event::sprint_planning" = "Perencanaan sprint";
+"catalog.event::team_workshop" = "Workshop tim";
+"catalog.event::release_day" = "Hari rilis";
+"catalog.event::lunch" = "Makan siang dengan Sara";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Lapor pajak";
+"catalog.todo::reply_landlord" = "Balas pesan pemilik kos";
+"catalog.todo::water_plants" = "Siram tanaman";
+"catalog.todo::book_flight" = "Pesan tiket pesawat";
+"catalog.todo::renew_passport" = "Perpanjang paspor";
+"catalog.todo::send_invoice" = "Kirim tagihan";
+"catalog.todo::cancel_subscription" = "Berhenti langganan yang tidak dipakai";
+"catalog.todo::return_books" = "Kembalikan buku perpustakaan";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Bawa wireframe yang sudah dicetak.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Pekerjaan";
+"catalog.tag::family" = "Keluarga";
+"catalog.tag::health" = "Kesehatan";
+"catalog.tag::study" = "Belajar";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "makan siang dengan Sara Jumat pukul 12";
+"catalog.ai::result" = "“Makan siang dengan Sara” ditambahkan pada Jumat, 13 Maret pukul 12.00.";

--- a/Supports/SnapshotTestHelpKit/Resources/it.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/it.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Giorno del Movimento d'indipendenza";
+"catalog.event::project_kickoff" = "Avvio del progetto";
+"catalog.event::dentist" = "Dentista";
+"catalog.event::trip" = "Viaggio a Jeju";
+"catalog.event::design_review" = "Revisione del design";
+"catalog.event::dinner" = "Cena con Sara";
+"catalog.event::sprint_planning" = "Pianificazione dello sprint";
+"catalog.event::team_workshop" = "Workshop di team";
+"catalog.event::release_day" = "Giorno del rilascio";
+"catalog.event::lunch" = "Pranzo con Sara";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Presentare la dichiarazione dei redditi";
+"catalog.todo::reply_landlord" = "Rispondere al padrone di casa";
+"catalog.todo::water_plants" = "Annaffiare le piante";
+"catalog.todo::book_flight" = "Prenotare il volo";
+"catalog.todo::renew_passport" = "Rinnovare il passaporto";
+"catalog.todo::send_invoice" = "Inviare la fattura";
+"catalog.todo::cancel_subscription" = "Disdire l'abbonamento inutilizzato";
+"catalog.todo::return_books" = "Restituire i libri della biblioteca";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Portare i wireframe stampati.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Lavoro";
+"catalog.tag::family" = "Famiglia";
+"catalog.tag::health" = "Salute";
+"catalog.tag::study" = "Studio";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "pranzo con Sara venerdì a mezzogiorno";
+"catalog.ai::result" = "«Pranzo con Sara» aggiunto a venerdì 13 marzo alle 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/ja.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/ja.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "三一節";
+"catalog.event::project_kickoff" = "プロジェクトキックオフ";
+"catalog.event::dentist" = "歯医者";
+"catalog.event::trip" = "済州旅行";
+"catalog.event::design_review" = "デザインレビュー";
+"catalog.event::dinner" = "サラと夕食";
+"catalog.event::sprint_planning" = "スプリント計画";
+"catalog.event::team_workshop" = "チームワークショップ";
+"catalog.event::release_day" = "リリース日";
+"catalog.event::lunch" = "サラとランチ";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "確定申告を出す";
+"catalog.todo::reply_landlord" = "大家さんに返信する";
+"catalog.todo::water_plants" = "植物に水をやる";
+"catalog.todo::book_flight" = "航空券を予約する";
+"catalog.todo::renew_passport" = "パスポートを更新する";
+"catalog.todo::send_invoice" = "請求書を送る";
+"catalog.todo::cancel_subscription" = "使っていないサブスクを解約する";
+"catalog.todo::return_books" = "図書館の本を返す";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "ソウル・スタートアップハブ";
+"catalog.memo::wireframes" = "印刷したワイヤーフレームを持っていく。";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "仕事";
+"catalog.tag::family" = "家族";
+"catalog.tag::health" = "健康";
+"catalog.tag::study" = "勉強";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "金曜のお昼にサラとランチ";
+"catalog.ai::result" = "「サラとランチ」を3月13日(金)の12:00に追加しました。";

--- a/Supports/SnapshotTestHelpKit/Resources/ko.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/ko.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "삼일절";
+"catalog.event::project_kickoff" = "프로젝트 킥오프";
+"catalog.event::dentist" = "치과";
+"catalog.event::trip" = "제주 여행";
+"catalog.event::design_review" = "디자인 리뷰";
+"catalog.event::dinner" = "사라랑 저녁";
+"catalog.event::sprint_planning" = "스프린트 계획";
+"catalog.event::team_workshop" = "팀 워크숍";
+"catalog.event::release_day" = "릴리즈 날";
+"catalog.event::lunch" = "사라랑 점심";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "세금 신고하기";
+"catalog.todo::reply_landlord" = "집주인에게 답장하기";
+"catalog.todo::water_plants" = "화분에 물 주기";
+"catalog.todo::book_flight" = "항공권 예약하기";
+"catalog.todo::renew_passport" = "여권 갱신하기";
+"catalog.todo::send_invoice" = "청구서 보내기";
+"catalog.todo::cancel_subscription" = "안 쓰는 구독 해지하기";
+"catalog.todo::return_books" = "도서관 책 반납하기";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "서울 창업허브";
+"catalog.memo::wireframes" = "출력한 와이어프레임 챙기기.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "업무";
+"catalog.tag::family" = "가족";
+"catalog.tag::health" = "건강";
+"catalog.tag::study" = "공부";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "금요일 12시에 사라랑 점심";
+"catalog.ai::result" = "“사라랑 점심”을 3월 13일 금요일 오후 12시에 추가했어요.";

--- a/Supports/SnapshotTestHelpKit/Resources/ms.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/ms.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Hari Gerakan Kemerdekaan";
+"catalog.event::project_kickoff" = "Permulaan projek";
+"catalog.event::dentist" = "Doktor gigi";
+"catalog.event::trip" = "Percutian ke Jeju";
+"catalog.event::design_review" = "Semakan reka bentuk";
+"catalog.event::dinner" = "Makan malam dengan Sara";
+"catalog.event::sprint_planning" = "Perancangan sprint";
+"catalog.event::team_workshop" = "Bengkel pasukan";
+"catalog.event::release_day" = "Hari pelancaran";
+"catalog.event::lunch" = "Makan tengah hari dengan Sara";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Failkan cukai";
+"catalog.todo::reply_landlord" = "Balas mesej tuan rumah";
+"catalog.todo::water_plants" = "Siram pokok";
+"catalog.todo::book_flight" = "Tempah tiket penerbangan";
+"catalog.todo::renew_passport" = "Perbaharui pasport";
+"catalog.todo::send_invoice" = "Hantar invois";
+"catalog.todo::cancel_subscription" = "Batalkan langganan yang tidak digunakan";
+"catalog.todo::return_books" = "Pulangkan buku perpustakaan";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Bawa wireframe yang dicetak.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Kerja";
+"catalog.tag::family" = "Keluarga";
+"catalog.tag::health" = "Kesihatan";
+"catalog.tag::study" = "Belajar";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "makan tengah hari dengan Sara Jumaat tengah hari";
+"catalog.ai::result" = "“Makan tengah hari dengan Sara” ditambah pada Jumaat, 13 Mac jam 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/nb.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/nb.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Uavhengighetsbevegelsens dag";
+"catalog.event::project_kickoff" = "Prosjektoppstart";
+"catalog.event::dentist" = "Tannlege";
+"catalog.event::trip" = "Tur til Jeju";
+"catalog.event::design_review" = "Designgjennomgang";
+"catalog.event::dinner" = "Middag med Sara";
+"catalog.event::sprint_planning" = "Sprintplanlegging";
+"catalog.event::team_workshop" = "Teamworkshop";
+"catalog.event::release_day" = "Lanseringsdag";
+"catalog.event::lunch" = "Lunsj med Sara";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Lever inn skattemeldingen";
+"catalog.todo::reply_landlord" = "Svar utleieren";
+"catalog.todo::water_plants" = "Vann plantene";
+"catalog.todo::book_flight" = "Bestill flyet";
+"catalog.todo::renew_passport" = "Forny passet";
+"catalog.todo::send_invoice" = "Send fakturaen";
+"catalog.todo::cancel_subscription" = "Si opp abonnementet jeg ikke bruker";
+"catalog.todo::return_books" = "Lever tilbake bibliotekbøkene";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Ta med de utskrevne wireframene.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Arbeid";
+"catalog.tag::family" = "Familie";
+"catalog.tag::health" = "Helse";
+"catalog.tag::study" = "Studier";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "lunsj med Sara fredag kl. 12";
+"catalog.ai::result" = "«Lunsj med Sara» er lagt til fredag 13. mars kl. 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/nl.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/nl.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Dag van de Onafhankelijkheidsbeweging";
+"catalog.event::project_kickoff" = "Projectkickoff";
+"catalog.event::dentist" = "Tandarts";
+"catalog.event::trip" = "Reis naar Jeju";
+"catalog.event::design_review" = "Designreview";
+"catalog.event::dinner" = "Diner met Sara";
+"catalog.event::sprint_planning" = "Sprintplanning";
+"catalog.event::team_workshop" = "Teamworkshop";
+"catalog.event::release_day" = "Releasedag";
+"catalog.event::lunch" = "Lunch met Sara";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Belastingaangifte indienen";
+"catalog.todo::reply_landlord" = "De verhuurder antwoorden";
+"catalog.todo::water_plants" = "Planten water geven";
+"catalog.todo::book_flight" = "Vlucht boeken";
+"catalog.todo::renew_passport" = "Paspoort verlengen";
+"catalog.todo::send_invoice" = "Factuur versturen";
+"catalog.todo::cancel_subscription" = "Ongebruikt abonnement opzeggen";
+"catalog.todo::return_books" = "Bibliotheekboeken terugbrengen";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Geprinte wireframes meenemen.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Werk";
+"catalog.tag::family" = "Gezin";
+"catalog.tag::health" = "Gezondheid";
+"catalog.tag::study" = "Studie";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "vrijdag om twaalf uur lunchen met Sara";
+"catalog.ai::result" = "“Lunch met Sara” toegevoegd op vrijdag 13 maart om 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/pl.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/pl.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Dzień Ruchu Niepodległościowego";
+"catalog.event::project_kickoff" = "Kick-off projektu";
+"catalog.event::dentist" = "Dentysta";
+"catalog.event::trip" = "Wyjazd na Jeju";
+"catalog.event::design_review" = "Przegląd projektu graficznego";
+"catalog.event::dinner" = "Kolacja z Sarą";
+"catalog.event::sprint_planning" = "Planowanie sprintu";
+"catalog.event::team_workshop" = "Warsztaty zespołowe";
+"catalog.event::release_day" = "Dzień wydania";
+"catalog.event::lunch" = "Obiad z Sarą";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Złożyć zeznanie podatkowe";
+"catalog.todo::reply_landlord" = "Odpisać właścicielowi mieszkania";
+"catalog.todo::water_plants" = "Podlać kwiaty";
+"catalog.todo::book_flight" = "Zarezerwować lot";
+"catalog.todo::renew_passport" = "Wyrobić nowy paszport";
+"catalog.todo::send_invoice" = "Wysłać fakturę";
+"catalog.todo::cancel_subscription" = "Anulować nieużywaną subskrypcję";
+"catalog.todo::return_books" = "Oddać książki do biblioteki";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Zabrać wydrukowane makiety.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Praca";
+"catalog.tag::family" = "Rodzina";
+"catalog.tag::health" = "Zdrowie";
+"catalog.tag::study" = "Nauka";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "obiad z Sarą w piątek w południe";
+"catalog.ai::result" = "„Obiad z Sarą” dodano na piątek 13 marca o 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/pt-BR.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/pt-BR.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Dia do Movimento de Independência";
+"catalog.event::project_kickoff" = "Início do projeto";
+"catalog.event::dentist" = "Dentista";
+"catalog.event::trip" = "Viagem a Jeju";
+"catalog.event::design_review" = "Revisão de design";
+"catalog.event::dinner" = "Jantar com a Sara";
+"catalog.event::sprint_planning" = "Planejamento da sprint";
+"catalog.event::team_workshop" = "Workshop do time";
+"catalog.event::release_day" = "Dia do lançamento";
+"catalog.event::lunch" = "Almoço com a Sara";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Entregar a declaração de imposto";
+"catalog.todo::reply_landlord" = "Responder ao locador";
+"catalog.todo::water_plants" = "Regar as plantas";
+"catalog.todo::book_flight" = "Reservar o voo";
+"catalog.todo::renew_passport" = "Renovar o passaporte";
+"catalog.todo::send_invoice" = "Enviar a fatura";
+"catalog.todo::cancel_subscription" = "Cancelar a assinatura que não uso";
+"catalog.todo::return_books" = "Devolver os livros da biblioteca";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Levar os wireframes impressos.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Trabalho";
+"catalog.tag::family" = "Família";
+"catalog.tag::health" = "Saúde";
+"catalog.tag::study" = "Estudos";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "almoço com a Sara sexta ao meio-dia";
+"catalog.ai::result" = "“Almoço com a Sara” adicionado na sexta, 13 de março, às 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/ro.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/ro.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Ziua Mișcării de Independență";
+"catalog.event::project_kickoff" = "Startul proiectului";
+"catalog.event::dentist" = "Dentist";
+"catalog.event::trip" = "Călătorie în Jeju";
+"catalog.event::design_review" = "Revizuire de design";
+"catalog.event::dinner" = "Cină cu Sara";
+"catalog.event::sprint_planning" = "Planificarea sprintului";
+"catalog.event::team_workshop" = "Atelier de echipă";
+"catalog.event::release_day" = "Ziua lansării";
+"catalog.event::lunch" = "Prânz cu Sara";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Depune declarația fiscală";
+"catalog.todo::reply_landlord" = "Răspunde proprietarului";
+"catalog.todo::water_plants" = "Udă plantele";
+"catalog.todo::book_flight" = "Rezervă biletul de avion";
+"catalog.todo::renew_passport" = "Reînnoiește pașaportul";
+"catalog.todo::send_invoice" = "Trimite factura";
+"catalog.todo::cancel_subscription" = "Anulează abonamentul nefolosit";
+"catalog.todo::return_books" = "Returnează cărțile la bibliotecă";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Ia wireframe-urile printate.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Muncă";
+"catalog.tag::family" = "Familie";
+"catalog.tag::health" = "Sănătate";
+"catalog.tag::study" = "Studiu";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "prânz cu Sara vineri la ora 12";
+"catalog.ai::result" = "„Prânz cu Sara” a fost adăugat vineri, 13 martie, la 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/ru.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/ru.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "День движения за независимость";
+"catalog.event::project_kickoff" = "Старт проекта";
+"catalog.event::dentist" = "Стоматолог";
+"catalog.event::trip" = "Поездка на Чеджу";
+"catalog.event::design_review" = "Дизайн-ревью";
+"catalog.event::dinner" = "Ужин с Сарой";
+"catalog.event::sprint_planning" = "Планирование спринта";
+"catalog.event::team_workshop" = "Командный воркшоп";
+"catalog.event::release_day" = "День релиза";
+"catalog.event::lunch" = "Обед с Сарой";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Подать налоговую декларацию";
+"catalog.todo::reply_landlord" = "Ответить арендодателю";
+"catalog.todo::water_plants" = "Полить цветы";
+"catalog.todo::book_flight" = "Забронировать билет на самолёт";
+"catalog.todo::renew_passport" = "Продлить загранпаспорт";
+"catalog.todo::send_invoice" = "Отправить счёт";
+"catalog.todo::cancel_subscription" = "Отменить неиспользуемую подписку";
+"catalog.todo::return_books" = "Вернуть книги в библиотеку";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Взять распечатанные вайрфреймы.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Работа";
+"catalog.tag::family" = "Семья";
+"catalog.tag::health" = "Здоровье";
+"catalog.tag::study" = "Учёба";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "обед с Сарой в пятницу в полдень";
+"catalog.ai::result" = "«Обед с Сарой» добавлен на пятницу, 13 марта, 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/sk.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/sk.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Deň hnutia za nezávislosť";
+"catalog.event::project_kickoff" = "Štart projektu";
+"catalog.event::dentist" = "Zubár";
+"catalog.event::trip" = "Cesta na Čedžu";
+"catalog.event::design_review" = "Design review";
+"catalog.event::dinner" = "Večera so Sárou";
+"catalog.event::sprint_planning" = "Plánovanie šprintu";
+"catalog.event::team_workshop" = "Tímový workshop";
+"catalog.event::release_day" = "Deň vydania";
+"catalog.event::lunch" = "Obed so Sárou";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Podať daňové priznanie";
+"catalog.todo::reply_landlord" = "Odpovedať majiteľovi bytu";
+"catalog.todo::water_plants" = "Poliať kvety";
+"catalog.todo::book_flight" = "Rezervovať let";
+"catalog.todo::renew_passport" = "Obnoviť pas";
+"catalog.todo::send_invoice" = "Poslať faktúru";
+"catalog.todo::cancel_subscription" = "Zrušiť nepoužívané predplatné";
+"catalog.todo::return_books" = "Vrátiť knihy do knižnice";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Vziať vytlačené drôtené modely.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Práca";
+"catalog.tag::family" = "Rodina";
+"catalog.tag::health" = "Zdravie";
+"catalog.tag::study" = "Štúdium";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "obed so Sárou v piatok napoludnie";
+"catalog.ai::result" = "„Obed so Sárou“ bol pridaný na piatok 13. marca o 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/sv.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/sv.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Självständighetsrörelsens dag";
+"catalog.event::project_kickoff" = "Projektstart";
+"catalog.event::dentist" = "Tandläkare";
+"catalog.event::trip" = "Resa till Jeju";
+"catalog.event::design_review" = "Designgenomgång";
+"catalog.event::dinner" = "Middag med Sara";
+"catalog.event::sprint_planning" = "Sprintplanering";
+"catalog.event::team_workshop" = "Teamworkshop";
+"catalog.event::release_day" = "Releasedag";
+"catalog.event::lunch" = "Lunch med Sara";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Lämna in deklarationen";
+"catalog.todo::reply_landlord" = "Svara hyresvärden";
+"catalog.todo::water_plants" = "Vattna växterna";
+"catalog.todo::book_flight" = "Boka flyget";
+"catalog.todo::renew_passport" = "Förnya passet";
+"catalog.todo::send_invoice" = "Skicka fakturan";
+"catalog.todo::cancel_subscription" = "Säga upp prenumerationen jag inte använder";
+"catalog.todo::return_books" = "Lämna tillbaka biblioteksböckerna";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Ta med de utskrivna wireframesen.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Arbete";
+"catalog.tag::family" = "Familj";
+"catalog.tag::health" = "Hälsa";
+"catalog.tag::study" = "Studier";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "lunch med Sara på fredag kl. 12";
+"catalog.ai::result" = "”Lunch med Sara” har lagts till fredag 13 mars kl. 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/th.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/th.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "วันขบวนการเอกราช";
+"catalog.event::project_kickoff" = "คิกออฟโปรเจกต์";
+"catalog.event::dentist" = "หมอฟัน";
+"catalog.event::trip" = "เที่ยวเชจู";
+"catalog.event::design_review" = "รีวิวงานออกแบบ";
+"catalog.event::dinner" = "มื้อเย็นกับซาร่า";
+"catalog.event::sprint_planning" = "วางแผนสปรินต์";
+"catalog.event::team_workshop" = "เวิร์กช็อปทีม";
+"catalog.event::release_day" = "วันปล่อยเวอร์ชัน";
+"catalog.event::lunch" = "มื้อเที่ยงกับซาร่า";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "ยื่นภาษี";
+"catalog.todo::reply_landlord" = "ตอบเจ้าของบ้าน";
+"catalog.todo::water_plants" = "รดน้ำต้นไม้";
+"catalog.todo::book_flight" = "จองตั๋วเครื่องบิน";
+"catalog.todo::renew_passport" = "ต่ออายุพาสปอร์ต";
+"catalog.todo::send_invoice" = "ส่งใบแจ้งหนี้";
+"catalog.todo::cancel_subscription" = "ยกเลิกสมาชิกที่ไม่ได้ใช้";
+"catalog.todo::return_books" = "คืนหนังสือห้องสมุด";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "เอาแบบร่างที่ปรินต์ไว้ไปด้วย";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "งาน";
+"catalog.tag::family" = "ครอบครัว";
+"catalog.tag::health" = "สุขภาพ";
+"catalog.tag::study" = "การเรียน";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "มื้อเที่ยงกับซาร่าวันศุกร์เที่ยงตรง";
+"catalog.ai::result" = "เพิ่ม “มื้อเที่ยงกับซาร่า” ในวันศุกร์ที่ 13 มีนาคม เวลา 12:00 แล้ว";

--- a/Supports/SnapshotTestHelpKit/Resources/tr.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/tr.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Bağımsızlık Hareketi Günü";
+"catalog.event::project_kickoff" = "Proje başlangıcı";
+"catalog.event::dentist" = "Diş hekimi";
+"catalog.event::trip" = "Jeju gezisi";
+"catalog.event::design_review" = "Tasarım incelemesi";
+"catalog.event::dinner" = "Sara ile akşam yemeği";
+"catalog.event::sprint_planning" = "Sprint planlama";
+"catalog.event::team_workshop" = "Ekip atölyesi";
+"catalog.event::release_day" = "Yayın günü";
+"catalog.event::lunch" = "Sara ile öğle yemeği";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Vergi beyannamesini ver";
+"catalog.todo::reply_landlord" = "Ev sahibine yanıt yaz";
+"catalog.todo::water_plants" = "Bitkileri sula";
+"catalog.todo::book_flight" = "Uçuşu ayırt";
+"catalog.todo::renew_passport" = "Pasaportu yenile";
+"catalog.todo::send_invoice" = "Faturayı gönder";
+"catalog.todo::cancel_subscription" = "Kullanmadığım aboneliği iptal et";
+"catalog.todo::return_books" = "Kütüphane kitaplarını iade et";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Basılı wireframe'leri yanına al.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "İş";
+"catalog.tag::family" = "Aile";
+"catalog.tag::health" = "Sağlık";
+"catalog.tag::study" = "Çalışma";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "cuma öğlen Sara ile öğle yemeği";
+"catalog.ai::result" = "“Sara ile öğle yemeği” 13 Mart Cuma 12:00'ye eklendi.";

--- a/Supports/SnapshotTestHelpKit/Resources/uk.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/uk.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "День руху за незалежність";
+"catalog.event::project_kickoff" = "Старт проєкту";
+"catalog.event::dentist" = "Стоматолог";
+"catalog.event::trip" = "Подорож на Чеджу";
+"catalog.event::design_review" = "Дизайн-рев'ю";
+"catalog.event::dinner" = "Вечеря із Сарою";
+"catalog.event::sprint_planning" = "Планування спринту";
+"catalog.event::team_workshop" = "Командний воркшоп";
+"catalog.event::release_day" = "День релізу";
+"catalog.event::lunch" = "Обід із Сарою";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Подати податкову декларацію";
+"catalog.todo::reply_landlord" = "Відповісти орендодавцю";
+"catalog.todo::water_plants" = "Полити квіти";
+"catalog.todo::book_flight" = "Забронювати авіаквиток";
+"catalog.todo::renew_passport" = "Оновити закордонний паспорт";
+"catalog.todo::send_invoice" = "Надіслати рахунок";
+"catalog.todo::cancel_subscription" = "Скасувати непотрібну підписку";
+"catalog.todo::return_books" = "Повернути книжки до бібліотеки";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Взяти роздруковані вайрфрейми.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Робота";
+"catalog.tag::family" = "Сім'я";
+"catalog.tag::health" = "Здоров'я";
+"catalog.tag::study" = "Навчання";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "обід із Сарою в п'ятницю опівдні";
+"catalog.ai::result" = "«Обід із Сарою» додано на п'ятницю, 13 березня, 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/vi.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/vi.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "Ngày Phong trào Độc lập";
+"catalog.event::project_kickoff" = "Khởi động dự án";
+"catalog.event::dentist" = "Nha sĩ";
+"catalog.event::trip" = "Chuyến đi Jeju";
+"catalog.event::design_review" = "Duyệt thiết kế";
+"catalog.event::dinner" = "Ăn tối với Sara";
+"catalog.event::sprint_planning" = "Lập kế hoạch sprint";
+"catalog.event::team_workshop" = "Workshop nhóm";
+"catalog.event::release_day" = "Ngày phát hành";
+"catalog.event::lunch" = "Ăn trưa với Sara";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "Nộp tờ khai thuế";
+"catalog.todo::reply_landlord" = "Trả lời chủ nhà";
+"catalog.todo::water_plants" = "Tưới cây";
+"catalog.todo::book_flight" = "Đặt vé máy bay";
+"catalog.todo::renew_passport" = "Gia hạn hộ chiếu";
+"catalog.todo::send_invoice" = "Gửi hóa đơn";
+"catalog.todo::cancel_subscription" = "Hủy gói đăng ký không dùng";
+"catalog.todo::return_books" = "Trả sách thư viện";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.memo::wireframes" = "Mang theo bản wireframe đã in.";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "Công việc";
+"catalog.tag::family" = "Gia đình";
+"catalog.tag::health" = "Sức khỏe";
+"catalog.tag::study" = "Học tập";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "ăn trưa với Sara thứ Sáu lúc 12 giờ";
+"catalog.ai::result" = "Đã thêm “Ăn trưa với Sara” vào thứ Sáu, 13 tháng 3 lúc 12:00.";

--- a/Supports/SnapshotTestHelpKit/Resources/zh-Hans.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/zh-Hans.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "三一节";
+"catalog.event::project_kickoff" = "项目启动会";
+"catalog.event::dentist" = "牙医";
+"catalog.event::trip" = "济州岛旅行";
+"catalog.event::design_review" = "设计评审";
+"catalog.event::dinner" = "和 Sara 吃晚饭";
+"catalog.event::sprint_planning" = "冲刺规划";
+"catalog.event::team_workshop" = "团队工作坊";
+"catalog.event::release_day" = "发布日";
+"catalog.event::lunch" = "和 Sara 吃午饭";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "报税";
+"catalog.todo::reply_landlord" = "回复房东";
+"catalog.todo::water_plants" = "给植物浇水";
+"catalog.todo::book_flight" = "订机票";
+"catalog.todo::renew_passport" = "更换护照";
+"catalog.todo::send_invoice" = "发送账单";
+"catalog.todo::cancel_subscription" = "退订不用的订阅";
+"catalog.todo::return_books" = "还图书馆的书";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "首尔创业中心";
+"catalog.memo::wireframes" = "带上打印好的线框图。";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "工作";
+"catalog.tag::family" = "家庭";
+"catalog.tag::health" = "健康";
+"catalog.tag::study" = "学习";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "周五中午和 Sara 吃午饭";
+"catalog.ai::result" = "已把“和 Sara 吃午饭”添加到 3 月 13 日周五 12:00。";

--- a/Supports/SnapshotTestHelpKit/Resources/zh-Hant.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/zh-Hant.lproj/CatalogStrings.strings
@@ -1,0 +1,42 @@
+/* 화면 카탈로그(app-catalog) 더미 텍스트 — 앱 번들에 실리지 않는다 */
+
+// MARK: - 캘린더 이벤트
+
+"catalog.event::holiday" = "三一節";
+"catalog.event::project_kickoff" = "專案啟動會";
+"catalog.event::dentist" = "牙醫";
+"catalog.event::trip" = "濟州島旅行";
+"catalog.event::design_review" = "設計審查";
+"catalog.event::dinner" = "和 Sara 吃晚餐";
+"catalog.event::sprint_planning" = "衝刺規劃";
+"catalog.event::team_workshop" = "團隊工作坊";
+"catalog.event::release_day" = "發布日";
+"catalog.event::lunch" = "和 Sara 吃午餐";
+
+// MARK: - 할일
+
+"catalog.todo::tax_return" = "報稅";
+"catalog.todo::reply_landlord" = "回覆房東";
+"catalog.todo::water_plants" = "幫植物澆水";
+"catalog.todo::book_flight" = "訂機票";
+"catalog.todo::renew_passport" = "更換護照";
+"catalog.todo::send_invoice" = "寄送帳單";
+"catalog.todo::cancel_subscription" = "取消不用的訂閱";
+"catalog.todo::return_books" = "還圖書館的書";
+
+// MARK: - 이벤트 상세
+
+"catalog.place::startup_hub" = "首爾創業中心";
+"catalog.memo::wireframes" = "帶上列印好的線框圖。";
+
+// MARK: - 이벤트 타입
+
+"catalog.tag::work" = "工作";
+"catalog.tag::family" = "家庭";
+"catalog.tag::health" = "健康";
+"catalog.tag::study" = "學習";
+
+// MARK: - AI 빠른 입력
+
+"catalog.ai::command" = "星期五中午和 Sara 吃午餐";
+"catalog.ai::result" = "已將「和 Sara 吃午餐」加到 3 月 13 日星期五 12:00。";

--- a/Supports/SnapshotTestHelpKit/Sources/CatalogStrings.swift
+++ b/Supports/SnapshotTestHelpKit/Sources/CatalogStrings.swift
@@ -1,0 +1,20 @@
+//
+//  CatalogStrings.swift
+//  SnapshotTestHelpKit
+//
+//  Created by sudo.park on 8/25/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+
+
+public extension String {
+
+    /// 프로덕션에 노출되지 않는 문구라 앱 리소스가 아니라 이 헬퍼 번들에서 찾는다.
+    func catalogLocalized() -> String {
+        return NSLocalizedString(
+            self, tableName: "CatalogStrings", bundle: Bundle.module, comment: ""
+        )
+    }
+}

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -81,6 +81,7 @@ extension Project {
         destinations: Destinations,
         iOSTargetVersion: String,
         withSourceFile: Bool = true,
+        resources: ResourceFileElements? = nil,
         snapshotTests: Bool = false,
         dependencies: [TargetDependency] = [],
         customSetting: [String: SettingValue] = [:]
@@ -90,6 +91,7 @@ extension Project {
             destinations: destinations,
             iOSTargetVersion: iOSTargetVersion,
             withSourceFile: withSourceFile,
+            resources: resources,
             dependencies: dependencies,
             customSetting: customSetting
         )
@@ -176,6 +178,7 @@ extension Project {
         destinations: Destinations,
         iOSTargetVersion: String,
         withSourceFile: Bool,
+        resources: ResourceFileElements? = nil,
         dependencies: [TargetDependency] = [],
         customSetting: [String: SettingValue] = [:]
     )
@@ -189,7 +192,7 @@ extension Project {
                              deploymentTargets: .iOS(iOSTargetVersion),
                              infoPlist: .default,
                              sources: withSourceFile ? ["Sources/**"] : [],
-                             resources: [],
+                             resources: resources,
                              headers: Headers.headers(public: "\(name).h"),
                              dependencies: dependencies,
                              settings: .settings(

--- a/scripts/capture-guide-screenshots.sh
+++ b/scripts/capture-guide-screenshots.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# 서비스 이용 가이드용 화면 스크린샷을 언어별로 촬영한다.
+#
+# usage:
+#   scripts/capture-guide-screenshots.sh <lang> [<lang> ...]
+#   scripts/capture-guide-screenshots.sh --all
+#
+# 결과: snapshot-guide/<lang>/<가이드 파일명>.png (gitignore 대상, 언어별 격리)
+# 촬영 후 Terms 레포 guide/images/<lang>/ 로 복사하는 것은 별도 단계다.
+#
+# app-catalog 스킬 §3 과 규격은 같고 두 가지가 다르다:
+#   - -testLanguage/-testRegion 을 언어별로 바꾼다
+#   - -only-testing 으로 카탈로그 스위트만 돌린다. 스킴 전체를 돌리면 같은 스킴의 검증
+#     스위트(__Snapshots__/ — 커밋 대상)가 그 언어로 재기록돼 워킹트리가 오염된다
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DESTINATION='platform=iOS Simulator,name=iPhone 17 - snapshot_ref,OS=26.2'
+
+ALL_LANGS=(en ko ja zh-Hans zh-Hant vi th es fr it pt-BR ca de nl sv da nb fi pl cs sk hu ru uk ro el hr tr id ms hi)
+
+region_of() {
+    case "$1" in
+        en) echo US ;; ko) echo KR ;; ja) echo JP ;;
+        zh-Hans) echo CN ;; zh-Hant) echo TW ;;
+        vi) echo VN ;; th) echo TH ;; es) echo ES ;; fr) echo FR ;;
+        it) echo IT ;; pt-BR) echo BR ;; ca) echo ES ;; de) echo DE ;;
+        nl) echo NL ;; sv) echo SE ;; da) echo DK ;; nb) echo NO ;;
+        fi) echo FI ;; pl) echo PL ;; cs) echo CZ ;; sk) echo SK ;;
+        hu) echo HU ;; ru) echo RU ;; uk) echo UA ;; ro) echo RO ;;
+        el) echo GR ;; hr) echo HR ;; tr) echo TR ;; id) echo ID ;;
+        ms) echo MY ;; hi) echo IN ;;
+        *) echo "region_of: 알 수 없는 언어 $1" >&2; return 1 ;;
+    esac
+}
+
+# <스킴>|<카탈로그 스위트>|<모듈 디렉토리>
+SUITES=(
+    "CalendarScenesSnapshots|CalendarScenesCatalogSnapshots|CalendarScenes"
+    "EventDetailSceneSnapshots|EventDetailSceneCatalogSnapshots|EventDetailScene"
+    "EventListScenesSnapshots|EventListScenesCatalogSnapshots|EventListScenes"
+    "SettingSceneSnapshots|SettingSceneCatalogSnapshots|SettingScene"
+    "AIAgentSceneSnapshots|AIAgentSceneCatalogSnapshots|AIAgentScene"
+    "TodoCalendarAppWidgetSnapshots|WidgetCatalogSnapshots|Widget"
+)
+
+# <가이드 파일명>|<모듈 디렉토리>/<스위트>/<캡처 파일명>
+MAPPING=(
+    "calendar|CalendarScenes/CalendarScenesCatalogSnapshots/test_calendar.calendar-light.png"
+    "event-detail|EventDetailScene/EventDetailSceneCatalogSnapshots/test_eventDetail.eventDetail-light.png"
+    "repeat-options|EventDetailScene/EventDetailSceneCatalogSnapshots/test_repeatOptions.repeatOptions-light.png"
+    "done-todos|EventListScenes/EventListScenesCatalogSnapshots/test_doneTodos.doneTodos-light.png"
+    "settings|SettingScene/SettingSceneCatalogSnapshots/test_settingItemList.settingItemList-light.png"
+    "event-type-list|SettingScene/SettingSceneCatalogSnapshots/test_eventTypeList.eventTypeList-light.png"
+    "appearance-setting|SettingScene/SettingSceneCatalogSnapshots/test_appearanceSetting.appearanceSetting-light.png"
+    "ai-input|AIAgentScene/AIAgentSceneCatalogSnapshots/test_aiInput.aiInput-light.png"
+    "ai-result|AIAgentScene/AIAgentSceneCatalogSnapshots/test_aiResult.aiResult-light.png"
+    "widget-today-and-next|Widget/WidgetCatalogSnapshots/test_widgetTodayAndNext.widget-today-and-next-light.png"
+    "widget-event-list|Widget/WidgetCatalogSnapshots/test_widgetEventList.widget-event-list-light.png"
+    "widget-today|Widget/WidgetCatalogSnapshots/test_widgetToday.widget-today-light.png"
+    "widget-foremost|Widget/WidgetCatalogSnapshots/test_widgetForemost.widget-foremost-light.png"
+    "widget-month|Widget/WidgetCatalogSnapshots/test_widgetMonth.widget-month-light.png"
+)
+
+capture_lang() {
+    local lang="$1" region
+    region="$(region_of "$lang")"
+    echo "▶︎ [$lang] 촬영 시작 (region=$region)"
+
+    for entry in "${SUITES[@]}"; do
+        IFS='|' read -r scheme suite _ <<< "$entry"
+        echo "  · $scheme/$suite"
+        xcodebuild test \
+            -workspace "$ROOT/TodoCalendar.xcworkspace" \
+            -scheme "$scheme" \
+            -destination "$DESTINATION" \
+            -only-testing:"$scheme/$suite" \
+            -testLanguage "$lang" -testRegion "${lang%%-*}_$region" \
+            > "/tmp/capture-$lang-$scheme.log" 2>&1 \
+            || { echo "  ✗ 실패 — /tmp/capture-$lang-$scheme.log"; return 1; }
+    done
+
+    local out="$ROOT/snapshot-guide/$lang"
+    mkdir -p "$out"
+    for entry in "${MAPPING[@]}"; do
+        IFS='|' read -r name source <<< "$entry"
+        local src="$ROOT/snapshot-catalog/$source"
+        [ -f "$src" ] || { echo "  ✗ 누락: $source"; return 1; }
+        cp "$src" "$out/$name.png"
+    done
+    echo "  ✓ [$lang] ${#MAPPING[@]}장 → snapshot-guide/$lang/"
+
+    # 검증 스위트 png 가 섞여 들어가지 않았는지 — 섞였다면 -only-testing 이 안 먹은 것이다
+    if ! git -C "$ROOT" diff --quiet -- '*__Snapshots__*'; then
+        echo "  ⚠︎ [$lang] 커밋 대상 __Snapshots__/ 가 변경됐다. git restore 로 되돌리고 원인을 확인할 것" >&2
+        return 1
+    fi
+}
+
+if [ "${1:-}" = "--all" ]; then
+    set -- "${ALL_LANGS[@]}"
+fi
+[ $# -gt 0 ] || { sed -n '2,10p' "$0"; exit 1; }
+
+failed=()
+for lang in "$@"; do
+    capture_lang "$lang" || failed+=("$lang")
+done
+
+if [ ${#failed[@]} -gt 0 ]; then
+    echo "✗ 실패한 언어: ${failed[*]}" >&2
+    exit 1
+fi
+echo "✓ 전체 완료 — $# 개 언어"

--- a/scripts/check-guide-parity.py
+++ b/scripts/check-guide-parity.py
@@ -47,10 +47,16 @@ def parse(path):
     headings = [(len(hashes), title) for hashes, title in HEADING.findall(text)]
     return {
         "links": LINK.findall(text),
-        "images": sorted(IMG.findall(text)),
+        "images": sorted(image_name(url) for url in IMG.findall(text)),
         "levels": [level for level, _ in headings],
         "anchors": anchors_of(headings),
     }
+
+def image_name(url):
+    """스크린샷은 언어별로 `images/<lang>/` 아래 갈리므로 언어 세그먼트를 걷어내고 파일명만 본다 —
+    아직 촬영 안 된 언어는 en 이 있는 루트를 계속 가리켜서 URL 자체는 일치하지 않는다."""
+    return url.rsplit('/', 1)[-1]
+
 
 def guide_files(guide_dir):
     """검사 대상 파일 세트는 en 디렉토리가 정본 — 원고에 문서가 늘어도 이 스크립트를 고칠 필요가 없다."""
@@ -76,7 +82,7 @@ def check(guide_dir, files, lang):
             print(f"[{lang}] {name} link target mismatch: en={en_targets} {lang}={xx_targets}")
             file_ok = False
         if en["images"] != xx["images"]:
-            print(f"[{lang}] {name} image url mismatch: only-en={sorted(set(en['images'])-set(xx['images']))} only-{lang}={sorted(set(xx['images'])-set(en['images']))}")
+            print(f"[{lang}] {name} image set mismatch: only-en={sorted(set(en['images'])-set(xx['images']))} only-{lang}={sorted(set(xx['images'])-set(en['images']))}")
             file_ok = False
         if en["levels"] != xx["levels"]:
             print(f"[{lang}] {name} heading level sequence: en={en['levels']} {lang}={xx['levels']}")

--- a/scripts/rewrite-guide-image-lang.py
+++ b/scripts/rewrite-guide-image-lang.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""가이드 원고의 스크린샷 URL 을 언어별 이미지 경로로 바꾼다.
+
+usage:
+  scripts/rewrite-guide-image-lang.py <terms-repo-경로>            # dry-run
+  scripts/rewrite-guide-image-lang.py <terms-repo-경로> --write    # 적용
+
+`guide/images/calendar.png` (전 언어 공유) 를 `guide/images/<lang>/calendar.png` 로 옮기는
+전환에 맞춰, 각 언어 md 의 절대 URL 을 그 언어 디렉토리로 가리키게 한다.
+
+- **그 언어 이미지가 실제로 있을 때만** 바꾼다. md 는 정적이라 fallback 이 없어서,
+  없는 경로를 가리키면 깨진 이미지가 그대로 노출된다. 촬영이 밀린 언어는 en 을 가리킨 채 남는다.
+- 언어별로 찍지 않는 공유 자산(app-icon 등)은 `guide/images/` 루트에 그대로 두고 건드리지 않는다.
+"""
+import re, sys
+from pathlib import Path
+
+RAW_BASE = "https://raw.githubusercontent.com/sudopark/TodoCalendar-Terms/main/guide/images"
+SHARED = {"app-icon.png"}
+SRC = re.compile(rf'({re.escape(RAW_BASE)}/)((?:[\w-]+/)?)([\w.-]+\.png)')
+
+
+def rewrite(guide_dir, lang, write):
+    changes = []
+    for md in sorted((guide_dir / lang).glob("*.md")):
+        text = md.read_text(encoding="utf-8")
+
+        def replace(match):
+            prefix, _current_dir, name = match.groups()
+            if name in SHARED:
+                return f"{prefix}{name}"
+            if not (guide_dir / "images" / lang / name).exists():
+                return match.group(0)
+            return f"{prefix}{lang}/{name}"
+
+        updated = SRC.sub(replace, text)
+        if updated == text:
+            continue
+        changed = sum(1 for a, b in zip(SRC.findall(text), SRC.findall(updated)) if a != b)
+        changes.append((md, changed))
+        if write:
+            md.write_text(updated, encoding="utf-8")
+    return changes
+
+
+def main(args):
+    if not args:
+        print(__doc__)
+        return 1
+    guide_dir = Path(args[0]).expanduser().resolve() / "guide"
+    write = "--write" in args[1:]
+    if not guide_dir.is_dir():
+        print(f"guide 디렉토리를 찾을 수 없다: {guide_dir}")
+        return 1
+
+    langs = sorted(p.name for p in guide_dir.iterdir() if p.is_dir() and p.name != "images")
+    total = 0
+    for lang in langs:
+        changes = rewrite(guide_dir, lang, write)
+        for md, count in changes:
+            print(f"[{lang}] {md.relative_to(guide_dir.parent)}: {count} URL")
+            total += count
+    print(f"{'적용' if write else 'dry-run'} — {total} URL")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
가이드(`sudopark/TodoCalendar-Terms` `guide/`)는 31개 언어로 번역됐지만 스크린샷은 영문 한 벌을 전 언어가 공유했다. 본문이 그 언어 lproj 값을 그대로 인용하는데 그림 속 라벨은 영어라, 독자가 안내받은 버튼을 자기 화면에서 못 찾는 상태였다.

## 접근

촬영 인프라는 이미 있었다 — app-catalog 카탈로그 스위트에 `-testLanguage` 를 주면 된다. 막고 있던 건 **카탈로그 더미가 화면 텍스트를 영문으로 박아둔 것**이라, 언어를 바꿔도 UI 크롬만 번역되고 이벤트 이름·요일·날짜·시각은 영어로 남았다.

더미를 두 갈래로 갈라 처리했다:

- **프로덕션이 실제로 그리는 값** (요일 헤더·날짜 헤더·반복 주기·알림 시각·태그명·시각/기간 표기) — 손으로 적은 문자열 대신 프로덕션 경로로 세운다. 셀은 도메인 이벤트를 만들어 프로덕션 이니셜라이저에 넘기고, 나머지는 해당 lproj 키를 부른다. 부수적으로 기존 하드코딩이 프로덕션과 어긋나 있던 요일·날짜 형식도 실제 화면과 일치하게 됐다.
- **유저가 입력했을 법한 콘텐츠** (이벤트 이름·메모·AI 명령문) — 대응하는 프로덕션 키가 없어 `SnapshotTestHelpKit` 전용 리소스 `CatalogStrings.strings` 31개 언어 26키로 담았다. 프로덕션에 노출되지 않는 문구라 앱 lproj 에 두면 앱 번들과 파리티 검사가 오염된다.

AI 명령·응답문의 번역 정본은 각 언어 가이드 본문이다 — `02-ai-input.md` 가 같은 예시 문장을 인용하고 있어 어긋나면 독자가 같은 예시로 못 읽는다.

촬영·배치는 스크립트 두 개로 감쌌다. 촬영은 `-only-testing` 으로 카탈로그 스위트만 한정한다 — 같은 스킴의 검증 스냅샷(`__Snapshots__/`, 커밋 대상)이 그 언어로 재기록되는 것을 막고, 실행 후 그 diff 가 비었는지 확인해 실패시킨다. 본문 URL 치환은 그 언어 이미지가 실제로 있을 때만 한다 — md 는 정적이라 폴백이 없어서, 촬영이 밀린 언어는 루트(en)를 계속 가리켜야 이미지가 안 깨진다.

## 검증

- 31개 언어 × 14장 촬영 완료, `plutil -lint`·en 대비 키 파리티 0 위반
- ko·de·ja·th·hi 육안 확인 — 문자 깨짐·레이아웃 넘침 없음
- `Project.framework` 의 `resources` 파라미터 추가는 기본값 nil 이라 나머지 9개 호출처 무영향 (AdService 빌드 확인)

원고 쪽 배치는 sudopark/TodoCalendar-Terms 의 별도 PR 로 나간다.
