### PR TITLE
[#999] 굴절어권 반복 옵션 문구를 요일 문법성에 맞게 렌더

### DIFF
--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -65,7 +65,7 @@ paths:
 - **도메인 3계층 용어 분리**: Event ⊃ {Todo, Schedule}는 언어마다 서로 다른 단어여야 한다 (`total::event::count`/`todo::count`/`schedule::count`가 리트머스). 예: de Ereignis/Aufgabe/Termin, fr événement/tâche/rendez-vous.
 - **aiAgent 구획의 "Task"는 그 언어의 Todo 예약어 금지** — "명령(command)" 계열로 (예: sv Kommandot, de Befehl, fr commande). AI 명령 완료가 "할 일 완료"로 오독되는 충돌 방지.
 - **위젯 명칭 일관**: D-day 위젯 관련 신규 문구는 그 언어의 기존 `widget.dday::name` 용어를 재사용 (언어별로 D-Day 차용/번역 클러스터가 다름 — zh-Hans 倒计时, de Countdown, tr Geri Sayım).
-- **복수형**: stringsdict 미도입 — `%d minute(s)` 류는 각 언어의 단·복수 겸용 자연 표기. 슬라브어권 격변화 한계는 감수(#626 확정).
+- **복수형**: stringsdict 미도입 — `%d minute(s)` 류는 각 언어의 단·복수 겸용 자연 표기. 슬라브어권 수사 격변화는 격변화를 타지 않는 표현(전치격 복수·서수 표기·축약)으로 재작성해 피한다 (#999).
 - **포맷 지정자**: multiset은 en과 일치. 어순상 재배치가 필요하면 positional(`%1$@`)로.
 
 ## 3. 날짜 포맷 키 — 번역 금지

--- a/Domain/Sources/Models/Calendar/Times.swift
+++ b/Domain/Sources/Models/Calendar/Times.swift
@@ -21,40 +21,32 @@ public enum DayOfWeeks: Int, Sendable {
         return self == .sunday || self == .saturday
     }
     
+    private var localizeKeyStem: String {
+        switch self {
+        case .sunday: return "dayname::sunday"
+        case .monday: return "dayname::monday"
+        case .tuesday: return "dayname::tuesday"
+        case .wednesday: return "dayname::wednesday"
+        case .thursday: return "dayname::thursday"
+        case .friday: return "dayname::friday"
+        case .saturday: return "dayname::saturday"
+        }
+    }
+
     public var text: String {
-        switch self {
-        case .sunday: return "dayname::sunday".localized()
-        case .monday: return "dayname::monday".localized()
-        case .tuesday: return "dayname::tuesday".localized()
-        case .wednesday: return "dayname::wednesday".localized()
-        case .thursday: return "dayname::thursday".localized()
-        case .friday: return "dayname::friday".localized()
-        case .saturday: return "dayname::saturday".localized()
-        }
+        return self.localizeKeyStem.localized()
     }
-    
+
+    public var localizedGrammaticalGender: String {
+        return "\(self.localizeKeyStem):gender".localized()
+    }
+
     public var shortText: String {
-        switch self {
-        case .sunday: return "dayname::sunday:short".localized()
-        case .monday: return "dayname::monday:short".localized()
-        case .tuesday: return "dayname::tuesday:short".localized()
-        case .wednesday: return "dayname::wednesday:short".localized()
-        case .thursday: return "dayname::thursday:short".localized()
-        case .friday: return "dayname::friday:short".localized()
-        case .saturday: return "dayname::saturday:short".localized()
-        }
+        return "\(self.localizeKeyStem):short".localized()
     }
-    
+
     public var veryShortText: String {
-        switch self {
-        case .sunday: return "dayname::sunday:very_short".localized()
-        case .monday: return "dayname::monday:very_short".localized()
-        case .tuesday: return "dayname::tuesday:very_short".localized()
-        case .wednesday: return "dayname::wednesday:very_short".localized()
-        case .thursday: return "dayname::thursday:very_short".localized()
-        case .friday: return "dayname::friday:very_short".localized()
-        case .saturday: return "dayname::saturday:very_short".localized()
-        }
+        return "\(self.localizeKeyStem):very_short".localized()
     }
 }
 

--- a/Domain/Sources/Utils/RRule+EventRepeating.swift
+++ b/Domain/Sources/Utils/RRule+EventRepeating.swift
@@ -302,7 +302,7 @@ extension WeekOrdinal {
 
 extension RRule.ByDay.WeekDay {
 
-    fileprivate var asDayOfWeeks: DayOfWeeks {
+    public var asDayOfWeeks: DayOfWeeks {
         switch self {
         case .SU: return .sunday
         case .MO: return .monday

--- a/Presentations/CommonPresentation/Sources/Extensions/EventRepeatingOption+Extensions.swift
+++ b/Presentations/CommonPresentation/Sources/Extensions/EventRepeatingOption+Extensions.swift
@@ -67,11 +67,12 @@ public extension EventRepeatingOption {
             return R.String.EventDetail.Repeating.everyLastWeekDaysOfEveryMonthTitle
 
         case .everyMonthSomeWeekDay(let seq, let weekDay):
-            return "eventDetail.repeating.every\(seq)WeekOfEveryMonth::someday"
+            return "eventDetail.repeating.every\(seq)WeekOfEveryMonth::someday::\(weekDay.localizedGrammaticalGender)"
                 .localized(with: weekDay.text)
 
         case .everyMonthLastWeekDay(let weekDay):
-            return R.String.EventDetail.Repeating.everyLastWeekOfEveryMonthSomeday(weekDay.text)
+            return "eventDetail.repeating.everyLastWeekOfEveryMonth::someday::\(weekDay.localizedGrammaticalGender)"
+                .localized(with: weekDay.text)
         }
     }
 }

--- a/Presentations/CommonPresentation/Sources/Extensions/RRule+DisplayText.swift
+++ b/Presentations/CommonPresentation/Sources/Extensions/RRule+DisplayText.swift
@@ -135,7 +135,8 @@ extension RRule.ByDay {
         case .none:
             return self.weekDay.text()
         case .some(let n) where n == -1:
-            return "\("eventDetail.repeating.last".localized()) \(self.weekDay.text())"
+            let gender = self.weekDay.asDayOfWeeks.localizedGrammaticalGender
+            return "\("eventDetail.repeating.last::\(gender)".localized()) \(self.weekDay.text())"
         case .some(let n):
             return n.ordinal.map { "\($0) \(self.weekDay.text())" } ?? self.weekDay.text()
         }

--- a/Presentations/EventDetailScene/Tests/RRuleDisplayTextTests.swift
+++ b/Presentations/EventDetailScene/Tests/RRuleDisplayTextTests.swift
@@ -71,4 +71,55 @@ struct RRuleDisplayTextTests {
         // then
         #expect(text == "Every Week\n5 time(s)")
     }
+
+    @Test func rrule_displayText_unsupportedMonthlyWithLastWeekDay_appendsGenderedLastText() throws {
+        // given
+        let rruleLine = "RRULE:FREQ=MONTHLY;BYMONTHDAY=15;BYDAY=-1FR"
+        let rrule = try #require(RRuleParser.parse(rruleLine))
+        let timeZone = try #require(TimeZone(identifier: "UTC"))
+        let startTime = Date(timeIntervalSince1970: 1_700_000_000)
+
+        // when
+        let text = rrule.displayText(startTime: startTime, timeZone)
+
+        // then
+        let asEventRepeating = rrule.asEventRepeating(
+            startTime: startTime.timeIntervalSince1970, timeZone: timeZone
+        )
+        #expect(asEventRepeating == nil)
+        let expectedLastText = "eventDetail.repeating.last::m".localized()
+        #expect(text.contains("\(expectedLastText) \(DayOfWeeks.friday.shortText)"))
+    }
+
+    @Test func summaryText_everyMonthSomeWeekDay_usesGenderedTemplateKey() throws {
+        // given
+        let timeZone = try #require(TimeZone(identifier: "UTC"))
+        var option = EventRepeatingOptions.EveryMonth(timeZone: timeZone)
+        option.selection = .week([.seq(3)], [.wednesday])
+        let startTime = Date(timeIntervalSince1970: 1_700_000_000)
+
+        // when
+        let text = option.summaryText(startTime: startTime, timeZone: timeZone)
+
+        // then
+        let expected = "eventDetail.repeating.every3WeekOfEveryMonth::someday::m"
+            .localized(with: DayOfWeeks.wednesday.text)
+        #expect(text == expected)
+    }
+
+    @Test func summaryText_everyMonthLastWeekDay_usesGenderedTemplateKey() throws {
+        // given
+        let timeZone = try #require(TimeZone(identifier: "UTC"))
+        var option = EventRepeatingOptions.EveryMonth(timeZone: timeZone)
+        option.selection = .week([.last], [.wednesday])
+        let startTime = Date(timeIntervalSince1970: 1_700_000_000)
+
+        // when
+        let text = option.summaryText(startTime: startTime, timeZone: timeZone)
+
+        // then
+        let expected = "eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m"
+            .localized(with: DayOfWeeks.wednesday.text)
+        #expect(text == expected)
+    }
 }

--- a/Presentations/EventDetailScene/Tests/SelectEventRepeatOptionViewModelTests.swift
+++ b/Presentations/EventDetailScene/Tests/SelectEventRepeatOptionViewModelTests.swift
@@ -94,11 +94,11 @@ extension SelectEventRepeatOptionViewModelTests {
             ],
             [
                 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title".localized(),
-                "eventDetail.repeating.every1WeekOfEveryMonth::someday".localized(with: "Sunday"),
-                "eventDetail.repeating.every2WeekOfEveryMonth::someday".localized(with: "Sunday"),
-                "eventDetail.repeating.every3WeekOfEveryMonth::someday".localized(with: "Sunday"),
-                "eventDetail.repeating.every4WeekOfEveryMonth::someday".localized(with: "Sunday"),
-                "eventDetail.repeating.everyLastWeekOfEveryMonth::someday".localized(with: "Sunday")
+                "eventDetail.repeating.every1WeekOfEveryMonth::someday::m".localized(with: "Sunday"),
+                "eventDetail.repeating.every2WeekOfEveryMonth::someday::m".localized(with: "Sunday"),
+                "eventDetail.repeating.every3WeekOfEveryMonth::someday::m".localized(with: "Sunday"),
+                "eventDetail.repeating.every4WeekOfEveryMonth::someday::m".localized(with: "Sunday"),
+                "eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m".localized(with: "Sunday")
             ]
         ]
     }
@@ -234,7 +234,7 @@ extension SelectEventRepeatOptionViewModelTests {
         
         // then
         XCTAssertNotNil(id)
-        let findingText = "eventDetail.repeating.every3WeekOfEveryMonth::someday".localized(with: "Wednesday")
+        let findingText = "eventDetail.repeating.every3WeekOfEveryMonth::someday::m".localized(with: "Wednesday")
         let week3thWedId = options?.flatMap { $0 }.first(where: { $0.text == findingText })?.id
         XCTAssertEqual(id, week3thWedId)
         let allItemCount = options?.flatMap { $0 }.count

--- a/Supports/Extensions/Resources/ca.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ca.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "DV";
 "dayname::saturday:very_short" = "DS";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Cada any %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Cada any %@ (calendari lunar)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Tots els dies de l'última setmana de cada mes";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "El primer %@ de cada mes";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "El segon %@ de cada mes";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "El tercer %@ de cada mes";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "El quart %@ de cada mes";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "El cinquè %@ de cada mes";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "El sisè %@ de cada mes";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "El setè %@ de cada mes";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "L'últim %@ de cada mes";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "El primer %@ de cada mes";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "El primer %@ de cada mes";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "El primer %@ de cada mes";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "El segon %@ de cada mes";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "El segon %@ de cada mes";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "El segon %@ de cada mes";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "El tercer %@ de cada mes";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "El tercer %@ de cada mes";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "El tercer %@ de cada mes";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "El quart %@ de cada mes";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "El quart %@ de cada mes";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "El quart %@ de cada mes";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "El cinquè %@ de cada mes";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "El cinquè %@ de cada mes";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "El cinquè %@ de cada mes";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "El sisè %@ de cada mes";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "El sisè %@ de cada mes";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "El sisè %@ de cada mes";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "El setè %@ de cada mes";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "El setè %@ de cada mes";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "El setè %@ de cada mes";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "L'últim %@ de cada mes";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "L'últim %@ de cada mes";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "L'últim %@ de cada mes";
+"eventDetail.repeating.last::m" = "Últim";
+"eventDetail.repeating.last::f" = "Últim";
+"eventDetail.repeating.last::n" = "Últim";
 "eventDetail.repeating.endtime::title" = "Final de la repetició";
 "eventDetail.repeating.endtime::option::never" = "Mai";
 "eventDetail.repeating.endtime::option::on" = "El";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "A partir de %@, %d vegades";
 
 "eventDetail.repeating.everyNDays:title" = "Cada %d dies";
-"eventDetail.repeating.last" = "Últim";
 "eventDetail.repeating.everyNMonths:title" = "Cada %d mesos";
 "eventDetail.repeating.everyNYears:title" = "Cada %d anys";
 "eventDetail.repeating::endoption_until" = "fins a %@";

--- a/Supports/Extensions/Resources/cs.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/cs.lproj/Localizable.strings
@@ -55,13 +55,13 @@
 
 // MARK: - event
 
-"dayname::sunday" = "Neděle";
-"dayname::monday" = "Pondělí";
-"dayname::tuesday" = "Úterý";
-"dayname::wednesday" = "Středa";
-"dayname::thursday" = "Čtvrtek";
-"dayname::friday" = "Pátek";
-"dayname::saturday" = "Sobota";
+"dayname::sunday" = "neděle";
+"dayname::monday" = "pondělí";
+"dayname::tuesday" = "úterý";
+"dayname::wednesday" = "středa";
+"dayname::thursday" = "čtvrtek";
+"dayname::friday" = "pátek";
+"dayname::saturday" = "sobota";
 
 "dayname::sunday:short" = "NE";
 "dayname::monday:short" = "PO";

--- a/Supports/Extensions/Resources/cs.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/cs.lproj/Localizable.strings
@@ -185,10 +185,10 @@
 "eventDetail.repeating.starttime:title" = "Čas začátku opakování";
 "eventDetail.repeating.everyDay:title" = "Každý den";
 "eventDetail.repeating.everyWeek:title" = "Každý týden";
-"eventDetail.repeating.everyWeekSomeDay:title" = "Každé %@";
-"eventDetail.repeating.everySomeWeek:title" = "Každých %d týdnů";
+"eventDetail.repeating.everyWeekSomeDay:title" = "Každý týden: %@";
+"eventDetail.repeating.everySomeWeek:title" = "Po %d týdnech";
 "eventDetail.repeating.everyWeekDays:title" = "Každý pracovní den";
-"eventDetail.repeating.everySomeWeekSomeDay:title" = "Každých %d týdnů v %@";
+"eventDetail.repeating.everySomeWeekSomeDay:title" = "Po %d týdnech: %@";
 "eventDetail.repeating.everyMonth:title" = "Každý měsíc";
 "eventDetail.repeating.everyMonth_someDay:title" = "%@ každý měsíc.";
 "eventDetail.repeating.everyYear:title" = "Každý rok";
@@ -212,10 +212,10 @@
 "eventDetail.repeating.endtime::shouldFutureThanStartTime" = "Čas konce opakování musí být pozdější než čas začátku.\n(Datum začátku opakování: %@)";
 "eventDetail.repeating::period_endcount" = "Od %@, %d krát";
 
-"eventDetail.repeating.everyNDays:title" = "Každých %d dní";
+"eventDetail.repeating.everyNDays:title" = "Po %d dnech";
 "eventDetail.repeating.last" = "Poslední";
-"eventDetail.repeating.everyNMonths:title" = "Každých %d měsíců";
-"eventDetail.repeating.everyNYears:title" = "Každých %d let";
+"eventDetail.repeating.everyNMonths:title" = "Po %d měsících";
+"eventDetail.repeating.everyNYears:title" = "Po %d letech";
 "eventDetail.repeating::endoption_until" = "do %@";
 "eventDetail.repeating::endoption_times" = "%d krát";
 

--- a/Supports/Extensions/Resources/cs.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/cs.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "P";
 "dayname::saturday:very_short" = "S";
 
+"dayname::sunday:gender" = "f";
+"dayname::monday:gender" = "n";
+"dayname::tuesday:gender" = "n";
+"dayname::wednesday:gender" = "f";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "f";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Každý rok %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Každý rok %@ (lunární kalendář)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Všechny dny posledního týdne každého měsíce";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "První %@ každého měsíce";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "Druhý %@ každého měsíce";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "Třetí %@ každého měsíce";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "Čtvrtý %@ každého měsíce";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "Pátý %@ každého měsíce";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "Šestý %@ každého měsíce";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "Sedmý %@ každého měsíce";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "Poslední %@ každého měsíce";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "První %@ každého měsíce";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "První %@ každého měsíce";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "První %@ každého měsíce";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "Druhý %@ každého měsíce";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "Druhá %@ každého měsíce";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "Druhé %@ každého měsíce";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "Třetí %@ každého měsíce";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "Třetí %@ každého měsíce";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "Třetí %@ každého měsíce";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "Čtvrtý %@ každého měsíce";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "Čtvrtá %@ každého měsíce";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "Čtvrté %@ každého měsíce";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "Pátý %@ každého měsíce";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "Pátá %@ každého měsíce";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "Páté %@ každého měsíce";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "Šestý %@ každého měsíce";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "Šestá %@ každého měsíce";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "Šesté %@ každého měsíce";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "Sedmý %@ každého měsíce";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "Sedmá %@ každého měsíce";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "Sedmé %@ každého měsíce";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "Poslední %@ každého měsíce";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "Poslední %@ každého měsíce";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "Poslední %@ každého měsíce";
+"eventDetail.repeating.last::m" = "Poslední";
+"eventDetail.repeating.last::f" = "Poslední";
+"eventDetail.repeating.last::n" = "Poslední";
 "eventDetail.repeating.endtime::title" = "Konec opakování";
 "eventDetail.repeating.endtime::option::never" = "Nikdy";
 "eventDetail.repeating.endtime::option::on" = "Dne";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "Od %@, %d krát";
 
 "eventDetail.repeating.everyNDays:title" = "Po %d dnech";
-"eventDetail.repeating.last" = "Poslední";
 "eventDetail.repeating.everyNMonths:title" = "Po %d měsících";
 "eventDetail.repeating.everyNYears:title" = "Po %d letech";
 "eventDetail.repeating::endoption_until" = "do %@";

--- a/Supports/Extensions/Resources/da.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/da.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "F";
 "dayname::saturday:very_short" = "L";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Hvert år %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Hvert år %@ (månekalender)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Alle dage i den sidste uge i hver måned";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "Den første %@ i hver måned";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "Den anden %@ i hver måned";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "Den tredje %@ i hver måned";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "Den fjerde %@ i hver måned";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "Den femte %@ i hver måned";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "Den sjette %@ i hver måned";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "Den syvende %@ i hver måned";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "Den sidste %@ i hver måned";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "Den første %@ i hver måned";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "Den første %@ i hver måned";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "Den første %@ i hver måned";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "Den anden %@ i hver måned";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "Den anden %@ i hver måned";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "Den anden %@ i hver måned";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "Den tredje %@ i hver måned";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "Den tredje %@ i hver måned";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "Den tredje %@ i hver måned";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "Den fjerde %@ i hver måned";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "Den fjerde %@ i hver måned";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "Den fjerde %@ i hver måned";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "Den femte %@ i hver måned";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "Den femte %@ i hver måned";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "Den femte %@ i hver måned";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "Den sjette %@ i hver måned";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "Den sjette %@ i hver måned";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "Den sjette %@ i hver måned";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "Den syvende %@ i hver måned";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "Den syvende %@ i hver måned";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "Den syvende %@ i hver måned";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "Den sidste %@ i hver måned";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "Den sidste %@ i hver måned";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "Den sidste %@ i hver måned";
+"eventDetail.repeating.last::m" = "Sidste";
+"eventDetail.repeating.last::f" = "Sidste";
+"eventDetail.repeating.last::n" = "Sidste";
 "eventDetail.repeating.endtime::title" = "Gentagelse slutter";
 "eventDetail.repeating.endtime::option::never" = "Aldrig";
 "eventDetail.repeating.endtime::option::on" = "Den";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "Starter %@, %d gange";
 
 "eventDetail.repeating.everyNDays:title" = "Hver %d. dag";
-"eventDetail.repeating.last" = "Sidste";
 "eventDetail.repeating.everyNMonths:title" = "Hver %d. måned";
 "eventDetail.repeating.everyNYears:title" = "Hvert %d. år";
 "eventDetail.repeating::endoption_until" = "indtil %@";

--- a/Supports/Extensions/Resources/de.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/de.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "F";
 "dayname::saturday:very_short" = "S";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Jährlich am %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Jährlich am %@ (Mondkalender)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Alle Tage der letzten Woche jeden Monats";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "Der erste %@ jeden Monats";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "Der zweite %@ jeden Monats";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "Der dritte %@ jeden Monats";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "Der vierte %@ jeden Monats";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "Der fünfte %@ jeden Monats";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "Der sechste %@ jeden Monats";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "Der siebte %@ jeden Monats";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "Der letzte %@ jeden Monats";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "Der erste %@ jeden Monats";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "Der erste %@ jeden Monats";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "Der erste %@ jeden Monats";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "Der zweite %@ jeden Monats";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "Der zweite %@ jeden Monats";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "Der zweite %@ jeden Monats";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "Der dritte %@ jeden Monats";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "Der dritte %@ jeden Monats";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "Der dritte %@ jeden Monats";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "Der vierte %@ jeden Monats";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "Der vierte %@ jeden Monats";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "Der vierte %@ jeden Monats";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "Der fünfte %@ jeden Monats";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "Der fünfte %@ jeden Monats";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "Der fünfte %@ jeden Monats";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "Der sechste %@ jeden Monats";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "Der sechste %@ jeden Monats";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "Der sechste %@ jeden Monats";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "Der siebte %@ jeden Monats";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "Der siebte %@ jeden Monats";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "Der siebte %@ jeden Monats";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "Der letzte %@ jeden Monats";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "Der letzte %@ jeden Monats";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "Der letzte %@ jeden Monats";
+"eventDetail.repeating.last::m" = "Letzter";
+"eventDetail.repeating.last::f" = "Letzter";
+"eventDetail.repeating.last::n" = "Letzter";
 "eventDetail.repeating.endtime::title" = "Wiederholung endet";
 "eventDetail.repeating.endtime::option::never" = "Nie";
 "eventDetail.repeating.endtime::option::on" = "Am";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "Ab %@, %d Mal";
 
 "eventDetail.repeating.everyNDays:title" = "Alle %d Tage";
-"eventDetail.repeating.last" = "Letzter";
 "eventDetail.repeating.everyNMonths:title" = "Alle %d Monate";
 "eventDetail.repeating.everyNYears:title" = "Alle %d Jahre";
 "eventDetail.repeating::endoption_until" = "bis %@";

--- a/Supports/Extensions/Resources/el.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/el.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "Π";
 "dayname::saturday:very_short" = "Σ";
 
+"dayname::sunday:gender" = "f";
+"dayname::monday:gender" = "f";
+"dayname::tuesday:gender" = "f";
+"dayname::wednesday:gender" = "f";
+"dayname::thursday:gender" = "f";
+"dayname::friday:gender" = "f";
+"dayname::saturday:gender" = "n";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Κάθε χρόνο %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Κάθε χρόνο %@ (σεληνιακό ημερολόγιο)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Όλες οι ημέρες της τελευταίας εβδομάδας κάθε μήνα";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "Η πρώτη %@ κάθε μήνα";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "Η δεύτερη %@ κάθε μήνα";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "Η τρίτη %@ κάθε μήνα";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "Η τέταρτη %@ κάθε μήνα";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "Η πέμπτη %@ κάθε μήνα";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "Η έκτη %@ κάθε μήνα";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "Η έβδομη %@ κάθε μήνα";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "Η τελευταία %@ κάθε μήνα";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "Ο πρώτος %@ κάθε μήνα";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "Η πρώτη %@ κάθε μήνα";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "Το πρώτο %@ κάθε μήνα";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "Ο δεύτερος %@ κάθε μήνα";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "Η δεύτερη %@ κάθε μήνα";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "Το δεύτερο %@ κάθε μήνα";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "Ο τρίτος %@ κάθε μήνα";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "Η τρίτη %@ κάθε μήνα";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "Το τρίτο %@ κάθε μήνα";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "Ο τέταρτος %@ κάθε μήνα";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "Η τέταρτη %@ κάθε μήνα";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "Το τέταρτο %@ κάθε μήνα";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "Ο πέμπτος %@ κάθε μήνα";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "Η πέμπτη %@ κάθε μήνα";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "Το πέμπτο %@ κάθε μήνα";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "Ο έκτος %@ κάθε μήνα";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "Η έκτη %@ κάθε μήνα";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "Το έκτο %@ κάθε μήνα";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "Ο έβδομος %@ κάθε μήνα";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "Η έβδομη %@ κάθε μήνα";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "Το έβδομο %@ κάθε μήνα";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "Ο τελευταίος %@ κάθε μήνα";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "Η τελευταία %@ κάθε μήνα";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "Το τελευταίο %@ κάθε μήνα";
+"eventDetail.repeating.last::m" = "Τελευταίος";
+"eventDetail.repeating.last::f" = "Τελευταία";
+"eventDetail.repeating.last::n" = "Τελευταίο";
 "eventDetail.repeating.endtime::title" = "Λήξη επανάληψης";
 "eventDetail.repeating.endtime::option::never" = "Ποτέ";
 "eventDetail.repeating.endtime::option::on" = "Στις";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "Από %@, %d φορές";
 
 "eventDetail.repeating.everyNDays:title" = "Κάθε %d ημέρες";
-"eventDetail.repeating.last" = "Τελευταίο";
 "eventDetail.repeating.everyNMonths:title" = "Κάθε %d μήνες";
 "eventDetail.repeating.everyNYears:title" = "Κάθε %d χρόνια";
 "eventDetail.repeating::endoption_until" = "έως %@";

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "F";
 "dayname::saturday:very_short" = "S";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Every Year %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Every year %@ (lunar calendar)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "All days of the last week of every month";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "The first %@ of every month";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "The second %@ of every month";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "The third %@ of every month";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "The fourth %@ of every month";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "The fifth %@ of every month";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "The sixth %@ of every month";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "The seventh %@ of every month";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "The last %@ of every month";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "The first %@ of every month";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "The first %@ of every month";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "The first %@ of every month";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "The second %@ of every month";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "The second %@ of every month";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "The second %@ of every month";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "The third %@ of every month";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "The third %@ of every month";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "The third %@ of every month";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "The fourth %@ of every month";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "The fourth %@ of every month";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "The fourth %@ of every month";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "The fifth %@ of every month";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "The fifth %@ of every month";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "The fifth %@ of every month";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "The sixth %@ of every month";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "The sixth %@ of every month";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "The sixth %@ of every month";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "The seventh %@ of every month";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "The seventh %@ of every month";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "The seventh %@ of every month";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "The last %@ of every month";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "The last %@ of every month";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "The last %@ of every month";
+"eventDetail.repeating.last::m" = "Last";
+"eventDetail.repeating.last::f" = "Last";
+"eventDetail.repeating.last::n" = "Last";
 "eventDetail.repeating.endtime::title" = "Repeat Ends";
 "eventDetail.repeating.endtime::option::never" = "Never";
 "eventDetail.repeating.endtime::option::on" = "On";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "Starting %@ %d times";
 
 "eventDetail.repeating.everyNDays:title" = "Every %d Days";
-"eventDetail.repeating.last" = "Last";
 "eventDetail.repeating.everyNMonths:title" = "Every %d Months";
 "eventDetail.repeating.everyNYears:title" = "Every %d Years";
 "eventDetail.repeating::endoption_until" = "until %@";

--- a/Supports/Extensions/Resources/es.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/es.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "V";
 "dayname::saturday:very_short" = "S";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Cada año %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Cada año %@ (calendario lunar)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Todos los días de la última semana de cada mes";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "El primer %@ de cada mes";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "El segundo %@ de cada mes";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "El tercer %@ de cada mes";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "El cuarto %@ de cada mes";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "El quinto %@ de cada mes";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "El sexto %@ de cada mes";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "El séptimo %@ de cada mes";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "El último %@ de cada mes";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "El primer %@ de cada mes";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "El primer %@ de cada mes";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "El primer %@ de cada mes";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "El segundo %@ de cada mes";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "El segundo %@ de cada mes";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "El segundo %@ de cada mes";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "El tercer %@ de cada mes";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "El tercer %@ de cada mes";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "El tercer %@ de cada mes";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "El cuarto %@ de cada mes";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "El cuarto %@ de cada mes";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "El cuarto %@ de cada mes";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "El quinto %@ de cada mes";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "El quinto %@ de cada mes";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "El quinto %@ de cada mes";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "El sexto %@ de cada mes";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "El sexto %@ de cada mes";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "El sexto %@ de cada mes";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "El séptimo %@ de cada mes";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "El séptimo %@ de cada mes";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "El séptimo %@ de cada mes";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "El último %@ de cada mes";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "El último %@ de cada mes";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "El último %@ de cada mes";
+"eventDetail.repeating.last::m" = "Último";
+"eventDetail.repeating.last::f" = "Último";
+"eventDetail.repeating.last::n" = "Último";
 "eventDetail.repeating.endtime::title" = "Fin de la repetición";
 "eventDetail.repeating.endtime::option::never" = "Nunca";
 "eventDetail.repeating.endtime::option::on" = "El";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "A partir del %@, %d veces";
 
 "eventDetail.repeating.everyNDays:title" = "Cada %d días";
-"eventDetail.repeating.last" = "Último";
 "eventDetail.repeating.everyNMonths:title" = "Cada %d meses";
 "eventDetail.repeating.everyNYears:title" = "Cada %d años";
 "eventDetail.repeating::endoption_until" = "hasta %@";

--- a/Supports/Extensions/Resources/fi.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/fi.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "P";
 "dayname::saturday:very_short" = "L";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Joka vuosi %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Joka vuosi %@ (kuukalenteri)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Kuukauden viimeisen viikon kaikki päivät";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "Kuukauden ensimmäinen %@";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "Kuukauden toinen %@";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "Kuukauden kolmas %@";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "Kuukauden neljäs %@";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "Kuukauden viides %@";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "Kuukauden kuudes %@";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "Kuukauden seitsemäs %@";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "Kuukauden viimeinen %@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "Kuukauden ensimmäinen %@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "Kuukauden ensimmäinen %@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "Kuukauden ensimmäinen %@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "Kuukauden toinen %@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "Kuukauden toinen %@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "Kuukauden toinen %@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "Kuukauden kolmas %@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "Kuukauden kolmas %@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "Kuukauden kolmas %@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "Kuukauden neljäs %@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "Kuukauden neljäs %@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "Kuukauden neljäs %@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "Kuukauden viides %@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "Kuukauden viides %@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "Kuukauden viides %@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "Kuukauden kuudes %@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "Kuukauden kuudes %@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "Kuukauden kuudes %@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "Kuukauden seitsemäs %@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "Kuukauden seitsemäs %@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "Kuukauden seitsemäs %@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "Kuukauden viimeinen %@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "Kuukauden viimeinen %@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "Kuukauden viimeinen %@";
+"eventDetail.repeating.last::m" = "Viimeinen";
+"eventDetail.repeating.last::f" = "Viimeinen";
+"eventDetail.repeating.last::n" = "Viimeinen";
 "eventDetail.repeating.endtime::title" = "Toisto päättyy";
 "eventDetail.repeating.endtime::option::never" = "Ei koskaan";
 "eventDetail.repeating.endtime::option::on" = "Päivänä";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "Alkaen %@, %d kertaa";
 
 "eventDetail.repeating.everyNDays:title" = "Joka %d. päivä";
-"eventDetail.repeating.last" = "Viimeinen";
 "eventDetail.repeating.everyNMonths:title" = "Joka %d. kuukausi";
 "eventDetail.repeating.everyNYears:title" = "Joka %d. vuosi";
 "eventDetail.repeating::endoption_until" = "kunnes %@";

--- a/Supports/Extensions/Resources/fr.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/fr.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "V";
 "dayname::saturday:very_short" = "S";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Tous les ans %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Tous les ans %@ (calendrier lunaire)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Tous les jours de la dernière semaine de chaque mois";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "Le premier %@ de chaque mois";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "Le deuxième %@ de chaque mois";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "Le troisième %@ de chaque mois";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "Le quatrième %@ de chaque mois";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "Le cinquième %@ de chaque mois";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "Le sixième %@ de chaque mois";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "Le septième %@ de chaque mois";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "Le dernier %@ de chaque mois";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "Le premier %@ de chaque mois";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "Le premier %@ de chaque mois";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "Le premier %@ de chaque mois";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "Le deuxième %@ de chaque mois";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "Le deuxième %@ de chaque mois";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "Le deuxième %@ de chaque mois";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "Le troisième %@ de chaque mois";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "Le troisième %@ de chaque mois";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "Le troisième %@ de chaque mois";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "Le quatrième %@ de chaque mois";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "Le quatrième %@ de chaque mois";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "Le quatrième %@ de chaque mois";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "Le cinquième %@ de chaque mois";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "Le cinquième %@ de chaque mois";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "Le cinquième %@ de chaque mois";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "Le sixième %@ de chaque mois";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "Le sixième %@ de chaque mois";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "Le sixième %@ de chaque mois";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "Le septième %@ de chaque mois";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "Le septième %@ de chaque mois";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "Le septième %@ de chaque mois";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "Le dernier %@ de chaque mois";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "Le dernier %@ de chaque mois";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "Le dernier %@ de chaque mois";
+"eventDetail.repeating.last::m" = "Dernier";
+"eventDetail.repeating.last::f" = "Dernier";
+"eventDetail.repeating.last::n" = "Dernier";
 "eventDetail.repeating.endtime::title" = "Fin de la répétition";
 "eventDetail.repeating.endtime::option::never" = "Jamais";
 "eventDetail.repeating.endtime::option::on" = "Le";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "À partir du %@, %d fois";
 
 "eventDetail.repeating.everyNDays:title" = "Tous les %d jours";
-"eventDetail.repeating.last" = "Dernier";
 "eventDetail.repeating.everyNMonths:title" = "Tous les %d mois";
 "eventDetail.repeating.everyNYears:title" = "Tous les %d ans";
 "eventDetail.repeating::endoption_until" = "jusqu'au %@";

--- a/Supports/Extensions/Resources/hi.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/hi.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "शु";
 "dayname::saturday:very_short" = "श";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "हर साल %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "हर साल %@ (चंद्र कैलेंडर)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "हर महीने के अंतिम सप्ताह के सभी दिन";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "हर महीने का पहला %@";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "हर महीने का दूसरा %@";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "हर महीने का तीसरा %@";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "हर महीने का चौथा %@";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "हर महीने का पांचवां %@";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "हर महीने का छठा %@";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "हर महीने का सातवां %@";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "हर महीने का अंतिम %@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "हर महीने का पहला %@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "हर महीने का पहला %@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "हर महीने का पहला %@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "हर महीने का दूसरा %@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "हर महीने का दूसरा %@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "हर महीने का दूसरा %@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "हर महीने का तीसरा %@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "हर महीने का तीसरा %@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "हर महीने का तीसरा %@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "हर महीने का चौथा %@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "हर महीने का चौथा %@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "हर महीने का चौथा %@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "हर महीने का पांचवां %@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "हर महीने का पांचवां %@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "हर महीने का पांचवां %@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "हर महीने का छठा %@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "हर महीने का छठा %@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "हर महीने का छठा %@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "हर महीने का सातवां %@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "हर महीने का सातवां %@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "हर महीने का सातवां %@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "हर महीने का अंतिम %@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "हर महीने का अंतिम %@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "हर महीने का अंतिम %@";
+"eventDetail.repeating.last::m" = "अंतिम";
+"eventDetail.repeating.last::f" = "अंतिम";
+"eventDetail.repeating.last::n" = "अंतिम";
 "eventDetail.repeating.endtime::title" = "दोहराव समाप्ति";
 "eventDetail.repeating.endtime::option::never" = "कभी नहीं";
 "eventDetail.repeating.endtime::option::on" = "तारीख को";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "%@ से शुरू, %d बार";
 
 "eventDetail.repeating.everyNDays:title" = "हर %d दिन में";
-"eventDetail.repeating.last" = "अंतिम";
 "eventDetail.repeating.everyNMonths:title" = "हर %d महीने में";
 "eventDetail.repeating.everyNYears:title" = "हर %d साल में";
 "eventDetail.repeating::endoption_until" = "%@ तक";

--- a/Supports/Extensions/Resources/hr.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/hr.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "P";
 "dayname::saturday:very_short" = "S";
 
+"dayname::sunday:gender" = "f";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "f";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "f";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Svake godine %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Svake godine %@ (lunarni kalendar)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Svi dani zadnjeg tjedna svakog mjeseca";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "Prvi %@ svakog mjeseca";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "Drugi %@ svakog mjeseca";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "Treći %@ svakog mjeseca";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "Četvrti %@ svakog mjeseca";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "Peti %@ svakog mjeseca";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "Šesti %@ svakog mjeseca";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "Sedmi %@ svakog mjeseca";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "Zadnji %@ svakog mjeseca";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "Prvi %@ svakog mjeseca";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "Prva %@ svakog mjeseca";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "Prvo %@ svakog mjeseca";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "Drugi %@ svakog mjeseca";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "Druga %@ svakog mjeseca";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "Drugo %@ svakog mjeseca";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "Treći %@ svakog mjeseca";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "Treća %@ svakog mjeseca";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "Treće %@ svakog mjeseca";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "Četvrti %@ svakog mjeseca";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "Četvrta %@ svakog mjeseca";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "Četvrto %@ svakog mjeseca";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "Peti %@ svakog mjeseca";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "Peta %@ svakog mjeseca";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "Peto %@ svakog mjeseca";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "Šesti %@ svakog mjeseca";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "Šesta %@ svakog mjeseca";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "Šesto %@ svakog mjeseca";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "Sedmi %@ svakog mjeseca";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "Sedma %@ svakog mjeseca";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "Sedmo %@ svakog mjeseca";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "Zadnji %@ svakog mjeseca";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "Zadnja %@ svakog mjeseca";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "Zadnje %@ svakog mjeseca";
+"eventDetail.repeating.last::m" = "Zadnji";
+"eventDetail.repeating.last::f" = "Zadnja";
+"eventDetail.repeating.last::n" = "Zadnje";
 "eventDetail.repeating.endtime::title" = "Kraj ponavljanja";
 "eventDetail.repeating.endtime::option::never" = "Nikada";
 "eventDetail.repeating.endtime::option::on" = "Na dan";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "Od %@, %d puta";
 
 "eventDetail.repeating.everyNDays:title" = "Svaki %d. dan";
-"eventDetail.repeating.last" = "Zadnji";
 "eventDetail.repeating.everyNMonths:title" = "Svaki %d. mjesec";
 "eventDetail.repeating.everyNYears:title" = "Svake %d. godine";
 "eventDetail.repeating::endoption_until" = "do %@";

--- a/Supports/Extensions/Resources/hr.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/hr.lproj/Localizable.strings
@@ -55,13 +55,13 @@
 
 // MARK: - event
 
-"dayname::sunday" = "Nedjelja";
-"dayname::monday" = "Ponedjeljak";
-"dayname::tuesday" = "Utorak";
-"dayname::wednesday" = "Srijeda";
-"dayname::thursday" = "Četvrtak";
-"dayname::friday" = "Petak";
-"dayname::saturday" = "Subota";
+"dayname::sunday" = "nedjelja";
+"dayname::monday" = "ponedjeljak";
+"dayname::tuesday" = "utorak";
+"dayname::wednesday" = "srijeda";
+"dayname::thursday" = "četvrtak";
+"dayname::friday" = "petak";
+"dayname::saturday" = "subota";
 
 "dayname::sunday:short" = "NED";
 "dayname::monday:short" = "PON";

--- a/Supports/Extensions/Resources/hr.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/hr.lproj/Localizable.strings
@@ -185,10 +185,10 @@
 "eventDetail.repeating.starttime:title" = "Vrijeme početka ponavljanja";
 "eventDetail.repeating.everyDay:title" = "Svaki dan";
 "eventDetail.repeating.everyWeek:title" = "Svaki tjedan";
-"eventDetail.repeating.everyWeekSomeDay:title" = "Svaki %@";
-"eventDetail.repeating.everySomeWeek:title" = "Svaka %d tjedna";
+"eventDetail.repeating.everyWeekSomeDay:title" = "Svaki tjedan: %@";
+"eventDetail.repeating.everySomeWeek:title" = "Svaki %d. tjedan";
 "eventDetail.repeating.everyWeekDays:title" = "Svaki radni dan";
-"eventDetail.repeating.everySomeWeekSomeDay:title" = "Svaka %d tjedna, %@";
+"eventDetail.repeating.everySomeWeekSomeDay:title" = "Svaki %d. tjedan: %@";
 "eventDetail.repeating.everyMonth:title" = "Svaki mjesec";
 "eventDetail.repeating.everyMonth_someDay:title" = "%@ svakog mjeseca.";
 "eventDetail.repeating.everyYear:title" = "Svake godine";
@@ -212,10 +212,10 @@
 "eventDetail.repeating.endtime::shouldFutureThanStartTime" = "Vrijeme kraja ponavljanja mora biti kasnije od vremena početka.\n(Datum početka ponavljanja: %@)";
 "eventDetail.repeating::period_endcount" = "Od %@, %d puta";
 
-"eventDetail.repeating.everyNDays:title" = "Svaka %d dana";
+"eventDetail.repeating.everyNDays:title" = "Svaki %d. dan";
 "eventDetail.repeating.last" = "Zadnji";
-"eventDetail.repeating.everyNMonths:title" = "Svaka %d mjeseca";
-"eventDetail.repeating.everyNYears:title" = "Svaka %d godine";
+"eventDetail.repeating.everyNMonths:title" = "Svaki %d. mjesec";
+"eventDetail.repeating.everyNYears:title" = "Svake %d. godine";
 "eventDetail.repeating::endoption_until" = "do %@";
 "eventDetail.repeating::endoption_times" = "%d puta";
 

--- a/Supports/Extensions/Resources/hu.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/hu.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "P";
 "dayname::saturday:very_short" = "Sz";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Minden évben %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Minden évben %@ (holdnaptár szerint)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Minden hónap utolsó hetének minden napja";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "Minden hónap első %@";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "Minden hónap második %@";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "Minden hónap harmadik %@";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "Minden hónap negyedik %@";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "Minden hónap ötödik %@";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "Minden hónap hatodik %@";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "Minden hónap hetedik %@";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "Minden hónap utolsó %@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "Minden hónap első %@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "Minden hónap első %@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "Minden hónap első %@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "Minden hónap második %@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "Minden hónap második %@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "Minden hónap második %@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "Minden hónap harmadik %@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "Minden hónap harmadik %@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "Minden hónap harmadik %@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "Minden hónap negyedik %@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "Minden hónap negyedik %@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "Minden hónap negyedik %@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "Minden hónap ötödik %@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "Minden hónap ötödik %@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "Minden hónap ötödik %@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "Minden hónap hatodik %@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "Minden hónap hatodik %@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "Minden hónap hatodik %@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "Minden hónap hetedik %@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "Minden hónap hetedik %@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "Minden hónap hetedik %@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "Minden hónap utolsó %@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "Minden hónap utolsó %@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "Minden hónap utolsó %@";
+"eventDetail.repeating.last::m" = "Utolsó";
+"eventDetail.repeating.last::f" = "Utolsó";
+"eventDetail.repeating.last::n" = "Utolsó";
 "eventDetail.repeating.endtime::title" = "Ismétlés vége";
 "eventDetail.repeating.endtime::option::never" = "Soha";
 "eventDetail.repeating.endtime::option::on" = "Ekkor";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "%@-tól kezdve, %d alkalommal";
 
 "eventDetail.repeating.everyNDays:title" = "Minden %d. napon";
-"eventDetail.repeating.last" = "Utolsó";
 "eventDetail.repeating.everyNMonths:title" = "Minden %d. hónapban";
 "eventDetail.repeating.everyNYears:title" = "Minden %d. évben";
 "eventDetail.repeating::endoption_until" = "eddig: %@";

--- a/Supports/Extensions/Resources/id.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/id.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "J";
 "dayname::saturday:very_short" = "S";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Setiap tahun %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Setiap tahun %@ (kalender lunar)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Semua hari di minggu terakhir setiap bulan";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "%@ pertama setiap bulan";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "%@ kedua setiap bulan";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "%@ ketiga setiap bulan";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "%@ keempat setiap bulan";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "%@ kelima setiap bulan";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "%@ keenam setiap bulan";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "%@ ketujuh setiap bulan";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "%@ terakhir setiap bulan";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "%@ pertama setiap bulan";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "%@ pertama setiap bulan";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "%@ pertama setiap bulan";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "%@ kedua setiap bulan";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "%@ kedua setiap bulan";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "%@ kedua setiap bulan";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "%@ ketiga setiap bulan";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "%@ ketiga setiap bulan";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "%@ ketiga setiap bulan";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "%@ keempat setiap bulan";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "%@ keempat setiap bulan";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "%@ keempat setiap bulan";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "%@ kelima setiap bulan";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "%@ kelima setiap bulan";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "%@ kelima setiap bulan";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "%@ keenam setiap bulan";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "%@ keenam setiap bulan";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "%@ keenam setiap bulan";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "%@ ketujuh setiap bulan";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "%@ ketujuh setiap bulan";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "%@ ketujuh setiap bulan";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "%@ terakhir setiap bulan";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "%@ terakhir setiap bulan";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "%@ terakhir setiap bulan";
+"eventDetail.repeating.last::m" = "Terakhir";
+"eventDetail.repeating.last::f" = "Terakhir";
+"eventDetail.repeating.last::n" = "Terakhir";
 "eventDetail.repeating.endtime::title" = "Akhir Pengulangan";
 "eventDetail.repeating.endtime::option::never" = "Tidak pernah";
 "eventDetail.repeating.endtime::option::on" = "Pada tanggal";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "Mulai %@, %d kali";
 
 "eventDetail.repeating.everyNDays:title" = "Setiap %d hari";
-"eventDetail.repeating.last" = "Terakhir";
 "eventDetail.repeating.everyNMonths:title" = "Setiap %d bulan";
 "eventDetail.repeating.everyNYears:title" = "Setiap %d tahun";
 "eventDetail.repeating::endoption_until" = "hingga %@";

--- a/Supports/Extensions/Resources/it.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/it.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "V";
 "dayname::saturday:very_short" = "S";
 
+"dayname::sunday:gender" = "f";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Ogni anno il %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Ogni anno il %@ (calendario lunare)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Tutti i giorni dell'ultima settimana di ogni mese";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "Il primo %@ di ogni mese";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "Il secondo %@ di ogni mese";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "Il terzo %@ di ogni mese";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "Il quarto %@ di ogni mese";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "Il quinto %@ di ogni mese";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "Il sesto %@ di ogni mese";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "Il settimo %@ di ogni mese";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "L'ultimo %@ di ogni mese";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "Il primo %@ di ogni mese";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "La prima %@ di ogni mese";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "Il primo %@ di ogni mese";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "Il secondo %@ di ogni mese";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "La seconda %@ di ogni mese";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "Il secondo %@ di ogni mese";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "Il terzo %@ di ogni mese";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "La terza %@ di ogni mese";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "Il terzo %@ di ogni mese";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "Il quarto %@ di ogni mese";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "La quarta %@ di ogni mese";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "Il quarto %@ di ogni mese";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "Il quinto %@ di ogni mese";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "La quinta %@ di ogni mese";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "Il quinto %@ di ogni mese";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "Il sesto %@ di ogni mese";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "La sesta %@ di ogni mese";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "Il sesto %@ di ogni mese";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "Il settimo %@ di ogni mese";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "La settima %@ di ogni mese";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "Il settimo %@ di ogni mese";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "L'ultimo %@ di ogni mese";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "L'ultima %@ di ogni mese";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "L'ultimo %@ di ogni mese";
+"eventDetail.repeating.last::m" = "Ultimo";
+"eventDetail.repeating.last::f" = "Ultima";
+"eventDetail.repeating.last::n" = "Ultimo";
 "eventDetail.repeating.endtime::title" = "Fine ricorrenza";
 "eventDetail.repeating.endtime::option::never" = "Mai";
 "eventDetail.repeating.endtime::option::on" = "Il giorno";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "A partire dal %@ per %d volte";
 
 "eventDetail.repeating.everyNDays:title" = "Ogni %d giorni";
-"eventDetail.repeating.last" = "Ultimo";
 "eventDetail.repeating.everyNMonths:title" = "Ogni %d mesi";
 "eventDetail.repeating.everyNYears:title" = "Ogni %d anni";
 "eventDetail.repeating::endoption_until" = "fino al %@";

--- a/Supports/Extensions/Resources/it.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/it.lproj/Localizable.strings
@@ -188,7 +188,7 @@
 "eventDetail.repeating.everyWeekSomeDay:title" = "Ogni %@";
 "eventDetail.repeating.everySomeWeek:title" = "Ogni %d settimane";
 "eventDetail.repeating.everyWeekDays:title" = "Ogni giorno feriale";
-"eventDetail.repeating.everySomeWeekSomeDay:title" = "Ogni %d settimane il %@";
+"eventDetail.repeating.everySomeWeekSomeDay:title" = "Ogni %d settimane: %@";
 "eventDetail.repeating.everyMonth:title" = "Ogni mese";
 "eventDetail.repeating.everyMonth_someDay:title" = "Il %@ di ogni mese.";
 "eventDetail.repeating.everyYear:title" = "Ogni anno";

--- a/Supports/Extensions/Resources/it.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/it.lproj/Localizable.strings
@@ -391,7 +391,7 @@
 "manage_account::delete_account_button::description" = "Dopo aver richiesto l'eliminazione dell'account, il tuo account verrà eliminato.\nUna volta eliminato, le informazioni dell'account non potranno essere recuperate.";
 "signIn::title" = "Accedi";
 "signIn::feature::sync" = "Backup degli eventi e sincronizzazione tra dispositivi";
-"signIn::feature::aiAgent" = "Gestisci la tua agenda con l'agente AI";
+"signIn::feature::aiAgent" = "Gestisci la tua agenda con l'agente IA";
 "signIn::feature::web" = "Usalo sul web · todo-calendar.com";
 
 
@@ -585,8 +585,8 @@
 "widget.dday.target::registered" = "Fissato";
 "widget.dday.turn::name" = "Turno %d";
 
-"widget.aiCommand::title" = "Aggiungi con l'AI";
-"widget.aiCommand::explain" = "Tocca una volta per aprire l'inserimento AI.";
+"widget.aiCommand::title" = "Aggiungi con l'IA";
+"widget.aiCommand::explain" = "Tocca una volta per aprire l'inserimento IA.";
 
 // MARK: - liveActivity
 
@@ -623,14 +623,14 @@
 "aiAgent::state::failed" = "Attività non riuscita";
 "aiAgent::done::default" = "Fatto";
 "aiAgent::failed::default" = "Impossibile completare l'operazione";
-"aiAgent::failed::dailyLimitExceeded" = "Hai esaurito i crediti AI di oggi.";
+"aiAgent::failed::dailyLimitExceeded" = "Hai esaurito i crediti IA di oggi.";
 "aiAgent::retry" = "Riprova";
 "aiAgent::needSignIn::title" = "Accesso richiesto";
-"aiAgent::needSignIn::message" = "Accedi per usare l'inserimento rapido con AI.";
+"aiAgent::needSignIn::message" = "Accedi per usare l'inserimento rapido con IA.";
 "aiAgent::speechPermissionDenied::title" = "Autorizzazione richiesta";
 "aiAgent::speechPermissionDenied::message" = "Consenti l'accesso al microfono e al riconoscimento vocale nelle Impostazioni per usare l'inserimento vocale.";
 "aiAgent::speechPermissionDenied::confirm" = "Apri Impostazioni";
-"aiAgent::title" = "Inserimento rapido AI";
+"aiAgent::title" = "Inserimento rapido IA";
 "aiAgent::keyboard::stop" = "Interrompi";
 "aiAgent::keyboard::send" = "Invia";
 "aiAgent::stop" = "Interrompi";
@@ -721,18 +721,18 @@
 
 // MARK: - share extension
 
-"share.ai::title" = "Invia all'AI";
+"share.ai::title" = "Invia all'IA";
 "share.ai::text::placeholder" = "Testo da inviare";
 "share.ai::instruction::placeholder" = "Aggiungi un'istruzione (facoltativo)";
-"share.ai::needSignIn" = "Esegui l'accesso nell'app per usare l'inserimento rapido con AI.";
+"share.ai::needSignIn" = "Esegui l'accesso nell'app per usare l'inserimento rapido con IA.";
 "share.ai::pending" = "Una richiesta precedente è ancora in attesa. Apri l'app per vederne l'avanzamento o il risultato.";
 "share.ai::sent" = "Inviato. Puoi vedere il risultato nell'app.";
 "share.ai::failed" = "Impossibile inviare. Riprova.";
 "share.ai::sentButUntracked" = "Inviato, ma l'app non può tracciare il risultato. Controlla il calendario tra poco.";
 "share.ai::textTooLong" = "Il testo è troppo lungo da inviare. Accorcialo e riprova.";
 "share.ai::instructionTooLong" = "La tua istruzione è troppo lunga. Accorciala.";
-"share.ai::limitExceeded" = "Hai esaurito i crediti AI di oggi. Si azzerano a mezzanotte UTC.";
-"share.ai::image::title" = "Invia l'immagine all'AI";
+"share.ai::limitExceeded" = "Hai esaurito i crediti IA di oggi. Si azzerano a mezzanotte UTC.";
+"share.ai::image::title" = "Invia l'immagine all'IA";
 "share.ai::image::recognizing" = "Lettura del testo dall'immagine…";
 "share.ai::image::text::caption" = "Testo letto dall'immagine. Modificalo se qualcosa non ti convince.";
 "share.ai::image::text::placeholder" = "Testo letto dall'immagine";

--- a/Supports/Extensions/Resources/it.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/it.lproj/Localizable.strings
@@ -55,13 +55,13 @@
 
 // MARK: - event
 
-"dayname::sunday" = "Domenica";
-"dayname::monday" = "Lunedì";
-"dayname::tuesday" = "Martedì";
-"dayname::wednesday" = "Mercoledì";
-"dayname::thursday" = "Giovedì";
-"dayname::friday" = "Venerdì";
-"dayname::saturday" = "Sabato";
+"dayname::sunday" = "domenica";
+"dayname::monday" = "lunedì";
+"dayname::tuesday" = "martedì";
+"dayname::wednesday" = "mercoledì";
+"dayname::thursday" = "giovedì";
+"dayname::friday" = "venerdì";
+"dayname::saturday" = "sabato";
 
 "dayname::sunday:short" = "DOM";
 "dayname::monday:short" = "LUN";

--- a/Supports/Extensions/Resources/ja.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ja.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "金";
 "dayname::saturday:very_short" = "土";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "毎年%@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "毎年%@（旧暦）";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "毎月最終週のすべての曜日";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "毎月第1%@";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "毎月第2%@";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "毎月第3%@";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "毎月第4%@";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "毎月第5%@";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "毎月第6%@";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "毎月第7%@";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "毎月最終%@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "毎月第1%@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "毎月第1%@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "毎月第1%@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "毎月第2%@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "毎月第2%@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "毎月第2%@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "毎月第3%@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "毎月第3%@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "毎月第3%@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "毎月第4%@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "毎月第4%@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "毎月第4%@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "毎月第5%@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "毎月第5%@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "毎月第5%@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "毎月第6%@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "毎月第6%@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "毎月第6%@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "毎月第7%@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "毎月第7%@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "毎月第7%@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "毎月最終%@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "毎月最終%@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "毎月最終%@";
+"eventDetail.repeating.last::m" = "最終";
+"eventDetail.repeating.last::f" = "最終";
+"eventDetail.repeating.last::n" = "最終";
 "eventDetail.repeating.endtime::title" = "繰り返しの終了";
 "eventDetail.repeating.endtime::option::never" = "しない";
 "eventDetail.repeating.endtime::option::on" = "日付指定";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "%@から%d回";
 
 "eventDetail.repeating.everyNDays:title" = "%d日ごと";
-"eventDetail.repeating.last" = "最終";
 "eventDetail.repeating.everyNMonths:title" = "%dヶ月ごと";
 "eventDetail.repeating.everyNYears:title" = "%d年ごと";
 "eventDetail.repeating::endoption_until" = "%@まで";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "금";
 "dayname::saturday:very_short" = "토";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "매년 %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "매년 음력 %@";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "매달의 마지막주의 모든일";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "매달 첫번째 %@";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "매달 두번째 %@";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "매달 세번째 %@";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "매달 네번째 %@";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "매달 다섯번째 %@";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "매달 여섯번째 %@";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "매달 일곱번째 %@";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "매달 마지막 %@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "매달 첫번째 %@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "매달 첫번째 %@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "매달 첫번째 %@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "매달 두번째 %@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "매달 두번째 %@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "매달 두번째 %@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "매달 세번째 %@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "매달 세번째 %@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "매달 세번째 %@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "매달 네번째 %@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "매달 네번째 %@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "매달 네번째 %@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "매달 다섯번째 %@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "매달 다섯번째 %@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "매달 다섯번째 %@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "매달 여섯번째 %@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "매달 여섯번째 %@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "매달 여섯번째 %@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "매달 일곱번째 %@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "매달 일곱번째 %@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "매달 일곱번째 %@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "매달 마지막 %@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "매달 마지막 %@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "매달 마지막 %@";
+"eventDetail.repeating.last::m" = "마지막";
+"eventDetail.repeating.last::f" = "마지막";
+"eventDetail.repeating.last::n" = "마지막";
 "eventDetail.repeating.endtime::title" = "반복 종료";
 "eventDetail.repeating.endtime::option::never" = "안함";
 "eventDetail.repeating.endtime::option::on" = "시간";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "%@ 부터 %d회";
 
 "eventDetail.repeating.everyNDays:title" = "매%d일";
-"eventDetail.repeating.last" = "마지막";
 "eventDetail.repeating.everyNMonths:title" = "매%d달";
 "eventDetail.repeating.everyNYears:title" = "매%d년";
 "eventDetail.repeating::endoption_until" = "%@ 까지";

--- a/Supports/Extensions/Resources/ms.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ms.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "J";
 "dayname::saturday:very_short" = "S";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Setiap tahun %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Setiap tahun %@ (kalendar lunar)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Semua hari pada minggu terakhir setiap bulan";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "%@ pertama setiap bulan";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "%@ kedua setiap bulan";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "%@ ketiga setiap bulan";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "%@ keempat setiap bulan";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "%@ kelima setiap bulan";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "%@ keenam setiap bulan";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "%@ ketujuh setiap bulan";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "%@ terakhir setiap bulan";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "%@ pertama setiap bulan";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "%@ pertama setiap bulan";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "%@ pertama setiap bulan";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "%@ kedua setiap bulan";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "%@ kedua setiap bulan";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "%@ kedua setiap bulan";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "%@ ketiga setiap bulan";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "%@ ketiga setiap bulan";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "%@ ketiga setiap bulan";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "%@ keempat setiap bulan";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "%@ keempat setiap bulan";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "%@ keempat setiap bulan";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "%@ kelima setiap bulan";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "%@ kelima setiap bulan";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "%@ kelima setiap bulan";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "%@ keenam setiap bulan";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "%@ keenam setiap bulan";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "%@ keenam setiap bulan";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "%@ ketujuh setiap bulan";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "%@ ketujuh setiap bulan";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "%@ ketujuh setiap bulan";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "%@ terakhir setiap bulan";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "%@ terakhir setiap bulan";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "%@ terakhir setiap bulan";
+"eventDetail.repeating.last::m" = "Terakhir";
+"eventDetail.repeating.last::f" = "Terakhir";
+"eventDetail.repeating.last::n" = "Terakhir";
 "eventDetail.repeating.endtime::title" = "Tamat Pengulangan";
 "eventDetail.repeating.endtime::option::never" = "Tidak sekali-kali";
 "eventDetail.repeating.endtime::option::on" = "Pada";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "Bermula %@, %d kali";
 
 "eventDetail.repeating.everyNDays:title" = "Setiap %d hari";
-"eventDetail.repeating.last" = "Terakhir";
 "eventDetail.repeating.everyNMonths:title" = "Setiap %d bulan";
 "eventDetail.repeating.everyNYears:title" = "Setiap %d tahun";
 "eventDetail.repeating::endoption_until" = "sehingga %@";

--- a/Supports/Extensions/Resources/nb.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/nb.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "F";
 "dayname::saturday:very_short" = "L";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Hvert år %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Hvert år %@ (månekalender)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Alle dager i siste uke av hver måned";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "Den første %@ i hver måned";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "Den andre %@ i hver måned";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "Den tredje %@ i hver måned";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "Den fjerde %@ i hver måned";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "Den femte %@ i hver måned";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "Den sjette %@ i hver måned";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "Den sjuende %@ i hver måned";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "Den siste %@ i hver måned";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "Den første %@ i hver måned";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "Den første %@ i hver måned";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "Den første %@ i hver måned";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "Den andre %@ i hver måned";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "Den andre %@ i hver måned";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "Den andre %@ i hver måned";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "Den tredje %@ i hver måned";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "Den tredje %@ i hver måned";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "Den tredje %@ i hver måned";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "Den fjerde %@ i hver måned";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "Den fjerde %@ i hver måned";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "Den fjerde %@ i hver måned";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "Den femte %@ i hver måned";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "Den femte %@ i hver måned";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "Den femte %@ i hver måned";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "Den sjette %@ i hver måned";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "Den sjette %@ i hver måned";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "Den sjette %@ i hver måned";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "Den sjuende %@ i hver måned";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "Den sjuende %@ i hver måned";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "Den sjuende %@ i hver måned";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "Den siste %@ i hver måned";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "Den siste %@ i hver måned";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "Den siste %@ i hver måned";
+"eventDetail.repeating.last::m" = "Siste";
+"eventDetail.repeating.last::f" = "Siste";
+"eventDetail.repeating.last::n" = "Siste";
 "eventDetail.repeating.endtime::title" = "Gjentakelse avsluttes";
 "eventDetail.repeating.endtime::option::never" = "Aldri";
 "eventDetail.repeating.endtime::option::on" = "Den";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "Fra %@, %d ganger";
 
 "eventDetail.repeating.everyNDays:title" = "Hver %d. dag";
-"eventDetail.repeating.last" = "Siste";
 "eventDetail.repeating.everyNMonths:title" = "Hver %d. måned";
 "eventDetail.repeating.everyNYears:title" = "Hvert %d. år";
 "eventDetail.repeating::endoption_until" = "til %@";

--- a/Supports/Extensions/Resources/nl.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/nl.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "V";
 "dayname::saturday:very_short" = "Z";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Elk jaar %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Elk jaar %@ (maankalender)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Alle dagen van de laatste week van elke maand";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "De eerste %@ van elke maand";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "De tweede %@ van elke maand";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "De derde %@ van elke maand";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "De vierde %@ van elke maand";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "De vijfde %@ van elke maand";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "De zesde %@ van elke maand";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "De zevende %@ van elke maand";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "De laatste %@ van elke maand";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "De eerste %@ van elke maand";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "De eerste %@ van elke maand";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "De eerste %@ van elke maand";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "De tweede %@ van elke maand";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "De tweede %@ van elke maand";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "De tweede %@ van elke maand";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "De derde %@ van elke maand";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "De derde %@ van elke maand";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "De derde %@ van elke maand";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "De vierde %@ van elke maand";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "De vierde %@ van elke maand";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "De vierde %@ van elke maand";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "De vijfde %@ van elke maand";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "De vijfde %@ van elke maand";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "De vijfde %@ van elke maand";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "De zesde %@ van elke maand";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "De zesde %@ van elke maand";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "De zesde %@ van elke maand";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "De zevende %@ van elke maand";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "De zevende %@ van elke maand";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "De zevende %@ van elke maand";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "De laatste %@ van elke maand";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "De laatste %@ van elke maand";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "De laatste %@ van elke maand";
+"eventDetail.repeating.last::m" = "Laatste";
+"eventDetail.repeating.last::f" = "Laatste";
+"eventDetail.repeating.last::n" = "Laatste";
 "eventDetail.repeating.endtime::title" = "Einde van de herhaling";
 "eventDetail.repeating.endtime::option::never" = "Nooit";
 "eventDetail.repeating.endtime::option::on" = "Op";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "Vanaf %@, %d keer";
 
 "eventDetail.repeating.everyNDays:title" = "Elke %d dagen";
-"eventDetail.repeating.last" = "Laatste";
 "eventDetail.repeating.everyNMonths:title" = "Elke %d maanden";
 "eventDetail.repeating.everyNYears:title" = "Elke %d jaar";
 "eventDetail.repeating::endoption_until" = "tot %@";

--- a/Supports/Extensions/Resources/pl.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/pl.lproj/Localizable.strings
@@ -55,13 +55,13 @@
 
 // MARK: - event
 
-"dayname::sunday" = "Niedziela";
-"dayname::monday" = "Poniedziałek";
-"dayname::tuesday" = "Wtorek";
-"dayname::wednesday" = "Środa";
-"dayname::thursday" = "Czwartek";
-"dayname::friday" = "Piątek";
-"dayname::saturday" = "Sobota";
+"dayname::sunday" = "niedziela";
+"dayname::monday" = "poniedziałek";
+"dayname::tuesday" = "wtorek";
+"dayname::wednesday" = "środa";
+"dayname::thursday" = "czwartek";
+"dayname::friday" = "piątek";
+"dayname::saturday" = "sobota";
 
 "dayname::sunday:short" = "NIE";
 "dayname::monday:short" = "PON";

--- a/Supports/Extensions/Resources/pl.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/pl.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "P";
 "dayname::saturday:very_short" = "S";
 
+"dayname::sunday:gender" = "f";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "f";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "f";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Co rok %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Co rok %@ (kalendarz księżycowy)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Wszystkie dni ostatniego tygodnia każdego miesiąca";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "Pierwszy %@ każdego miesiąca";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "Drugi %@ każdego miesiąca";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "Trzeci %@ każdego miesiąca";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "Czwarty %@ każdego miesiąca";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "Piąty %@ każdego miesiąca";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "Szósty %@ każdego miesiąca";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "Siódmy %@ każdego miesiąca";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "Ostatni %@ każdego miesiąca";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "Pierwszy %@ każdego miesiąca";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "Pierwsza %@ każdego miesiąca";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "Pierwsze %@ każdego miesiąca";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "Drugi %@ każdego miesiąca";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "Druga %@ każdego miesiąca";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "Drugie %@ każdego miesiąca";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "Trzeci %@ każdego miesiąca";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "Trzecia %@ każdego miesiąca";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "Trzecie %@ każdego miesiąca";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "Czwarty %@ każdego miesiąca";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "Czwarta %@ każdego miesiąca";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "Czwarte %@ każdego miesiąca";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "Piąty %@ każdego miesiąca";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "Piąta %@ każdego miesiąca";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "Piąte %@ każdego miesiąca";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "Szósty %@ każdego miesiąca";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "Szósta %@ każdego miesiąca";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "Szóste %@ każdego miesiąca";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "Siódmy %@ każdego miesiąca";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "Siódma %@ każdego miesiąca";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "Siódme %@ każdego miesiąca";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "Ostatni %@ każdego miesiąca";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "Ostatnia %@ każdego miesiąca";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "Ostatnie %@ każdego miesiąca";
+"eventDetail.repeating.last::m" = "Ostatni";
+"eventDetail.repeating.last::f" = "Ostatnia";
+"eventDetail.repeating.last::n" = "Ostatnie";
 "eventDetail.repeating.endtime::title" = "Koniec powtarzania";
 "eventDetail.repeating.endtime::option::never" = "Nigdy";
 "eventDetail.repeating.endtime::option::on" = "W dniu";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "Od %@, %d razy";
 
 "eventDetail.repeating.everyNDays:title" = "Co %d. dzień";
-"eventDetail.repeating.last" = "Ostatni";
 "eventDetail.repeating.everyNMonths:title" = "Co %d. miesiąc";
 "eventDetail.repeating.everyNYears:title" = "Co %d. rok";
 "eventDetail.repeating::endoption_until" = "do %@";

--- a/Supports/Extensions/Resources/pl.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/pl.lproj/Localizable.strings
@@ -185,10 +185,10 @@
 "eventDetail.repeating.starttime:title" = "Czas rozpoczęcia powtarzania";
 "eventDetail.repeating.everyDay:title" = "Codziennie";
 "eventDetail.repeating.everyWeek:title" = "Co tydzień";
-"eventDetail.repeating.everyWeekSomeDay:title" = "Co %@";
-"eventDetail.repeating.everySomeWeek:title" = "Co %d tygodni";
+"eventDetail.repeating.everyWeekSomeDay:title" = "Co tydzień: %@";
+"eventDetail.repeating.everySomeWeek:title" = "Co %d. tydzień";
 "eventDetail.repeating.everyWeekDays:title" = "Każdego dnia roboczego";
-"eventDetail.repeating.everySomeWeekSomeDay:title" = "Co %d tygodni w %@";
+"eventDetail.repeating.everySomeWeekSomeDay:title" = "Co %d. tydzień: %@";
 "eventDetail.repeating.everyMonth:title" = "Co miesiąc";
 "eventDetail.repeating.everyMonth_someDay:title" = "%@ każdego miesiąca.";
 "eventDetail.repeating.everyYear:title" = "Co rok";
@@ -212,10 +212,10 @@
 "eventDetail.repeating.endtime::shouldFutureThanStartTime" = "Czas zakończenia powtarzania musi być późniejszy niż czas rozpoczęcia.\n(Data rozpoczęcia powtarzania: %@)";
 "eventDetail.repeating::period_endcount" = "Od %@, %d razy";
 
-"eventDetail.repeating.everyNDays:title" = "Co %d dni";
+"eventDetail.repeating.everyNDays:title" = "Co %d. dzień";
 "eventDetail.repeating.last" = "Ostatni";
-"eventDetail.repeating.everyNMonths:title" = "Co %d miesięcy";
-"eventDetail.repeating.everyNYears:title" = "Co %d lat";
+"eventDetail.repeating.everyNMonths:title" = "Co %d. miesiąc";
+"eventDetail.repeating.everyNYears:title" = "Co %d. rok";
 "eventDetail.repeating::endoption_until" = "do %@";
 "eventDetail.repeating::endoption_times" = "%d razy";
 

--- a/Supports/Extensions/Resources/pt-BR.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/pt-BR.lproj/Localizable.strings
@@ -55,13 +55,13 @@
 
 // MARK: - event
 
-"dayname::sunday" = "Domingo";
-"dayname::monday" = "Segunda-feira";
-"dayname::tuesday" = "Terça-feira";
-"dayname::wednesday" = "Quarta-feira";
-"dayname::thursday" = "Quinta-feira";
-"dayname::friday" = "Sexta-feira";
-"dayname::saturday" = "Sábado";
+"dayname::sunday" = "domingo";
+"dayname::monday" = "segunda-feira";
+"dayname::tuesday" = "terça-feira";
+"dayname::wednesday" = "quarta-feira";
+"dayname::thursday" = "quinta-feira";
+"dayname::friday" = "sexta-feira";
+"dayname::saturday" = "sábado";
 
 "dayname::sunday:short" = "DOM";
 "dayname::monday:short" = "SEG";

--- a/Supports/Extensions/Resources/pt-BR.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/pt-BR.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "S";
 "dayname::saturday:very_short" = "S";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "f";
+"dayname::tuesday:gender" = "f";
+"dayname::wednesday:gender" = "f";
+"dayname::thursday:gender" = "f";
+"dayname::friday:gender" = "f";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Todo ano %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Todo ano %@ (calendário lunar)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Todos os dias da última semana de cada mês";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "O primeiro %@ de cada mês";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "O segundo %@ de cada mês";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "O terceiro %@ de cada mês";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "O quarto %@ de cada mês";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "O quinto %@ de cada mês";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "O sexto %@ de cada mês";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "O sétimo %@ de cada mês";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "O último %@ de cada mês";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "O primeiro %@ de cada mês";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "A primeira %@ de cada mês";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "O primeiro %@ de cada mês";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "O segundo %@ de cada mês";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "A segunda %@ de cada mês";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "O segundo %@ de cada mês";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "O terceiro %@ de cada mês";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "A terceira %@ de cada mês";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "O terceiro %@ de cada mês";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "O quarto %@ de cada mês";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "A quarta %@ de cada mês";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "O quarto %@ de cada mês";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "O quinto %@ de cada mês";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "A quinta %@ de cada mês";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "O quinto %@ de cada mês";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "O sexto %@ de cada mês";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "A sexta %@ de cada mês";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "O sexto %@ de cada mês";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "O sétimo %@ de cada mês";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "A sétima %@ de cada mês";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "O sétimo %@ de cada mês";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "O último %@ de cada mês";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "A última %@ de cada mês";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "O último %@ de cada mês";
+"eventDetail.repeating.last::m" = "Último";
+"eventDetail.repeating.last::f" = "Última";
+"eventDetail.repeating.last::n" = "Último";
 "eventDetail.repeating.endtime::title" = "Término da recorrência";
 "eventDetail.repeating.endtime::option::never" = "Nunca";
 "eventDetail.repeating.endtime::option::on" = "Em";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "A partir de %@ %d vezes";
 
 "eventDetail.repeating.everyNDays:title" = "A cada %d dias";
-"eventDetail.repeating.last" = "Último";
 "eventDetail.repeating.everyNMonths:title" = "A cada %d meses";
 "eventDetail.repeating.everyNYears:title" = "A cada %d anos";
 "eventDetail.repeating::endoption_until" = "até %@";

--- a/Supports/Extensions/Resources/pt-BR.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/pt-BR.lproj/Localizable.strings
@@ -185,10 +185,10 @@
 "eventDetail.repeating.starttime:title" = "Início da recorrência";
 "eventDetail.repeating.everyDay:title" = "Todos os dias";
 "eventDetail.repeating.everyWeek:title" = "Toda semana";
-"eventDetail.repeating.everyWeekSomeDay:title" = "Toda %@";
+"eventDetail.repeating.everyWeekSomeDay:title" = "Toda semana: %@";
 "eventDetail.repeating.everySomeWeek:title" = "A cada %d semanas";
 "eventDetail.repeating.everyWeekDays:title" = "Todo dia útil";
-"eventDetail.repeating.everySomeWeekSomeDay:title" = "A cada %d semanas %@";
+"eventDetail.repeating.everySomeWeekSomeDay:title" = "A cada %d semanas: %@";
 "eventDetail.repeating.everyMonth:title" = "Todo mês";
 "eventDetail.repeating.everyMonth_someDay:title" = "%@ de cada mês.";
 "eventDetail.repeating.everyYear:title" = "Todo ano";

--- a/Supports/Extensions/Resources/ro.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ro.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "V";
 "dayname::saturday:very_short" = "S";
 
+"dayname::sunday:gender" = "f";
+"dayname::monday:gender" = "f";
+"dayname::tuesday:gender" = "f";
+"dayname::wednesday:gender" = "f";
+"dayname::thursday:gender" = "f";
+"dayname::friday:gender" = "f";
+"dayname::saturday:gender" = "f";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "În fiecare an %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "În fiecare an %@ (calendar lunar)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Toate zilele din ultima săptămână a fiecărei luni";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "Prima %@ din fiecare lună";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "A doua %@ din fiecare lună";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "A treia %@ din fiecare lună";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "A patra %@ din fiecare lună";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "A cincea %@ din fiecare lună";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "A șasea %@ din fiecare lună";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "A șaptea %@ din fiecare lună";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "Ultima %@ din fiecare lună";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "Prima %@ din fiecare lună";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "Prima %@ din fiecare lună";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "Prima %@ din fiecare lună";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "A doua %@ din fiecare lună";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "A doua %@ din fiecare lună";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "A doua %@ din fiecare lună";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "A treia %@ din fiecare lună";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "A treia %@ din fiecare lună";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "A treia %@ din fiecare lună";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "A patra %@ din fiecare lună";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "A patra %@ din fiecare lună";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "A patra %@ din fiecare lună";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "A cincea %@ din fiecare lună";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "A cincea %@ din fiecare lună";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "A cincea %@ din fiecare lună";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "A șasea %@ din fiecare lună";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "A șasea %@ din fiecare lună";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "A șasea %@ din fiecare lună";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "A șaptea %@ din fiecare lună";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "A șaptea %@ din fiecare lună";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "A șaptea %@ din fiecare lună";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "Ultima %@ din fiecare lună";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "Ultima %@ din fiecare lună";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "Ultima %@ din fiecare lună";
+"eventDetail.repeating.last::m" = "Ultima";
+"eventDetail.repeating.last::f" = "Ultima";
+"eventDetail.repeating.last::n" = "Ultima";
 "eventDetail.repeating.endtime::title" = "Sfârșitul repetării";
 "eventDetail.repeating.endtime::option::never" = "Niciodată";
 "eventDetail.repeating.endtime::option::on" = "La data";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "Începând cu %@, de %d ori";
 
 "eventDetail.repeating.everyNDays:title" = "La fiecare %d zile";
-"eventDetail.repeating.last" = "Ultima";
 "eventDetail.repeating.everyNMonths:title" = "La fiecare %d luni";
 "eventDetail.repeating.everyNYears:title" = "La fiecare %d ani";
 "eventDetail.repeating::endoption_until" = "până la %@";

--- a/Supports/Extensions/Resources/ru.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ru.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "П";
 "dayname::saturday:very_short" = "С";
 
+"dayname::sunday:gender" = "n";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "f";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "f";
+"dayname::saturday:gender" = "f";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Каждый год %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Каждый год %@ (лунный календарь)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Все дни последней недели каждого месяца";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "Первое %@ каждого месяца";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "Второе %@ каждого месяца";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "Третье %@ каждого месяца";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "Четвёртое %@ каждого месяца";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "Пятое %@ каждого месяца";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "Шестое %@ каждого месяца";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "Седьмое %@ каждого месяца";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "Последнее %@ каждого месяца";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "Первый %@ каждого месяца";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "Первая %@ каждого месяца";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "Первое %@ каждого месяца";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "Второй %@ каждого месяца";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "Вторая %@ каждого месяца";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "Второе %@ каждого месяца";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "Третий %@ каждого месяца";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "Третья %@ каждого месяца";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "Третье %@ каждого месяца";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "Четвёртый %@ каждого месяца";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "Четвёртая %@ каждого месяца";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "Четвёртое %@ каждого месяца";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "Пятый %@ каждого месяца";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "Пятая %@ каждого месяца";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "Пятое %@ каждого месяца";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "Шестой %@ каждого месяца";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "Шестая %@ каждого месяца";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "Шестое %@ каждого месяца";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "Седьмой %@ каждого месяца";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "Седьмая %@ каждого месяца";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "Седьмое %@ каждого месяца";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "Последний %@ каждого месяца";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "Последняя %@ каждого месяца";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "Последнее %@ каждого месяца";
+"eventDetail.repeating.last::m" = "Последний";
+"eventDetail.repeating.last::f" = "Последняя";
+"eventDetail.repeating.last::n" = "Последнее";
 "eventDetail.repeating.endtime::title" = "Окончание повтора";
 "eventDetail.repeating.endtime::option::never" = "Никогда";
 "eventDetail.repeating.endtime::option::on" = "В дату";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "С %@, %d раз";
 
 "eventDetail.repeating.everyNDays:title" = "Каждые %d дн.";
-"eventDetail.repeating.last" = "Последний";
 "eventDetail.repeating.everyNMonths:title" = "Каждые %d мес.";
 "eventDetail.repeating.everyNYears:title" = "Каждые %d г.";
 "eventDetail.repeating::endoption_until" = "до %@";

--- a/Supports/Extensions/Resources/ru.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ru.lproj/Localizable.strings
@@ -55,13 +55,13 @@
 
 // MARK: - event
 
-"dayname::sunday" = "Воскресенье";
-"dayname::monday" = "Понедельник";
-"dayname::tuesday" = "Вторник";
-"dayname::wednesday" = "Среда";
-"dayname::thursday" = "Четверг";
-"dayname::friday" = "Пятница";
-"dayname::saturday" = "Суббота";
+"dayname::sunday" = "воскресенье";
+"dayname::monday" = "понедельник";
+"dayname::tuesday" = "вторник";
+"dayname::wednesday" = "среда";
+"dayname::thursday" = "четверг";
+"dayname::friday" = "пятница";
+"dayname::saturday" = "суббота";
 
 "dayname::sunday:short" = "ВС";
 "dayname::monday:short" = "ПН";

--- a/Supports/Extensions/Resources/ru.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ru.lproj/Localizable.strings
@@ -185,10 +185,10 @@
 "eventDetail.repeating.starttime:title" = "Время начала повтора";
 "eventDetail.repeating.everyDay:title" = "Каждый день";
 "eventDetail.repeating.everyWeek:title" = "Каждую неделю";
-"eventDetail.repeating.everyWeekSomeDay:title" = "Каждое %@";
+"eventDetail.repeating.everyWeekSomeDay:title" = "Каждую неделю: %@";
 "eventDetail.repeating.everySomeWeek:title" = "Каждые %d нед.";
 "eventDetail.repeating.everyWeekDays:title" = "Каждый будний день";
-"eventDetail.repeating.everySomeWeekSomeDay:title" = "Каждые %d нед. по %@";
+"eventDetail.repeating.everySomeWeekSomeDay:title" = "Каждые %d нед.: %@";
 "eventDetail.repeating.everyMonth:title" = "Каждый месяц";
 "eventDetail.repeating.everyMonth_someDay:title" = "%@ каждого месяца.";
 "eventDetail.repeating.everyYear:title" = "Каждый год";
@@ -215,9 +215,9 @@
 "eventDetail.repeating.everyNDays:title" = "Каждые %d дн.";
 "eventDetail.repeating.last" = "Последний";
 "eventDetail.repeating.everyNMonths:title" = "Каждые %d мес.";
-"eventDetail.repeating.everyNYears:title" = "Каждые %d лет";
+"eventDetail.repeating.everyNYears:title" = "Каждые %d г.";
 "eventDetail.repeating::endoption_until" = "до %@";
-"eventDetail.repeating::endoption_times" = "%d раз";
+"eventDetail.repeating::endoption_times" = "Повторов: %d";
 
 "eventDetail.place::placeholder" = "Место";
 "eventDetail.place::remove_button" = "Удалить место";

--- a/Supports/Extensions/Resources/sk.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/sk.lproj/Localizable.strings
@@ -55,13 +55,13 @@
 
 // MARK: - event
 
-"dayname::sunday" = "Nedeľa";
-"dayname::monday" = "Pondelok";
-"dayname::tuesday" = "Utorok";
-"dayname::wednesday" = "Streda";
-"dayname::thursday" = "Štvrtok";
-"dayname::friday" = "Piatok";
-"dayname::saturday" = "Sobota";
+"dayname::sunday" = "nedeľa";
+"dayname::monday" = "pondelok";
+"dayname::tuesday" = "utorok";
+"dayname::wednesday" = "streda";
+"dayname::thursday" = "štvrtok";
+"dayname::friday" = "piatok";
+"dayname::saturday" = "sobota";
 
 "dayname::sunday:short" = "NE";
 "dayname::monday:short" = "PO";

--- a/Supports/Extensions/Resources/sk.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/sk.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "P";
 "dayname::saturday:very_short" = "S";
 
+"dayname::sunday:gender" = "f";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "f";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "f";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Každý rok %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Každý rok %@ (lunárny kalendár)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Všetky dni posledného týždňa každého mesiaca";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "Prvý %@ každého mesiaca";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "Druhý %@ každého mesiaca";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "Tretí %@ každého mesiaca";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "Štvrtý %@ každého mesiaca";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "Piaty %@ každého mesiaca";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "Šiesty %@ každého mesiaca";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "Siedmy %@ každého mesiaca";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "Posledný %@ každého mesiaca";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "Prvý %@ každého mesiaca";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "Prvá %@ každého mesiaca";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "Prvé %@ každého mesiaca";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "Druhý %@ každého mesiaca";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "Druhá %@ každého mesiaca";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "Druhé %@ každého mesiaca";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "Tretí %@ každého mesiaca";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "Tretia %@ každého mesiaca";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "Tretie %@ každého mesiaca";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "Štvrtý %@ každého mesiaca";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "Štvrtá %@ každého mesiaca";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "Štvrté %@ každého mesiaca";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "Piaty %@ každého mesiaca";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "Piata %@ každého mesiaca";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "Piate %@ každého mesiaca";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "Šiesty %@ každého mesiaca";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "Šiesta %@ každého mesiaca";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "Šieste %@ každého mesiaca";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "Siedmy %@ každého mesiaca";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "Siedma %@ každého mesiaca";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "Siedme %@ každého mesiaca";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "Posledný %@ každého mesiaca";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "Posledná %@ každého mesiaca";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "Posledné %@ každého mesiaca";
+"eventDetail.repeating.last::m" = "Posledný";
+"eventDetail.repeating.last::f" = "Posledná";
+"eventDetail.repeating.last::n" = "Posledné";
 "eventDetail.repeating.endtime::title" = "Koniec opakovania";
 "eventDetail.repeating.endtime::option::never" = "Nikdy";
 "eventDetail.repeating.endtime::option::on" = "Dňa";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "Od %@, %d krát";
 
 "eventDetail.repeating.everyNDays:title" = "Po %d dňoch";
-"eventDetail.repeating.last" = "Posledný";
 "eventDetail.repeating.everyNMonths:title" = "Po %d mesiacoch";
 "eventDetail.repeating.everyNYears:title" = "Po %d rokoch";
 "eventDetail.repeating::endoption_until" = "do %@";

--- a/Supports/Extensions/Resources/sk.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/sk.lproj/Localizable.strings
@@ -185,10 +185,10 @@
 "eventDetail.repeating.starttime:title" = "Čas začiatku opakovania";
 "eventDetail.repeating.everyDay:title" = "Každý deň";
 "eventDetail.repeating.everyWeek:title" = "Každý týždeň";
-"eventDetail.repeating.everyWeekSomeDay:title" = "Každý %@";
-"eventDetail.repeating.everySomeWeek:title" = "Každých %d týždňov";
+"eventDetail.repeating.everyWeekSomeDay:title" = "Každý týždeň: %@";
+"eventDetail.repeating.everySomeWeek:title" = "Po %d týždňoch";
 "eventDetail.repeating.everyWeekDays:title" = "Každý pracovný deň";
-"eventDetail.repeating.everySomeWeekSomeDay:title" = "Každých %d týždňov v %@";
+"eventDetail.repeating.everySomeWeekSomeDay:title" = "Po %d týždňoch: %@";
 "eventDetail.repeating.everyMonth:title" = "Každý mesiac";
 "eventDetail.repeating.everyMonth_someDay:title" = "%@ každého mesiaca.";
 "eventDetail.repeating.everyYear:title" = "Každý rok";
@@ -212,10 +212,10 @@
 "eventDetail.repeating.endtime::shouldFutureThanStartTime" = "Čas konca opakovania musí byť neskorší ako čas začiatku.\n(Dátum začiatku opakovania: %@)";
 "eventDetail.repeating::period_endcount" = "Od %@, %d krát";
 
-"eventDetail.repeating.everyNDays:title" = "Každých %d dní";
+"eventDetail.repeating.everyNDays:title" = "Po %d dňoch";
 "eventDetail.repeating.last" = "Posledný";
-"eventDetail.repeating.everyNMonths:title" = "Každých %d mesiacov";
-"eventDetail.repeating.everyNYears:title" = "Každých %d rokov";
+"eventDetail.repeating.everyNMonths:title" = "Po %d mesiacoch";
+"eventDetail.repeating.everyNYears:title" = "Po %d rokoch";
 "eventDetail.repeating::endoption_until" = "do %@";
 "eventDetail.repeating::endoption_times" = "%d krát";
 

--- a/Supports/Extensions/Resources/sv.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/sv.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "F";
 "dayname::saturday:very_short" = "L";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Varje år %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Varje år %@ (månkalender)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Alla dagar i den sista veckan varje månad";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "Den första %@ i varje månad";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "Den andra %@ i varje månad";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "Den tredje %@ i varje månad";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "Den fjärde %@ i varje månad";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "Den femte %@ i varje månad";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "Den sjätte %@ i varje månad";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "Den sjunde %@ i varje månad";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "Den sista %@ i varje månad";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "Den första %@ i varje månad";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "Den första %@ i varje månad";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "Den första %@ i varje månad";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "Den andra %@ i varje månad";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "Den andra %@ i varje månad";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "Den andra %@ i varje månad";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "Den tredje %@ i varje månad";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "Den tredje %@ i varje månad";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "Den tredje %@ i varje månad";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "Den fjärde %@ i varje månad";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "Den fjärde %@ i varje månad";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "Den fjärde %@ i varje månad";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "Den femte %@ i varje månad";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "Den femte %@ i varje månad";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "Den femte %@ i varje månad";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "Den sjätte %@ i varje månad";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "Den sjätte %@ i varje månad";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "Den sjätte %@ i varje månad";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "Den sjunde %@ i varje månad";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "Den sjunde %@ i varje månad";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "Den sjunde %@ i varje månad";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "Den sista %@ i varje månad";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "Den sista %@ i varje månad";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "Den sista %@ i varje månad";
+"eventDetail.repeating.last::m" = "Sista";
+"eventDetail.repeating.last::f" = "Sista";
+"eventDetail.repeating.last::n" = "Sista";
 "eventDetail.repeating.endtime::title" = "Upprepning slutar";
 "eventDetail.repeating.endtime::option::never" = "Aldrig";
 "eventDetail.repeating.endtime::option::on" = "Den";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "Från %@, %d gånger";
 
 "eventDetail.repeating.everyNDays:title" = "Var %d:e dag";
-"eventDetail.repeating.last" = "Sista";
 "eventDetail.repeating.everyNMonths:title" = "Var %d:e månad";
 "eventDetail.repeating.everyNYears:title" = "Vart %d:e år";
 "eventDetail.repeating::endoption_until" = "till %@";

--- a/Supports/Extensions/Resources/th.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/th.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "ศ";
 "dayname::saturday:very_short" = "ส";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "ทุกปี%@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "ทุกปี%@ (ปฏิทินจันทรคติ)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "ทุกวันในสัปดาห์สุดท้ายของทุกเดือน";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "%@แรกของทุกเดือน";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "%@ที่สองของทุกเดือน";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "%@ที่สามของทุกเดือน";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "%@ที่สี่ของทุกเดือน";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "%@ที่ห้าของทุกเดือน";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "%@ที่หกของทุกเดือน";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "%@ที่เจ็ดของทุกเดือน";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "%@สุดท้ายของทุกเดือน";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "%@แรกของทุกเดือน";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "%@แรกของทุกเดือน";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "%@แรกของทุกเดือน";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "%@ที่สองของทุกเดือน";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "%@ที่สองของทุกเดือน";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "%@ที่สองของทุกเดือน";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "%@ที่สามของทุกเดือน";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "%@ที่สามของทุกเดือน";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "%@ที่สามของทุกเดือน";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "%@ที่สี่ของทุกเดือน";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "%@ที่สี่ของทุกเดือน";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "%@ที่สี่ของทุกเดือน";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "%@ที่ห้าของทุกเดือน";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "%@ที่ห้าของทุกเดือน";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "%@ที่ห้าของทุกเดือน";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "%@ที่หกของทุกเดือน";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "%@ที่หกของทุกเดือน";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "%@ที่หกของทุกเดือน";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "%@ที่เจ็ดของทุกเดือน";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "%@ที่เจ็ดของทุกเดือน";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "%@ที่เจ็ดของทุกเดือน";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "%@สุดท้ายของทุกเดือน";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "%@สุดท้ายของทุกเดือน";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "%@สุดท้ายของทุกเดือน";
+"eventDetail.repeating.last::m" = "สุดท้าย";
+"eventDetail.repeating.last::f" = "สุดท้าย";
+"eventDetail.repeating.last::n" = "สุดท้าย";
 "eventDetail.repeating.endtime::title" = "สิ้นสุดการทำซ้ำ";
 "eventDetail.repeating.endtime::option::never" = "ไม่สิ้นสุด";
 "eventDetail.repeating.endtime::option::on" = "ในวันที่";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "เริ่ม%@ %dครั้ง";
 
 "eventDetail.repeating.everyNDays:title" = "ทุก%dวัน";
-"eventDetail.repeating.last" = "สุดท้าย";
 "eventDetail.repeating.everyNMonths:title" = "ทุก%dเดือน";
 "eventDetail.repeating.everyNYears:title" = "ทุก%dปี";
 "eventDetail.repeating::endoption_until" = "จนถึง%@";

--- a/Supports/Extensions/Resources/tr.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/tr.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "C";
 "dayname::saturday:very_short" = "C";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Her yıl %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Her yıl %@ (ay takvimi)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Her ayın son haftasının tüm günleri";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "Her ayın ilk %@ günü";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "Her ayın ikinci %@ günü";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "Her ayın üçüncü %@ günü";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "Her ayın dördüncü %@ günü";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "Her ayın beşinci %@ günü";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "Her ayın altıncı %@ günü";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "Her ayın yedinci %@ günü";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "Her ayın son %@ günü";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "Her ayın ilk %@ günü";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "Her ayın ilk %@ günü";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "Her ayın ilk %@ günü";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "Her ayın ikinci %@ günü";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "Her ayın ikinci %@ günü";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "Her ayın ikinci %@ günü";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "Her ayın üçüncü %@ günü";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "Her ayın üçüncü %@ günü";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "Her ayın üçüncü %@ günü";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "Her ayın dördüncü %@ günü";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "Her ayın dördüncü %@ günü";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "Her ayın dördüncü %@ günü";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "Her ayın beşinci %@ günü";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "Her ayın beşinci %@ günü";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "Her ayın beşinci %@ günü";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "Her ayın altıncı %@ günü";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "Her ayın altıncı %@ günü";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "Her ayın altıncı %@ günü";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "Her ayın yedinci %@ günü";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "Her ayın yedinci %@ günü";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "Her ayın yedinci %@ günü";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "Her ayın son %@ günü";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "Her ayın son %@ günü";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "Her ayın son %@ günü";
+"eventDetail.repeating.last::m" = "Son";
+"eventDetail.repeating.last::f" = "Son";
+"eventDetail.repeating.last::n" = "Son";
 "eventDetail.repeating.endtime::title" = "Tekrarlama Bitişi";
 "eventDetail.repeating.endtime::option::never" = "Asla";
 "eventDetail.repeating.endtime::option::on" = "Tarihte";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "%@ tarihinden itibaren %d kez";
 
 "eventDetail.repeating.everyNDays:title" = "Her %d günde bir";
-"eventDetail.repeating.last" = "Son";
 "eventDetail.repeating.everyNMonths:title" = "Her %d ayda bir";
 "eventDetail.repeating.everyNYears:title" = "Her %d yılda bir";
 "eventDetail.repeating::endoption_until" = "%@ tarihine kadar";

--- a/Supports/Extensions/Resources/uk.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/uk.lproj/Localizable.strings
@@ -55,13 +55,13 @@
 
 // MARK: - event
 
-"dayname::sunday" = "Неділя";
-"dayname::monday" = "Понеділок";
-"dayname::tuesday" = "Вівторок";
-"dayname::wednesday" = "Середа";
-"dayname::thursday" = "Четвер";
-"dayname::friday" = "П'ятниця";
-"dayname::saturday" = "Субота";
+"dayname::sunday" = "неділя";
+"dayname::monday" = "понеділок";
+"dayname::tuesday" = "вівторок";
+"dayname::wednesday" = "середа";
+"dayname::thursday" = "четвер";
+"dayname::friday" = "п'ятниця";
+"dayname::saturday" = "субота";
 
 "dayname::sunday:short" = "НД";
 "dayname::monday:short" = "ПН";

--- a/Supports/Extensions/Resources/uk.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/uk.lproj/Localizable.strings
@@ -185,10 +185,10 @@
 "eventDetail.repeating.starttime:title" = "Час початку повторення";
 "eventDetail.repeating.everyDay:title" = "Щодня";
 "eventDetail.repeating.everyWeek:title" = "Щотижня";
-"eventDetail.repeating.everyWeekSomeDay:title" = "Щотижня в %@";
+"eventDetail.repeating.everyWeekSomeDay:title" = "Щотижня: %@";
 "eventDetail.repeating.everySomeWeek:title" = "Кожні %d тиж.";
 "eventDetail.repeating.everyWeekDays:title" = "Щобудня";
-"eventDetail.repeating.everySomeWeekSomeDay:title" = "Кожні %d тиж. у %@";
+"eventDetail.repeating.everySomeWeekSomeDay:title" = "Кожні %d тиж.: %@";
 "eventDetail.repeating.everyMonth:title" = "Щомісяця";
 "eventDetail.repeating.everyMonth_someDay:title" = "%@ щомісяця.";
 "eventDetail.repeating.everyYear:title" = "Щороку";
@@ -215,9 +215,9 @@
 "eventDetail.repeating.everyNDays:title" = "Кожні %d дн.";
 "eventDetail.repeating.last" = "Останній";
 "eventDetail.repeating.everyNMonths:title" = "Кожні %d міс.";
-"eventDetail.repeating.everyNYears:title" = "Кожні %d років";
+"eventDetail.repeating.everyNYears:title" = "Кожні %d р.";
 "eventDetail.repeating::endoption_until" = "до %@";
-"eventDetail.repeating::endoption_times" = "%d разів";
+"eventDetail.repeating::endoption_times" = "Повторів: %d";
 
 "eventDetail.place::placeholder" = "Місце";
 "eventDetail.place::remove_button" = "Видалити місце";

--- a/Supports/Extensions/Resources/uk.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/uk.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "П";
 "dayname::saturday:very_short" = "С";
 
+"dayname::sunday:gender" = "f";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "f";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "f";
+"dayname::saturday:gender" = "f";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Щороку %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Щороку %@ (місячний календар)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Усі дні останнього тижня кожного місяця";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "Перший %@ кожного місяця";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "Другий %@ кожного місяця";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "Третій %@ кожного місяця";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "Четвертий %@ кожного місяця";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "П'ятий %@ кожного місяця";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "Шостий %@ кожного місяця";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "Сьомий %@ кожного місяця";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "Останній %@ кожного місяця";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "Перший %@ кожного місяця";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "Перша %@ кожного місяця";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "Перше %@ кожного місяця";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "Другий %@ кожного місяця";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "Друга %@ кожного місяця";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "Друге %@ кожного місяця";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "Третій %@ кожного місяця";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "Третя %@ кожного місяця";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "Третє %@ кожного місяця";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "Четвертий %@ кожного місяця";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "Четверта %@ кожного місяця";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "Четверте %@ кожного місяця";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "П'ятий %@ кожного місяця";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "П'ята %@ кожного місяця";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "П'яте %@ кожного місяця";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "Шостий %@ кожного місяця";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "Шоста %@ кожного місяця";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "Шосте %@ кожного місяця";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "Сьомий %@ кожного місяця";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "Сьома %@ кожного місяця";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "Сьоме %@ кожного місяця";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "Останній %@ кожного місяця";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "Остання %@ кожного місяця";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "Останнє %@ кожного місяця";
+"eventDetail.repeating.last::m" = "Останній";
+"eventDetail.repeating.last::f" = "Остання";
+"eventDetail.repeating.last::n" = "Останнє";
 "eventDetail.repeating.endtime::title" = "Закінчення повторення";
 "eventDetail.repeating.endtime::option::never" = "Ніколи";
 "eventDetail.repeating.endtime::option::on" = "У дату";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "З %@, %d разів";
 
 "eventDetail.repeating.everyNDays:title" = "Кожні %d дн.";
-"eventDetail.repeating.last" = "Останній";
 "eventDetail.repeating.everyNMonths:title" = "Кожні %d міс.";
 "eventDetail.repeating.everyNYears:title" = "Кожні %d р.";
 "eventDetail.repeating::endoption_until" = "до %@";

--- a/Supports/Extensions/Resources/vi.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/vi.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "6";
 "dayname::saturday:very_short" = "7";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "Mỗi năm %@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "Mỗi năm %@ (âm lịch)";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "Tất cả các ngày của tuần cuối mỗi tháng";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "%@ đầu tiên của mỗi tháng";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "%@ thứ hai của mỗi tháng";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "%@ thứ ba của mỗi tháng";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "%@ thứ tư của mỗi tháng";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "%@ thứ năm của mỗi tháng";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "%@ thứ sáu của mỗi tháng";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "%@ thứ bảy của mỗi tháng";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "%@ cuối cùng của mỗi tháng";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "%@ đầu tiên của mỗi tháng";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "%@ đầu tiên của mỗi tháng";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "%@ đầu tiên của mỗi tháng";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "%@ thứ hai của mỗi tháng";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "%@ thứ hai của mỗi tháng";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "%@ thứ hai của mỗi tháng";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "%@ thứ ba của mỗi tháng";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "%@ thứ ba của mỗi tháng";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "%@ thứ ba của mỗi tháng";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "%@ thứ tư của mỗi tháng";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "%@ thứ tư của mỗi tháng";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "%@ thứ tư của mỗi tháng";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "%@ thứ năm của mỗi tháng";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "%@ thứ năm của mỗi tháng";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "%@ thứ năm của mỗi tháng";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "%@ thứ sáu của mỗi tháng";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "%@ thứ sáu của mỗi tháng";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "%@ thứ sáu của mỗi tháng";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "%@ thứ bảy của mỗi tháng";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "%@ thứ bảy của mỗi tháng";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "%@ thứ bảy của mỗi tháng";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "%@ cuối cùng của mỗi tháng";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "%@ cuối cùng của mỗi tháng";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "%@ cuối cùng của mỗi tháng";
+"eventDetail.repeating.last::m" = "Cuối cùng";
+"eventDetail.repeating.last::f" = "Cuối cùng";
+"eventDetail.repeating.last::n" = "Cuối cùng";
 "eventDetail.repeating.endtime::title" = "Kết thúc lặp lại";
 "eventDetail.repeating.endtime::option::never" = "Không bao giờ";
 "eventDetail.repeating.endtime::option::on" = "Vào ngày";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "Bắt đầu từ %@, %d lần";
 
 "eventDetail.repeating.everyNDays:title" = "Mỗi %d ngày";
-"eventDetail.repeating.last" = "Cuối cùng";
 "eventDetail.repeating.everyNMonths:title" = "Mỗi %d tháng";
 "eventDetail.repeating.everyNYears:title" = "Mỗi %d năm";
 "eventDetail.repeating::endoption_until" = "đến %@";

--- a/Supports/Extensions/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/zh-Hans.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "五";
 "dayname::saturday:very_short" = "六";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "每年%@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "每年%@（农历）";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "每月最后一周的所有日子";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "每月第一个%@";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "每月第二个%@";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "每月第三个%@";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "每月第四个%@";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "每月第五个%@";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "每月第六个%@";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "每月第七个%@";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "每月最后一个%@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "每月第一个%@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "每月第一个%@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "每月第一个%@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "每月第二个%@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "每月第二个%@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "每月第二个%@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "每月第三个%@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "每月第三个%@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "每月第三个%@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "每月第四个%@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "每月第四个%@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "每月第四个%@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "每月第五个%@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "每月第五个%@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "每月第五个%@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "每月第六个%@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "每月第六个%@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "每月第六个%@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "每月第七个%@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "每月第七个%@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "每月第七个%@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "每月最后一个%@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "每月最后一个%@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "每月最后一个%@";
+"eventDetail.repeating.last::m" = "最后";
+"eventDetail.repeating.last::f" = "最后";
+"eventDetail.repeating.last::n" = "最后";
 "eventDetail.repeating.endtime::title" = "重复结束";
 "eventDetail.repeating.endtime::option::never" = "永不";
 "eventDetail.repeating.endtime::option::on" = "于";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "从%@开始，共%d次";
 
 "eventDetail.repeating.everyNDays:title" = "每%d天";
-"eventDetail.repeating.last" = "最后";
 "eventDetail.repeating.everyNMonths:title" = "每%d个月";
 "eventDetail.repeating.everyNYears:title" = "每%d年";
 "eventDetail.repeating::endoption_until" = "直到%@";

--- a/Supports/Extensions/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/zh-Hant.lproj/Localizable.strings
@@ -79,6 +79,14 @@
 "dayname::friday:very_short" = "五";
 "dayname::saturday:very_short" = "六";
 
+"dayname::sunday:gender" = "m";
+"dayname::monday:gender" = "m";
+"dayname::tuesday:gender" = "m";
+"dayname::wednesday:gender" = "m";
+"dayname::thursday:gender" = "m";
+"dayname::friday:gender" = "m";
+"dayname::saturday:gender" = "m";
+
 
 // MARK: - event notification
 
@@ -196,14 +204,33 @@
 "eventDetail.repeating.everyYearSomeDay:title" = "每年%@";
 "eventDetail.repeating.lunarCalendar_everyYearSomeDay:title" = "每年%@（農曆）";
 "eventDetail.repeating.everyLastWeekDaysOfEveryMonth:title" = "每個月最後一週的所有日子";
-"eventDetail.repeating.every1WeekOfEveryMonth::someday" = "每個月的第一個%@";
-"eventDetail.repeating.every2WeekOfEveryMonth::someday" = "每個月的第二個%@";
-"eventDetail.repeating.every3WeekOfEveryMonth::someday" = "每個月的第三個%@";
-"eventDetail.repeating.every4WeekOfEveryMonth::someday" = "每個月的第四個%@";
-"eventDetail.repeating.every5WeekOfEveryMonth::someday" = "每個月的第五個%@";
-"eventDetail.repeating.every6WeekOfEveryMonth::someday" = "每個月的第六個%@";
-"eventDetail.repeating.every7WeekOfEveryMonth::someday" = "每個月的第七個%@";
-"eventDetail.repeating.everyLastWeekOfEveryMonth::someday" = "每個月的最後一個%@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::m" = "每個月的第一個%@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::f" = "每個月的第一個%@";
+"eventDetail.repeating.every1WeekOfEveryMonth::someday::n" = "每個月的第一個%@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::m" = "每個月的第二個%@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::f" = "每個月的第二個%@";
+"eventDetail.repeating.every2WeekOfEveryMonth::someday::n" = "每個月的第二個%@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::m" = "每個月的第三個%@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::f" = "每個月的第三個%@";
+"eventDetail.repeating.every3WeekOfEveryMonth::someday::n" = "每個月的第三個%@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::m" = "每個月的第四個%@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::f" = "每個月的第四個%@";
+"eventDetail.repeating.every4WeekOfEveryMonth::someday::n" = "每個月的第四個%@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::m" = "每個月的第五個%@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::f" = "每個月的第五個%@";
+"eventDetail.repeating.every5WeekOfEveryMonth::someday::n" = "每個月的第五個%@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::m" = "每個月的第六個%@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::f" = "每個月的第六個%@";
+"eventDetail.repeating.every6WeekOfEveryMonth::someday::n" = "每個月的第六個%@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::m" = "每個月的第七個%@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::f" = "每個月的第七個%@";
+"eventDetail.repeating.every7WeekOfEveryMonth::someday::n" = "每個月的第七個%@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::m" = "每個月的最後一個%@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::f" = "每個月的最後一個%@";
+"eventDetail.repeating.everyLastWeekOfEveryMonth::someday::n" = "每個月的最後一個%@";
+"eventDetail.repeating.last::m" = "最後";
+"eventDetail.repeating.last::f" = "最後";
+"eventDetail.repeating.last::n" = "最後";
 "eventDetail.repeating.endtime::title" = "重複結束";
 "eventDetail.repeating.endtime::option::never" = "永不";
 "eventDetail.repeating.endtime::option::on" = "指定日期";
@@ -213,7 +240,6 @@
 "eventDetail.repeating::period_endcount" = "從%@開始，共%d次";
 
 "eventDetail.repeating.everyNDays:title" = "每%d天";
-"eventDetail.repeating.last" = "最後";
 "eventDetail.repeating.everyNMonths:title" = "每%d個月";
 "eventDetail.repeating.everyNYears:title" = "每%d年";
 "eventDetail.repeating::endoption_until" = "直到%@";


### PR DESCRIPTION
반복 옵션 문구가 굴절어권 9개 언어에서 비문으로 렌더된다. `%@` 에 주격 요일명이 들어가는데 앞뒤 수식어의 성·격이 고정돼 있어서다. en `Every %@` 이 굴절이 없어 그대로 이식된 자리다. 부수로 it 의 `AI`/`IA` 표기 흔들림도 같이 정리한다.

닫는 이슈: #999

## 접근

수식어가 요일·수사에 매달리는 자리를 둘로 갈라, 재작성으로 피할 수 있는 쪽은 리소스만 고치고 못 피하는 쪽은 데이터로 푼다.

**재작성으로 푼 것** — 주간·주기 문구. 형제 옵션인 `everyWeek:title` 의 기존 번역을 앞에 세우고 요일을 콜론 뒤로 빼면 수식을 안 받아 주격 그대로 맞는다 (ru `Каждое %@` → `Каждую неделю: %@`). 수사 격변화는 cs·sk 가 전치격 복수(`Po %d týdnech` — 2~4든 5+든 형태가 같다), pl·hr 이 서수 표기(`Co %d. tydzień`), ru·uk 가 축약(`Каждые %d г.`)으로 각각 피한다. 이슈 §2 가 짚은 `everySomeWeek` 외에 `everyNDays`·`everyNMonths`·`everyNYears`·`endoption_times` 에도 같은 결함이 있어 함께 고쳤다.

**데이터로 푼 것** — 월 N번째·마지막 문구. 서수와 "마지막" 은 요일의 성에 맞물려서 한 템플릿으로는 7개 요일을 못 덮는다. `dayname::<요일>:gender` 로 요일의 문법성을 리소스에 노출하고, 템플릿을 `::m`/`::f`/`::n` 3변형으로 두고, `DayOfWeeks.localizedGrammaticalGender` 가 고른 접미를 코드가 키에 붙인다. 문법성이 없는 22개 언어는 세 변형이 현행 문자열 복제라 출력이 안 바뀐다.

요일명 자체도 해당 언어 정서법대로 소문자로 바꿨다 (el 은 그리스어가 요일을 대문자로 써서 제외). 같은 키를 쓰는 설정 "주 시작 요일" 피커 표시도 함께 소문자가 된다 — 의도된 결과다.

## 동작 변화

- `EventRepeatingOption.summaryText` — `.everyMonthSomeWeekDay`·`.everyMonthLastWeekDay` 가 요일 문법성으로 성별 템플릿을 골라, ru `Первый четверг` / `Первая среда` / `Первое воскресенье` 가 각각 맞게 나온다
- `RRule.ByDay.text()` — `n == -1` 분기의 "마지막" 도 같은 축으로 갈려, 외부 캘린더 반복 일정 표시가 함께 고쳐진다
- `DayOfWeeks` — 요일 키 stem 을 `localizeKeyStem` 한 곳으로 모았다. `text`·`shortText`·`veryShortText`·`localizedGrammaticalGender` 가 매핑을 각자 반복하던 걸 없앤 것인데, en 은 7요일 성 값이 전부 같아 성 오선택이 테스트로는 안 잡히는 자리라 구조로 막았다
- it — `l'AI`·무관사 `AI` 10건을 다수파 `IA` 로 통일

## 짝지어진 갱신

- 서비스 이용 가이드가 이 문구들을 앱 렌더 그대로 인용해뒀다. 대응 PR: sudopark/TodoCalendar-Terms#5
- `.claude/rules/localization.md` §2 의 "슬라브어권 격변화 한계는 감수(#626 확정)" 를 이번 회피 전략으로 갱신했다

## 검증

31개 언어 × 신규 25키의 값을 계획 표와 기계 대조해 0 불일치, `check-localization-parity.py` 전 언어 0 위반, `plutil -lint` 31개 파일 OK, `Extensions`·`Domain`·`EventDetailScene` 스킴 통과.
