### PR TITLE
릴리즈 노트 원고·현지화·업로드를 release-notes 스킬로 고정

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: release-notes
+description: Use when writing the App Store "What's New" copy for a new app version — ko 원고 워싱과 en 원문 확정에 각각 걸린 두 승인 게이트, 29개 ASC 로케일 현지화 원칙, 업로드 전 검증과 fastlane 업로드를 다룬다. Triggers on "릴리즈 노트 쓰자", "이번 버전 변경내용 정리해줘", "새 버전 출시 문구 만들어줘". Does NOT trigger on 버전과 무관한 메타데이터 수정(앱 설명·키워드·subtitle — fastlane/metadata/README.md 절차), 스크린샷 작업(fastlane/screenshots.md), 앱 내 문구 번역(.claude/rules/localization.md), 테스트 빌드 배포(test-deploy 스킬).
+---
+
+# Release Notes — 버전별 변경내용 원고·현지화
+
+원고 정본은 `fastlane/metadata/<ASC 로케일>/release_notes.txt` 31개다. **en 이 나머지 29개 언어의 번역 소스**라, 순서가 이 스킬의 전부다 — ko 초안을 워싱해 승인받고, en 을 확정해 승인받고, 그 뒤에야 번역한다.
+
+## 0. 착수 — 버전 짝 확인
+
+- `Tuist/ProjectDescriptionHelpers/Project+AppVersion.swift` 의 `appVersion` ↔ 유저가 말한 버전이 같은지 본다. 다르면 어느 쪽이 맞는지 되묻는다.
+- **`promotional_text.txt` 가 버전 번호를 본문에 박고 있으면 같이 갱신 대상이다** (현재 31개 로케일 전부 `3.0.0 — ` 로 시작한다). 짝을 놓치면 노트는 새 버전인데 프로모션 문구가 이전 버전을 광고한다.
+  **갱신은 버전 번호 표기에 한정한다** — 나머지 문구는 유저 승인이 끝난 원고라 건드리지 않는다 (`fastlane/metadata/README.md`). 문구 자체를 새로 쓰기로 했으면 그것도 §1·§2 게이트를 태운다.
+- `release_notes.txt` 는 버전마다 덮어쓴다. **과거 버전 원고 아카이브를 만들지 않는다** — 히스토리는 git log 가 갖는다.
+
+## 1. 워싱 — 한글 초안 → ko 원고 (승인 게이트)
+
+유저가 준 한글 초안은 개발자 시점 메모다. 옮겨 적지 말고 아래 기준으로 다시 쓴다:
+
+- **톤은 `fastlane/metadata/ko/description.txt`** — 존댓말 평서문, 담백. 감탄·과장·이모지 없음.
+- **화면 라벨은 ko lproj 값을 그대로 인용한다.** 자유번역 금지 — 노트가 앱 버튼을 다른 말로 부르면 독자가 그 버튼을 못 찾는다. 인용 소스는 lproj 3곳 전부다 (`.claude/rules/localization.md` 서두).
+- **라벨을 정확히 못 찾으면 채우지 말고 되묻는다.** 초안 표현으로 ko lproj 를 부분 grep 하고, 안 걸리면 그 라벨이 있는 화면·플로우 이름으로 다시 찾는다. 그래도 못 찾으면 어느 화면의 어느 버튼인지 유저에게 묻는다. §3 은 승인된 en 을 앵커로 키를 역추적하지만 **§1 시점엔 그 앵커가 없다** — 기억으로 채우면 이 조항이 막으려는 실수를 여기서 재현한다.
+- **내부 용어 금지** — 리팩토링·마이그레이션·유즈케이스·리포지토리 같은 구현 어휘는 유저 시점 결과로 바꾼다. "코드가 어떻게 달라졌나"가 아니라 "이제 뭘 할 수 있나".
+- **초안에 없는 기능을 지어내지 않는다.** 초안이 모호하면 채우지 말고 유저에게 되묻는다.
+- 항목 순서는 유저 체감 크기순. 자잘한 수정은 마지막 한 줄로 묶는다.
+
+ko 원고를 보여주고 승인받는다. **승인 전에 en 을 쓰지 않는다.**
+
+## 2. en 원문 (승인 게이트)
+
+ko 승인본을 기준으로 en 을 쓴다. **여기가 급소다** — en 이 틀리면 29개 언어가 충실히 번역해 30배로 번진다 (#1015 가 그 사고였다: 가이드 en 이 앱 라벨 대신 일반명사를 써서 30개 언어가 전부 틀렸다).
+
+- **화면 라벨은 en lproj 값 그대로.** ko 라벨을 영어로 옮기지 말고 en lproj 에서 찾아 쓴다.
+- ko 를 직역하지 않는다 — `en-US/description.txt` 의 어휘·리듬에 맞춘다.
+- **도메인 3계층(Event ⊃ Todo / Schedule)을 en 에서 먼저 정확히 가른다.** 여기서 뭉개면 29개 언어가 같이 뭉갠다 (localization.md §2).
+
+승인받는다. **승인 전에 번역을 시작하지 않는다.**
+
+## 3. 29개 언어
+
+en 승인본을 소스로 나머지를 채운다. 디렉토리명은 lproj 코드가 아니라 **ASC 코드**다 — 6개가 다르고 매핑표는 `fastlane/metadata/README.md` 에 있다.
+
+- 번역 원칙은 `.claude/rules/localization.md` §2 — 도메인 3계층 용어 분리, aiAgent 구획의 "명령" 계열, 위젯 명칭 일관.
+- **각 언어의 화면 라벨은 그 언어 lproj 값을 grep 해 인용한다.** en 라벨로 en lproj 를 grep 해 키를 얻고, 같은 키를 대상 언어 lproj 에서 읽는다.
+- 이 번역은 lproj 가 아니라 ASC 메타데이터다 — **번역 대기 트래킹 이슈 대상이 아니다.** 여기서 31개를 다 채운다. 미룰 자리가 없다.
+
+## 4. 검증·업로드
+
+```bash
+python3 scripts/check-release-notes.py
+```
+
+31개 완비·4000자 상한·en 복사본(번역 누락) 여부를 본다. **0 위반이어야 다음으로 간다.**
+
+원고를 커밋한 뒤(commit 스킬) 올린다. release_notes 전용 lane 은 없다 — 텍스트 메타데이터 lane 이 같이 올린다:
+
+```bash
+bundle exec fastlane ios upload_app_store_metadata
+```
+
+- 이 환경에서 처음 올리는 거면 `fastlane/metadata/README.md` 의 "업로드 전에 반드시 이 순서로" 를 먼저 탄다 — `deliver init` 기준선이 없으면 lane 이 스스로 중단한다.
+- `ASC_KEY_ID`·`ASC_ISSUER_ID`·`ASC_KEY_CONTENT` 는 유저 환경에만 있다. **없으면 여기서 멈추고 유저에게 인계한다** — 실행을 흉내내지 않는다.
+- 심사 제출은 콘솔에서 유저가 한다.
+
+## Red Flags — 이 생각이 들면 STOP
+
+| 생각 | 실제 |
+|---|---|
+| "ko 승인 기다리는 동안 en 초안이라도 잡아두자" | 게이트가 순서인 이유는 재작업이 아니라 번짐이다 — ko 가 바뀌면 en 도 다시 쓴다 |
+| "ko 랑 en 을 한 번에 보여주면 왕복이 준다" | 유저가 둘을 같이 보면 ko 교정이 en 에 반영 안 된 채 넘어간다 |
+| "라벨은 뜻만 맞으면 된다" | 노트가 앱 버튼을 다른 말로 부르면 독자가 못 찾는다 — lproj 값 그대로 |
+| "나머지 언어는 트래킹 이슈에 미루자" | 그건 lproj 소관이다. ASC 메타데이터엔 미룰 자리가 없다 |
+| "버그 수정뿐이라 쓸 게 없다" | 유저 체감 결과로 한 줄은 쓴다. 빈 노트는 업데이트 버전에서 로케일마다 심사 제출을 막는다 |
+
+## 종료 기록 — skill_end
+
+업로드를 마쳤거나 키가 없어 유저에게 인계하며 끝나는 시점에 `log-record.py skill_end` 를 1회 기록한다 (명령·compliance 규칙은 CLAUDE.md §1).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ tuist generate --no-open      # 파일 추가/삭제 후 재실행 필수
 | 파일·프레임워크 추가 | add-file / add-framework 스킬 |
 | 테스트 실행 | run-tests 스킬 (스킴 목록 정본) |
 | 테스트 빌드 배포 | test-deploy 스킬 (Firebase App Distribution) |
+| 새 버전 출시 변경내용 작성 | release-notes 스킬 (한글 초안 → 31개 로케일 → ASC 업로드) |
 | UI 디자인 | design 스킬 |
 | 스냅샷 검증·화면 카탈로그 | snapshot-check / app-catalog 스킬 |
 | 코드 분석 (로직·추적·관계·영향도) | analyze 스킬 → code-analyzer subagent |

--- a/fastlane/metadata/README.md
+++ b/fastlane/metadata/README.md
@@ -51,7 +51,13 @@ bundle exec fastlane ios upload_app_store_metadata
 31개 ASC 로케일 각각에 `subtitle.txt`·`description.txt`·`keywords.txt`·`promotional_text.txt`.
 
 유저 승인이 끝난 최종 원고다. 문구를 임의로 다듬지 말 것.
+다만 `promotional_text.txt` 는 31개 로케일 전부 버전 번호로 시작한다 — 그 표기만은 버전을 올릴 때
+함께 갱신하고, 그건 `release-notes` 스킬 §0 소관이다.
 길이 제한(문자 수 기준): subtitle 30, keywords 100, promotional_text 170, description 4000.
+
+`release_notes.txt`(이번 버전의 새로운 기능, 상한 4000자)는 버전마다 갈리는 필드라 여기 없다 —
+원고 작성·31개 로케일 현지화·업로드 절차는 `release-notes` 스킬 소관이고, 검사는
+`python3 scripts/check-release-notes.py` 다.
 
 ## lproj ↔ ASC 로케일 매핑
 

--- a/scripts/check-release-notes.py
+++ b/scripts/check-release-notes.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""`fastlane/metadata/<로케일>/release_notes.txt` 가 업로드 가능한 상태인지 검사.
+
+usage:
+  scripts/check-release-notes.py                      # 전 로케일 검사
+  scripts/check-release-notes.py --metadata <경로>
+
+release-notes 스킬 §4 의 업로드 직전 게이트다. 위반이 하나라도 있으면 종료코드 1.
+
+deliver 는 파일이 없는 필드를 조용히 건너뛴다 — 그래서 번역이 덜 된 채로 올려도 업로드 자체는
+성공하고, ASC 에서 그 로케일만 이전 버전 노트가 남거나 심사 제출이 막힌다. 로컬에서 먼저 잡는다.
+"""
+import argparse
+import sys
+from pathlib import Path
+
+FIELD = "release_notes"
+
+# ASC 의 "이번 버전의 새로운 기능" 필드 상한
+MAX_CHARACTERS = 4000
+
+SOURCE_LOCALE = "en-US"
+
+# deliver 가 로케일이 아닌 용도로 쓰는 하위 디렉토리
+NON_LOCALE_DIRS = {
+    "review_information",
+    "trade_representative_contact_information",
+    "app_clip_review_information",
+}
+
+
+def locale_dirs(root: Path) -> list[Path]:
+    return sorted(
+        d for d in root.iterdir()
+        if d.is_dir() and d.name not in NON_LOCALE_DIRS
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--metadata", default="fastlane/metadata", type=Path)
+    args = parser.parse_args()
+
+    root: Path = args.metadata
+    if not root.is_dir():
+        print(f"[중단] {root} 가 없다. --metadata 경로를 확인해라.")
+        return 1
+
+    targets = locale_dirs(root)
+    if not targets:
+        print(f"[중단] {root} 에 로케일 디렉토리가 없다.")
+        return 1
+
+    notes: dict[str, str] = {}
+    violations: list[str] = []
+
+    for target in targets:
+        path = target / f"{FIELD}.txt"
+        if not path.exists():
+            violations.append(f"{target.name} — {FIELD}.txt 없음")
+            continue
+        # 길이 판정과 중복 판정이 같은 문자열을 보게 정규화를 한 번만 한다
+        text = path.read_text(encoding="utf-8").strip()
+        if not text:
+            violations.append(f"{target.name} — 비어 있음")
+            continue
+        length = len(text)
+        if length > MAX_CHARACTERS:
+            violations.append(
+                f"{target.name} — {length}자로 상한 {MAX_CHARACTERS}자를 넘음 ({length - MAX_CHARACTERS}자 초과)"
+            )
+            continue
+        notes[target.name] = text
+
+    source = notes.get(SOURCE_LOCALE)
+    if source is None:
+        # en-US 가 탈락하면 비교 기준이 없어 나머지 로케일의 복사본이 이번 회차엔 안 드러난다
+        print(f"[건너뜀] {SOURCE_LOCALE} 가 위에서 걸려 번역 누락 검사를 못 했다 — 고친 뒤 다시 돌려라")
+    else:
+        for locale, text in sorted(notes.items()):
+            if locale != SOURCE_LOCALE and text == source:
+                violations.append(f"{locale} — {SOURCE_LOCALE} 원문과 글자까지 같다 (번역이 안 된 복사본)")
+
+    for line in violations:
+        print(f"[위반] {line}")
+
+    print()
+    print(f"로케일 {len(targets)}개 · 통과 {len(notes)}개 · 위반 {len(violations)}개")
+    if violations:
+        print("업로드하지 마라 — 위 로케일을 채운 뒤 다시 돌려라.")
+        return 1
+    print(f"전부 통과. 최장 {max(len(t) for t in notes.values())}자 / 상한 {MAX_CHARACTERS}자.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
버전을 올려 출시할 때마다 App Store "이번 버전의 새로운 기능"을 31개 로케일로 채워야 하는데, 그 절차가 어디에도 없었다. `fastlane/metadata/`에는 버전과 무관한 4필드만 있고 `release_notes.txt`는 아예 없다.

## 접근

원고 흐름을 **한글 초안 → ko 워싱 → en 원문 → 29개 언어** 로 고정하고, 승인 게이트를 **ko와 en 두 지점**에 뒀다.

en 앞에 게이트를 하나 더 두는 게 이 PR의 핵심이다. en이 나머지 29개 언어의 번역 소스라, en이 틀리면 30배로 번진다 — #1015가 정확히 그 사고였다. 가이드 en이 앱 라벨 대신 일반명사를 써서 30개 언어가 충실히 번역해 전부 틀렸다. ko 승인만 받고 en을 번역 단계에 흘려보내면 같은 구조가 재현된다.

같은 이유로 화면 라벨은 자유번역을 막고 각 언어 lproj 값을 grep해 인용하게 했다. 노트가 앱 버튼을 다른 말로 부르면 독자가 그 버튼을 못 찾는다.

`scripts/check-release-notes.py`는 업로드 직전 게이트다. `deliver`는 파일 없는 필드를 조용히 건너뛰어서, 번역이 덜 된 채로 올려도 업로드 자체는 성공하고 그 로케일만 ASC에 이전 버전 노트가 남는다. 그래서 31개 완비·4000자 상한에 더해 **en-US와 글자까지 같은 로케일**을 번역 누락으로 잡는다.

`release_notes` 전용 lane은 만들지 않았다. 기존 `upload_app_store_metadata`가 이미 같이 올리고, `warn_missing_release_notes` 가드도 이미 있다.

## 버전 짝

`promotional_text.txt`가 31개 로케일 전부 `3.0.0 — `로 시작한다. 노트만 갈고 두면 새 버전 노트 옆에서 이전 버전을 광고하게 돼서, 스킬 §0에 `appVersion` ↔ 프로모션 문구 버전 표기 짝 확인을 넣었다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwttEcCB9zPS9CoLEuFf1Q