### PR TITLE
[#1009] 라이브 액티비티 등록 상태를 이벤트 리스트·상세에 표시

### DIFF
--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventCellViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventCellViewModel.swift
@@ -173,6 +173,7 @@ public protocol EventCellViewModel: Sendable {
     var moreActions: EventListMoreActionModel? { get }
     var isAlldayEvent: Bool { get }
     var liveActivityTarget: LiveActivityTarget? { get }
+    var isLiveActivityRegistered: Bool { get }
 
     /// 셀이 그리는 값 + 셀 액션이 소비하는 값 전부를 담는다. 이 키가 같으면 셀 목록 재방출이 생략된다.
     /// 프로토콜 밖 프로퍼티는 각 타입이 `makeCustomCompareKey`의 추가 성분으로 직접 얹어야 한다 — 빠뜨리면 그 값의 변경이 화면·동작에 안 붙는다.
@@ -182,6 +183,7 @@ public protocol EventCellViewModel: Sendable {
 extension EventCellViewModel {
 
     public var liveActivityTarget: LiveActivityTarget? { nil }
+    public var isLiveActivityRegistered: Bool { false }
 
     fileprivate func makeCustomCompareKey(_ additionalComponents: [String?]) -> String {
         let baseComponents: [String?] = [
@@ -194,6 +196,7 @@ extension EventCellViewModel {
             "\(self.isForemost)",
             "\(self.isRepeating)",
             "\(self.isAlldayEvent)",
+            "\(self.isLiveActivityRegistered)",
             String(describing: self.moreActions)
         ]
         return (baseComponents + additionalComponents)

--- a/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellView.swift
+++ b/Presentations/CalendarScenes/Sources/Common/EventListCell/EventListCellView.swift
@@ -88,6 +88,12 @@ struct EventListCellView: View {
         .padding(.vertical, spacing: .xsmall).padding(.horizontal, spacing: .small)
         .frame(idealHeight: 50)
         .backgroundAsRoundedRectForEventList(self.appearance)
+        .overlay(alignment: .topTrailing) {
+            if self.cellViewModel.isLiveActivityRegistered {
+                self.liveActivityBadgeView
+                    .offset(x: 6, y: -6)
+            }
+        }
         .onTapGesture {
             self.appearance.impactIfNeed()
             self.requestShowDetail(self.cellViewModel)
@@ -328,6 +334,16 @@ struct EventListCellView: View {
     private var foremostMarkingView: some View {
         return LoadingCircleView(appearance.colorSet.accent.asColor, lineWidth: 1.5)
             .frame(width: 24, height: 24)
+    }
+
+    private var liveActivityBadgeView: some View {
+        return Image(systemName: "timer")
+            .font(.system(size: 10, weight: .bold))
+            .foregroundColor(appearance.colorSet.primaryBtnText.asColor)
+            .frame(width: 18, height: 18)
+            .background(
+                Circle().fill(appearance.colorSet.accent.asColor)
+            )
     }
     
     private func todoDoneButton(_ todoId: String) -> some View {

--- a/Presentations/CalendarScenes/Tests/Common/EventCellViewModelTests.swift
+++ b/Presentations/CalendarScenes/Tests/Common/EventCellViewModelTests.swift
@@ -133,6 +133,18 @@ extension EventCellViewModelTests {
         // when + then
         #expect(cell?.customCompareKey != writableChangedCell?.customCompareKey)
     }
+
+    @Test("미완료 투두 셀은 more action에 라이브액티비티 항목이 없어도 등록 여부가 달라지면 compare key가 달라진다")
+    func uncompletedTodoCell_compareKeyIsDifferent_whenLiveActivityRegistrationChanged() {
+        // given
+        let cell = self.makeTodoCell(rawTime: .at(100)) |> \.isUncompletedTodo .~ true
+        let registeredCell = self.makeTodoCell(rawTime: .at(100))
+            |> \.isUncompletedTodo .~ true
+            |> \.isLiveActivityRegistered .~ true
+
+        // when + then
+        #expect(cell.customCompareKey != registeredCell.customCompareKey)
+    }
 }
 
 extension EventCellViewModelTests {

--- a/Presentations/EventDetailScene/CLAUDE.md
+++ b/Presentations/EventDetailScene/CLAUDE.md
@@ -185,6 +185,7 @@ graph TD
 | `EventTimeSelectView` | clock 아이콘 + 선택 시각(`EventTimeTextView` 재사용, 탭하면 인라인 DatePicker 토글) + 종일 토글. 피커 토글 상태는 내부 `@State` 소유, `onBeginSelecting` 훅으로 부모가 텍스트 포커스 해제 | GoogleCalendarEventDetailView, AppleCalendarEventDetailView |
 | `EventTextInputRow` | 아이콘 + 한 줄 TextField (장소·URL 등 공용). 포커스는 부모 `@FocusState` 바인딩 | GoogleCalendarEventDetailView, AppleCalendarEventDetailView |
 | `EventMemoInputView` | doc.text 아이콘 + placeholder 겹친 TextEditor. 포커스는 부모 `@FocusState` 바인딩 | GoogleCalendarEventDetailView, AppleCalendarEventDetailView |
+| `LiveActivityBadgeView` | 라이브액티비티 등록 상태 표시 행 — timer 아이콘 + "잠금화면에 표시 중" 문구. 표시 전용이라 파라미터·이벤트 연결 없음 (#1009) | EventDetailView, HolidayEventDetailView, AppleCalendarEventDetailView, GoogleCalendarEventDetailView |
 
 `GuideView/`의 가이드 오버레이 2종(ForemostEventGuideView·TodoEventGuideView)은 컴포넌트 패밀리로 별도 그룹.
 

--- a/Presentations/EventDetailScene/Sources/Components/LiveActivityBadgeView.swift
+++ b/Presentations/EventDetailScene/Sources/Components/LiveActivityBadgeView.swift
@@ -1,0 +1,32 @@
+//
+//  LiveActivityBadgeView.swift
+//  EventDetailScene
+//
+//  Created by sudo.park on 8/26/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import SwiftUI
+import CommonPresentation
+
+
+// MARK: - LiveActivityBadgeView
+
+struct LiveActivityBadgeView: View {
+
+    @Environment(ViewAppearance.self) private var appearance
+
+    var body: some View {
+        HStack(spacing: Metric.Spacing.small) {
+            Image(systemName: "timer")
+                .font(.system(size: 16, weight: .light))
+                .foregroundColor(self.appearance.colorSet.accent.asColor)
+
+            Text("calendar::event::more_action:live_activity:showing".localized())
+                .foregroundStyle(self.appearance.colorSet.text0.asColor)
+                .font(self.appearance.fontSet.normal.asFont)
+
+            Spacer()
+        }
+    }
+}

--- a/Presentations/EventDetailScene/Sources/EventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailView.swift
@@ -36,7 +36,8 @@ import Scenes
     var isAllDay: Bool = false
     var availableMoreActions: [[EventDetailMoreAction]] = []
     var isForemost: Bool = false
-    
+    var isLiveActivityRegistered: Bool = false
+
     @ObservationIgnored var suggestEventEndTime: () -> Date? = { nil }
     var selectedStartDate: Date = Date()
     var selectedEndDate: Date = Date().addingTimeInterval(60)
@@ -169,7 +170,14 @@ import Scenes
                 self?.isForemost = isForemost
             })
             .store(in: self.cancellables)
-        
+
+        viewModel.isLiveActivityRegistered
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self] isRegistered in
+                self?.isLiveActivityRegistered = isRegistered
+            })
+            .store(in: self.cancellables)
+
         viewModel.isSaving
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] isSaving in
@@ -314,6 +322,9 @@ struct EventDetailView: View {
                     self.nameInputView
                     if state.isForemost {
                         self.foremostEventView
+                    }
+                    if state.isLiveActivityRegistered {
+                        LiveActivityBadgeView()
                     }
                     self.eventDetailTypeView
                     self.timeSelectView

--- a/Presentations/EventDetailScene/Sources/EventDetailViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/EventDetailViewModel.swift
@@ -92,6 +92,7 @@ protocol EventDetailViewModel: Sendable, AnyObject {
     
     // presenter
     var isForemost: AnyPublisher<Bool, Never> { get }
+    var isLiveActivityRegistered: AnyPublisher<Bool, Never> { get }
     var isLoading: AnyPublisher<Bool, Never> { get }
     var eventDetailTypeModel: AnyPublisher<EventDetailTypeModel, Never> { get }
     var hasChanges: AnyPublisher<Bool, Never> { get }

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Apple/AppleCalendarEventDetailView.swift
@@ -240,6 +240,10 @@ struct AppleCalendarEventDetailView: View {
                         .id(InputFields.name.id)
                         .disabled(!state.isEditable)
 
+                    if self.state.liveActivityActionModel?.isRegistered == true {
+                        LiveActivityBadgeView()
+                    }
+
                     self.eventTypeView
 
                     VStack(spacing: Metric.Spacing.regular) {

--- a/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/ExernalCalendar/Google/GoogleCalendarEventDetailView.swift
@@ -290,6 +290,10 @@ struct GoogleCalendarEventDetailView: View {
                         .id(InputFields.name.id)
                         .disabled(!state.isEditable)
 
+                    if self.state.liveActivityActionModel?.isRegistered == true {
+                        LiveActivityBadgeView()
+                    }
+
                     self.eventTypeView
 
                     VStack(spacing: Metric.Spacing.regular) {

--- a/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailView.swift
+++ b/Presentations/EventDetailScene/Sources/HolidayDetail/HolidayEventDetailView.swift
@@ -136,6 +136,10 @@ struct HolidayEventDetailView: View {
                 Spacer(minLength: 5)
                 self.nameView
 
+                if self.state.liveActivityActionModel?.isRegistered == true {
+                    LiveActivityBadgeView()
+                }
+
                 VStack(spacing: Metric.Spacing.large) {
                     if let model = self.state.countryModel {
                         self.countryInfoView(model)

--- a/Presentations/EventDetailScene/Sources/ViewModels/AddEventViewModel.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/AddEventViewModel.swift
@@ -301,7 +301,11 @@ extension AddEventViewModelImple {
     var isForemost: AnyPublisher<Bool, Never> {
         return Just(false).eraseToAnyPublisher()
     }
-    
+
+    var isLiveActivityRegistered: AnyPublisher<Bool, Never> {
+        return Just(false).eraseToAnyPublisher()
+    }
+
     var isLoading: AnyPublisher<Bool, Never> {
         let transform: (EventDetailBasicData?, EventDetailData?) -> Bool = { basic, addition in
             return basic == nil || addition == nil

--- a/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/EditScheduleEventDetailViewModelImple.swift
@@ -646,6 +646,24 @@ extension EditScheduleEventDetailViewModelImple {
         .removeDuplicates()
         .eraseToAnyPublisher()
     }
+
+    var isLiveActivityRegistered: AnyPublisher<Bool, Never> {
+        let (scheduleId, targetTime) = (self.scheduleId, self.repeatingEventTargetTime)
+        let transform: (EventDetailBasicData, LiveActivityTarget?) -> Bool = { basic, registeredTarget in
+            return registeredTarget == LiveActivityTarget(
+                scheduleId: scheduleId,
+                targetTime: targetTime,
+                isRepeating: basic.isRepeatingEvent
+            )
+        }
+        return Publishers.CombineLatest(
+            self.subject.basicData.compactMap { $0?.origin },
+            self.liveActivityToggleViewModel.registeredTarget
+        )
+        .map(transform)
+        .removeDuplicates()
+        .eraseToAnyPublisher()
+    }
 }
 
 private extension EventDetailBasicData {

--- a/Presentations/EventDetailScene/Sources/ViewModels/EditTodoEventDetailViewModelImple.swift
+++ b/Presentations/EventDetailScene/Sources/ViewModels/EditTodoEventDetailViewModelImple.swift
@@ -537,6 +537,14 @@ extension EditTodoEventDetailViewModelImple {
         .removeDuplicates()
         .eraseToAnyPublisher()
     }
+
+    var isLiveActivityRegistered: AnyPublisher<Bool, Never> {
+        let todoId = self.todoId
+        return self.liveActivityToggleViewModel.registeredTarget
+            .map { $0 == .todo(id: todoId) }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
 }
 
 

--- a/Presentations/EventDetailScene/Tests/EditScheduleEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/EditScheduleEventDetailViewModelImpleTests.swift
@@ -1358,5 +1358,42 @@ extension EditScheduleEventDetailViewModelImpleTests {
         )
         XCTAssertNil(self.spyRouter.didShowError)
     }
+
+    func testViewModel_whenRegisteredTurnMatches_isLiveActivityRegisteredIsTrue() {
+        // given
+        let expect = expectation(description: "열린 회차와 같은 타겟이 등록되면 isLiveActivityRegistered 가 true")
+        let targetTime = EventTime.at(300)
+        let viewModel = self.makeViewModel(
+            repeatingEventTargetTime: targetTime,
+            registeredLiveActivityTarget: .schedule(id: "dummy_schedule", turnKey: targetTime.customKey)
+        )
+
+        // when
+        let isRegistered = self.waitFirstOutput(expect, for: viewModel.isLiveActivityRegistered) {
+            viewModel.prepare()
+        }
+
+        // then
+        XCTAssertEqual(isRegistered, true)
+    }
+
+    func testViewModel_whenRegisteredTurnIsOther_isLiveActivityRegisteredIsFalse() {
+        // given
+        let expect = expectation(description: "다른 회차가 등록되면 isLiveActivityRegistered 가 false")
+        let targetTime = EventTime.at(300)
+        let otherTurnTime = EventTime.at(900)
+        let viewModel = self.makeViewModel(
+            repeatingEventTargetTime: targetTime,
+            registeredLiveActivityTarget: .schedule(id: "dummy_schedule", turnKey: otherTurnTime.customKey)
+        )
+
+        // when
+        let isRegistered = self.waitFirstOutput(expect, for: viewModel.isLiveActivityRegistered) {
+            viewModel.prepare()
+        }
+
+        // then
+        XCTAssertEqual(isRegistered, false)
+    }
 }
 

--- a/Presentations/EventDetailScene/Tests/EditTodoEventDetailViewModelImpleTests.swift
+++ b/Presentations/EventDetailScene/Tests/EditTodoEventDetailViewModelImpleTests.swift
@@ -913,4 +913,32 @@ extension EditTodoEventDetailViewModelImpleTests {
             expectMessage: "calendar::event::more_action:live_activity:unavail::too_far_future".localized()
         )
     }
+
+    func testViewModel_whenLiveActivityRegistered_isLiveActivityRegisteredIsTrue() {
+        // given
+        let expect = expectation(description: "등록된 todo 는 isLiveActivityRegistered 가 true")
+        let viewModel = self.makeViewModel(
+            registeredLiveActivityTarget: .todo(id: "dummy_todo")
+        )
+
+        // when
+        let isRegistered = self.waitFirstOutput(expect, for: viewModel.isLiveActivityRegistered)
+
+        // then
+        XCTAssertEqual(isRegistered, true)
+    }
+
+    func testViewModel_whenOtherEventRegistered_isLiveActivityRegisteredIsFalse() {
+        // given
+        let expect = expectation(description: "다른 이벤트가 등록됐으면 isLiveActivityRegistered 가 false")
+        let viewModel = self.makeViewModel(
+            registeredLiveActivityTarget: .todo(id: "other_todo")
+        )
+
+        // when
+        let isRegistered = self.waitFirstOutput(expect, for: viewModel.isLiveActivityRegistered)
+
+        // then
+        XCTAssertEqual(isRegistered, false)
+    }
 }

--- a/Supports/Extensions/Resources/en.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/en.lproj/Localizable.strings
@@ -159,6 +159,7 @@
 "calendar::event::more_action:live_activity:unregister:confirm" = "Do you want to remove this event from the Lock Screen?";
 "calendar::event::more_action:live_activity:replace:confirm" = "Another event is showing on the Lock Screen. Replace it with this one?";
 "calendar::event::more_action:live_activity:register:success" = "Now showing on the Lock Screen. Lock your device to see it.";
+"calendar::event::more_action:live_activity:showing" = "Showing on Lock Screen";
 "calendar::event::more_action:copy:item_name" = "Copy event";
 "calendar::event::more_action:share:item_name" = "Share";
 "event_detail::share::field::time" = "Time";

--- a/Supports/Extensions/Resources/ko.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ko.lproj/Localizable.strings
@@ -159,6 +159,7 @@
 "calendar::event::more_action:live_activity:unregister:confirm" = "이 이벤트를 잠금화면에서 제거할까요?";
 "calendar::event::more_action:live_activity:replace:confirm" = "다른 이벤트가 잠금화면에 표시 중이에요. 이 이벤트로 바꿀까요?";
 "calendar::event::more_action:live_activity:register:success" = "잠금화면에 표시했어요. 기기를 잠그고 확인해보세요.";
+"calendar::event::more_action:live_activity:showing" = "잠금화면에 표시 중";
 "calendar::event::more_action:copy:item_name" = "이벤트 복사";
 "calendar::event::more_action:share:item_name" = "공유";
 "event_detail::share::field::time" = "시간";


### PR DESCRIPTION
라이브 액티비티에 등록된 이벤트가 앱 안에서는 어디에도 표시되지 않았다. 등록 여부는 컨텍스트 메뉴가 "잠금화면에 표시"를 띄우느냐 "제거"를 띄우느냐로만 드러나서, 메뉴를 열기 전엔 어떤 이벤트가 잠금화면에 떠 있는지 알 방법이 없었다.

데이터는 이미 흐르고 있었다 — `EventLiveActivityUsecase.registeredTarget`이 `DayEventListViewModelImple`의 셀 퍼블리셔 세 갈래와 상세 뷰모델들에 적용돼 있고, 그 값이 메뉴 라벨에만 소비되던 상태였다. 그래서 이번 작업은 표시 레이어만 얹는다.

## 리스트 셀 — 우상단 코너 배지

셀의 trailing 슬롯은 foremost 마킹 서클과 투두 완료 버튼이 `else if`로 배타 점유하고 있어 새 뷰를 나란히 넣을 자리가 없다. 배경 라운드렉트 위에 `topTrailing` 오버레이로 accent 원 + 흰 timer 아이콘을 얹었다. `EventListCellView` 하나만 고쳐서 날짜 리스트·최상단 이벤트·미완료 투두 세 화면에 함께 반영된다.

`isLiveActivityRegistered`는 5개 셀 타입에 concrete 프로퍼티로만 있어 뷰가 `any EventCellViewModel`로 읽을 수 없었다. 프로토콜 요구로 승격하고(미보유 타입은 extension 기본값 `false`) `makeCustomCompareKey`의 base 성분에 실었다. 후자가 없으면 `removeDuplicates(by: customCompareKey)`가 재방출을 걸러 배지가 안 붙는다 — 지금까지는 `moreActions` 문자열에 딸려 간접 반영됐지만, 미완료 투두는 라이브 액티비티 액션 자체가 빠져 그 경로가 성립하지 않았다.

## 상세 — 이름 아래 표시 행

`EventDetailView.foremostEventView`와 같은 구성에서 도움말 버튼만 뺀 `LiveActivityBadgeView`를 만들어 상세 4개 화면(편집 투두·일정, 공휴일, Apple, Google)에 붙였다.

편집 상세는 `EventDetailViewModel`에 `isLiveActivityRegistered` 퍼블리셔를 추가했다. 일정 쪽 회차 판정은 `moreActions`가 쓰는 것과 같은 `LiveActivityTarget(scheduleId:targetTime:isRepeating:)` init에 위임해 비반복 일정에 turnKey가 섞이지 않게 했다. 공휴일·Apple·Google은 `liveActivityActionModel.isRegistered`가 이미 뷰 스테이트에 있어 뷰만 고쳤다.

## 검증

- `CalendarScenes` 212 / `EventDetailScene` 177 / `Extensions`·`TodoCalendarApp`·`TodoCalendarAppWidget` 전부 통과.
- 스냅샷: `CalendarScenesSnapshots`·`EventDetailSceneSnapshots` 재실행으로 비등록 상태 무영향 확인, 별도로 등록 상태를 켠 일회성 캡처로 라이트·다크 양쪽 배지 렌더를 눈으로 대조했다.
- 문구는 en/ko만 반영했고 나머지 29개 언어는 #1001 대기 목록에 올렸다.

Closes #1009
