### PR TITLE
[#1016] 토큰 갱신이 응답을 못 받고 실패하면 연동을 해제하지 않는다

### DIFF
--- a/Repository/Sources/Remote/Authenticators/CalendarAPIAutenticator.swift
+++ b/Repository/Sources/Remote/Authenticators/CalendarAPIAutenticator.swift
@@ -94,6 +94,11 @@ extension CalendarAPIAutenticator {
                 completion(.success(credential))
                 
             case .failure(let error):
+                guard error.isServerResponseNotReceived == false else {
+                    logger.log(level: .error, "token refresh fail without server response, keep credential..:\(error)")
+                    completion(.failure(error))
+                    return
+                }
                 logger.log(level: .error, "token refresh failed..\(error)")
                 try? self?.firebaseAuthService.signOut()
                 self?.credentialStore.removeCredential()

--- a/Repository/Sources/Remote/Authenticators/Error+ServerResponse.swift
+++ b/Repository/Sources/Remote/Authenticators/Error+ServerResponse.swift
@@ -1,0 +1,38 @@
+//
+//  Error+ServerResponse.swift
+//  Repository
+//
+//  Created by sudo.park on 8/28/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+import Domain
+
+extension Error {
+
+    var isServerResponseNotReceived: Bool {
+        switch self {
+        case let serverError as ServerErrorModel:
+            return serverError.statusCode == nil && serverError.code == .cancelled
+
+        case let afError as AFError:
+            if afError.isExplicitlyCancelledError {
+                return true
+            }
+            guard let underlyingError = afError.underlyingError else { return false }
+            return underlyingError.isServerResponseNotReceived
+
+        default:
+            let nsError = self as NSError
+            if nsError.domain == NSURLErrorDomain {
+                return true
+            }
+            guard let underlyingError = nsError.userInfo[NSUnderlyingErrorKey] as? Error else {
+                return false
+            }
+            return underlyingError.isServerResponseNotReceived
+        }
+    }
+}

--- a/Repository/Sources/Remote/Authenticators/GoogleAPIAuthenticator.swift
+++ b/Repository/Sources/Remote/Authenticators/GoogleAPIAuthenticator.swift
@@ -128,6 +128,11 @@ extension GoogleAPIAuthenticator {
                 self?.listener?.oauthAutenticator(self, didRefresh: newCredential)
                 completion(.success(newCredential))
             } catch {
+                guard error.isServerResponseNotReceived == false else {
+                    logger.log(level: .error, "google api token refresh fail without server response, keep credential..:\(error)")
+                    completion(.failure(error))
+                    return
+                }
                 logger.log(level: .error, "google api token refresh fail..:\(error)")
                 self?.credentialStore.removeCredential()
                 self?.listener?.oauthAutenticator(self, didRefreshFailed: error)

--- a/Repository/Tests/Auth/AuthRepositoryImpleTests.swift
+++ b/Repository/Tests/Auth/AuthRepositoryImpleTests.swift
@@ -162,10 +162,10 @@ class StubFirebaseAuthService: FirebaseAuthService {
         return DummyResult()
     }
     
-    var shouldFailRefresh: Bool = false
+    var refreshFailError: (any Error)?
     func refreshToken(_ resultHandler: @escaping (Result<AuthRefreshResult, Error>) -> Void) {
-        if self.shouldFailRefresh {
-            resultHandler(.failure(RuntimeError("failed")))
+        if let refreshFailError = self.refreshFailError {
+            resultHandler(.failure(refreshFailError))
         } else {
             let result = AuthRefreshResult(uid: "uid", idToken: "access-new", refreshToken: "refresh-new")
             resultHandler(.success(result))

--- a/Repository/Tests/Auth/CalendarAPIAutenticatorTests.swift
+++ b/Repository/Tests/Auth/CalendarAPIAutenticatorTests.swift
@@ -38,8 +38,9 @@ class CalendarAPIAutenticatorTests: BaseTestCase {
         self.spyListener = nil
     }
     
-    private func makeAuthenticator() -> CalendarAPIAutenticator {
-        
+    private func makeAuthenticator(refreshFailError: (any Error)? = nil) -> CalendarAPIAutenticator {
+
+        self.stubFirebaseService.refreshFailError = refreshFailError
         let authenticator = CalendarAPIAutenticator(
             credentialStore: self.spyAuthStore,
             firebaseAuthService: self.stubFirebaseService
@@ -196,7 +197,7 @@ extension CalendarAPIAutenticatorTests {
         func parameterizeTest(_ shouldFail: Bool) {
             // given
             self.spyAuthStore.saveAuth(self.dummyAuth)
-            self.stubFirebaseService.shouldFailRefresh = shouldFail
+            self.stubFirebaseService.refreshFailError = shouldFail ? RuntimeError("failed") : nil
             let expect = expectation(description: "wait-refresh")
             var result: Result<APICredential, any Error>?
             
@@ -229,7 +230,38 @@ extension CalendarAPIAutenticatorTests {
         parameterizeTest(true)
         parameterizeTest(false)
     }
-    
+
+    func testAuthenticator_whenRefreshFailWithoutServerResponse_keepCredentialAndNotSignOut() {
+        // given
+        let refreshFailError = NSError(
+            domain: "FIRAuthErrorDomain",
+            code: 17020,
+            userInfo: [NSUnderlyingErrorKey: URLError(.timedOut)]
+        )
+        let authenticator = self.makeAuthenticator(refreshFailError: refreshFailError)
+        self.spyAuthStore.saveAuth(self.dummyAuth)
+        let expect = expectation(description: "wait-refresh")
+        var result: Result<APICredential, any Error>?
+
+        // when
+        let credential = APICredential(auth: self.dummyAuth)
+        authenticator.refresh(credential, for: Session()) {
+            result = $0
+            expect.fulfill()
+        }
+        self.wait(for: [expect], timeout: self.timeout)
+
+        // then
+        guard case .failure = result
+        else {
+            XCTFail("refresh should fail")
+            return
+        }
+        XCTAssertEqual(self.spyAuthStore.loadCurrentAuth()?.accessToken, "access")
+        XCTAssertEqual(self.spyListener?.didTokenRefreshFailed, nil)
+        XCTAssertEqual(self.stubFirebaseService.didSignout, nil)
+    }
+
     // check token has changed
     func testAuthenticator_checkTokenChanged() {
         // given

--- a/Repository/Tests/Auth/ErrorServerResponseTests.swift
+++ b/Repository/Tests/Auth/ErrorServerResponseTests.swift
@@ -1,0 +1,107 @@
+//
+//  ErrorServerResponseTests.swift
+//  RepositoryTests
+//
+//  Created by sudo.park on 8/28/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Testing
+import Alamofire
+import Prelude
+import Optics
+import Domain
+import Extensions
+
+@testable import Repository
+
+struct ErrorServerResponseTests {
+
+    struct ServerResponseCase: @unchecked Sendable {
+        let label: String
+        let error: any Error
+        let isNotReceived: Bool
+    }
+
+    @Test("에러가 서버 응답을 받지 못한 상황을 나타내는지 판정", arguments: [
+        ServerResponseCase(
+            label: "URLError(.timedOut)",
+            error: URLError(.timedOut),
+            isNotReceived: true
+        ),
+        ServerResponseCase(
+            label: "URLError(.notConnectedToInternet)",
+            error: URLError(.notConnectedToInternet),
+            isNotReceived: true
+        ),
+        ServerResponseCase(
+            label: "URLError(.networkConnectionLost)",
+            error: URLError(.networkConnectionLost),
+            isNotReceived: true
+        ),
+        ServerResponseCase(
+            label: "AFError.sessionTaskFailed(URLError(.timedOut))",
+            error: AFError.sessionTaskFailed(error: URLError(.timedOut)),
+            isNotReceived: true
+        ),
+        ServerResponseCase(
+            label: "AFError.explicitlyCancelled",
+            error: AFError.explicitlyCancelled,
+            isNotReceived: true
+        ),
+        ServerResponseCase(
+            label: "AFError.responseValidationFailed(.unacceptableStatusCode(400))",
+            error: AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 400)),
+            isNotReceived: false
+        ),
+        ServerResponseCase(
+            label: "ServerErrorModel(statusCode: 400)",
+            error: ServerErrorModel() |> \.statusCode .~ 400,
+            isNotReceived: false
+        ),
+        ServerResponseCase(
+            label: "ServerErrorModel(code: .cancelled, statusCode: nil)",
+            error: ServerErrorModel() |> \.code .~ .cancelled,
+            isNotReceived: true
+        ),
+        ServerResponseCase(
+            label: "ServerErrorModel(code: .cancelled, statusCode: 400)",
+            error: ServerErrorModel() |> \.code .~ .cancelled |> \.statusCode .~ 400,
+            isNotReceived: false
+        ),
+        ServerResponseCase(
+            label: "ServerErrorModel(code: nil, statusCode: nil)",
+            error: ServerErrorModel(),
+            isNotReceived: false
+        ),
+        ServerResponseCase(
+            label: "NSError(FIRAuthErrorDomain, 17020, underlying: URLError(.timedOut))",
+            error: NSError(
+                domain: "FIRAuthErrorDomain",
+                code: 17020,
+                userInfo: [NSUnderlyingErrorKey: URLError(.timedOut)]
+            ),
+            isNotReceived: true
+        ),
+        ServerResponseCase(
+            label: "NSError(FIRAuthErrorDomain, 17011, user not found)",
+            error: NSError(domain: "FIRAuthErrorDomain", code: 17011, userInfo: [:]),
+            isNotReceived: false
+        ),
+        ServerResponseCase(
+            label: "RuntimeError(\"not current user\")",
+            error: RuntimeError("not current user"),
+            isNotReceived: false
+        )
+    ])
+    func error_checkServerResponseNotReceived(_ testCase: ServerResponseCase) {
+        // given
+        let error = testCase.error
+
+        // when
+        let isNotReceived = error.isServerResponseNotReceived
+
+        // then
+        #expect(isNotReceived == testCase.isNotReceived, "\(testCase.label)")
+    }
+}

--- a/Repository/Tests/Auth/GoogleAPIAuthenticatorTests.swift
+++ b/Repository/Tests/Auth/GoogleAPIAuthenticatorTests.swift
@@ -137,6 +137,30 @@ extension GoogleAPIAuthenticatorTests {
         #expect(credentailAfterRefreshFail == nil)
         #expect(self.spyListener.didTokenRefreshFailed == true)
     }
+
+    @Test func authenticator_whenRefreshFailWithoutServerResponse_keepCredentialAndNotNotifyFailed() async throws {
+        // given
+        let authenticator = self.makeAuthenticator()
+
+        // when
+        let credential = APICredential(accessToken: "access")
+            |> \.refreshToken .~ "refresh_timeout"
+
+        let result = await withCheckedContinuation { continuation in
+            authenticator.refresh(credential, for: Session()) { res in
+                continuation.resume(returning: res)
+            }
+        }
+
+        // then
+        guard case .failure = result
+        else {
+            Issue.record("토큰갱신이 실패하지 않음")
+            return
+        }
+        #expect(self.spyCredentialStore.loadCredential()?.accessToken == "old_credential")
+        #expect(self.spyListener.didTokenRefreshFailed == nil)
+    }
 }
 
 private final class FakeKeyChainStore: KeyChainStorage, @unchecked Sendable {
@@ -188,6 +212,14 @@ extension GoogleAPIAuthenticatorTests {
                     return params["refresh_token"] as? String == "refresh_fail"
                 },
                 resultJsonString: .failure(RuntimeError("failed"))
+            ),
+            .init(
+                method: .post,
+                endpoint: GoogleAuthEndpoint.token,
+                parameterCompare: { _, params in
+                    return params["refresh_token"] as? String == "refresh_timeout"
+                },
+                resultJsonString: .failure(URLError(.timedOut))
             ),
             .init(
                 method: .get,


### PR DESCRIPTION
## 문제

구글 캘린더 토큰 갱신 요청이 백그라운드 서스펜드로 타임아웃되면, 연동이 실제로 살아있는데도 "연동이 만료되었다" 다이얼로그가 뜬다. 갱신 실패 사유가 인증 거부인지 일시적 네트워크 오류인지 구분하지 않고 무조건 credential 을 지우기 때문이다.

다이얼로그는 증상이고 실제 손실은 그 뒤에 있다. 지워지는 건 키체인 credential 이고 Alamofire interceptor 의 in-memory credential 은 남아 있어(`AuthenticationInterceptor.handleRefreshFailure`) 그 세션 동안은 갱신이 재시도돼 정상 동작하는 것처럼 보인다. 하지만 앱을 재시작하면 `ExternalCalendarIntegrateRepositoryImple.checkActiveAccountInfo` 가 credential 없는 계정을 활성 목록에서 걸러내 **연동이 사라진다.**

앱 인증(`CalendarAPIAutenticator`)도 같은 구조라, 같은 상황에 `signOut()` 까지 타서 강제 로그아웃으로 이어졌다.

## 접근

갱신 실패를 **"서버가 응답했나"** 로 가른다. HTTP 응답이 왔으면(구글 400 `invalid_grant`, Firebase 인증 거부) 인증 실패로 확정하고, 응답 자체를 못 받았으면(타임아웃·연결 끊김·오프라인) credential 을 유지한 채 그 요청만 실패시킨다.

- `Error.isServerResponseNotReceived` — `ServerErrorModel`(statusCode 가 실렸으면 응답 받음) / `AFError`(취소 또는 underlying 재귀) / 그 외 `NSError`(`NSURLErrorDomain` 또는 `NSUnderlyingErrorKey` 재귀) 세 갈래로 판정한다. Firebase 는 응답 데이터가 아예 없을 때만 `networkError`(17020) 로 감싸고 underlying 에 원본 `URLError` 를 싣기 때문에, FirebaseAuth 를 import 하지 않고도 체인만 훑어 판정된다.
- `GoogleAPIAuthenticator.refresh` · `CalendarAPIAutenticator.refresh` — 응답을 못 받은 실패에서 credential 제거·만료 통지·`signOut()` 을 건너뛴다. `completion(.failure)` 는 양쪽 경로에서 그대로 호출해 Alamofire 의 대기 요청이 정리되게 둔다.

재시도는 새로 만들지 않았다. Alamofire 가 갱신 실패 시 in-memory credential 을 유지하므로 다음 요청이 401 을 받아 갱신을 다시 태우고, 진짜 만료였다면 그때 400 응답을 받아 정상적으로 만료 처리된다. 오판이 한쪽으로만 새도록 판정을 화이트리스트로 좁게 잡은 이유이기도 하다 — 전송 실패를 놓치면 기존 동작이 남을 뿐이고, 반대로 오판해도 다음 401 에서 자기 교정된다.

## 유저 검증 대기

- **실기기 백그라운드 서스펜드 시나리오** — 구글 캘린더 사용 중 토큰 갱신이 나간 상태에서 앱을 백그라운드로 보냈다가 복귀시켰을 때, 만료 다이얼로그가 뜨지 않고 이어지는 요청이 정상 동작하는지. 여기에 더해 **앱을 완전히 종료 후 재실행했을 때 연동이 유지되는지** 까지 확인이 필요하다 — 이 PR 이 실제로 막으려는 손실이 그 지점이다.
- **오프라인 상태에서의 앱 인증 갱신** — 네트워크를 끈 채 앱을 띄웠을 때 강제 로그아웃되지 않는지. 유닛 테스트는 Firebase 가 `17020 + underlying URLError` 를 준다는 전제 위에 서 있고, 그 전제 자체는 실측이 필요하다.

closes #1016
