### PR TITLE
[#1027] 앱스토어 앱 내 이벤트 현지화·업로드를 스킬로 하네스화

### DIFF
--- a/.claude/skills/app-catalog/SKILL.md
+++ b/.claude/skills/app-catalog/SKILL.md
@@ -37,6 +37,7 @@ xcodebuild test -workspace TodoCalendar.xcworkspace -scheme <Name>Snapshots \
 - **`-only-testing` 은 필수다.** 같은 스킴에 검증 스위트(`__Snapshots__/`, 커밋 대상)가 함께 살아서, 한정하지 않으면 그쪽이 이 언어·이 시점으로 재기록돼 워킹트리가 오염된다. 실행 후 `git status --short -- '*__Snapshots__*'` 가 비어 있어야 한다.
 - **언어는 요청받은 것으로 바꾼다.** 지정이 없으면 en/en_US.
 - 서비스 이용 가이드용 전 언어 촬영은 `scripts/capture-guide-screenshots.sh` 가 위 절차와 파일명 매핑을 감싼다 (`.claude/rules/localization.md` §1 가이드 절).
+- 앱 내 이벤트 이미지의 소스 장면은 `scripts/capture-event-screenshots.sh` 가 감싼다 — 어느 장면을 뜰지는 `fastlane/in_app_events/<event_id>/event.json` 이 지정한다 (in-app-event 스킬).
 
 - **기기 변경 가능**: 유저가 다른 기기·OS로 요청하면 `-destination`의 name/OS 교체 (`xcrun simctl list devices available`로 가용 확인). 여러 기기 세트 요청이면 destination만 바꿔 반복 실행.
 - 기본 시뮬레이터가 없으면 생성: `xcrun simctl create 'iPhone 17 - snapshot_ref' 'iPhone 17' iOS26.2`.

--- a/.claude/skills/in-app-event/SKILL.md
+++ b/.claude/skills/in-app-event/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: in-app-event
+description: Use when filling in an App Store in-app event's localized copy and images — 절차·순서·게이트는 본문이 정한다. Triggers on "앱 내 이벤트 현지화하자", "인앱 이벤트 이미지 만들어줘", "인앱 이벤트 텍스트 올려줘". Does NOT trigger on 도메인 이벤트(Todo·Schedule) 편집, 버전별 변경내용(release-notes 스킬), 앱 설명·키워드 등 버전 무관 메타데이터(fastlane/metadata/README.md), 앱스토어 스크린샷(fastlane/screenshots.md), 앱 내 문구 번역(.claude/rules/localization.md), 이벤트 생성·일정·territory 설정(ASC 콘솔에서 유저가 한다).
+---
+
+# In-App Event — 앱 내 이벤트 현지화·업로드
+
+`deliver` 는 In-App Events 를 모른다. ASC API 를 직접 때리는 스크립트 셋을 순서대로 엮는 것이 이 스킬의 전부다.
+
+**이 스킬이 만지는 것은 로케일 텍스트·뱃지·이미지 셋뿐이다.** 이벤트 생성, 일정(`territorySchedules`), `deepLink`·`purpose`·`priority` 는 유저가 ASC 콘솔에서 한다.
+
+## 0. 준비 — 실행 환경과 자격증명
+
+- ruby PATH 는 [`docs/appstore-connect-operations.md`](../../../docs/appstore-connect-operations.md) §1 이 정본이다. 명령마다 `export PATH="/opt/homebrew/opt/ruby/bin:$PATH"` 를 같은 줄에 실어 보낸다 — 에이전트 셸은 명령마다 새로 떠서 앞선 `export` 가 넘어가지 않는다.
+- 자격증명은 스크립트가 `secret/asc-api-key.json` 에서 읽는다 (형식은 [`secret/README.md`](../../../secret/README.md), 발급·권한은 ops 문서 §2). 환경변수 셋이 차 있으면 그쪽이 우선한다.
+- **파일도 환경변수도 없으면 인증이 필요한 절에서 멈추고 유저에게 인계한다** — 실행을 흉내내지 않는다.
+
+**자격증명이 필요한 절은 §1·§3·§5 뿐이다.** §2(원고·번역)와 §4(촬영·합성)는 파일만 만들어 네트워크를 안 탄다 — 키가 없어도 거기까지는 진행하고, 업로드만 남겨 인계한다.
+
+## 1. 대상 이벤트 확정
+
+인자로 이벤트를 받았으면 그대로 쓴다. 없으면 조회해 목록을 제시하고 추천한다:
+
+```sh
+bundle exec ruby scripts/asc-in-app-event.rb list
+```
+
+- `eventState` 가 `PUBLISHED`·`PAST`·`ARCHIVED` 면 스크립트가 경고한다 — **게시된 이벤트를 덮어쓰는 게 맞는지 유저에게 확인받는다.**
+- 목록이 비면 콘솔에서 먼저 만들라고 안내하고 멈춘다. 이 스킬은 이벤트를 만들지 않는다.
+- 원고·설정을 담을 자리를 만든다: `fastlane/in_app_events/<event_id>/`. `event_id` 는 사람이 읽는 슬러그이고(예: `2026-03-spring`), ASC 이벤트 id 는 `event.json` 의 `ascEventId` 에 적는다.
+
+## 2. 원고 — 승인 게이트 2개
+
+원고 정본은 `fastlane/in_app_events/<event_id>/<ASC 로케일>/{name,short_description,long_description}.txt` 31벌이다. **en 이 나머지 29개 언어의 번역 소스**라 순서가 전부다.
+
+| 필드 | 상한 | 노출 위치 |
+|---|---|---|
+| `name.txt` | 30자 | 이벤트 카드·상세 |
+| `short_description.txt` | 50자 | 이벤트 카드 |
+| `long_description.txt` | 120자 | 이벤트 상세 페이지 |
+
+### 2-1. ko 원고 (승인 게이트)
+
+유저가 한국어로 셋을 준다. **옮겨 적지 말고 상한에 맞춰 워싱한다:**
+
+- 톤은 `fastlane/metadata/ko/description.txt` — 존댓말 평서문, 담백. 감탄·과장·이모지 없음.
+- **화면 라벨은 ko lproj 값을 그대로 인용한다.** 자유번역 금지 — 이벤트가 앱 버튼을 다른 말로 부르면 독자가 그 버튼을 못 찾는다. 인용 소스는 lproj 3곳 전부다 (`.claude/rules/localization.md` 서두).
+- **라벨을 정확히 못 찾으면 채우지 말고 되묻는다.** 초안 표현으로 ko lproj 를 부분 grep 하고, 안 걸리면 그 라벨이 있는 화면·플로우 이름으로 다시 찾는다. 그래도 못 찾으면 어느 화면의 어느 버튼인지 유저에게 묻는다 — 기억으로 채우면 이 조항이 막으려는 실수를 여기서 재현한다.
+- 상한이 빠듯하다. **줄이느라 유저가 말한 혜택·조건을 지어내거나 빼지 않는다** — 못 줄이겠으면 유저에게 무엇을 뺄지 되묻는다.
+
+ko 원고를 보여주고 승인받는다. **승인 전에 en 을 쓰지 않는다.**
+
+### 2-2. en 원문 (승인 게이트)
+
+**여기가 급소다** — en 이 틀리면 29개 언어가 충실히 번역해 30배로 번진다 (#1015 가 그 사고였다).
+
+- **화면 라벨은 en lproj 값 그대로.** ko 라벨을 영어로 옮기지 말고 en lproj 에서 찾아 쓴다.
+- ko 를 직역하지 않는다 — `fastlane/metadata/en-US/description.txt` 의 어휘·리듬에 맞춘다.
+- **도메인 3계층(Event ⊃ Todo / Schedule)을 en 에서 먼저 정확히 가른다.** 여기서 뭉개면 29개 언어가 같이 뭉갠다.
+
+승인받는다. **승인 전에 번역을 시작하지 않는다.**
+
+### 2-3. 29개 언어
+
+- 디렉토리명은 lproj 코드가 아니라 **ASC 코드**다 — 6개가 다르고 매핑표는 `fastlane/metadata/README.md`.
+- 번역 원칙·라벨 역추적 절차는 release-notes 스킬 §3 과 같다 (정본은 `.claude/rules/localization.md` §2). 여기서 재서술하지 않는다.
+- **각 언어의 화면 라벨은 그 언어 lproj 값을 grep 해 인용한다.** en 라벨로 en lproj 를 grep 해 키를 얻고, 같은 키를 대상 언어 lproj 에서 읽는다.
+- **번역 대기 트래킹 이슈 대상이 아니다.** 그건 lproj 소관이고, ASC 메타데이터엔 미룰 자리가 없다. 여기서 31개를 다 채운다.
+- 상한 초과는 `--dry-run` 이 위반을 전량 모아 보여준다. 언어별로 짧게 다시 쓴다.
+
+## 3. 뱃지
+
+7종 중 이벤트 성격에 맞는 것을 제시하고 유저가 고른다:
+
+`LIVE_EVENT` · `PREMIERE` · `CHALLENGE` · `COMPETITION` · `NEW_SEASON` · `MAJOR_UPDATE` · `SPECIAL_EVENT`
+
+```sh
+bundle exec ruby scripts/asc-in-app-event.rb set-badge <ascEventId> <BADGE>
+```
+
+## 4. 이미지
+
+**합성 규칙의 정본은 유저의 문서다:**
+`/Users/sudo.park/Documents/sudo/인디앱 개발/To-do Calendar/공통지침-인앱이벤트-이미지-합성-파이프라인.md`
+
+레포에 복사본을 두지 않는다 — 가이드 레포와 같은 처리이고, 복사하면 짝이 어긋난다.
+
+**정본과 한 군데 다르다**: 지침 §4 는 "라이선스 문제 없는 목업, 라운드 사각형+노치를 코드로 그려도 충분" 이라 하지만, 이 파이프라인은 `scripts/compose-appstore-screenshots.py` 선례를 따라 **애플 공식 베젤**을 쓴다 (마케팅 가이드라인 허용 범위, non-transferable 라이선스라 레포에 커밋하지 않고 캐시에 받아 쓴다). **이미지 작업을 시작할 때 그 문서를 연다.** 이벤트마다 바뀌는 장면·카피·더미 데이터는 유저가 "[이벤트별 지침] 스크린샷 명세"로 따로 준다.
+
+### 4-1. 장면 정하기
+
+이벤트별 명세가 지정한 장면이 `snapshot-catalog/` 에 이미 있으면 그걸 쓴다. 없으면 **카탈로그 스냅샷 테스트를 신설한다** (app-catalog 스킬 §1·§2 — 더미 텍스트는 하드코딩하지 말고 `CatalogStrings.strings` 나 프로덕션 경로로).
+
+`event.json` 스키마 정본은 [`fastlane/in_app_events/README.md`](../../../fastlane/in_app_events/README.md) 다 — 스크립트가 읽는 필드와 기본값이 거기 적혀 있다.
+
+장면 값은 세 형태(카탈로그 경로 / 앱스토어 원본 / 조립)이고 카드는 기기를 여러 대 세울 수 있다 — 형태·조각·기본값은 전부 그 README 소관이다. **`captureSuites` 는 카탈로그를 쓰는 장면의 스위트를 다 덮어야 한다** — 안 덮으면 스크립트가 촬영 전에 끊는다 (안 끊으면 이전 실행이 남긴 다른 언어·다른 기기 규격 파일이 조용히 섞인다).
+
+### 4-2. 촬영·합성
+
+```sh
+scripts/capture-event-screenshots.sh <event_id> ko          # 먼저 한 언어로 확인
+scripts/capture-event-screenshots.sh <event_id> --all       # 31개 언어 (오래 걸린다)
+python3 scripts/compose-event-images.py --event <event_id> --all-locales
+```
+
+- 촬영은 언어당 스위트 수만큼 `xcodebuild test` 를 돌린다. **31개 언어는 시간 단위다** — 백그라운드로 돌리고, 먼저 ko 한 언어로 결과를 유저에게 보여 방향을 확정한 뒤 전 언어로 간다.
+- **하단 1/3 은 배치가 보장한다** — 목업 하단이 `CARD_DEVICE_BOTTOM`(680)에 고정되고 위로만 자라므로 `cardDeviceHeight` 를 키워도 침범하지 않는다. 합성기는 그 결과를 산출물 픽셀로 재확인할 뿐이다(배치 코드가 바뀌었을 때를 위한 방어).
+- 실제로 끊기는 건 셋이다 — 좌우 96px 침범(그려진 픽셀 기준), 기울임 5~10도 이탈, 알파 잔존. 좌우 침범은 기기가 한 대면 `cardDeviceHeight`, 여러 대면 `cardFlankSpread` 나 `cardFlankScale` 을 줄여 해소한다.
+
+### 4-3. 기계가 못 보는 자가 검증
+
+`compose-event-images.py` 의 `verify()` 는 해상도·알파·산출물 트리만 본다. **나머지는 이미지를 열어서 확인한다:**
+
+- [ ] **홍보 문구·로고 워터마크 없음** — 카피는 App Store 가 카드 하단에 얹는다 (지침 §2-5·§3-4)
+- [ ] **한 이미지 안 언어 혼용 없음** — ko 이미지에 영어 UI 가 섞이지 않았나
+- [ ] **더미 데이터에 실명·실제 개인 일정·실존 회사명 없음**
+- [ ] **새 이벤트가 코드 수정 0 으로 도는가** — `event.json` 만 바꿔 한 번 돌려본다 (지침 §6 마지막 항)
+- [ ] **앱에 없는 기능을 연출하지 않았나** — 이벤트별 명세에 적혀 있어도 **실제 빌드에 없으면 제외하고 유저에게 보고한다.** 오해 소지 메타데이터는 심사 리젝 사유다
+
+## 5. 업로드
+
+**텍스트가 먼저다** — 이미지는 로케일에 매달리므로 부모가 없으면 못 올린다.
+
+```sh
+bundle exec ruby scripts/asc-in-app-event.rb push-text   --event <event_id> --all-locales --dry-run
+bundle exec ruby scripts/asc-in-app-event.rb push-text   --event <event_id> --all-locales
+bundle exec ruby scripts/asc-in-app-event.rb push-images --event <event_id> --all-locales --dry-run
+bundle exec ruby scripts/asc-in-app-event.rb push-images --event <event_id> --all-locales
+```
+
+- `--dry-run` 을 먼저 돌려 POST/PATCH 갈림과 길이를 유저에게 보여준다.
+- `push-text` 는 올린 뒤 재조회로 31개가 실제로 찼는지 대조한다. **lane 성공이 반영을 뜻하지 않는다**는 선례가 있다 (`docs/troubleshooting/2026-08-29-deliver-metadata-upload-silent-noop.md`).
+- 심사 제출은 콘솔에서 유저가 한다.
+
+## 6. 새 이벤트 추가
+
+`fastlane/in_app_events/<새 event_id>/` 를 만들고 `event.json` 과 원고를 채우면 끝이다. **스크립트 코드를 고쳐야 하는 상황이 오면 파이프라인 설계 실패다** (지침 §4) — 고치지 말고 유저에게 보고한다.
+
+## Red Flags — 이 생각이 들면 STOP
+
+| 생각 | 실제 |
+|---|---|
+| "ko 승인 기다리는 동안 en 초안이라도 잡아두자" | ko 가 바뀌면 en 도 다시 쓴다 — 게이트가 순서인 이유는 재작업이 아니라 번짐이다 |
+| "이미지에 이벤트 이름을 크게 넣자" | App Store 가 카드 하단 1/3 에 이름·설명을 겹쳐 그린다. 넣으면 겹친다 |
+| "카드가 허전하니 로고라도 넣자" | 지침 §2-5 가 워터마크를 금지한다. 허전하면 `cardDeviceHeight` 를 키우거나 `scenes.card` 에 기기를 더 세운다 |
+| "나머지 언어는 번역 대기 이슈로 미루자" | 그건 lproj 소관이다. ASC 메타데이터엔 미룰 자리가 없다 |
+| "31개 이미지가 다 같으니 en 만 올리자" | 이미지 속 UI 가 언어별로 다르다. 언어 혼용은 지침 §5 위반 |
+| "상한 2자 초과니까 조사만 빼자" | 문장이 깨지면 번역 29개가 같이 깨진다. 못 줄이겠으면 유저에게 되묻는다 |
+| "명세에 있는 기능이니 없어도 그려 넣자" | 없는 기능 연출은 심사 리젝 사유다. 빼고 보고한다 |
+
+## 종료 기록 — skill_end
+
+업로드를 마쳤거나 자격증명이 없어 유저에게 인계하며 끝나는 시점에 `log-record.py skill_end` 를 1회 기록한다 (명령·compliance 규칙은 CLAUDE.md §1).

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-notes
-description: Use when writing the App Store "What's New" copy for a new app version — ko 원고 워싱과 en 원문 확정에 각각 걸린 두 승인 게이트, 29개 ASC 로케일 현지화 원칙, 업로드 전 검증과 fastlane 업로드를 다룬다. Triggers on "릴리즈 노트 쓰자", "이번 버전 변경내용 정리해줘", "새 버전 출시 문구 만들어줘". Does NOT trigger on 버전과 무관한 메타데이터 수정(앱 설명·키워드·subtitle — fastlane/metadata/README.md 절차), 스크린샷 작업(fastlane/screenshots.md), 앱 내 문구 번역(.claude/rules/localization.md), 테스트 빌드 배포(test-deploy 스킬).
+description: Use when writing the App Store "What's New" copy for a new app version — ko 원고 워싱과 en 원문 확정에 각각 걸린 두 승인 게이트, 29개 ASC 로케일 현지화 원칙, 업로드 전 검증과 fastlane 업로드를 다룬다. Triggers on "릴리즈 노트 쓰자", "이번 버전 변경내용 정리해줘", "새 버전 출시 문구 만들어줘". Does NOT trigger on 앱 내 이벤트 현지화(in-app-event 스킬), 버전과 무관한 메타데이터 수정(앱 설명·키워드·subtitle — fastlane/metadata/README.md 절차), 스크린샷 작업(fastlane/screenshots.md), 앱 내 문구 번역(.claude/rules/localization.md), 테스트 빌드 배포(test-deploy 스킬).
 ---
 
 # Release Notes — 버전별 변경내용 원고·현지화

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,17 @@ fastlane/screenshots/
 
 # ASC 심사 정보(데모 계정·담당자 연락처) — deliver init 이 내려받는다. public 레포라 커밋 금지
 fastlane/metadata/review_information/
+
+# 앱 내 이벤트 소스 장면 (촬영마다 재생성)
+snapshot-event/
+
+# 앱 내 이벤트 원고·설정·합성 이미지 — 정본은 ASC 다. README 만 커밋한다
+fastlane/in_app_events/*
+!fastlane/in_app_events/README.md
+
+# importlib 로 하이픈 파일명 스크립트를 불러올 때 생긴다
+scripts/__pycache__/
+
+# 자격증명 — README 만 커밋한다
+secret/*
+!secret/README.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ tuist generate --no-open      # 파일 추가/삭제 후 재실행 필수
 | 테스트 실행 | run-tests 스킬 (스킴 목록 정본) |
 | 테스트 빌드 배포 | test-deploy 스킬 (Firebase App Distribution) |
 | 새 버전 출시 변경내용 작성 | release-notes 스킬 (한글 초안 → 31개 로케일 → ASC 업로드) |
+| 앱 내 이벤트 현지화·이미지·업로드 | in-app-event 스킬 (한글 원고 → 31개 로케일 → 촬영·합성 → ASC 업로드) |
 | UI 디자인 | design 스킬 |
 | 스냅샷 검증·화면 카탈로그 | snapshot-check / app-catalog 스킬 |
 | 코드 분석 (로직·추적·관계·영향도) | analyze 스킬 → code-analyzer subagent |

--- a/TodoCalendarApp/AppExtensions/Widget/Snapshots/WidgetCatalogSnapshots.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Snapshots/WidgetCatalogSnapshots.swift
@@ -33,6 +33,13 @@ final class WidgetCatalogSnapshots: XCTestCase {
         static let outerInset: CGFloat = 14
     }
 
+    // 잠금화면 요소 규격 — 시스템이 벽지 위에 직접 얹으므로 카드 여백이 없다
+    private enum LockScreenCanvas {
+        static let accessoryInline = CGSize(width: 240, height: 26)
+        static let accessoryRectangular = CGSize(width: 160, height: 72)
+        static let liveActivity = CGSize(width: 360, height: 160)
+    }
+
     @MainActor
     private func capture<V: View>(
         _ name: String,
@@ -110,6 +117,91 @@ final class WidgetCatalogSnapshots: XCTestCase {
             let model = WeekEventsViewModel.sample(.wholeMonth(.current))
             return WeekEventsWidgetView(
                 entry: ResultTimelineEntry(date: Date(), result: .success(model))
+            )
+        }
+    }
+
+    // 잠금화면 요소는 홈 화면 위젯과 렌더가 다르다 — 둥근 카드도 불투명 배경도 없고,
+    // 시스템이 벽지 위에 vibrancy 로 얹는다. 그래서 합성 단계가 벽지에 올릴 수 있도록
+    // 투명 배경으로 찍는다.
+    @MainActor
+    private func captureLockScreen<V: View>(
+        _ name: String,
+        canvas: CGSize,
+        testName: String = #function,
+        @ViewBuilder makeView: @escaping () -> V
+    ) {
+        captureSnapshotPair(
+            named: name,
+            layout: .fixed(width: canvas.width, height: canvas.height),
+            snapshotDirectory: catalogSnapshotDirectory(),
+            testName: testName
+        ) { _ in
+            makeView()
+                .frame(width: canvas.width, height: canvas.height)
+                .environment(\.colorScheme, .dark)
+        }
+    }
+
+    @MainActor
+    func test_widgetLockScreenForemost() {
+        self.captureLockScreen("lockscreen-foremost", canvas: LockScreenCanvas.accessoryInline) {
+            InlineSizeForemostEventView(model: ForemostEventWidgetViewModel.sample())
+                .previewContext(WidgetPreviewContext(family: .accessoryInline))
+        }
+    }
+
+    @MainActor
+    func test_widgetLockScreenNext() {
+        self.captureLockScreen("lockscreen-next", canvas: LockScreenCanvas.accessoryRectangular) {
+            NextEventRectangleWidgetView(
+                model: .init(
+                    timeText: .init(text: "14:00"),
+                    eventTitle: "catalog.event::team_workshop".catalogLocalized()
+                )
+            )
+                .previewContext(WidgetPreviewContext(family: .accessoryRectangular))
+        }
+    }
+
+    @MainActor
+    func test_widgetLockScreenNextRemain() {
+        self.captureLockScreen("lockscreen-next-remain", canvas: LockScreenCanvas.accessoryRectangular) {
+            NextRemainEventVListiew(
+                model: .init(models: [
+                    .init(timeText: .init(text: "14:00"), eventTitle: "catalog.event::team_workshop".catalogLocalized()),
+                    .init(timeText: .init(text: "16:00"), eventTitle: "catalog.event::dentist".catalogLocalized()),
+                    .init(timeText: .init(text: "18:30"), eventTitle: "catalog.event::dinner".catalogLocalized())
+                ])
+            )
+                .previewContext(WidgetPreviewContext(family: .accessoryRectangular))
+        }
+    }
+
+    @MainActor
+    func test_widgetLockScreenLiveActivity() {
+        self.captureLockScreen("lockscreen-live-activity", canvas: LockScreenCanvas.liveActivity) {
+            // 카운트다운은 now 기준이라 딱 떨어지는 값이면 만들어낸 티가 난다. 표기 시각도
+            // 잠금화면 합성이 박는 9:41 에서 그만큼 뒤로 맞춘다 — 로케일 표기는 포매터로
+            let eventDate = Date().addingTimeInterval(42 * 60 + 17)
+            let displayTime = Calendar.current.date(
+                bySettingHour: 10, minute: 23, second: 0, of: Date()
+            ) ?? eventDate
+            let timeFormatter = DateFormatter()
+            timeFormatter.dateStyle = .none
+            timeFormatter.timeStyle = .short
+            let attributes = EventCountdownActivityAttributes(target: .todo(id: "sample"))
+            let state = EventCountdownActivityAttributes.State(
+                eventName: "catalog.event::design_review".catalogLocalized(),
+                eventTimeText: timeFormatter.string(from: displayTime),
+                tagColorHex: "#2F6FED",
+                eventDate: eventDate,
+                startDate: eventDate.addingTimeInterval(-75 * 60),
+                placeName: "catalog.place::startup_hub".catalogLocalized()
+            )
+            return EventCountdownLockScreenView(
+                model: EventCountdownActivityViewModel(attributes, state),
+                isStale: false
             )
         }
     }

--- a/fastlane/in_app_events/README.md
+++ b/fastlane/in_app_events/README.md
@@ -1,0 +1,105 @@
+# fastlane/in_app_events/
+
+App Store 앱 내 이벤트(In-App Event)의 원고·설정 자리다. 절차는 `in-app-event` 스킬 소관.
+
+**이 디렉토리의 내용물은 커밋하지 않는다** — 이 README 만 예외다. 원고의 정본은 업로드된 ASC 쪽이고,
+여기 파일은 올리기 전 작업 자리다. 다시 손보려면 ASC 콘솔의 현재 값을 보고 채운다.
+
+```
+<event_id>/
+  event.json
+  <ASC 로케일>/name.txt                            # 30자
+  <ASC 로케일>/short_description.txt               # 50자
+  <ASC 로케일>/long_description.txt                # 120자
+  images/<ASC 로케일>/event-card_1920x1080.png     # 합성 산출물
+  images/<ASC 로케일>/event-detail_1080x1920.png
+```
+
+`<event_id>` 는 사람이 읽는 슬러그다(예: `2026-03-spring`). **ASC 리소스 id 와 다르다** — 스크립트
+인자로는 슬러그를 주고, ASC id 는 `event.json` 의 `ascEventId` 에서 읽는다.
+
+로케일 디렉토리 이름은 lproj 가 아니라 **ASC 코드**다 (6개가 다르다 — `../metadata/README.md` 매핑표).
+
+## `event.json`
+
+```json
+{
+  "ascEventId": "6806709988",
+  "badge": "MAJOR_UPDATE",
+  "scenes": {
+    "card": [
+      { "from": "snapshot-appstore", "file": "01-calendar.png" },
+      {
+        "assemble": "lock-screen",
+        "foremost": "Widget/WidgetCatalogSnapshots/test_widgetLockScreenForemost.lockscreen-foremost-dark.png",
+        "next": "Widget/WidgetCatalogSnapshots/test_widgetLockScreenNext.lockscreen-next-dark.png",
+        "nextRemain": "Widget/WidgetCatalogSnapshots/test_widgetLockScreenNextRemain.lockscreen-next-remain-dark.png",
+        "liveActivity": "Widget/WidgetCatalogSnapshots/test_widgetLockScreenLiveActivity.lockscreen-live-activity-dark.png"
+      },
+      {
+        "assemble": "ai-sheet",
+        "background": { "from": "snapshot-appstore", "file": "01-calendar.png" },
+        "sheet": "AIAgentScene/AIAgentSceneCatalogSnapshots/test_aiResult.aiResult-light.png"
+      }
+    ],
+    "detail": "CalendarScenes/CalendarScenesCatalogSnapshots/test_storeCalendar.storeCalendar-light.png"
+  },
+  "captureSuites": [
+    "TodoCalendarAppWidgetSnapshots|WidgetCatalogSnapshots",
+    "AIAgentSceneSnapshots|AIAgentSceneCatalogSnapshots"
+  ],
+  "style": {
+    "backgroundTop": "#2B3A67",
+    "backgroundBottom": "#4A5D9B",
+    "cardTiltDegrees": 7,
+    "cardDeviceHeight": 760,
+    "cardFlankScale": 0.8,
+    "cardFlankSpread": 0.85
+  }
+}
+```
+
+| 필드 | 읽는 곳 | 필수 | 기본값 |
+|---|---|---|---|
+| `ascEventId` | `asc-in-app-event.rb` (`push-text`·`push-images`) | ✅ | — |
+| `badge` | 사람이 참고 — `set-badge` 는 CLI 인자로 받는다 | ❌ | — |
+| `scenes.card` · `scenes.detail` | `capture-event-screenshots.sh`·`build_event_sources.py` | ✅ | — |
+| `captureSuites` | `capture-event-screenshots.sh` | ✅ | — |
+| `style.backgroundTop` · `backgroundBottom` | `compose-event-images.py` | ✅ | — |
+| `style.cardTiltDegrees` | `compose-event-images.py` | ❌ | `7` (허용 5~10) |
+| `style.cardDeviceHeight` | `compose-event-images.py` | ❌ | `1100` |
+| `style.cardFlankScale` | `compose-event-images.py` | ❌ | `0.8` |
+| `style.cardFlankSpread` | `compose-event-images.py` | ❌ | `0.85` |
+
+### 장면 값의 세 형태
+
+`scenes.card`·`scenes.detail` 과 조립 조각은 모두 같은 세 형태를 받는다 (조각도 재귀로 풀린다):
+
+| 형태 | 뜻 |
+|---|---|
+| `"<Framework>/<스위트클래스>/<파일>"` | `snapshot-catalog/` 기준 상대 경로 |
+| `{ "from": "snapshot-appstore", "file": "..." }` | 앱스토어 스샷 파이프라인의 **캡션 얹기 전 원본**. 캡션이 구워진 `fastlane/screenshots/` 는 홍보 문구 금지 조항에 걸려 못 쓴다 |
+| `{ "assemble": "<종류>", ...조각 }` | 조각을 합성해 만든다 |
+
+`assemble` 종류와 조각:
+
+| 종류 | 조각 | 결과 |
+|---|---|---|
+| `lock-screen` | `foremost` · `next` · `nextRemain` · `liveActivity` | 벽지 + 시계 + accessory 위젯 + 라이브 액티비티 |
+| `ai-sheet` | `background` · `sheet` | 배경 화면에 딤 30% + 하단 시트 (`showBottomSlide` 와 같은 모양) |
+
+### 카드에 기기 여러 대
+
+`scenes.card` 에 리스트를 주면 그 수만큼 기기가 선다. **리스트 순서가 좌→우이고 가운데가 히어로**다
+(원래 크기, 맨 앞에 그려진다). 나머지는 `cardFlankScale` 만큼 작아져 뒤로 물러난다. 세 대가 실용
+한계다 — 넷 이상은 `cardFlankSpread` 로 좌우 여백을 못 지킬 수 있고, 그때 합성이 끊긴다.
+
+`scenes.detail` 은 풀블리드 한 장이라 리스트를 받지 않는다.
+
+### 그 밖
+
+- **`captureSuites` 는 카탈로그를 쓰는 장면의 스위트를 다 덮어야 한다** — 안 덮으면 촬영 전에 끊긴다.
+  안 끊으면 이전 실행이 남긴 다른 언어·다른 기기 규격 파일이 조용히 복사된다. `from` 형태는
+  카탈로그가 아니라 검사 대상이 아니다.
+- 앱 화면 스냅샷은 safe area 없이 콘텐츠만 찍혀 나오므로, `from` 으로 불러올 때 상단에 상태창
+  자리를 낸다 (`status_bar.inset`). 상태창 자체는 그리지 않는다.

--- a/scripts/ai_sheet.py
+++ b/scripts/ai_sheet.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""AI 빠른 입력 시트가 캘린더 위에 떠 있는 장면을 조립한다.
+
+카탈로그는 시트를 화면과 따로 찍지만, 실제로는 `showBottomSlide` 가 캘린더 위에 띄운다
+(`Presentations/Scenes/Sources/BaseComponents.swift`). 그 모습을 여기서 만든다.
+딤·코너는 프로덕션 값을 그대로 쓴다 — 딤은 검정 30%(`BottomSlideTransitions.swift`),
+시트는 상단 좌우 코너 10pt(`BottomSlideView.swift`).
+"""
+
+from PIL import Image, ImageDraw
+
+SCREEN = (1206, 2622)          # iPhone 17 @3x — 카탈로그 촬영 규격과 같다
+DIM_RATIO = 0.3                # .black.withAlphaComponent(0.3)
+SHEET_CORNER = 30              # topLeadingRadius/topTrailingRadius 10pt @3x
+SHEET_PADDING = 48             # BottomSlideView 가 시트 콘텐츠에 주는 .padding() 16pt @3x
+SAFE_AREA_BOTTOM = 102         # 홈 인디케이터 34pt @3x
+
+
+def sheet_top(sheet):
+    """시트가 시작하는 y — 콘텐츠 첫 행에서 시트 패딩만큼 거슬러 올라간 자리다.
+
+    BottomSlideView 는 시트 위쪽을 투명 탭 영역으로 두는데 스냅샷은 그 영역을 캡처
+    배경색으로 채워 내보내고, 그 색이 시트 배경색과 같아 경계가 픽셀로 안 보인다.
+    언어마다 콘텐츠 높이가 달라 시트 상단도 함께 움직이므로 상수로 박으면 안 된다.
+    """
+    rgb = sheet.convert("RGB")
+    width, height = rgb.size
+    background = rgb.getpixel((0, 0))
+    for y in range(height):
+        row = rgb.crop((0, y, width, y + 1))
+        single = row.getcolors(maxcolors=1)
+        if single is None or single[0][1] != background:
+            return max(0, y - SHEET_PADDING)
+    raise SystemExit("✗ AI 시트 스냅샷이 배경색 한 가지뿐이다 — 촬영이 비었다")
+
+
+def rounded_top_mask(size, radius):
+    """상단 두 모서리만 둥근 마스크 — 하단 라운딩은 캔버스 밖으로 밀어 각지게 남긴다."""
+    mask = Image.new("L", size, 0)
+    ImageDraw.Draw(mask).rounded_rectangle(
+        (0, 0, size[0] - 1, size[1] - 1 + radius), radius=radius, fill=255
+    )
+    return mask
+
+
+def extended_to_bottom(sheet, height):
+    """시트 아래에 자기 배경색 띠를 덧대 safe area 를 채운다."""
+    extended = Image.new("RGB", (sheet.width, sheet.height + height), sheet.getpixel((0, sheet.height - 1)))
+    extended.paste(sheet, (0, 0))
+    return extended
+
+
+def compose(background, sheet):
+    screen = background.convert("RGB").resize(SCREEN, Image.LANCZOS)
+    dimmed = Image.blend(screen, Image.new("RGB", SCREEN, (0, 0, 0)), DIM_RATIO)
+
+    cropped = sheet.convert("RGB")
+    cropped = cropped.crop((0, sheet_top(cropped), cropped.width, cropped.height))
+    ratio = SCREEN[0] / cropped.width
+    cropped = cropped.resize((SCREEN[0], round(cropped.height * ratio)), Image.LANCZOS)
+
+    # 시트 배경은 .ignoresSafeArea(edges: .bottom) 으로 홈 인디케이터까지 내려가고 콘텐츠는
+    # 그 위에서 끝난다. 고정 프레임 스냅샷엔 그 여백이 없어 버튼이 화면 끝에 붙어 나온다.
+    cropped = extended_to_bottom(cropped, SAFE_AREA_BOTTOM)
+
+    if cropped.height >= SCREEN[1]:
+        raise SystemExit("✗ AI 시트가 화면을 다 덮는다 — 뒤 캘린더가 안 보인다")
+
+    dimmed.paste(
+        cropped, (0, SCREEN[1] - cropped.height), rounded_top_mask(cropped.size, SHEET_CORNER)
+    )
+    return dimmed

--- a/scripts/asc-in-app-event.rb
+++ b/scripts/asc-in-app-event.rb
@@ -1,0 +1,577 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# App Store Connect 앱 내 이벤트(In-App Event)를 조회하고 갱신한다.
+#
+# usage (PATH 는 docs/appstore-connect-operations.md §1, 자격증명은 secret/README.md):
+#   export PATH="/opt/homebrew/opt/ruby/bin:$PATH"
+#   bundle exec ruby scripts/asc-in-app-event.rb list
+#   bundle exec ruby scripts/asc-in-app-event.rb show <event-id>
+#   bundle exec ruby scripts/asc-in-app-event.rb set-badge <event-id> <BADGE>
+#   bundle exec ruby scripts/asc-in-app-event.rb push-text --event <id> (--locale <ASC로케일>|--all-locales) [--dry-run]
+#   bundle exec ruby scripts/asc-in-app-event.rb push-images --event <id> (--locale <ASC로케일>|--all-locales) [--dry-run]
+#
+# fastlane deliver 는 In-App Events 를 모른다 (deliver 전체에 app_event 키가 없다).
+# 그래서 lane 이 아니라 spaceship 의 raw ASC 클라이언트를 직접 쓴다.
+
+require "json"
+require "spaceship"
+
+BADGES = %w[
+  LIVE_EVENT PREMIERE CHALLENGE COMPETITION NEW_SEASON MAJOR_UPDATE SPECIAL_EVENT
+].freeze
+
+# 게시된 이벤트를 덮어쓰는 중일 수 있어 경고 대상이 되는 상태
+PUBLISHED_STATES = %w[PUBLISHED PAST ARCHIVED].freeze
+
+REQUIRED_ENV = {
+  "ASC_KEY_ID" => "App Store Connect > 사용자 및 액세스 > 통합에서 발급한 키 ID",
+  "ASC_ISSUER_ID" => "같은 화면의 Issuer ID",
+  "ASC_KEY_CONTENT" => "AuthKey_<키ID>.p8 를 base64 로 인코딩한 값 — base64 -i AuthKey_<키ID>.p8"
+}.freeze
+
+SECRET_KEYS = %w[key_id issuer_id key_filepath].freeze
+
+ROOT = File.expand_path("..", __dir__)
+EVENT_ROOT = File.join(ROOT, "fastlane", "in_app_events")
+METADATA_ROOT = File.join(ROOT, "fastlane", "metadata")
+
+# 파일명 = ASC 필드. 상한은 코드포인트 수 기준이라 바이트로 세면 CJK 가 전부 위반이 된다.
+FIELDS = [
+  { file: "name", attribute: "name", limit: 30 },
+  { file: "short_description", attribute: "shortDescription", limit: 50 },
+  { file: "long_description", attribute: "longDescription", limit: 120 }
+].freeze
+
+# 로케일당 두 슬롯. 파일명은 compose-event-images.py 의 산출물 이름과 짝이다.
+IMAGE_SLOTS = [
+  { file: "event-card_1920x1080.png", asset_type: "EVENT_CARD" },
+  { file: "event-detail_1080x1920.png", asset_type: "EVENT_DETAILS_PAGE" }
+].freeze
+
+# deliver 가 로케일이 아닌 용도로 쓰는 하위 디렉토리 (fastlane/Fastfile 과 같은 목록)
+NON_LOCALE_METADATA_DIRS = %w[
+  review_information
+  trade_representative_contact_information
+  app_clip_review_information
+].freeze
+
+def abort_with(message)
+  warn(message)
+  exit(1)
+end
+
+# 자격증명 파일 경로. 테스트가 실제 자격증명을 안 집게 덮어쓸 수 있어야 한다.
+def secret_path
+  ENV["ASC_SECRET_FILE"] || File.join(ROOT, "secret", "asc-api-key.json")
+end
+
+def credentials_from_env
+  missing = REQUIRED_ENV.select { |name, _| ENV[name].to_s.strip.empty? }
+  return nil unless missing.empty?
+
+  {
+    key_id: ENV.fetch("ASC_KEY_ID"),
+    issuer_id: ENV.fetch("ASC_ISSUER_ID"),
+    key: ENV.fetch("ASC_KEY_CONTENT"),
+    is_key_content_base64: true
+  }
+end
+
+# .p8 은 base64 로 바꾸지 않는다 — Token.create 가 filepath 를 직접 읽는다.
+def credentials_from_secret_file
+  path = secret_path
+  return nil unless File.exist?(path)
+
+  parsed = begin
+    JSON.parse(File.read(path))
+  rescue JSON::ParserError => error
+    abort_with("#{path} 가 JSON 이 아니다 — #{error.message}\n\n형식은 secret/README.md")
+  end
+
+  absent = SECRET_KEYS.reject { |key| parsed[key].to_s.strip.empty? == false }
+  abort_with("#{path} 에 #{absent.join(", ")} 가 없다 — 형식은 secret/README.md") unless absent.empty?
+
+  key_filepath = File.expand_path(parsed["key_filepath"])
+  unless File.exist?(key_filepath)
+    abort_with("key_filepath 가 가리키는 #{key_filepath} 가 없다 — .p8 을 옮겼거나 경로가 틀렸다")
+  end
+
+  { key_id: parsed["key_id"], issuer_id: parsed["issuer_id"], filepath: key_filepath }
+end
+
+def credentials
+  resolved = credentials_from_env || credentials_from_secret_file
+  return resolved if resolved
+
+  abort_with(<<~MESSAGE)
+    App Store Connect 자격증명을 못 찾았다. 둘 중 하나를 갖춰라.
+
+    (1) #{secret_path} — 형식은 secret/README.md
+        { "key_id": "...", "issuer_id": "...", "key_filepath": "/절대/경로/AuthKey_<키ID>.p8" }
+
+    (2) 환경변수 셋 (CI 처럼 파일을 못 두는 자리)
+    #{REQUIRED_ENV.map { |name, hint| "    #{name} — #{hint}" }.join("\n")}
+  MESSAGE
+end
+
+def bundle_identifier
+  appfile = File.join(ROOT, "fastlane", "Appfile")
+  match = File.read(appfile)[/app_identifier\(["']([^"']+)["']\)/, 1]
+  return match if match
+
+  abort_with("fastlane/Appfile 에서 app_identifier 를 못 읽었다")
+end
+
+def authenticated_client
+  Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.create(**credentials)
+  Spaceship::ConnectAPI.tunes_request_client
+end
+
+class ASCEventClient
+  def initialize(client:)
+    @client = client
+  end
+
+  def app_id(bundle_id:)
+    apps = @client.get(v1("apps"), { "filter[bundleId]" => bundle_id }).body["data"] || []
+    apps.first&.dig("id")
+  end
+
+  # appEvents 는 컬렉션 조회를 안 받는다(GET_COLLECTION 불가) — 앱 관계로 타고 들어간다.
+  def events(app_id:)
+    paged(v1("apps/#{app_id}/appEvents"), { "limit" => 200 })
+  end
+
+  def event(id:)
+    @client.get(v1("appEvents/#{id}")).body["data"]
+  end
+
+  def update_badge(id:, badge:)
+    body = { data: { type: "appEvents", id: id, attributes: { badge: badge } } }
+    @client.patch(v1("appEvents/#{id}"), body).body["data"]
+  end
+
+  def localizations(event_id:)
+    paged(v1("appEvents/#{event_id}/localizations"), { "limit" => 50 })
+      .each_with_object({}) do |entry, collected|
+        locale = entry.dig("attributes", "locale")
+        collected[locale] = entry if locale
+      end
+  end
+
+  def create_localization(event_id:, locale:, attributes:)
+    body = {
+      data: {
+        type: "appEventLocalizations",
+        attributes: attributes.merge(locale: locale),
+        relationships: { appEvent: { data: { type: "appEvents", id: event_id } } }
+      }
+    }
+    @client.post(v1("appEventLocalizations"), body).body["data"]
+  end
+
+  # PATCH 에는 locale 을 싣지 않는다 — 생성 시점에만 정해지는 값이다.
+  def update_localization(id:, attributes:)
+    body = { data: { type: "appEventLocalizations", id: id, attributes: attributes } }
+    @client.patch(v1("appEventLocalizations/#{id}"), body).body["data"]
+  end
+
+  def screenshots(localization_id:)
+    paged(v1("appEventLocalizations/#{localization_id}/appEventScreenshots"), { "limit" => 50 })
+  end
+
+  def delete_screenshot(id:)
+    @client.delete(v1("appEventScreenshots/#{id}"))
+  end
+
+  # 예약(POST) → 바이너리 PUT → uploaded PATCH commit 3단계.
+  # AppScreenshot.create 와 같은 절차지만 commit 페이로드가 다르다 — appEventScreenshots 에는
+  # sourceFileChecksum 이 없어서(appScreenshots 전용) 함께 보내면 요청 전체가 거부된다.
+  def upload_screenshot(localization_id:, path:, asset_type:)
+    bytes = File.binread(path)
+    reserved = @client.post(v1("appEventScreenshots"), {
+      data: {
+        type: "appEventScreenshots",
+        attributes: {
+          fileSize: bytes.bytesize,
+          fileName: File.basename(path),
+          appEventAssetType: asset_type
+        },
+        relationships: {
+          appEventLocalization: { data: { type: "appEventLocalizations", id: localization_id } }
+        }
+      }
+    }).body["data"]
+
+    Spaceship::ConnectAPI::FileUploader.upload(reserved.dig("attributes", "uploadOperations"), bytes)
+
+    @client.patch(v1("appEventScreenshots/#{reserved["id"]}"), {
+      data: {
+        type: "appEventScreenshots",
+        id: reserved["id"],
+        attributes: { uploaded: true }
+      }
+    }).body["data"]
+
+    reserved
+  end
+
+  def screenshot(id:)
+    @client.get(v1("appEventScreenshots/#{id}")).body["data"]
+  end
+
+  private
+
+  # spaceship 의 tunes 클라이언트는 https://appstoreconnect.apple.com/iris/ 를 base 로 잡고,
+  # 리소스 경로는 전부 v1/ 로 시작한다 (gem 의 tunes.rb 가 모든 호출에 Version::V1 을 붙인다).
+  # 접두를 빼면 "path does not match a defined resource type" 로 돌아온다.
+  def v1(path)
+    "v1/#{path}"
+  end
+
+  # ASC 는 200건이 페이지 상한이라 links.next 를 따라가야 전량이 나온다.
+  def paged(path, params)
+    collected = []
+    response = @client.get(path, params)
+    loop do
+      body = response.body
+      collected.concat(body["data"] || [])
+      next_url = body.dig("links", "next")
+      break unless next_url
+
+      response = @client.get(next_url)
+    end
+    collected
+  end
+end
+
+def event_client
+  ASCEventClient.new(client: authenticated_client)
+end
+
+def resolved_app(client)
+  bundle_id = bundle_identifier
+  app_id = client.app_id(bundle_id: bundle_id)
+  abort_with("bundleId #{bundle_id} 로 앱을 못 찾았다 — 키에 이 앱 권한이 있는지 확인해라") unless app_id
+  app_id
+end
+
+def warn_if_published(attributes)
+  state = attributes["eventState"]
+  return unless PUBLISHED_STATES.include?(state)
+
+  warn("⚠︎ eventState=#{state} — 이미 게시됐거나 종료된 이벤트다. 덮어쓰는 게 맞는지 확인해라")
+end
+
+def run_list
+  client = event_client
+  events = client.events(app_id: resolved_app(client))
+  abort_with("앱 내 이벤트가 없다 — App Store Connect 콘솔에서 먼저 만들어라") if events.empty?
+
+  puts(format("%-14s  %-28s  %-14s  %-16s  %s", "ID", "REFERENCE NAME", "BADGE", "STATE", "PRIMARY"))
+  events.each do |entry|
+    attributes = entry["attributes"] || {}
+    puts(format(
+      "%-14s  %-28s  %-14s  %-16s  %s",
+      entry["id"],
+      attributes["referenceName"],
+      attributes["badge"],
+      attributes["eventState"],
+      attributes["primaryLocale"]
+    ))
+  end
+  puts("\n#{events.size}건")
+end
+
+def run_show(event_id)
+  client = event_client
+  entry = client.event(id: event_id)
+  attributes = entry["attributes"] || {}
+  locales = client.localizations(event_id: event_id).keys
+
+  attributes.each { |key, value| puts(format("%-28s %s", key, value.inspect)) }
+  puts(format("%-28s %d개 — %s", "localizations", locales.size, locales.sort.join(" ")))
+  warn_if_published(attributes)
+end
+
+def run_set_badge(event_id, badge)
+  unless BADGES.include?(badge)
+    abort_with("badge 는 다음 7종 중 하나다:\n  #{BADGES.join("\n  ")}")
+  end
+
+  client = event_client
+  current = client.event(id: event_id)
+  warn_if_published(current["attributes"] || {})
+  updated = client.update_badge(id: event_id, badge: badge)
+  puts("✓ badge → #{updated.dig("attributes", "badge")}")
+end
+
+# 로케일 축의 정본은 fastlane/metadata 의 디렉토리 이름(ASC 코드)이다.
+def metadata_locales
+  Dir.children(METADATA_ROOT).sort.select do |name|
+    File.directory?(File.join(METADATA_ROOT, name)) && !NON_LOCALE_METADATA_DIRS.include?(name)
+  end
+end
+
+def event_directory(event_id)
+  path = File.join(EVENT_ROOT, event_id)
+  abort_with("#{path} 가 없다 — 이벤트 원고 디렉토리를 먼저 만들어라") unless File.directory?(path)
+  path
+end
+
+# --event 는 사람이 읽는 디렉토리 슬러그다. ASC 리소스 id 는 event.json 에 따로 있다 —
+# 슬러그를 그대로 API 에 넘기면 그런 이벤트가 없다는 응답이 온다.
+def asc_event_id(event_dir)
+  path = File.join(event_dir, "event.json")
+  abort_with("#{path} 가 없다 — ascEventId 를 담을 설정 파일이 필요하다") unless File.exist?(path)
+
+  config = begin
+    JSON.parse(File.read(path))
+  rescue JSON::ParserError => error
+    abort_with("#{path} 가 JSON 이 아니다 — #{error.message}")
+  end
+
+  id = config["ascEventId"].to_s.strip
+  abort_with("#{path} 의 ascEventId 가 비었다 — `list` 로 확인해 채워라") if id.empty?
+  id
+end
+
+def read_copy(event_dir, locale)
+  FIELDS.each_with_object({}) do |field, collected|
+    path = File.join(event_dir, locale, "#{field[:file]}.txt")
+    collected[field[:file]] = File.exist?(path) ? File.read(path).strip : nil
+  end
+end
+
+# 위반을 첫 건에서 멈추지 않고 전량 모은다 — 31개 로케일을 한 번에 고치게 한다.
+def copy_violations(event_dir, locales)
+  locales.flat_map do |locale|
+    copy = read_copy(event_dir, locale)
+    FIELDS.filter_map do |field|
+      text = copy[field[:file]]
+      next "#{locale} #{field[:file]} — 파일이 없거나 비었다" if text.nil? || text.empty?
+      next if text.length <= field[:limit]
+
+      "#{locale} #{field[:file]} — #{text.length}자 (상한 #{field[:limit]})"
+    end
+  end
+end
+
+def asc_attributes(copy)
+  FIELDS.each_with_object({}) { |field, collected| collected[field[:attribute]] = copy[field[:file]] }
+end
+
+def target_locales(event_dir, locale_option, all_locales)
+  return metadata_locales if all_locales
+
+  abort_with("--locale <ASC로케일> 또는 --all-locales 중 하나가 필요하다") unless locale_option
+  unless File.directory?(File.join(event_dir, locale_option))
+    abort_with("#{event_dir}/#{locale_option} 가 없다 — 로케일 코드는 lproj 가 아니라 ASC 코드다 (fastlane/metadata/README.md)")
+  end
+  [locale_option]
+end
+
+def print_text_plan(event_dir, locales, existing)
+  puts(format("%-10s  %-8s  %s", "LOCALE", "ACTION", "길이 (name/short/long)"))
+  locales.each do |locale|
+    copy = read_copy(event_dir, locale)
+    lengths = FIELDS.map { |field| copy[field[:file]].to_s.length }.join("/")
+    puts(format("%-10s  %-8s  %s", locale, existing.key?(locale) ? "PATCH" : "POST", lengths))
+  end
+end
+
+def run_push_text(event_id, locale_option, all_locales, dry_run)
+  event_dir = event_directory(event_id)
+  locales = target_locales(event_dir, locale_option, all_locales)
+
+  violations = copy_violations(event_dir, locales)
+  unless violations.empty?
+    abort_with("원고가 ASC 제약을 어겼다 — #{violations.size}건\n\n#{violations.map { |line| "  #{line}" }.join("\n")}")
+  end
+
+  asc_id = asc_event_id(event_dir)
+  client = event_client
+  existing = client.localizations(event_id: asc_id)
+  print_text_plan(event_dir, locales, existing)
+
+  if dry_run
+    puts("\n--dry-run — 아무것도 올리지 않았다")
+    return
+  end
+
+  locales.each do |locale|
+    attributes = asc_attributes(read_copy(event_dir, locale))
+    entry = existing[locale]
+    if entry
+      client.update_localization(id: entry["id"], attributes: attributes)
+    else
+      client.create_localization(event_id: asc_id, locale: locale, attributes: attributes)
+    end
+    print(".")
+  end
+  puts
+
+  filled = client.localizations(event_id: asc_id).keys
+  missing = locales - filled
+  abort_with("올린 뒤 재조회했는데 #{missing.size}개 로케일이 비었다: #{missing.join(" ")}") unless missing.empty?
+  puts("✓ #{locales.size}개 로케일 — ASC 재조회로 확인됨 (전체 #{filled.size}개)")
+end
+
+def image_directory(event_id, locale)
+  File.join(EVENT_ROOT, event_id, "images", locale)
+end
+
+def missing_images(event_id, locales)
+  locales.flat_map do |locale|
+    IMAGE_SLOTS.filter_map do |slot|
+      path = File.join(image_directory(event_id, locale), slot[:file])
+      "#{locale} #{slot[:file]} — 없다" unless File.exist?(path)
+    end
+  end
+end
+
+def print_image_plan(event_id, locales, existing, client)
+  puts(format("%-10s  %-34s  %-9s  %s", "LOCALE", "FILE", "SIZE(KB)", "기존 슬롯"))
+  locales.each do |locale|
+    entry = existing[locale]
+    occupied = entry ? client.screenshots(localization_id: entry["id"]).map { |s| s.dig("attributes", "appEventAssetType") } : []
+    IMAGE_SLOTS.each do |slot|
+      path = File.join(image_directory(event_id, locale), slot[:file])
+      size = File.exist?(path) ? (File.size(path) / 1024.0).round : 0
+      puts(format(
+        "%-10s  %-34s  %-9s  %s",
+        locale, slot[:file], size,
+        occupied.include?(slot[:asset_type]) ? "점유 — 지우고 올린다" : "빔"
+      ))
+    end
+  end
+end
+
+# ASC 가 자산을 처리하는 데 시간이 걸린다. COMPLETE 가 되기 전에 다음으로 넘어가면
+# 콘솔에 자산이 안 붙은 채로 남는다.
+def await_delivery(client, screenshot_id)
+  30.times do
+    state = client.screenshot(id: screenshot_id).dig("attributes", "assetDeliveryState") || {}
+    return true if state["state"] == "COMPLETE"
+
+    if state["state"] == "FAILED"
+      messages = (state["errors"] || []).map { |error| [error["code"], error["description"]].compact.join(" - ") }
+      warn("    ✗ 업로드 실패 — #{messages.join(" / ")}")
+      return false
+    end
+    sleep(2)
+  end
+  warn("    ✗ 60초 안에 COMPLETE 가 안 됐다 (screenshot #{screenshot_id})")
+  false
+end
+
+def replace_slot(client, localization_id, event_id, locale, slot)
+  client.screenshots(localization_id: localization_id)
+        .select { |entry| entry.dig("attributes", "appEventAssetType") == slot[:asset_type] }
+        .each { |entry| client.delete_screenshot(id: entry["id"]) }
+
+  path = File.join(image_directory(event_id, locale), slot[:file])
+  uploaded = client.upload_screenshot(localization_id: localization_id, path: path, asset_type: slot[:asset_type])
+  await_delivery(client, uploaded["id"])
+end
+
+def run_push_images(event_id, locale_option, all_locales, dry_run)
+  event_dir = event_directory(event_id)
+  locales = target_locales(event_dir, locale_option, all_locales)
+
+  absent = missing_images(event_id, locales)
+  unless absent.empty?
+    abort_with("합성한 이미지가 없다 — #{absent.size}건\n\n#{absent.map { |line| "  #{line}" }.join("\n")}\n\ncompose-event-images.py 를 먼저 돌려라")
+  end
+
+  asc_id = asc_event_id(event_dir)
+  client = event_client
+  existing = client.localizations(event_id: asc_id)
+  orphans = locales - existing.keys
+  unless orphans.empty?
+    abort_with("이미지가 매달릴 로케일이 ASC 에 없다: #{orphans.join(" ")}\n\npush-text 를 먼저 돌려라 — 이미지는 로케일에 매달린다")
+  end
+
+  print_image_plan(event_id, locales, existing, client)
+  if dry_run
+    puts("\n--dry-run — 아무것도 올리지 않았다")
+    return
+  end
+
+  # all? 는 첫 실패에서 멈춰 나머지 슬롯을 건너뛴다 — map 으로 둘 다 시도한 뒤 판정한다.
+  # 한 로케일의 예외가 31개 배치를 통째로 끊지 않게 여기서 흡수한다.
+  failed = locales.reject do |locale|
+    puts("▶︎ [#{locale}]")
+    IMAGE_SLOTS.map do |slot|
+      begin
+        replace_slot(client, existing[locale]["id"], event_id, locale, slot)
+      rescue StandardError => error
+        warn("    ✗ #{slot[:asset_type]} — #{error.class}: #{error.message}")
+        false
+      end
+    end.all?
+  end
+
+  abort_with("실패한 로케일 #{failed.size}개: #{failed.join(" ")}") unless failed.empty?
+  verify_images_delivered(client, existing, locales)
+end
+
+# 올린 뒤 ASC 를 다시 읽어 자산이 실제로 붙었는지 센다. 예약(AWAITING_UPLOAD)만 만들어지고
+# 바이너리가 안 붙어도 슬롯은 "찬" 것처럼 보이므로, 슬롯 수가 아니라 전달 상태를 판정한다.
+def verify_images_delivered(client, existing, locales)
+  incomplete = locales.flat_map do |locale|
+    client.screenshots(localization_id: existing[locale]["id"]).filter_map do |shot|
+      state = (shot.dig("attributes", "assetDeliveryState") || {})["state"]
+      next if state == "COMPLETE"
+
+      "#{locale} #{shot.dig("attributes", "appEventAssetType")} → #{state}"
+    end
+  end
+
+  expected = locales.size * IMAGE_SLOTS.size
+  unless incomplete.empty?
+    abort_with(
+      "올린 뒤 재조회했는데 #{incomplete.size}/#{expected} 장이 COMPLETE 가 아니다\n\n" \
+      "#{incomplete.first(10).map { |line| "  #{line}" }.join("\n")}"
+    )
+  end
+  puts("✓ #{expected}장 — ASC 재조회로 전부 COMPLETE 확인됨")
+end
+
+USAGE = <<~TEXT
+  usage:
+    bundle exec ruby scripts/asc-in-app-event.rb list
+    bundle exec ruby scripts/asc-in-app-event.rb show <event-id>
+    bundle exec ruby scripts/asc-in-app-event.rb set-badge <event-id> <BADGE>
+    bundle exec ruby scripts/asc-in-app-event.rb push-text --event <id> (--locale <ASC로케일>|--all-locales) [--dry-run]
+    bundle exec ruby scripts/asc-in-app-event.rb push-images --event <id> (--locale <ASC로케일>|--all-locales) [--dry-run]
+TEXT
+
+# 다음 토큰이 또 다른 플래그면 값이 아니다 — `--event --dry-run` 이 "--dry-run" 을 id 로 삼는 걸 막는다.
+def flag_value(args, name)
+  index = args.index(name)
+  return nil unless index
+
+  value = args[index + 1]
+  value&.start_with?("--") ? nil : value
+end
+
+subcommand, *rest = ARGV
+case subcommand
+when "list" then rest.empty? ? run_list : abort_with(USAGE)
+when "show" then rest.size == 1 ? run_show(rest[0]) : abort_with(USAGE)
+when "set-badge" then rest.size == 2 ? run_set_badge(rest[0], rest[1]) : abort_with(USAGE)
+when "push-text", "push-images"
+  event_id = flag_value(rest, "--event")
+  abort_with(USAGE) unless event_id
+  locale = flag_value(rest, "--locale")
+  all_locales = rest.include?("--all-locales")
+  dry_run = rest.include?("--dry-run")
+  if subcommand == "push-text"
+    run_push_text(event_id, locale, all_locales, dry_run)
+  else
+    run_push_images(event_id, locale, all_locales, dry_run)
+  end
+else abort_with(USAGE)
+end

--- a/scripts/asc-in-app-event.test.sh
+++ b/scripts/asc-in-app-event.test.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# asc-in-app-event.rb 의 네트워크 없이 도는 가드 회귀 테스트.
+# 자격증명을 전부 지운 채로 돌려 "검증이 인증보다 앞선다"까지 함께 확인한다.
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT" || exit 1
+export PATH="/opt/homebrew/opt/ruby/bin:$PATH"
+PASS=0; FAIL=0
+
+FIXTURE="fastlane/in_app_events/_test_fixture"
+trap 'rm -rf "$ROOT/$FIXTURE"' EXIT
+
+# ASC_SECRET_FILE 을 없는 경로로 돌려, 이 기기에 실제 secret/asc-api-key.json 이 있어도
+# 테스트가 그걸 집어 네트워크를 타지 않게 한다.
+run() { # 인자를 그대로 넘기고 stdout+stderr 를 합쳐 돌려준다
+  env -u ASC_KEY_ID -u ASC_ISSUER_ID -u ASC_KEY_CONTENT \
+    ASC_SECRET_FILE=/nonexistent/asc-api-key.json \
+    bundle exec ruby scripts/asc-in-app-event.rb "$@" 2>&1
+}
+
+assert_contains() { # desc pattern actual
+  if printf '%s' "$3" | grep -qF -- "$2"; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1)); echo "FAIL: $1"; echo "  pattern [$2] not in:"; printf '%s\n' "$3" | sed 's/^/    /'
+  fi
+}
+assert_not_contains() { # desc pattern actual
+  if printf '%s' "$3" | grep -qF -- "$2"; then
+    FAIL=$((FAIL+1)); echo "FAIL: $1"; echo "  pattern [$2] unexpectedly present"
+  else
+    PASS=$((PASS+1))
+  fi
+}
+
+write_locale() { # locale name short long
+  mkdir -p "$FIXTURE/$1"
+  printf '%s' "$2" > "$FIXTURE/$1/name.txt"
+  printf '%s' "$3" > "$FIXTURE/$1/short_description.txt"
+  printf '%s' "$4" > "$FIXTURE/$1/long_description.txt"
+}
+
+# --- badge 검증은 인증보다 앞선다 ---
+assert_contains "badge 오타가 네트워크 전에 끊긴다" "badge 는 다음 7종" "$(run set-badge 123 NOT_A_BADGE)"
+assert_not_contains "badge 오타에서 자격증명 안내가 뜨지 않는다" "자격증명을 못 찾았다" "$(run set-badge 123 NOT_A_BADGE)"
+
+# --- 자격증명 가드 ---
+CREDS="$(run list)"
+assert_contains "자격증명 부재를 알린다" "자격증명을 못 찾았다" "$CREDS"
+assert_contains "secret 파일 경로를 안내한다" "asc-api-key.json" "$CREDS"
+assert_contains "환경변수 대안도 안내한다" "ASC_KEY_ID" "$CREDS"
+
+# --- 인자 파싱 ---
+assert_contains "인자 없으면 usage" "usage:" "$(run)"
+assert_contains "--event 값이 또 다른 플래그면 usage" "usage:" "$(run push-text --event --dry-run)"
+assert_contains "없는 이벤트 디렉토리를 짚는다" "이벤트 원고 디렉토리를 먼저 만들어라" "$(run push-text --event nope --locale ko --dry-run)"
+
+# --- 원고 검증 ---
+rm -rf "$FIXTURE"
+write_locale ko "가나다라마바사아자차카타파하가나다라마바사아자차카타파하가나다" "짧은 설명" "상세 설명"
+OVER="$(run push-text --event _test_fixture --locale ko --dry-run)"
+assert_contains "name 31자를 상한 위반으로 잡는다" "ko name — 31자 (상한 30)" "$OVER"
+assert_not_contains "상한 위반이면 인증까지 가지 않는다" "자격증명을 못 찾았다" "$OVER"
+
+rm -rf "$FIXTURE"
+write_locale ko "정상 이름" "짧은 설명" "상세 설명"
+rm "$FIXTURE/ko/long_description.txt"
+assert_contains "파일 결손을 잡는다" "ko long_description — 파일이 없거나 비었다" \
+  "$(run push-text --event _test_fixture --locale ko --dry-run)"
+
+rm -rf "$FIXTURE"
+write_locale ko "정상 이름" "짧은 설명" "상세 설명"
+assert_contains "--locale/--all-locales 없으면 끊는다" "--all-locales 중 하나가 필요하다" \
+  "$(run push-text --event _test_fixture --dry-run)"
+assert_contains "lproj 코드를 쓰면 ASC 코드임을 알린다" "lproj 가 아니라 ASC 코드다" \
+  "$(run push-text --event _test_fixture --locale de --dry-run)"
+printf '{"ascEventId":"6806709988"}' > "$FIXTURE/event.json"
+assert_contains "유효한 원고는 검증을 통과해 인증까지 간다" "자격증명을 못 찾았다" \
+  "$(run push-text --event _test_fixture --locale ko --dry-run)"
+rm -f "$FIXTURE/event.json"
+
+# --- --event 슬러그를 ASC 이벤트 id 로 오인하지 않는다 ---
+rm -rf "$FIXTURE"
+write_locale ko "정상 이름" "짧은 설명" "상세 설명"
+NOCONF="$(run push-text --event _test_fixture --locale ko --dry-run)"
+assert_contains "event.json 없으면 ascEventId 를 요구한다" "ascEventId 를 담을 설정 파일이 필요하다" "$NOCONF"
+assert_not_contains "설정이 없으면 인증까지 가지 않는다" "자격증명을 못 찾았다" "$NOCONF"
+
+printf '{"ascEventId":""}' > "$FIXTURE/event.json"
+EMPTYID="$(run push-text --event _test_fixture --locale ko --dry-run)"
+assert_contains "ascEventId 가 비면 채우라고 짚는다" "ascEventId 가 비었다" "$EMPTYID"
+assert_not_contains "빈 ascEventId 로 인증까지 가지 않는다" "자격증명을 못 찾았다" "$EMPTYID"
+
+printf '{"ascEventId":"6806709988"}' > "$FIXTURE/event.json"
+assert_contains "ascEventId 가 차면 인증까지 간다" "자격증명을 못 찾았다" \
+  "$(run push-text --event _test_fixture --locale ko --dry-run)"
+
+# --- push-images 는 합성 산출물이 없으면 인증 전에 끊는다 ---
+rm -rf "$FIXTURE"
+write_locale ko "정상 이름" "짧은 설명" "상세 설명"
+printf '{"ascEventId":"6806709988"}' > "$FIXTURE/event.json"
+NOIMG="$(run push-images --event _test_fixture --locale ko --dry-run)"
+assert_contains "합성 이미지 결손을 짚는다" "event-card_1920x1080.png — 없다" "$NOIMG"
+assert_contains "compose 를 먼저 돌리라고 안내한다" "compose-event-images.py 를 먼저 돌려라" "$NOIMG"
+assert_not_contains "이미지 결손이면 인증까지 가지 않는다" "자격증명을 못 찾았다" "$NOIMG"
+
+mkdir -p "$FIXTURE/images/ko"
+python3 - "$FIXTURE/images/ko" <<'PYIMG'
+import sys
+from pathlib import Path
+from PIL import Image
+directory = Path(sys.argv[1])
+Image.new("RGB", (1920, 1080), "#000000").save(directory / "event-card_1920x1080.png")
+Image.new("RGB", (1080, 1920), "#000000").save(directory / "event-detail_1080x1920.png")
+PYIMG
+assert_contains "이미지가 갖춰지면 인증까지 간다" "자격증명을 못 찾았다" \
+  "$(run push-images --event _test_fixture --locale ko --dry-run)"
+
+# --- 로케일 축이 fastlane/metadata 31개와 일치하는가 ---
+EXPECTED_LOCALES=$(find fastlane/metadata -mindepth 1 -maxdepth 1 -type d \
+  ! -name review_information ! -name trade_representative_contact_information \
+  ! -name app_clip_review_information | wc -l | tr -d ' ')
+rm -rf "$FIXTURE"; mkdir -p "$FIXTURE"
+ALL="$(run push-text --event _test_fixture --all-locales --dry-run)"
+assert_contains "--all-locales 는 metadata 로케일 전부를 본다" "$((EXPECTED_LOCALES * 3))건" "$ALL"
+
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/build_event_sources.py
+++ b/scripts/build_event_sources.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""촬영된 카탈로그 산출물에서 이벤트 소스 장면(s1/s2)을 만든다.
+
+usage: python3 scripts/build_event_sources.py <event_id> <lang>
+
+event.json 의 scenes 값은 셋 중 하나이고, 조립 조각도 같은 셋이라 재귀로 푼다:
+  - 문자열   — snapshot-catalog 기준 상대 경로
+  - {"from": "snapshot-appstore", "file": "..."} — 앱스토어 스샷 파이프라인의 **캡션 얹기 전 원본**을
+    언어별로 가져온다. 캡션이 구워진 fastlane/screenshots 쪽은 홍보 문구 금지 조항에 걸려 못 쓴다
+  - {"assemble": "<종류>", ...조각} — 잠금화면처럼 합성이 필요한 장면을 조립한다
+
+scenes.card 는 리스트도 받는다 — 카드에 기기를 여러 대 세우는 경우다. 리스트 순서가 좌→우이고
+가운데가 히어로다. 세부사항은 풀블리드 한 장이라 리스트를 받지 않는다.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import ai_sheet  # noqa: E402
+import lock_screen  # noqa: E402
+import status_bar  # noqa: E402
+
+ROOT = Path(__file__).resolve().parent.parent
+CATALOG = ROOT / "snapshot-catalog"
+SLOTS = {"card": "s1-card-source", "detail": "s2-detail-source"}
+MULTI_SLOTS = {"card"}
+
+ASSEMBLERS = {
+    "lock-screen": (lock_screen.compose, ["foremost", "next", "nextRemain", "liveActivity"]),
+    "ai-sheet": (ai_sheet.compose, ["background", "sheet"]),
+}
+
+
+def catalog_path(relative):
+    path = CATALOG / relative
+    if not path.exists():
+        raise SystemExit(f"✗ 누락: snapshot-catalog/{relative}")
+    return path
+
+
+def appstore_source(spec, lang):
+    path = ROOT / "snapshot-appstore" / lang / spec["file"]
+    if not path.exists():
+        raise SystemExit(
+            f"✗ 누락: snapshot-appstore/{lang}/{spec['file']} — "
+            "scripts/capture-appstore-screenshots.sh 로 그 언어를 먼저 촬영해라"
+        )
+    return path
+
+
+def assemble(spec, lang):
+    kind = spec.get("assemble")
+    entry = ASSEMBLERS.get(kind)
+    if entry is None:
+        raise SystemExit(f"✗ 모르는 assemble 종류: {kind} — 아는 것은 {', '.join(ASSEMBLERS)}")
+    compose, keys = entry
+    missing = [key for key in keys if not spec.get(key)]
+    if missing:
+        raise SystemExit(f"✗ {kind} 조립에 {', '.join(missing)} 가 없다 — event.json 을 확인해라")
+    return compose(*(resolve(spec[key], lang) for key in keys))
+
+
+def resolve(spec, lang):
+    if isinstance(spec, str):
+        return Image.open(catalog_path(spec))
+    if not isinstance(spec, dict):
+        raise SystemExit(f"✗ 장면 값이 문자열도 객체도 아니다: {spec!r}")
+    if spec.get("from") == "snapshot-appstore":
+        # 앱 화면 스냅샷은 safe area 없이 콘텐츠만 찍혀 나온다 — 상태창 자리를 여기서 낸다
+        with Image.open(appstore_source(spec, lang)) as source:
+            return status_bar.inset(source)
+    return assemble(spec, lang)
+
+
+def source_filename(stem, index):
+    return f"{stem}.png" if index == 0 else f"{stem}-{index + 1}.png"
+
+
+def slot_specs(slot, spec):
+    if not isinstance(spec, list):
+        return [spec]
+    if slot not in MULTI_SLOTS:
+        raise SystemExit(f"✗ scenes.{slot} 는 리스트를 받지 않는다 — 한 장만 적어라")
+    if not spec:
+        raise SystemExit(f"✗ scenes.{slot} 가 빈 리스트다")
+    return spec
+
+
+def main(event_id, lang):
+    config = json.loads((ROOT / "fastlane" / "in_app_events" / event_id / "event.json").read_text())
+    out = ROOT / "snapshot-event" / event_id / lang
+    out.mkdir(parents=True, exist_ok=True)
+
+    written = 0
+    for slot, stem in SLOTS.items():
+        for index, spec in enumerate(slot_specs(slot, config["scenes"][slot])):
+            resolve(spec, lang).save(out / source_filename(stem, index))
+            written += 1
+    print(f"  ✓ [{lang}] {written}장 → snapshot-event/{event_id}/{lang}/")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        raise SystemExit(__doc__)
+    main(sys.argv[1], sys.argv[2])

--- a/scripts/capture-event-screenshots.sh
+++ b/scripts/capture-event-screenshots.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+# 앱 내 이벤트(In-App Event) 이미지의 소스 장면을 언어별로 촬영한다.
+#
+# usage:
+#   scripts/capture-event-screenshots.sh <event_id> <lang> [<lang> ...]
+#   scripts/capture-event-screenshots.sh <event_id> --all
+#
+# 결과: snapshot-event/<event_id>/<lang>/s1-card-source.png   (카드용 장면)
+#       snapshot-event/<event_id>/<lang>/s2-detail-source.png (세부사항용 장면)
+#
+# capture-appstore-screenshots.sh 와 촬영 절차는 같고 셋이 다르다:
+#   - 어느 장면을 뜰지가 스크립트에 없다. fastlane/in_app_events/<event_id>/event.json 의
+#     scenes·captureSuites 를 읽는다 — 새 이벤트가 코드 수정 없이 돌아야 한다
+#   - 규격 실측을 하지 않는다. 소스 장면은 합성 입력이라 고정 해상도 요구가 없다
+#   - 카탈로그 기준 시뮬레이터(iPhone 17)를 쓴다. 앱스토어 스샷 전용기를 공유하지 않는다
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SIMULATOR_NAME='iPhone 17 - snapshot_ref'
+SIMULATOR_DEVICE_TYPE='com.apple.CoreSimulator.SimDeviceType.iPhone-17'
+
+ALL_LANGS=(en ko ja zh-Hans zh-Hant vi th es fr it pt-BR ca de nl sv da nb fi pl cs sk hu ru uk ro el hr tr id ms hi)
+
+region_of() {
+    case "$1" in
+        en) echo US ;; ko) echo KR ;; ja) echo JP ;;
+        zh-Hans) echo CN ;; zh-Hant) echo TW ;;
+        vi) echo VN ;; th) echo TH ;; es) echo ES ;; fr) echo FR ;;
+        it) echo IT ;; pt-BR) echo BR ;; ca) echo ES ;; de) echo DE ;;
+        nl) echo NL ;; sv) echo SE ;; da) echo DK ;; nb) echo NO ;;
+        fi) echo FI ;; pl) echo PL ;; cs) echo CZ ;; sk) echo SK ;;
+        hu) echo HU ;; ru) echo RU ;; uk) echo UA ;; ro) echo RO ;;
+        el) echo GR ;; hr) echo HR ;; tr) echo TR ;; id) echo ID ;;
+        ms) echo MY ;; hi) echo IN ;;
+        *) echo "region_of: 알 수 없는 언어 $1" >&2; return 1 ;;
+    esac
+}
+
+# scenes 가 문자열이든 조립형 객체든, 거기 쓰이는 카탈로그 경로를 전부 열거한다
+scene_paths() { # <event_id>
+    python3 - "$ROOT/fastlane/in_app_events/$1/event.json" <<'PY'
+import json, sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+if not path.exists():
+    sys.exit(f"✗ {path} 가 없다 — 이벤트 설정을 먼저 만들어라")
+scenes = json.loads(path.read_text()).get("scenes") or {}
+
+
+def catalog_scenes(spec):
+    """스위트 검사 대상인 카탈로그 경로만 — 조각도 같은 형식이라 재귀로 훑는다."""
+    if isinstance(spec, list):
+        for item in spec:
+            yield from catalog_scenes(item)
+    elif isinstance(spec, str):
+        yield spec
+    elif isinstance(spec, dict) and not spec.get("from"):
+        # from 은 카탈로그가 아니라 다른 파이프라인 산출물이다 — 검사 대상이 아니다
+        for key, value in spec.items():
+            if key != "assemble":
+                yield from catalog_scenes(value)
+
+
+for slot in ("card", "detail"):
+    spec = scenes.get(slot)
+    if not spec:
+        sys.exit(f"✗ {path} 에 scenes.{slot} 가 없다")
+    for scene in catalog_scenes(spec):
+        print(scene)
+PY
+}
+
+event_config() { # <event_id> <키경로>
+    python3 - "$ROOT/fastlane/in_app_events/$1/event.json" "$2" <<'PY'
+import json, sys
+from pathlib import Path
+
+path, key = Path(sys.argv[1]), sys.argv[2]
+if not path.exists():
+    sys.exit(f"✗ {path} 가 없다 — 이벤트 설정을 먼저 만들어라")
+config = json.loads(path.read_text())
+value = config
+for part in key.split("."):
+    if not isinstance(value, dict) or part not in value:
+        sys.exit(f"✗ {path} 에 {key} 가 없다")
+    value = value[part]
+print("\n".join(value) if isinstance(value, list) else value)
+PY
+}
+
+latest_ios_runtime() {
+    xcrun simctl list runtimes \
+        | sed -nE 's/^iOS [0-9.]+ \(([0-9.]+) - [^)]*\) - (com\.apple\.CoreSimulator\.SimRuntime\.iOS-[0-9-]+)$/\1 \2/p' \
+        | sort -k1,1V | tail -1 | cut -d' ' -f2
+}
+
+simulator_udid() {
+    xcrun simctl list devices available \
+        | grep -F "$SIMULATOR_NAME (" | head -1 \
+        | sed -E 's/.*\(([0-9A-Fa-f-]{36})\).*/\1/'
+}
+
+ensure_simulator() {
+    local udid runtime
+    udid="$(simulator_udid)"
+    if [ -n "$udid" ]; then echo "$udid"; return 0; fi
+    runtime="$(latest_ios_runtime)"
+    [ -n "$runtime" ] || { echo "설치된 iOS 시뮬레이터 런타임이 없다" >&2; return 1; }
+    echo "▶︎ '$SIMULATOR_NAME' 생성 ($runtime)" >&2
+    xcrun simctl create "$SIMULATOR_NAME" "$SIMULATOR_DEVICE_TYPE" "$runtime"
+}
+
+python_with_pillow() {
+    local candidate
+    for candidate in python3 /opt/homebrew/bin/python3 /usr/local/bin/python3; do
+        command -v "$candidate" >/dev/null 2>&1 || continue
+        "$candidate" -c 'import PIL' >/dev/null 2>&1 && { echo "$candidate"; return 0; }
+    done
+    return 1
+}
+
+# ASC 는 알파 채널이 있는 이미지를 거부한다. 흰/검으로 flatten 하지 않고 채널만 떨어뜨리므로
+# 이미 불투명한지 먼저 확인하고 아니면 실패로 끊는다.
+strip_alpha() {
+    local python_bin="$1" dir="$2"
+    "$python_bin" - "$dir" <<'PY'
+import sys
+from pathlib import Path
+from PIL import Image
+
+directory = Path(sys.argv[1])
+failures = []
+paths = sorted(directory.glob("*.png"))
+for path in paths:
+    with Image.open(path) as image:
+        if image.mode not in ("RGBA", "LA", "P"):
+            continue
+        converted = image.convert("RGBA")
+        low, _ = converted.getchannel("A").getextrema()
+        if low != 255:
+            failures.append(f"{path.name}: 투명 픽셀이 있다(alpha 최소 {low}) — 채널만 떨구면 검게 남는다")
+            continue
+        converted.convert("RGB").save(path)
+
+if failures:
+    print("\n".join(f"  ✗ {message}" for message in failures), file=sys.stderr)
+    sys.exit(1)
+print(f"  ✓ {len(paths)}장 / 알파 없음")
+PY
+}
+
+capture_lang() { # <event_id> <lang> <destination> <python_bin>
+    local event_id="$1" lang="$2" destination="$3" python_bin="$4" region
+    region="$(region_of "$lang")" || return 1
+    echo "▶︎ [$lang] 촬영 시작 (region=$region)"
+
+    local suite
+    while IFS= read -r suite; do
+        [ -n "$suite" ] || continue
+        local scheme="${suite%%|*}" class="${suite##*|}"
+        echo "  · $scheme/$class"
+        xcodebuild test \
+            -workspace "$ROOT/TodoCalendar.xcworkspace" \
+            -scheme "$scheme" \
+            -destination "$destination" \
+            -only-testing:"$scheme/$class" \
+            -testLanguage "$lang" -testRegion "${lang%%-*}_$region" \
+            > "/tmp/capture-event-$event_id-$lang-$scheme.log" 2>&1 \
+            || { echo "  ✗ 실패 — /tmp/capture-event-$event_id-$lang-$scheme.log"; return 1; }
+    done <<< "$CAPTURE_SUITES"
+
+    local out="$ROOT/snapshot-event/$event_id/$lang"
+    rm -rf "$out" || return 1
+    # 단순 복사와 조립(잠금화면 등)을 함께 다룬다
+    "$python_bin" "$ROOT/scripts/build_event_sources.py" "$event_id" "$lang" || return 1
+
+    strip_alpha "$python_bin" "$out" || return 1
+
+    # 검증 스위트 png 가 섞여 들어가지 않았는지 — 섞였다면 -only-testing 이 안 먹은 것이다
+    if ! git -C "$ROOT" diff --quiet -- '*__Snapshots__*'; then
+        echo "  ⚠︎ [$lang] 커밋 대상 __Snapshots__/ 가 변경됐다. git restore 로 되돌리고 원인을 확인할 것" >&2
+        return 1
+    fi
+}
+
+# scenes 가 가리키는 스위트가 captureSuites 에 없으면 이번 실행이 그 장면을 안 찍는다.
+# 그래도 snapshot-catalog 에 이전 실행이 남긴 파일이 있으면 조용히 복사돼, 언어도 기기 규격도
+# 다른 낡은 이미지가 섞인다. 촬영 전에 끊는다.
+ensure_scenes_are_captured() {
+    local scene suite_class missing=()
+    while IFS= read -r scene; do
+        [ -n "$scene" ] || continue
+        suite_class="$(echo "$scene" | cut -d/ -f2)"
+        grep -qF "|$suite_class" <<< "$CAPTURE_SUITES" || missing+=("$scene (스위트 $suite_class)")
+    done <<< "$SCENE_PATHS"
+    [ ${#missing[@]} -eq 0 ] && return 0
+
+    {
+        echo "✗ captureSuites 가 안 덮는 장면이 있다 — 이번 실행은 이 장면을 찍지 않는다:"
+        printf '    %s\n' "${missing[@]}"
+        echo "  event.json 의 captureSuites 에 '<스킴>|<스위트클래스>' 를 추가해라"
+    } >&2
+    return 1
+}
+
+[ $# -ge 2 ] || { sed -n '2,10p' "$0"; exit 1; }
+EVENT_ID="$1"; shift
+
+SCENE_PATHS="$(scene_paths "$EVENT_ID")"
+CAPTURE_SUITES="$(event_config "$EVENT_ID" captureSuites)"
+ensure_scenes_are_captured
+
+if [ "${1:-}" = "--all" ]; then set -- "${ALL_LANGS[@]}"; fi
+
+PYTHON_BIN="$(python_with_pillow)" || {
+    echo "Pillow 를 쓸 수 있는 python3 가 없다 (pip3 install Pillow)" >&2; exit 1
+}
+SIMULATOR_UDID="$(ensure_simulator)"
+DESTINATION="platform=iOS Simulator,id=$SIMULATOR_UDID"
+
+# capture_lang 을 `|| failed+=(...)` 로 부르면 bash 가 함수 실행 전 구간에서 errexit 을 끈다.
+# 종료코드를 따로 받아 판정해야 함수 안의 set -e 가 살아 있다.
+failed=()
+for lang in "$@"; do
+    capture_lang "$EVENT_ID" "$lang" "$DESTINATION" "$PYTHON_BIN"
+    status=$?
+    [ $status -eq 0 ] || failed+=("$lang")
+done
+
+if [ ${#failed[@]} -gt 0 ]; then
+    echo "✗ 실패한 언어: ${failed[*]}" >&2
+    exit 1
+fi
+echo "✓ 전체 완료 — $# 개 언어"

--- a/scripts/capture-event-screenshots.test.sh
+++ b/scripts/capture-event-screenshots.test.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# capture-event-screenshots.sh 의 촬영 전 가드 회귀 (xcodebuild 를 타지 않는 구간).
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT" || exit 1
+PASS=0; FAIL=0
+
+EVENT="_capture_test"
+EVENT_DIR="fastlane/in_app_events/$EVENT"
+trap 'rm -rf "$ROOT/$EVENT_DIR"' EXIT
+
+assert_contains() { # desc pattern actual
+  if printf '%s' "$3" | grep -qF -- "$2"; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1)); echo "FAIL: $1"; echo "  pattern [$2] not in:"; printf '%s\n' "$3" | sed 's/^/    /'
+  fi
+}
+
+write_config() { # <captureSuites JSON 배열>
+  mkdir -p "$EVENT_DIR"
+  cat > "$EVENT_DIR/event.json" <<JSON
+{
+  "ascEventId": "0",
+  "badge": "SPECIAL_EVENT",
+  "scenes": {
+    "card": "CalendarScenes/CalendarScenesCatalogSnapshots/test_storeCalendar.storeCalendar-light.png",
+    "detail": "EventDetailScene/EventDetailSceneCatalogSnapshots/test_eventDetail.eventDetail-light.png"
+  },
+  "captureSuites": $1,
+  "style": { "backgroundTop": "#000000", "backgroundBottom": "#111111", "cardTiltDegrees": 7 }
+}
+JSON
+}
+
+assert_contains "인자 부족이면 usage" "usage:" "$(scripts/capture-event-screenshots.sh 2>&1)"
+assert_contains "event.json 이 없으면 끊는다" "이벤트 설정을 먼저 만들어라" \
+  "$(scripts/capture-event-screenshots.sh nope ko 2>&1)"
+
+write_config '["CalendarScenesSnapshots|CalendarScenesCatalogSnapshots"]'
+# captureSuites 가 detail 장면의 스위트를 안 덮으면, snapshot-catalog 에 남은 이전 실행 산출물이
+# 조용히 복사돼 언어도 기기 규격도 다른 이미지가 섞인다
+MISSED="$(scripts/capture-event-screenshots.sh "$EVENT" ko 2>&1)"
+assert_contains "안 덮이는 장면을 촬영 전에 끊는다" "captureSuites 가 안 덮는 장면이 있다" "$MISSED"
+assert_contains "어느 장면인지 짚는다" "EventDetailSceneCatalogSnapshots" "$MISSED"
+if printf '%s' "$MISSED" | grep -qF "촬영 시작"; then
+  FAIL=$((FAIL+1)); echo "FAIL: 가드가 촬영보다 앞서야 한다"
+else
+  PASS=$((PASS+1))
+fi
+
+write_config '[]'
+assert_contains "captureSuites 가 비면 두 장면 다 짚는다" "CalendarScenesCatalogSnapshots" \
+  "$(scripts/capture-event-screenshots.sh "$EVENT" ko 2>&1)"
+
+python3 - "$EVENT_DIR/event.json" <<'PY'
+import json, sys
+from pathlib import Path
+path = Path(sys.argv[1])
+config = json.loads(path.read_text())
+del config["scenes"]["detail"]
+path.write_text(json.dumps(config))
+PY
+assert_contains "scenes 키 결손을 짚는다" "scenes.detail 가 없다" \
+  "$(scripts/capture-event-screenshots.sh "$EVENT" ko 2>&1)"
+
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/compose-event-images.py
+++ b/scripts/compose-event-images.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""촬영한 장면을 App Store 앱 내 이벤트 업로드용 이미지로 합성한다.
+
+usage:
+    python3 scripts/compose-event-images.py --event <event_id> --locale <lang>
+    python3 scripts/compose-event-images.py --event <event_id> --all-locales
+
+입력: snapshot-event/<event_id>/<lang>/s1-card-source.png, s2-detail-source.png
+출력: fastlane/in_app_events/<event_id>/images/<ASC 로케일>/event-card_1920x1080.png
+      fastlane/in_app_events/<event_id>/images/<ASC 로케일>/event-detail_1080x1920.png
+
+기하 규칙의 정본은 유저의 "[공통 지침] 앱 내 이벤트 이미지 합성 파이프라인" 문서다.
+이벤트마다 바뀌는 값은 전부 event.json 의 style 에 있어, 새 이벤트는 코드 수정 없이 돈다.
+
+**이미지에 홍보 문구를 그리지 않는다.** App Store 가 이벤트 이름·설명을 카드 하단에 겹쳐
+렌더링하므로 여기서 얹으면 겹친다 (지침 §2-5·§3-4).
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from PIL import Image, ImageChops
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from device_bezel import load_bezel, screen_hole  # noqa: E402
+
+ROOT = Path(__file__).resolve().parent.parent
+
+CARD_SIZE = (1920, 1080)
+DETAIL_SIZE = (1080, 1920)
+
+# App Store 가 이벤트 이름·설명을 카드 하단 1/3 에 겹쳐 그린다 — 목업이 침범하면 안 된다
+CARD_CLEAR_TOP = 720
+# 시스템 UI 크롭 대비 좌우 여백
+CARD_SIDE_MARGIN = 96
+CARD_DEVICE_BOTTOM = 680
+TILT_RANGE = (5, 10)
+# 카드에 기기를 여러 대 세울 때 — 가운데가 히어로, 나머지는 뒤로 물러난다
+CARD_FLANK_SCALE = 0.8
+CARD_FLANK_SPREAD = 0.85
+
+CARD_SOURCE_STEM = "s1-card-source"
+DETAIL_SOURCE = "s2-detail-source.png"
+
+# 잘려도 의미가 통해야 하는 영역 — 핵심 콘텐츠는 그 사이 중앙 밴드에 온다
+DETAIL_SAFE_TOP = 240
+DETAIL_SAFE_BOTTOM = 320
+
+ALL_LANGS = [
+    "en", "ko", "ja", "zh-Hans", "zh-Hant", "vi", "th", "es", "fr", "it", "pt-BR",
+    "ca", "de", "nl", "sv", "da", "nb", "fi", "pl", "cs", "sk", "hu", "ru", "uk",
+    "ro", "el", "hr", "tr", "id", "ms", "hi",
+]
+# lproj ↔ ASC 로케일이 다른 6개 (fastlane/metadata/README.md 매핑표와 같은 값)
+ASC_LOCALES = {
+    "en": "en-US", "de": "de-DE", "es": "es-ES",
+    "fr": "fr-FR", "nl": "nl-NL", "nb": "no",
+}
+
+
+def asc_locale(lang):
+    return ASC_LOCALES.get(lang, lang)
+
+
+def rgb(value):
+    value = value.lstrip("#")
+    return tuple(int(value[index:index + 2], 16) for index in (0, 2, 4))
+
+
+def card_background(style):
+    top, bottom = rgb(style["backgroundTop"]), rgb(style["backgroundBottom"])
+    width, height = CARD_SIZE
+    background = Image.new("RGB", CARD_SIZE)
+    for y in range(height):
+        ratio = y / (height - 1)
+        row = tuple(round(top[c] + (bottom[c] - top[c]) * ratio) for c in range(3))
+        background.paste(row, (0, y, width, y + 1))
+    return background
+
+
+def device_mockup(screenshot, bezel, hole_mask, hole_box, tilt):
+    """스크린샷을 베젤 화면 구멍에 넣고 기울인다. 반환값은 알파를 가진 RGBA."""
+    hole_width = hole_box[2] - hole_box[0]
+    hole_height = hole_box[3] - hole_box[1]
+    fitted = screenshot.convert("RGB").resize((hole_width, hole_height), Image.LANCZOS)
+
+    screen = Image.new("RGBA", bezel.size, (0, 0, 0, 0))
+    screen.paste(fitted, hole_box[:2])
+    screen.putalpha(hole_mask)
+
+    device = Image.alpha_composite(screen, bezel)
+    return device.rotate(tilt, resample=Image.BICUBIC, expand=True)
+
+
+def card_device(screenshot, height, tilt, bezel, hole_mask, hole_box):
+    aspect = bezel.width / bezel.height
+    scaled = bezel.resize((round(height * aspect), height), Image.LANCZOS)
+    scaled_mask = hole_mask.resize(scaled.size, Image.LANCZOS)
+    scaled_box = tuple(round(value * height / bezel.height) for value in hole_box)
+    return device_mockup(screenshot, scaled, scaled_mask, scaled_box, tilt)
+
+
+def compose_card(screenshots, style, bezel, hole_mask, hole_box):
+    tilt = style.get("cardTiltDegrees", 7)
+    if not TILT_RANGE[0] <= tilt <= TILT_RANGE[1]:
+        raise SystemExit(f"✗ cardTiltDegrees={tilt} — 허용 범위는 5~10 이다 (지침 §2-2)")
+
+    height = style.get("cardDeviceHeight", 1100)
+    flank_scale = style.get("cardFlankScale", CARD_FLANK_SCALE)
+    spread = style.get("cardFlankSpread", CARD_FLANK_SPREAD)
+    hero = len(screenshots) // 2
+
+    devices = [
+        card_device(
+            shot, round(height * (1 if index == hero else flank_scale)),
+            tilt, bezel, hole_mask, hole_box
+        )
+        for index, shot in enumerate(screenshots)
+    ]
+
+    background = card_background(style)
+    card = background.copy()
+    # 플랭크를 먼저 깔고 히어로를 맨 위에 — 히어로가 좌우를 덮어야 앞에 선 것으로 읽힌다
+    for index in sorted(range(len(devices)), key=lambda i: i == hero):
+        device = devices[index]
+        step = (devices[hero].width + device.width) / 2 * spread
+        center = round(CARD_SIZE[0] / 2 + step * (index - hero))
+        card.paste(device, (center - device.width // 2, CARD_DEVICE_BOTTOM - device.height), device)
+
+    verify_card_clearances(card, background)
+    return card
+
+
+def verify_card_clearances(card, background):
+    """배치 산식이 아니라 그려진 픽셀을 본다.
+
+    `top` 을 `CARD_DEVICE_BOTTOM - device.height` 로 잡으면 `top + device.height` 는 항상
+    그 상수라, 산식으로 하단 침범을 판정하면 무엇을 바꿔도 참이 안 되는 죽은 가드가 된다.
+    """
+    region = (0, CARD_CLEAR_TOP, CARD_SIZE[0], CARD_SIZE[1])
+    if card.crop(region).tobytes() != background.crop(region).tobytes():
+        raise SystemExit(
+            f"✗ 하단 1/3(y>={CARD_CLEAR_TOP})에 배경 아닌 픽셀이 있다 — "
+            "App Store 가 이벤트 이름·설명을 겹쳐 그리는 자리다. style.cardDeviceHeight 를 줄여라"
+        )
+
+    drawn = ImageChops.difference(card, background).getbbox()
+    if drawn is None:
+        raise SystemExit("✗ 배경만 남았다 — 소스 장면이나 베젤이 비었다")
+    if drawn[0] < CARD_SIDE_MARGIN or drawn[2] > CARD_SIZE[0] - CARD_SIDE_MARGIN:
+        raise SystemExit(
+            f"✗ 목업이 좌우 여백 {CARD_SIDE_MARGIN}px 를 침범했다 (x {drawn[0]}~{drawn[2]}) — "
+            "style.cardFlankSpread 를 줄여라"
+        )
+
+
+def compose_detail(screenshot):
+    """풀블리드 — 짧은 축에 맞춰 덮고 중앙 밴드를 남기며 잘라낸다."""
+    target_width, target_height = DETAIL_SIZE
+    source = screenshot.convert("RGB")
+    scale = max(target_width / source.width, target_height / source.height)
+    scaled = source.resize((round(source.width * scale), round(source.height * scale)), Image.LANCZOS)
+
+    left = (scaled.width - target_width) // 2
+    top = (scaled.height - target_height) // 2
+    return scaled.crop((left, top, left + target_width, top + target_height))
+
+
+def card_source_paths(source_dir):
+    """s1-card-source.png, -2, -3 … 을 붙은 데까지 순서대로 — 기기 좌→우 순이다."""
+    paths = []
+    while True:
+        index = len(paths)
+        name = f"{CARD_SOURCE_STEM}.png" if index == 0 else f"{CARD_SOURCE_STEM}-{index + 1}.png"
+        path = source_dir / name
+        if not path.exists():
+            return paths
+        paths.append(path)
+
+
+def compose_lang(event_id, lang, style, bezel, hole_mask, hole_box):
+    source_dir = ROOT / "snapshot-event" / event_id / lang
+    card_paths = card_source_paths(source_dir)
+    missing = [] if card_paths else [f"{CARD_SOURCE_STEM}.png"]
+    if not (source_dir / DETAIL_SOURCE).exists():
+        missing.append(DETAIL_SOURCE)
+    if missing:
+        raise SystemExit(f"✗ [{lang}] 소스 장면이 없다: {', '.join(missing)} — 먼저 촬영해라")
+
+    out = ROOT / "fastlane" / "in_app_events" / event_id / "images" / asc_locale(lang)
+    out.mkdir(parents=True, exist_ok=True)
+
+    card_sources = [Image.open(path) for path in card_paths]
+    try:
+        card = compose_card(card_sources, style, bezel, hole_mask, hole_box)
+    finally:
+        for source in card_sources:
+            source.close()
+    card.save(out / "event-card_1920x1080.png")
+
+    with Image.open(source_dir / DETAIL_SOURCE) as detail_source:
+        compose_detail(detail_source).save(out / "event-detail_1080x1920.png")
+    return out
+
+
+def verify(out_dirs):
+    """지침 §6 중 기계가 볼 수 있는 항목 — 해상도·알파·산출물 트리."""
+    expected = {"event-card_1920x1080.png": CARD_SIZE, "event-detail_1080x1920.png": DETAIL_SIZE}
+    failures = []
+    for out in out_dirs:
+        for name, size in expected.items():
+            path = out / name
+            if not path.exists():
+                failures.append(f"{path.relative_to(ROOT)}: 없다")
+                continue
+            with Image.open(path) as image:
+                if image.size != size:
+                    failures.append(f"{path.relative_to(ROOT)}: {image.size} — {size} 아님")
+                if image.mode != "RGB":
+                    failures.append(f"{path.relative_to(ROOT)}: mode={image.mode} — 알파가 남았다")
+    if failures:
+        raise SystemExit("\n".join(f"  ✗ {line}" for line in failures))
+    print(f"✓ {len(out_dirs)}개 로케일 × 2장 — 해상도·알파 확인됨")
+    print("  기계가 못 보는 항목은 스킬 체크리스트로: 홍보 문구 없음 / 언어 혼용 없음 / 더미 데이터에 실명 없음")
+
+
+def main(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--locale")
+    parser.add_argument("--all-locales", action="store_true")
+    args = parser.parse_args(argv)
+
+    config_path = ROOT / "fastlane" / "in_app_events" / args.event / "event.json"
+    if not config_path.exists():
+        raise SystemExit(f"✗ {config_path} 가 없다 — 이벤트 설정을 먼저 만들어라")
+    style = json.loads(config_path.read_text())["style"]
+
+    if args.all_locales:
+        langs = ALL_LANGS
+    elif args.locale:
+        langs = [args.locale]
+    else:
+        raise SystemExit("✗ --locale <lang> 또는 --all-locales 중 하나가 필요하다")
+
+    bezel = load_bezel()
+    hole_mask, hole_box = screen_hole(bezel)
+
+    out_dirs = [compose_lang(args.event, lang, style, bezel, hole_mask, hole_box) for lang in langs]
+    verify(out_dirs)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/scripts/compose-event-images.test.sh
+++ b/scripts/compose-event-images.test.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# compose-event-images.py 합성 규칙 회귀.
+# 지침의 하드 제약(하단 1/3 비움·정확한 해상도·알파 없음)이 코드로 지켜지는지 본다.
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT" || exit 1
+PASS=0; FAIL=0
+
+EVENT="_compose_test"
+EVENT_DIR="fastlane/in_app_events/$EVENT"
+SOURCE_DIR="snapshot-event/$EVENT/ko"
+trap 'rm -rf "$ROOT/$EVENT_DIR" "$ROOT/snapshot-event/$EVENT"' EXIT
+
+assert() { # desc actual_exit
+  if [ "$2" -eq 0 ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); echo "FAIL: $1"; fi
+}
+
+rm -rf "$EVENT_DIR" "snapshot-event/$EVENT"
+mkdir -p "$EVENT_DIR" "$SOURCE_DIR"
+cat > "$EVENT_DIR/event.json" <<'JSON'
+{
+  "ascEventId": "0",
+  "badge": "SPECIAL_EVENT",
+  "scenes": { "card": "unused", "detail": "unused" },
+  "captureSuites": [],
+  "style": { "backgroundTop": "#2B3A67", "backgroundBottom": "#4A5D9B", "cardTiltDegrees": 7 }
+}
+JSON
+
+# 소스 장면 대역 — 촬영 산출물과 같은 규격의 단색 이미지면 기하 검증엔 충분하다
+python3 - "$SOURCE_DIR" <<'PY'
+import sys
+from pathlib import Path
+from PIL import Image, ImageDraw
+
+directory = Path(sys.argv[1])
+for name in ("s1-card-source.png", "s2-detail-source.png"):
+    image = Image.new("RGB", (1320, 2868), "#FFFFFF")
+    draw = ImageDraw.Draw(image)
+    draw.rectangle([100, 100, 1220, 2768], fill="#E23D3D")
+    image.save(directory / name)
+PY
+
+python3 scripts/compose-event-images.py --event "$EVENT" --locale ko > /tmp/compose-test.log 2>&1
+assert "합성이 성공한다" $?
+
+OUT="$EVENT_DIR/images/ko"
+python3 - "$OUT" "$EVENT_DIR/event.json" <<'PY'
+import json, sys
+from pathlib import Path
+from PIL import Image
+
+out, config_path = Path(sys.argv[1]), Path(sys.argv[2])
+style = json.loads(config_path.read_text())["style"]
+failures = []
+
+card_path = out / "event-card_1920x1080.png"
+detail_path = out / "event-detail_1080x1920.png"
+
+for path, expected in ((card_path, (1920, 1080)), (detail_path, (1080, 1920))):
+    if not path.exists():
+        failures.append(f"{path.name}: 산출물이 없다")
+        continue
+    with Image.open(path) as image:
+        if image.size != expected:
+            failures.append(f"{path.name}: {image.size} — {expected} 아님")
+        if image.mode != "RGB":
+            failures.append(f"{path.name}: mode={image.mode} — 알파가 남았다")
+
+# 카드 하단 1/3 은 배경 그라데이션 그대로여야 한다 (App Store 가 이름·설명을 겹쳐 그린다)
+if card_path.exists():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("compose_event_images", "scripts/compose-event-images.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    card_background = module.card_background
+    with Image.open(card_path) as card:
+        region = card.convert("RGB").crop((0, 720, 1920, 1080))
+    expected_region = card_background(style).convert("RGB").crop((0, 720, 1920, 1080))
+    if region.tobytes() != expected_region.tobytes():
+        failures.append("event-card: 하단 1/3(y>=720)에 배경 아닌 픽셀이 있다")
+
+if failures:
+    print("\n".join(f"  ✗ {line}" for line in failures))
+    sys.exit(1)
+PY
+assert "규격·알파·하단 1/3 이 지침대로다" $?
+
+drawn_width() { # 배경 아닌 픽셀의 가로 폭 — 기기가 몇 대 섰는지의 대리 지표
+    python3 - "$OUT/event-card_1920x1080.png" "$EVENT_DIR/event.json" <<'WIDTH'
+import importlib.util, json, sys
+from pathlib import Path
+from PIL import Image, ImageChops
+
+spec = importlib.util.spec_from_file_location("cei", "scripts/compose-event-images.py")
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+style = json.loads(Path(sys.argv[2]).read_text())["style"]
+with Image.open(sys.argv[1]) as card:
+    box = ImageChops.difference(card.convert("RGB"), m.card_background(style)).getbbox()
+print(box[2] - box[0] if box else 0)
+WIDTH
+}
+SINGLE_WIDTH="$(drawn_width)"
+
+# 카드 소스가 여러 장이면 기기를 여러 대 세운다. 기본 style 만으로 좌우 여백 안에 들어와야
+# 새 이벤트가 코드 수정 없이 돈다 (지침 §4).
+python3 - "$SOURCE_DIR" <<'TRIO'
+import sys
+from pathlib import Path
+from PIL import Image, ImageDraw
+
+directory = Path(sys.argv[1])
+for index, color in ((2, "#2D8A4E"), (3, "#8A2D6F")):
+    image = Image.new("RGB", (1320, 2868), "#FFFFFF")
+    ImageDraw.Draw(image).rectangle([100, 100, 1220, 2768], fill=color)
+    image.save(directory / f"s1-card-source-{index}.png")
+TRIO
+python3 scripts/compose-event-images.py --event "$EVENT" --locale ko > /tmp/compose-trio.log 2>&1
+assert "기기 3대 카드가 기본 style 로 합성된다" $?
+TRIO_WIDTH="$(drawn_width)"
+if [ "$TRIO_WIDTH" -gt "$SINGLE_WIDTH" ]; then PASS=$((PASS+1)); else
+  FAIL=$((FAIL+1)); echo "FAIL: 소스가 늘어도 기기가 한 대만 섰다 ($SINGLE_WIDTH → $TRIO_WIDTH)"; fi
+rm -f "$SOURCE_DIR"/s1-card-source-2.png "$SOURCE_DIR"/s1-card-source-3.png
+
+# 좌우 여백 가드 — 기기를 여러 대 세우면 열리는 실패 경로다. 하단과 같은 함수가 잡는지 본다.
+python3 - <<'EDGE'
+import importlib.util, sys
+from PIL import Image
+
+spec = importlib.util.spec_from_file_location("cei", "scripts/compose-event-images.py")
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+
+background = m.card_background({"backgroundTop": "#000000", "backgroundBottom": "#111111"})
+card = background.copy()
+strip = Image.new("RGBA", (60, 200), (0, 255, 0, 255))
+card.paste(strip, (10, 300), strip)
+try:
+    m.verify_card_clearances(card, background)
+except SystemExit as error:
+    sys.exit(0 if "좌우 여백" in str(error) else f"다른 사유로 끊김: {error}")
+sys.exit("좌우 여백 가드가 침범을 통과시켰다")
+EDGE
+if [ $? -eq 0 ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); echo "FAIL: 좌우 여백 가드가 침범을 잡는다"; fi
+
+# 하단 1/3 가드 — 배치가 하단을 보장하므로 CLI 로는 침범을 못 만든다.
+# 가드가 살아 있는지는 함수를 직접 찔러 확인한다 (죽은 산식 가드로 되돌아가는 걸 막는 회귀).
+python3 - <<'GUARD'
+import importlib.util, sys
+from PIL import Image
+
+spec = importlib.util.spec_from_file_location("cei", "scripts/compose-event-images.py")
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+
+background = m.card_background({"backgroundTop": "#000000", "backgroundBottom": "#111111"})
+card = background.copy()
+# 하단 1/3 을 실제로 침범하는 불투명 사각형
+intruder = Image.new("RGBA", (200, 200), (255, 0, 0, 255))
+card.paste(intruder, (900, 800), intruder)
+try:
+    m.verify_card_clearances(card, background)
+except SystemExit as error:
+    sys.exit(0 if "하단 1/3" in str(error) else f"다른 사유로 끊김: {error}")
+sys.exit("가드가 침범을 통과시켰다")
+GUARD
+if [ $? -eq 0 ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); echo "FAIL: 하단 1/3 가드가 침범을 잡는다"; fi
+
+# 기울임 허용 범위 밖은 끊긴다
+python3 - "$EVENT_DIR/event.json" <<'PY'
+import json, sys
+from pathlib import Path
+path = Path(sys.argv[1])
+config = json.loads(path.read_text())
+config["style"]["cardTiltDegrees"] = 25
+path.write_text(json.dumps(config))
+PY
+python3 scripts/compose-event-images.py --event "$EVENT" --locale ko > /tmp/compose-tilt.log 2>&1
+if [ $? -ne 0 ] && grep -q "5~10" /tmp/compose-tilt.log; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); echo "FAIL: 기울임 범위 밖이 끊긴다"; cat /tmp/compose-tilt.log; fi
+
+# 소스 장면이 없으면 그 언어를 실패로 센다
+rm -f "$SOURCE_DIR/s1-card-source.png"
+python3 - "$EVENT_DIR/event.json" <<'PY'
+import json, sys
+from pathlib import Path
+path = Path(sys.argv[1])
+config = json.loads(path.read_text())
+config["style"]["cardTiltDegrees"] = 7
+path.write_text(json.dumps(config))
+PY
+python3 scripts/compose-event-images.py --event "$EVENT" --locale ko > /tmp/compose-missing.log 2>&1
+if [ $? -ne 0 ] && grep -q "s1-card-source.png" /tmp/compose-missing.log; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); echo "FAIL: 소스 결손을 짚는다"; cat /tmp/compose-missing.log; fi
+
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/device_bezel.py
+++ b/scripts/device_bezel.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""아이폰 기기 베젤(목업) 확보와 화면 구멍 산출.
+
+애플 공식 베젤만 쓴다 (마케팅·아이덴티티 가이드라인). 동봉 라이선스가 non-transferable 이라
+public 레포에 커밋하지 않고 캐시 디렉토리에 받아 쓴다.
+"""
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from PIL import Image, ImageDraw
+
+BEZEL_URL = "https://devimages-cdn.apple.com/design/resources/download/Bezel-iPhone-16.dmg"
+BEZEL_IN_DMG = "PNG/iPhone 16 Pro Max/iPhone 16 Pro Max - Black Titanium - Portrait.png"
+BEZEL_CACHE_DIR = Path.home() / "Library/Caches/todocalendar-appstore-bezel"
+BEZEL_CACHE_PATH = BEZEL_CACHE_DIR / "iPhone-16-Pro-Max-Black-Titanium-Portrait.png"
+
+
+def download_bezel():
+    BEZEL_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as workspace:
+        dmg_path = Path(workspace) / "bezel.dmg"
+        print(f"▶︎ 베젤 내려받는 중 — {BEZEL_URL}")
+        subprocess.run(["curl", "-fsSL", "-o", str(dmg_path), BEZEL_URL], check=True)
+
+        mount_point = Path(workspace) / "mount"
+        mount_point.mkdir()
+        # dmg 에 SLA 가 걸려 있어 동의 입력 없이는 attach 가 멈춘다
+        subprocess.run(
+            f'yes | hdiutil attach "{dmg_path}" -mountpoint "{mount_point}" -nobrowse -readonly',
+            shell=True, check=True, capture_output=True,
+        )
+        try:
+            source = mount_point / BEZEL_IN_DMG
+            if not source.exists():
+                raise SystemExit(f"✗ dmg 안에 {BEZEL_IN_DMG} 가 없다 — 베젤 배포 구조가 바뀌었다")
+            shutil.copyfile(source, BEZEL_CACHE_PATH)
+        finally:
+            subprocess.run(["hdiutil", "detach", str(mount_point)], check=False, capture_output=True)
+    print(f"  ✓ 캐시 — {BEZEL_CACHE_PATH}")
+
+
+def load_bezel():
+    if not BEZEL_CACHE_PATH.exists():
+        download_bezel()
+    return Image.open(BEZEL_CACHE_PATH).convert("RGBA")
+
+
+def screen_hole(bezel):
+    """베젤 갱신에도 안 깨지게 좌표를 박지 않고 알파 채널 flood-fill 로 화면 구멍을 찾는다."""
+    transparent = bezel.getchannel("A").point(lambda alpha: 255 if alpha == 0 else 0)
+    seed = (bezel.width // 2, bezel.height // 2)
+    if transparent.getpixel(seed) != 255:
+        raise SystemExit("✗ 베젤 중앙이 투명하지 않다 — 화면 구멍을 못 찾는다")
+    ImageDraw.floodfill(transparent, seed, 128)
+    mask = transparent.point(lambda value: 255 if value == 128 else 0)
+    box = mask.getbbox()
+    if box is None:
+        raise SystemExit("✗ 화면 구멍 영역이 비었다 — 베젤 알파 구조가 바뀌었다")
+    return mask, box

--- a/scripts/lock_screen.py
+++ b/scripts/lock_screen.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""잠금화면 장면을 조립한다 — 벽지 + 제일중요(인라인) + 시계 + 다음/남은 위젯 + 라이브 액티비티.
+
+카탈로그가 찍어주는 건 위젯·라이브 액티비티 조각뿐이라, 그걸 얹을 잠금화면은 여기서 만든다.
+`compose-appstore-screenshots.py` 의 `home_screen()` 이 홈화면판으로 같은 일을 한다.
+
+**시계 숫자 말고는 여기서 텍스트를 그리지 않는다** — Pillow 로는 31개 언어(데바나가리·타이·CJK)를
+한 TTF 로 못 그린다. 로케일별 문구는 전부 스냅샷 조각이 들고 온다.
+
+accessory 위젯은 실제 잠금화면에서 배경 없이 벽지 위에 얹힌다. 스냅샷은 불투명 검정 배경으로
+나오므로(captureSnapshotPair 에 투명 옵션이 없다) lighten 으로 합성해 검정을 떨군다.
+라이브 액티비티만 실제로도 어두운 카드라 그대로 얹는다.
+"""
+
+from pathlib import Path
+
+from PIL import Image, ImageChops, ImageDraw, ImageFont
+
+SCREEN = (1206, 2622)                 # iPhone 17 @3x — 카탈로그 촬영 규격과 같다
+CLOCK_FONT = "/System/Library/Fonts/SFNS.ttf"
+CLOCK_SIZE = 290
+
+# 카드는 폰 화면 위쪽을 잘라내고 담는다 — 인라인이 250 에 있으면 그 크롭선에 걸려 사라진다.
+# 스택 전체를 내려 잘림선 아래로 보낸다.
+INLINE_TOP = 430                      # 시계 위 인라인 슬롯
+CLOCK_TOP = 500
+ROW_TOP = 880                         # 시계 아래 좌우 2열
+ROW_GAP = 40
+# 라이브 액티비티는 실제로 화면 하단(손전등·카메라 버튼 위)에 뜬다
+LIVE_ACTIVITY_BOTTOM = 2280
+SIDE_MARGIN = 90
+
+WALLPAPER_TOP = (26, 32, 58)
+WALLPAPER_BOTTOM = (72, 58, 96)
+CORNER_RATIO = 0.16
+
+# 위젯 뷰의 Image("small_icon") 은 Bundle.main 을 뒤지는데, 스냅샷은 앱을 호스트로 돌고
+# 앱 번들엔 이 에셋이 없다(위젯 확장 번들 소유). 그래서 스냅샷엔 24pt 빈자리만 남는다.
+# 실기기에는 뜨는 아이콘이라, 실제와 같게 보이도록 합성 단계에서 원본 에셋을 그 자리에 얹는다.
+SMALL_ICON = Path(__file__).resolve().parent.parent / (
+    "TodoCalendarApp/AppExtensions/Widget/Resources/Assets.xcassets/"
+    "small_icon.imageset/appIcon-origin-dark-128.png"
+)
+ICON_SLOT_POINTS = 24          # 프로덕션 뷰의 .frame(width: 24, height: 24)
+ACCESSORY_SCALE = 3            # @3x 촬영
+
+
+def wallpaper(size):
+    width, height = size
+    image = Image.new("RGB", size)
+    for y in range(height):
+        ratio = y / (height - 1)
+        row = tuple(
+            round(WALLPAPER_TOP[c] + (WALLPAPER_BOTTOM[c] - WALLPAPER_TOP[c]) * ratio)
+            for c in range(3)
+        )
+        image.paste(row, (0, y, width, y + 1))
+    return image
+
+
+def draw_clock(canvas, text="9:41"):
+    draw = ImageDraw.Draw(canvas)
+    font = ImageFont.truetype(CLOCK_FONT, CLOCK_SIZE)
+    box = draw.textbbox((0, 0), text, font=font)
+    x = (canvas.width - (box[2] - box[0])) // 2 - box[0]
+    draw.text((x, CLOCK_TOP), text, font=font, fill=(255, 255, 255))
+
+
+def scaled(source, width):
+    piece = source.convert("RGB")
+    ratio = width / piece.width
+    return piece.resize((width, round(piece.height * ratio)), Image.LANCZOS)
+
+
+def first_text_band(piece, threshold=40):
+    """가장 위쪽 밝은 픽셀 띠 — 아이콘이 들어갈 타이틀 행이다."""
+    gray = piece.convert("L")
+    rows = [y for y in range(gray.height)
+            if max(gray.crop((0, y, gray.width, y + 1)).getdata()) > threshold]
+    if not rows:
+        return None
+    top = rows[0]
+    bottom = top
+    for y in rows:
+        if y - bottom > 4:
+            break
+        bottom = y
+    return top, bottom
+
+
+def with_small_icon(piece):
+    """비어 있는 아이콘 슬롯에 실제 에셋을 얹는다."""
+    band = first_text_band(piece)
+    if band is None or not SMALL_ICON.exists():
+        return piece
+
+    size = ICON_SLOT_POINTS * ACCESSORY_SCALE
+    with Image.open(SMALL_ICON) as source:
+        icon = source.convert("RGBA").resize((size, size), Image.LANCZOS)
+
+    out = piece.convert("RGBA")
+    top = (band[0] + band[1]) // 2 - size // 2
+    out.alpha_composite(icon, (0, max(0, top)))
+    return out.convert("RGB")
+
+
+def paste_vibrancy(canvas, piece, position):
+    """검정 배경을 떨구고 밝은 픽셀만 남긴다 — 실제 accessory 위젯의 vibrancy 와 같은 모양."""
+    left, top = position
+    region = canvas.crop((left, top, left + piece.width, top + piece.height))
+    canvas.paste(ImageChops.lighter(region, piece), (left, top))
+
+
+def paste_card(canvas, piece, position):
+    radius = round(min(piece.size) * CORNER_RATIO)
+    mask = Image.new("L", piece.size, 0)
+    ImageDraw.Draw(mask).rounded_rectangle([0, 0, piece.width - 1, piece.height - 1], radius, fill=255)
+    canvas.paste(piece, position, mask)
+
+
+def compose(foremost, next_event, next_remain, live_activity):
+    canvas = wallpaper(SCREEN)
+    usable = SCREEN[0] - SIDE_MARGIN * 2
+
+    inline = scaled(foremost, round(usable * 0.72))
+    paste_vibrancy(canvas, inline, ((SCREEN[0] - inline.width) // 2, INLINE_TOP))
+
+    draw_clock(canvas)
+
+    column = (usable - ROW_GAP) // 2
+    left_piece = with_small_icon(scaled(next_event, column))
+    right_piece = scaled(next_remain, column)
+    row_height = max(left_piece.height, right_piece.height)
+    paste_vibrancy(canvas, left_piece, (SIDE_MARGIN, ROW_TOP))
+    paste_vibrancy(canvas, right_piece, (SIDE_MARGIN + column + ROW_GAP, ROW_TOP))
+
+    activity = scaled(live_activity, usable)
+    paste_card(
+        canvas, activity,
+        ((SCREEN[0] - activity.width) // 2, LIVE_ACTIVITY_BOTTOM - activity.height)
+    )
+
+    return canvas

--- a/scripts/status_bar.py
+++ b/scripts/status_bar.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""앱 화면 스냅샷에 상태창 자리를 낸다.
+
+스냅샷은 safe area 없이 콘텐츠만 찍혀 나와, 목업에 넣으면 헤더가 화면 맨 위에 붙어
+실제 기기와 다르게 보인다. 상태창 자체는 그리지 않는다 — App Store 이미지 스펙이
+요구하지 않고, `compose-appstore-screenshots.py` 도 그리지 않는다.
+"""
+
+from PIL import Image
+
+LOGICAL_HEIGHT = 874           # iPhone 17 포인트 높이
+SAFE_AREA_TOP = 59             # 다이나믹 아일랜드 기기의 상단 safe area
+STATUS_RATIO = SAFE_AREA_TOP / LOGICAL_HEIGHT
+
+
+def inset(screen):
+    """상단에 상태창 자리를 만든다 — 화면 배경색 띠를 덧대고 그만큼 하단을 잘라 비율을 지킨다."""
+    source = screen.convert("RGB")
+    height = round(source.height * STATUS_RATIO)
+    result = Image.new("RGB", source.size, source.getpixel((2, 2)))
+    result.paste(source.crop((0, 0, source.width, source.height - height)), (0, height))
+    return result

--- a/secret/README.md
+++ b/secret/README.md
@@ -1,0 +1,35 @@
+# secret/
+
+레포에 커밋하지 않는 자격증명 자리다. `secret/` 전체가 gitignore 대상이고 이 README 만 예외다.
+
+## `asc-api-key.json` — App Store Connect API 키
+
+`scripts/asc-in-app-event.rb` 가 자격증명을 못 찾으면 이 파일을 읽는다. `.p8` 은 base64 로 바꿀
+필요 없이 **파일 경로만** 적는다 (spaceship 의 `Token.create` 가 `filepath:` 로 직접 읽는다).
+
+```json
+{
+  "key_id": "XXXXXXXXXX",
+  "issuer_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "key_filepath": "/절대/경로/AuthKey_XXXXXXXXXX.p8"
+}
+```
+
+- `key_id`·`issuer_id` 는 ASC → 사용자 및 액세스 → 통합 → App Store Connect API 에서 나온다.
+- **권한은 App Manager 이상.** Developer 등급은 읽기만 되고 쓰기에서 403 이 난다.
+- `.p8` 은 발급 직후 한 번만 내려받을 수 있다. 레포 밖에 두고 경로만 여기 적는다.
+
+발급·권한 상세는 [`docs/appstore-connect-operations.md`](../docs/appstore-connect-operations.md) §2.
+
+## 환경변수가 우선한다
+
+`ASC_KEY_ID`·`ASC_ISSUER_ID`·`ASC_KEY_CONTENT` 가 셋 다 차 있으면 그쪽을 쓴다. CI 처럼 파일을 둘 수
+없는 자리를 위한 경로다.
+
+fastlane lane(`upload_app_store_metadata` 등)은 아직 env 만 읽는다. 이 파일로 lane 을 돌리려면:
+
+```sh
+export ASC_KEY_ID=$(python3 -c "import json;print(json.load(open('secret/asc-api-key.json'))['key_id'])")
+export ASC_ISSUER_ID=$(python3 -c "import json;print(json.load(open('secret/asc-api-key.json'))['issuer_id'])")
+export ASC_KEY_CONTENT=$(base64 -i "$(python3 -c "import json;print(json.load(open('secret/asc-api-key.json'))['key_filepath'])")")
+```


### PR DESCRIPTION
## 문제

App Store 앱 내 이벤트(In-App Event)의 로케일 텍스트·이미지를 채울 방법이 없었다. fastlane `deliver` 는 In-App Events 를 모르고(전체에 `app_event` 키가 없다) spaceship 에도 이벤트 모델이 없어서, ASC API 를 직접 때려야 한다. 로케일이 31개, 이미지가 로케일당 2슬롯이라 손으로는 62번 업로드다.

## 접근

스크립트 셋을 언어별로 갈라 만들고 스킬이 순서로 엮는다. **ASC 호출은 Ruby** — Gemfile 의 fastlane 이 spaceship 을 물고 있어 JWT 서명도 자산 3단계 업로드(`FileUploader.upload`)도 이미 있다. **합성은 Python/Pillow**, **촬영은 bash** 로 기존 스크린샷 파이프라인을 따른다. 새 의존성은 0이다.

### 이벤트마다 바뀌는 것을 전부 데이터로 뺐다

`fastlane/in_app_events/<event_id>/` 아래 `event.json`(뱃지·장면 매핑·스타일)과 `<ASC 로케일>/{name,short_description,long_description}.txt` 만 채우면 새 이벤트가 **코드 수정 0으로** 돈다. 실제로 장면·배경·기울기·목업 크기가 다른 두 번째 이벤트를 인자만 바꿔 돌려 스크립트 4개의 해시가 전후 동일한 것을 확인했다.

장면 값은 세 형태이고 조립 조각도 같은 세 형태라 재귀로 풀린다 — 카탈로그 경로 / 앱스토어 스샷 원본 / `assemble`. 조립은 카탈로그가 조각으로만 찍어주는 화면을 실제 모습으로 되살리는 자리다: `lock-screen` 은 벽지·시계 위에 accessory 위젯과 라이브 액티비티를 얹고, `ai-sheet` 는 배경 화면에 딤 30% + 상단코너 10pt 시트를 얹어 `showBottomSlide` 와 같은 모양을 만든다. `scenes.card` 에 리스트를 주면 그 수만큼 기기가 서고 가운데가 히어로가 된다.

### 지침의 하드 제약을 코드가 끊는다

카드 하단 1/3(`y ≥ 720`)은 App Store 가 이벤트 이름·설명을 겹쳐 그리는 자리다. 목업 하단을 상수에 고정해 **배치가 그 여백을 보장**하고, 합성기는 그 결과를 산출물 픽셀로 재확인한다(배치 코드가 바뀌었을 때를 위한 방어). 실제로 끊기는 건 좌우 96px 침범·기울임 5~10도 이탈·알파 잔존 셋이다. **이미지에 텍스트를 그리는 코드는 아예 없다** (카피는 App Store 가 얹는다).

### 조용히 틀리는 세 자리를 막았다

- **낡은 장면 혼입** — `scenes` 가 가리키는 스위트가 `captureSuites` 에 없으면 이번 실행이 그 장면을 안 찍는데, `snapshot-catalog/` 에 이전 실행 산출물이 남아 있으면 그대로 복사된다. 스모크에서 실제로 카드 1206×2622 / 세부사항 1320×2868 이 나왔다. 촬영 전에 끊는다.
- **텍스트 업로드 무반영** — `push-text` 는 올린 뒤 재조회로 로케일이 실제로 찼는지 대조한다. lane 성공이 반영을 뜻하지 않는 선례가 있다 ([deliver silent no-op](docs/troubleshooting/2026-08-29-deliver-metadata-upload-silent-noop.md)).
- **이미지가 예약만 되고 안 붙음** — `appEventScreenshots` 의 commit 은 `uploaded` 만 받는다. `appScreenshots` 쪽 관례대로 `sourceFileChecksum` 을 실으면 요청 전체가 거부돼 바이너리 PUT 만 성공하고 자산이 `AWAITING_UPLOAD` 로 남는다. 슬롯이 찬 것처럼 보이므로 **슬롯 수가 아니라 `assetDeliveryState` 로** 판정한다.

### 사람이 봐야 하는 것은 사람에게 넘겼다

`compose-event-images.py` 의 `verify()` 는 해상도·알파·산출물 트리만 판정하고, 그걸 출력에 명시한다. 홍보 문구 없음 / 언어 혼용 없음 / 더미 데이터에 실명 없음 / 앱에 없는 기능 연출 없음은 스킬의 체크리스트로 넘어간다 — 마지막 항목은 심사 리젝 사유다.

## 검증

네트워크가 필요 없는 구간은 회귀 테스트 39건으로 잠갔다 (`asc-in-app-event.test.sh` 24 · `capture-event-screenshots.test.sh` 7 · `compose-event-images.test.sh` 8). 자격증명을 지운 채 돌려 **검증이 인증보다 앞선다**는 것까지 함께 본다.

파이프라인 전체를 실이벤트(3.0.0 major update)로 끝까지 돌렸다 — 31개 언어 촬영 → 62장 합성(규격·알파·하단 1/3 통과, `__Snapshots__` 오염 없음) → ASC 업로드. 텍스트 31개 로케일, 이미지 62장 모두 재조회로 `COMPLETE` 확인했다.

## 남은 과제

이벤트의 `territorySchedules` 가 비어 있어 심사 제출이 막힌다. 일정·지역은 ASC 콘솔에서 유저가 정하는 값이라 이 스킬의 범위 밖이다.

Closes #1027
