### PR TITLE
[#996] ko 반복 캡션을 나머지 캡션과 같은 명사구로 교체

### DIFF
--- a/Presentations/CommonPresentation/Snapshots/AppStoreCaptionSnapshots.swift
+++ b/Presentations/CommonPresentation/Snapshots/AppStoreCaptionSnapshots.swift
@@ -166,7 +166,7 @@ private enum StoreCaptionSlot: CaseIterable {
                 "id": "Aplikasi menyusun pengulangan",
                 "it": "L'app costruisce la ricorrenza",
                 "ja": "繰り返しはアプリが組み立てます",
-                "ko": "날짜만 고르면 반복은 앱이 만듭니다",
+                "ko": "다양한 반복 옵션, 음력까지",
                 "ms": "Aplikasi membina pengulangan",
                 "nb": "Appen bygger gjentakelsen",
                 "nl": "De app bouwt de herhaling",


### PR DESCRIPTION
ko 반복 옵션 캡션이 6장 중 혼자 완결 격식체 문장(`날짜만 고르면 반복은 앱이 만듭니다`)이라 나머지와 결이 안 맞았다. 나머지 다섯은 전부 명사구다 — `하나의 캘린더, 두 종류의 일` / `위치, 링크, 메모, 미리알림` / `쓰던 캘린더 그대로` / `앱을 열지 않고 하루 확인하기` / `내 방식대로`.

`StoreCaptionSlot.writtenCaptions` 의 ko `repeatOptions` 를 `다양한 반복 옵션, 음력까지` 로 교체한다. 01번과 같은 쉼표 대구 명사구이고, `음력` 은 앱 라벨(`eventDetail.repeating.lunarCalendar_everyYear:title` = `매년(음력)`) 그대로다. 실측 34pt 1줄로 01번과 같은 크기에 잡힌다.

다른 30개 언어는 여전히 "앱이 반복을 만들어 준다" 계열이라 ko 만 메시지가 다르다. 맞출지는 별도 판단으로 남긴다.
