### PR TITLE
[#994] 라이브 액티비티 잠금화면을 확장형과 같은 구성으로 재편

### DIFF
--- a/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLiveActivity.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLiveActivity.swift
@@ -26,7 +26,7 @@ struct EventCountdownLiveActivity: Widget {
 
             return DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
-                    EventCountdownRingBadge(model: model, diameter: 26)
+                    EventCountdownSymbolBadge(diameter: 26)
                         // 아일랜드 좌측 라운딩에 배지가 물려 잘린다 — 안쪽으로 들여 피한다.
                         .padding(.leading, 6)
                 }
@@ -43,8 +43,10 @@ struct EventCountdownLiveActivity: Widget {
 
                 // leading·trailing은 카메라 하우징 양옆이라 폭이 좁다 — 말줄임이 나는 텍스트는 전체 폭인 bottom에 둔다.
                 DynamicIslandExpandedRegion(.bottom) {
-                    VStack(alignment: .leading, spacing: 8) {
-                        EventCountdownExpandedTextBlock(model: model)
+                    VStack(alignment: .leading, spacing: 4) {
+                        EventCountdownTitleBlock(model: model)
+
+                        EventCountdownProgressBar(model: model)
 
                         EventCountdownActionButtonRow(model: model)
                     }
@@ -63,34 +65,6 @@ struct EventCountdownLiveActivity: Widget {
             }
             .widgetURL(model.deepLink)
         }
-    }
-}
-
-
-// MARK: - 다이나믹아일랜드 조각
-
-private struct EventCountdownExpandedTextBlock: View {
-
-    private let model: EventCountdownActivityViewModel
-    init(model: EventCountdownActivityViewModel) {
-        self.model = model
-    }
-
-    var body: some View {
-        HStack(alignment: .center, spacing: 8) {
-            EventCountdownTagColorBar(color: model.tagColor, width: 3)
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(model.eventName)
-                    .font(.system(size: 15, weight: .semibold))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .foregroundStyle(.primary)
-
-                EventCountdownTimeAndSubtitleText(model: model, font: .system(size: 12))
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
@@ -119,11 +93,11 @@ private let previewPastEventState = EventCountdownActivityAttributes.State(
     tagColorHex: "#2FB457", eventDate: .now.addingTimeInterval(-600), startDate: .now.addingTimeInterval(-4000)
 )
 
-/// 링이 실제로 줄어드는 게 몇 초 안에 보이는 짧은 케이스.
+/// 진행 바가 실제로 차오르는 게 몇 초 안에 보이는 짧은 케이스.
 private let previewShortRemainState = EventCountdownActivityAttributes.State(
     eventName: "타이머 확인", eventTimeText: "곧",
     tagColorHex: "#2FB457", eventDate: .now.addingTimeInterval(30), startDate: .now.addingTimeInterval(-30),
-    placeName: "링 테스트"
+    placeName: "진행 바 테스트"
 )
 
 #Preview("잠금화면", as: .content, using: EventCountdownActivityAttributes(target: .todo(id: "preview"))) {

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLockScreenView.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownLockScreenView.swift
@@ -21,33 +21,26 @@ struct EventCountdownLockScreenView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .center, spacing: 12) {
-                EventCountdownRingBadge(model: model, diameter: 34)
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(alignment: .center, spacing: 8) {
+                EventCountdownSymbolBadge(diameter: 20)
 
-                HStack(alignment: .center, spacing: 10) {
-                    EventCountdownTagColorBar(color: model.tagColor, width: 4)
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(model.eventName)
-                            .font(.system(size: 17, weight: .semibold))
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                            .foregroundStyle(.primary)
-
-                        EventCountdownTimeAndSubtitleText(model: model, font: .system(size: 13))
-                    }
-                }
-                .layoutPriority(1)
-
-                Spacer(minLength: 0)
+                // 이름 쪽만 무한 확장을 허용한다 — HStack이 덜 유연한 카운트다운에 고유 폭을 먼저 준다.
+                EventCountdownEventNameText(model: model)
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
                 EventCountdownTimerText(
                     model: model, isStale: isStale,
-                    liveFont: .system(size: 30, weight: .semibold),
-                    staleFont: .system(size: 17)
+                    liveFont: .system(size: 24, weight: .semibold),
+                    staleFont: .system(size: 15)
                 )
+                // 폭이 모자라면 Text(timerInterval:)은 말줄임이 아니라 자릿수를 --로 대체한다 — 최대 표기 "23:59:59" 폭을 바닥으로 깐다.
+                .frame(minWidth: 104, alignment: .trailing)
             }
+
+            EventCountdownTimeAndSubtitleText(model: model, font: .system(size: 12))
+
+            EventCountdownProgressBar(model: model)
 
             Divider()
 
@@ -93,20 +86,57 @@ struct EventCountdownTimerText: View {
     }
 }
 
-struct EventCountdownTagColorBar: View {
+struct EventCountdownProgressBar: View {
 
-    private let color: Color
-    private let width: CGFloat
-
-    init(color: Color, width: CGFloat) {
-        self.color = color
-        self.width = width
+    private let model: EventCountdownActivityViewModel
+    init(model: EventCountdownActivityViewModel) {
+        self.model = model
     }
 
     var body: some View {
-        RoundedRectangle(cornerRadius: width / 2)
-            .fill(color)
-            .frame(width: width)
+        // 만료 후에는 timerInterval range가 역전돼 트랩하므로 바 자체를 그리지 않는다.
+        if model.eventDate > .now, model.startDate < model.eventDate {
+            ProgressView(timerInterval: model.startDate...model.eventDate, countsDown: true) {
+                EmptyView()
+            } currentValueLabel: {
+                EmptyView()
+            }
+            .progressViewStyle(.linear)
+            .tint(model.tagColor)
+        }
+    }
+}
+
+struct EventCountdownEventNameText: View {
+
+    private let model: EventCountdownActivityViewModel
+    init(model: EventCountdownActivityViewModel) {
+        self.model = model
+    }
+
+    var body: some View {
+        Text(model.eventName)
+            .font(.system(size: 14, weight: .medium))
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .foregroundStyle(.primary)
+    }
+}
+
+struct EventCountdownTitleBlock: View {
+
+    private let model: EventCountdownActivityViewModel
+    init(model: EventCountdownActivityViewModel) {
+        self.model = model
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            EventCountdownEventNameText(model: model)
+
+            EventCountdownTimeAndSubtitleText(model: model, font: .system(size: 12))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
@@ -121,11 +151,15 @@ struct EventCountdownTimeAndSubtitleText: View {
     }
 
     var body: some View {
-        HStack(spacing: 5) {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(model.tagColor)
+                .frame(width: 7, height: 7)
+
             Text(model.eventTimeText)
 
             if let subtitle = model.subtitle {
-                Text(verbatim: "|")
+                Text(verbatim: "·")
 
                 Text(subtitle)
                     .lineLimit(1)
@@ -163,5 +197,6 @@ struct EventCountdownActionButtonRow: View {
             }
         }
         .buttonStyle(.bordered)
+        .controlSize(.small)
     }
 }

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownRingBadge.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/LiveActivities/EventCountdownRingBadge.swift
@@ -9,6 +9,44 @@
 import SwiftUI
 
 
+/// 색은 배치하는 쪽이 정한다 — 배경 위 대비가 영역마다 달라서다.
+struct EventCountdownAppSymbol: View {
+
+    private let diameter: CGFloat
+    init(diameter: CGFloat) {
+        self.diameter = diameter
+    }
+
+    var body: some View {
+        Image("app_symbol")
+            .resizable()
+            .renderingMode(.template)
+            .scaledToFit()
+            .frame(width: diameter, height: diameter)
+    }
+}
+
+/// 잠금화면·아일랜드 확장형 전용 — 잔량은 진행 바가 맡으므로 로고만 노출한다.
+struct EventCountdownSymbolBadge: View {
+
+    private let diameter: CGFloat
+    init(diameter: CGFloat) {
+        self.diameter = diameter
+    }
+
+    var body: some View {
+        Circle()
+            // 아일랜드(검정)·잠금화면(밝은 머티리얼) 양쪽에서 보이려면 적응색이어야 한다.
+            .fill(.primary.opacity(0.12))
+            .frame(width: diameter, height: diameter)
+            .overlay {
+                EventCountdownAppSymbol(diameter: diameter * 0.56)
+                    .foregroundStyle(.primary)
+            }
+    }
+}
+
+/// compact·minimal 전용 — 진행 바를 놓을 자리가 없어 링이 유일한 잔량 표현이다.
 struct EventCountdownRingBadge: View {
 
     private let model: EventCountdownActivityViewModel
@@ -23,11 +61,7 @@ struct EventCountdownRingBadge: View {
 
     var body: some View {
         ZStack {
-            Image("app_symbol")
-                .resizable()
-                .renderingMode(.template)
-                .scaledToFit()
-                .frame(width: symbolDiameter, height: symbolDiameter)
+            EventCountdownAppSymbol(diameter: symbolDiameter)
                 .foregroundStyle(.secondary)
 
             remainRing

--- a/docs/troubleshooting/2026-08-26-live-activity-timer-text-layout-traps.md
+++ b/docs/troubleshooting/2026-08-26-live-activity-timer-text-layout-traps.md
@@ -1,0 +1,36 @@
+---
+issue: "#994"
+subdomain: Event
+symptoms: [라이브액티비티 잠금화면 크래시, WidgetRenderer_Activities, EXC_BREAKPOINT, LayoutSubview.place, GeometryReaderLayout.placeSubviews, 카운트다운 1:15:--, Text(timerInterval:), fixedSize]
+resolution: fixed
+---
+
+# `Text(timerInterval:)` 을 좁은 행에 넣으면 크래시하거나 자릿수가 `--` 로 빠진다
+
+- **증상**: 잠금화면 라이브 액티비티를 한 행 구성(로고·이벤트명·카운트다운)으로 바꾸자 두 증상이 순서대로 났다.
+
+  1. `WidgetRenderer_Activities` 가 렌더 시점에 크래시. 앱 코드 프레임이 하나도 안 찍히는 순수 레이아웃 트랩이다.
+
+     ```
+     Exception Type: EXC_BREAKPOINT (SIGTRAP)
+     0 libswiftCore.dylib  _assertionFailure(_:_:file:line:flags:)
+     1 SwiftUICore         LayoutSubview.place(at:anchor:dimensions:)
+     2 SwiftUICore         specialized GeometryReaderLayout.placeSubviews(in:proposal:subviews:cache:)
+     ```
+
+  2. 크래시를 걷어내자 카운트다운이 `1:15:--` 로 렌더. 초 자리가 말줄임(`…`)이 아니라 `--` 로 나온다.
+
+- **근본 원인**: `Text(timerInterval:)` 은 자릿수가 매초 바뀌는 걸 시스템이 대신 그리는 특수 텍스트라, 일반 `Text` 와 두 가지가 다르다.
+
+  1. **미지정 제안을 못 받는다.** `.fixedSize()` 는 자식에게 "크기 미지정" 을 제안하는데, 이 텍스트의 내부 geometry 기반 레이아웃은 그 제안에서 유한 폭을 못 정한다. non-finite 치수가 `LayoutSubview.place` 로 들어가 어서션이 터진다.
+  2. **폭이 모자라면 말줄임이 아니라 `--` 로 대체한다.** 자릿수를 표시 시점에 시스템이 채우므로, 확보된 폭에 안 들어가는 자리는 잘리는 대신 플레이스홀더로 남는다. 그래서 "말줄임이 안 나니 폭은 충분하다" 는 판단이 성립하지 않는다.
+
+  `.frame(maxWidth: .infinity)` 를 얻은 이벤트명과 한 `HStack` 에서 남은 폭을 나눠 갖는 구성이라, 타이머 몫이 `23:59:59` 를 그릴 폭에 못 미쳤다.
+
+- **해결**: `EventCountdownLockScreenView` 1행에서
+  - `.fixedSize()` 를 쓰지 않는다 — 폭 보장은 `.frame(minWidth:)` 로 한다.
+  - 카운트다운에 `.frame(minWidth: 104, alignment: .trailing)` 로 최대 표기(`23:59:59`, 24pt monospaced digit) 폭을 바닥으로 깐다.
+  - 이벤트명에만 `.frame(maxWidth: .infinity, alignment: .leading)` 을 줘 남는 폭을 흡수시킨다.
+
+- **기각 방향**: 카운트다운에 `.layoutPriority(1)` — 이 텍스트가 제안된 폭을 크게 먹어서 이벤트명이 말줄임 기호만 남는 폭으로 눌린다. 우선순위는 둘 중 하나를 통째로 굶기는 레버라 이 배분엔 안 맞는다.
+- **기각 방향**: 이벤트명과 카운트다운 사이 `Spacer` — Spacer 가 이벤트명과 남은 폭을 또 나눠 가져 이름 몫이 한 번 더 깎인다.

--- a/docs/troubleshooting/INDEX.md
+++ b/docs/troubleshooting/INDEX.md
@@ -31,3 +31,4 @@
 - [2026-08-24 백그라운드 Task 에서 구독을 담다 Set 저장소가 깨진다](2026-08-24-cancelbag-data-race-crash.md) — Infra / fixed / unrecognized selector 0x8000000000000000·member:·CalendarScenes 랜덤 크래시
 - [2026-08-24 Paywall screenState 테스트가 방출 개수로 흔들린다](2026-08-24-paywall-screenstate-emission-count-flaky.md) — Billing / deferred / Confirmation was confirmed·PaywallViewModelImpleTests·BillingScenes 간헐 실패
 - [2026-08-25 CI 가 브랜치와 무관하게 매번 다른 테스트에서 타임아웃으로 깨진다](2026-08-25-ci-wallclock-timeout-flaky.md) — Infra / workaround / CI 반복 실패·Exceeded timeout of·매번 다른 테스트·로컬은 통과
+- [2026-08-26 `Text(timerInterval:)` 을 좁은 행에 넣으면 크래시하거나 자릿수가 `--` 로 빠진다](2026-08-26-live-activity-timer-text-layout-traps.md) — Event / fixed / 라이브액티비티 잠금화면 크래시·LayoutSubview.place·GeometryReaderLayout·카운트다운 1:15:--·fixedSize


### PR DESCRIPTION
## 문제

잠금화면 라이브 액티비티가 한 줄 안에 제목·부제·카운트다운을 전부 밀어넣고 있었다. 제목 블록에 `layoutPriority(1)`이 걸려 폭을 먼저 가져가서, 이벤트명이 길면 카운트다운이 잘렸다. 확장형은 카운트다운이 `trailing` 리전에 따로 있어 경쟁이 없어 멀쩡했다 — 잠금화면만 깨진 이유다.

세로 공간도 빠듯했다. 태그색 세로 라인이 이름 폭을 먹고, 액션 버튼 행이 기본 크기라 카드가 두꺼웠다.

## 접근

**잠금화면을 확장형과 같은 구성으로 맞췄다.** 로고·이름·카운트다운 한 줄 / 부제 / 진행 바 / 버튼. 두 표시 영역이 같은 조각을 공유하니 한쪽만 어긋나는 일이 없어진다.

카운트다운 폭은 우선순위가 아니라 **최소 폭 보장**으로 지킨다. `Text(timerInterval:)`은 폭이 모자라면 말줄임이 아니라 못 그린 자릿수를 `--`로 대체하고(`1:15:--`), `.fixedSize()`로 묶으면 미지정 제안에서 유한 폭을 못 정해 렌더러가 트랩한다. 최대 표기 폭을 `minWidth`로 깔고 이름 쪽에만 무한 확장을 허용해 둘 다 피했다. 이 두 함정은 `docs/troubleshooting/2026-08-26-live-activity-timer-text-layout-traps.md`에 남겼다.

**태그색은 세로 라인에서 진행 바로 옮겼다.** 라인은 태그색을 알려주기만 하는데, 진행 바는 같은 색으로 잔량까지 표현한다. 얇은 링에 태그색을 칠하는 안은 폐기했다 — 태그색은 유저가 만든 임의 hex라 배경 대비를 보장 못 해서, 어두운 색은 검정 아일랜드에서 링이 통째로 사라진다. 트랙이 깔린 바는 색이 묻혀도 잔량이 읽힌다.

**배지에서 링을 뺐다.** 진행 바가 잔량을 맡으니 링은 같은 정보를 두 번 그리는 셈이다. 잠금화면·확장형은 원형 배경에 로고만, 진행 바를 놓을 자리가 없는 compact·minimal은 링을 유지한다.

## 유저 검증 대기

- 시뮬레이터 잠금화면·다이나믹아일랜드 실물 확인은 완료 (카운트다운 자릿수·이름 노출·크래시 해소).
- 실기기 미확인: 태그색이 밝은/어두운 양극단일 때 진행 바 대비, `minWidth: 104`가 접근성 큰 글씨 설정에서도 `23:59:59`를 담는지.
