### PR TITLE
[#1029] 맞춤형 제품 페이지 4종을 31개 로케일로 만들어 업로드한다

### DIFF
--- a/.claude/skills/custom-product-page/SKILL.md
+++ b/.claude/skills/custom-product-page/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: custom-product-page
+description: Use when building or updating App Store custom product pages (맞춤형 제품 페이지 / CPP) — 페이지별 스크린샷 라인업·프로모션 문구를 로케일별로 만들어 App Store Connect 에 올리는 절차. Triggers on "맞춤형 제품 페이지 만들어", "CPP 올려", "커스텀 프로덕트 페이지 현지화". Does NOT trigger on 앱 내 이벤트(in-app-event 스킬)·기본 스토어 페이지 스샷 교체(deliver)·가이드 이미지(localization rules §1).
+---
+
+# Custom Product Page — 맞춤형 제품 페이지 현지화·업로드
+
+`deliver` 는 맞춤형 제품 페이지를 모른다. ASC API 를 직접 때리는 스크립트 셋을 순서대로 엮는 것이 이 스킬의 전부다.
+
+**인앱 이벤트와 셋이 다르다** — 헷갈리면 산출물이 통째로 어긋난다:
+
+| | in-app-event | custom-product-page |
+|---|---|---|
+| 이미지 안 캡션 | **금지** (App Store 가 얹는다) | **넣는 게 표준** |
+| 규격 | 1920×1080 가로 + 1080×1920 세로 | 1320×2868 세로 × 6장 |
+| 업로드 커밋 | `sourceFileChecksum` 넣으면 **거부** | `sourceFileChecksum` **필수** |
+
+## 0. 준비 — 실행 환경과 자격증명
+
+```sh
+export PATH="/opt/homebrew/opt/ruby/bin:$PATH"
+```
+
+자격증명은 `secret/asc-api-key.json` 이 정본이고, 없으면 `ASC_KEY_ID`·`ASC_ISSUER_ID`·`ASC_KEY_CONTENT` 로도 된다. 발급 절차는 [`docs/appstore-connect-operations.md`](../../../docs/appstore-connect-operations.md) §1·§2.
+
+**둘 다 없으면 여기서 멈추고 유저에게 인계한다** — 실행을 흉내내지 않는다.
+
+## 1. 대상 확정
+
+```sh
+bundle exec ruby scripts/asc-custom-product-page.rb list
+```
+
+- 페이지 구성 정본은 `fastlane/custom_product_pages/pages.json` 이다. 페이지 id 는 사람이 읽는 슬러그이고 ASC 리소스 id 는 `ascPageId` 에 들어간다.
+- **ASC 에 페이지가 없으면 `create` 가 만든다** — 인앱 이벤트와 달리 생성까지 스크립트가 덮는다. `ascPageId` 가 이미 찬 페이지는 건너뛰므로 재실행이 안전하다.
+- 디렉토리 규약은 [`fastlane/custom_product_pages/README.md`](../../../fastlane/custom_product_pages/README.md).
+
+## 2. 원고 — 승인 게이트 3개
+
+**순서가 전부다.** 앞 게이트를 통과하기 전에 다음 것을 만들지 않는다.
+
+### 2-1. ko 원고 (승인 게이트)
+
+캡션(장면 수만큼)과 프로모션 문구(페이지 수만큼)의 한국어본을 유저에게 보여 승인받는다.
+
+- 톤은 `fastlane/metadata/ko/description.txt` — 존댓말 평서문, 담백. 감탄·과장·이모지 없음.
+- **화면 라벨은 ko lproj 값을 그대로 인용한다.** 자유번역 금지 — 페이지가 앱 기능을 다른 말로 부르면 독자가 그 화면을 못 찾는다. lproj 는 3곳이다 (`.claude/rules/localization.md` 서두).
+  - 자주 틀리는 자리: 앱은 `할 일` 이 아니라 **`할일`**, `태그` 가 아니라 **`이벤트 종류`** 다.
+- 유저가 준 명세 원고를 **옮겨 적지 말고 라벨 기준으로 워싱한다.** 명세가 앱에 없는 말을 쓰면 그것이 30배로 번진다.
+- 프로모션 문구 상한 **170자**.
+
+### 2-2. en 원문 (승인 게이트)
+
+**여기가 급소다** — en 이 나머지 29개 언어의 번역 소스다 (#1015 가 그 사고였다).
+
+- **화면 라벨은 en lproj 값 그대로.** ko 라벨을 영어로 옮기지 말고 en lproj 에서 찾아 쓴다.
+- ko 를 직역하지 않는다 — `fastlane/metadata/en-US/description.txt` 의 어휘·리듬에 맞춘다. 캡션은 그 문서의 `■` 헤딩·본문 문장을 인용하면 대개 맞다.
+- **도메인 3계층(Event ⊃ Todo / Schedule)을 en 에서 먼저 정확히 가른다.**
+
+### 2-3. ko 이미지 한 세트 (승인 게이트) — 이 스킬 고유
+
+`--locale ko` 로 촬영·합성해 **페이지 × 6장을 유저에게 보여 확인받는다.** 승인 전에 전 언어로 넘어가지 않는다.
+
+31개 언어 촬영은 시간 단위다. 방향이 틀린 채로 돌리면 그 시간을 통째로 버린다.
+
+### 2-4. 나머지 언어
+
+- `captions.json` 은 **lproj 코드**, 프로모션 문구 디렉토리는 **ASC 코드**다. 6개가 다르고 매핑표는 `fastlane/metadata/README.md`.
+- 번역 원칙은 `.claude/rules/localization.md` §2 — 도메인 3계층 용어 분리, 위젯 명칭 일관.
+- **각 언어의 화면 라벨은 그 언어 lproj 값을 grep 해 인용한다.** en 라벨로 en lproj 를 grep 해 키를 얻고, 같은 키를 대상 언어 lproj 에서 읽는다.
+- **번역 대기 트래킹 이슈 대상이 아니다.** 그건 lproj 소관이고 ASC 메타데이터엔 미룰 자리가 없다.
+- 상한 초과는 `push-text --dry-run` 이 위반을 전량 모아 보여준다.
+
+## 3. 이미지
+
+**합성 규칙의 정본은 유저의 문서다:**
+`/Users/sudo.park/Documents/sudo/인디앱 개발/To-do Calendar/CPP지침-맞춤형-제품-페이지-3종-명세.md`
+
+레포에 복사본을 두지 않는다 — 가이드 레포와 같은 처리이고, 복사하면 짝이 어긋난다. **이미지 작업을 시작할 때 그 문서를 연다.**
+
+### 3-1. 장면 정하기
+
+장면 id → 화면 대응은 `scripts/cpp_scenes.py` 의 `SCENES` 다. 촬영 산출물은 `scripts/capture-appstore-screenshots.sh` 가 **기본 스토어 페이지와 함께 한 실행에** 뜬다.
+
+명세가 지정한 장면이 카탈로그에 없으면 **카탈로그 스냅샷 케이스를 신설한다** (app-catalog 스킬 §1·§2 — 더미 텍스트는 하드코딩하지 말고 `CatalogStrings.strings` 나 프로덕션 경로로). 신설하면 셋을 함께 갱신한다:
+
+- 카탈로그 케이스 (`<Framework>/Snapshots/<Name>CatalogSnapshots.swift`)
+- `capture-appstore-screenshots.sh` 의 매핑 배열 — 화면은 `MAPPING`, 위젯 조각은 `WIDGET_MAPPING`, 시트 조각은 `SHEET_MAPPING`
+- `cpp_scenes.SCENES`
+
+**규격이 다른 조각은 반드시 하위 디렉토리로 뺀다** (`widgets/`·`sheets/`·`captions/cpp/`) — `verify_and_strip_alpha` 가 `$out/*.png` 를 전부 1320×2868 로 검사해 끊는다.
+
+### 3-2. 촬영·합성
+
+```sh
+scripts/capture-appstore-screenshots.sh ko                       # 게이트 2-3
+python3 scripts/compose-cpp-screenshots.py --locale ko
+scripts/capture-appstore-screenshots.sh --all                    # 승인 후
+python3 scripts/compose-cpp-screenshots.py --all-locales
+```
+
+- 촬영기는 **`iPhone 16 Pro Max - appstore_ref` 전용기**다. 카탈로그 기본기(iPhone 17)를 공유하면 규격이 1206×2622 로 나와 검사에서 끊긴다.
+- 합성기는 규격·알파·장수·라인업 순서 이탈을 실패로 끊는다.
+- 촬영 뒤 `git status --short -- '*__Snapshots__*'` 가 비어야 한다. 안 비면 `-only-testing` 이 안 먹어 검증 스냅샷이 재기록된 것이다.
+
+### 3-3. 기계가 못 보는 자가 검증
+
+`verify()` 는 해상도·알파·장수·순서만 본다. **나머지는 이미지를 열어서 확인한다** (명세 §7):
+
+- [ ] **캡션 오탈자 없음 / 한 이미지 안 언어 혼용 없음** — 화면 안 더미 문자열까지 본다. 앱 lproj 가 아니라 `CatalogStrings.strings` 가 출처라 번역이 빠져 영어로 남기 쉽다
+- [ ] **더미 데이터에 실명·실제 개인 일정·실존 회사명·실존 기관명 없음** (명세 §5)
+- [ ] **각 페이지 첫 1~3장이 그 페이지 컨셉과 일치** (명세 §3 배치표)
+- [ ] **4페이지 배경·서체 톤 통일** — 기본 스토어 페이지와도 같아야 한다
+- [ ] **앱에 없는 기능을 연출하지 않았나** — 명세에 적혀 있어도 실제 빌드에 없으면 제외하고 유저에게 보고한다
+- [ ] **MCP 연동·타사 앱 UI 가 안 나온다** (명세 §2)
+
+## 4. 업로드
+
+**텍스트가 먼저다** — 이미지는 로케일에 매달리므로 부모가 없으면 못 올린다.
+
+```sh
+bundle exec ruby scripts/asc-custom-product-page.rb create
+bundle exec ruby scripts/asc-custom-product-page.rb push-text   --all-pages --all-locales --dry-run
+bundle exec ruby scripts/asc-custom-product-page.rb push-text   --all-pages --all-locales
+bundle exec ruby scripts/asc-custom-product-page.rb push-images --all-pages --all-locales --dry-run
+bundle exec ruby scripts/asc-custom-product-page.rb push-images --all-pages --all-locales
+```
+
+- `--dry-run` 을 먼저 돌려 POST/PATCH 갈림과 길이를 유저에게 보여준다.
+- 두 명령 다 올린 뒤 재조회로 대조한다. `push-images` 는 `assetDeliveryState.state == COMPLETE` 까지 본다 — **lane 성공이 반영을 뜻하지 않는다**는 선례가 있다 (`docs/troubleshooting/2026-08-29-deliver-metadata-upload-silent-noop.md`).
+- 심사 제출과 Apple Ads 캠페인 연결은 콘솔에서 유저가 한다.
+
+## 5. 새 페이지·새 로케일 추가
+
+`pages.json` 에 항목을 더하고 원고를 채우면 끝이다. 로케일 추가는 `captions.json` 에 그 언어를 넣고 문구 파일을 만들면 코드 수정 없이 돈다.
+
+**스크립트 코드를 고쳐야 하는 상황이 오면 파이프라인 설계 실패다** (명세 §4) — 고치지 말고 유저에게 보고한다. 단 **새 장면 추가는 예외**다 — 장면은 코드가 조립하므로 §3-1 의 셋을 함께 갱신한다.
+
+## Red Flags — 이 생각이 들면 STOP
+
+| 생각 | 실제 |
+|---|---|
+| "인앱 이벤트처럼 캡션은 빼자" | 스토어 스샷은 이미지 안 캡션이 표준이다 (명세 §4 서두). 빼면 빈 화면만 남는다 |
+| "ko 확인 없이 31개 돌리자" | 촬영이 시간 단위다. 방향이 틀리면 그 시간을 통째로 버린다 |
+| "31개가 다 같으니 en 만 올리자" | 이미지 속 UI 가 언어별로 다르다. 언어 혼용은 명세 §6 위반 |
+| "명세 원고를 그대로 쓰자" | 명세가 앱 라벨과 다른 말을 쓰면(태그/이벤트 종류) 30배로 번진다. lproj 를 grep 해 확인한다 |
+| "기본 스토어 페이지도 같이 바꾸자" | 심사 대기 중인 버전을 건드리게 된다. 별건이다 |
+| "명세에 있는 장면이니 없어도 그려 넣자" | 없는 기능 연출은 심사 리젝 사유다. 빼고 보고한다 |
+| "하단이 잘리니 목업을 줄이자" | 상단 인셋이 화면 아래를 버리는 것이 원인일 수 있다. 하단 고정 UI 가 있는 화면은 촬영 케이스가 safe area 를 직접 포함한다 |
+
+## 종료 기록 — skill_end
+
+업로드를 마쳤거나 자격증명이 없어 유저에게 인계하며 끝나는 시점에 `log-record.py skill_end` 를 1회 기록한다 (명령·compliance 규칙은 CLAUDE.md §1).

--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ scripts/__pycache__/
 # 자격증명 — README 만 커밋한다
 secret/*
 !secret/README.md
+
+fastlane/custom_product_pages/*
+!fastlane/custom_product_pages/README.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ tuist generate --no-open      # 파일 추가/삭제 후 재실행 필수
 | 테스트 빌드 배포 | test-deploy 스킬 (Firebase App Distribution) |
 | 새 버전 출시 변경내용 작성 | release-notes 스킬 (한글 초안 → 31개 로케일 → ASC 업로드) |
 | 앱 내 이벤트 현지화·이미지·업로드 | in-app-event 스킬 (한글 원고 → 31개 로케일 → 촬영·합성 → ASC 업로드) |
+| 맞춤형 제품 페이지 제작·업로드 | custom-product-page 스킬 (한글 원고 → 31개 로케일 → 촬영·합성 → ASC 업로드) |
 | UI 디자인 | design 스킬 |
 | 스냅샷 검증·화면 카탈로그 | snapshot-check / app-catalog 스킬 |
 | 코드 분석 (로직·추적·관계·영향도) | analyze 스킬 → code-analyzer subagent |

--- a/Presentations/AIAgentScene/Snapshots/AIAgentSceneCatalogSnapshots.swift
+++ b/Presentations/AIAgentScene/Snapshots/AIAgentSceneCatalogSnapshots.swift
@@ -31,6 +31,24 @@ final class AIAgentSceneCatalogSnapshots: XCTestCase {
     }
 
     @MainActor
+    private func commandStageView(
+        _ theme: SnapshotTheme, commandState: AIAgentCommandState? = nil
+    ) -> some View {
+        let state = AIAgentCommandViewState()
+        state.commandState = commandState ?? .done(
+            command: "catalog.ai::command".catalogLocalized(),
+            message: "catalog.ai::result".catalogLocalized()
+        )
+        state.usage = AIAgentUsage(input: 3200, output: 0, limit: 20000)
+            |> \.creditsUsed .~ 3200
+        state.userPlan = BillingUserPlan() |> \.planId .~ .standard
+        return AIAgentCommandStageView()
+            .environment(state)
+            .environment(AIAgentCommandViewEventHandler())
+            .environment(self.makeAppearance(theme))
+    }
+
+    @MainActor
     func test_aiInput() {
         captureSnapshotPair(
             named: "aiInput", layout: .fixed(width: 393, height: 300), snapshotDirectory: catalogSnapshotDirectory()
@@ -52,18 +70,37 @@ final class AIAgentSceneCatalogSnapshots: XCTestCase {
         captureSnapshotPair(
             named: "aiResult", layout: .fixed(width: 393, height: 320), snapshotDirectory: catalogSnapshotDirectory()
         ) { theme in
-            let state = AIAgentCommandViewState()
-            state.commandState = .done(
-                command: "catalog.ai::command".catalogLocalized(),
-                message: "catalog.ai::result".catalogLocalized()
+            self.commandStageView(theme)
+        }
+    }
+}
+
+
+// MARK: - App Store 스샷용 시트 조각
+
+/// 앱스토어 스샷 규격(iPhone 16 Pro Max)의 논리 너비가 440pt 다 — 393pt 로 찍으면 1179px 이라 1320px 캔버스에서 확대돼 뭉갠다.
+extension AIAgentSceneCatalogSnapshots {
+
+    /// 말하듯 적은 명령이 그대로 보이는 순간 — 빈 입력창보다 이 상태가 기능을 설명한다.
+    @MainActor
+    func test_storeAICommandProcessing() {
+        captureSnapshotPair(
+            named: "storeAICommandProcessing", layout: .fixed(width: 440, height: 300),
+            snapshotDirectory: catalogSnapshotDirectory()
+        ) { theme in
+            self.commandStageView(
+                theme, commandState: .processing(command: "catalog.ai::command".catalogLocalized())
             )
-            state.usage = AIAgentUsage(input: 3200, output: 0, limit: 20000)
-                |> \.creditsUsed .~ 3200
-            state.userPlan = BillingUserPlan() |> \.planId .~ .standard
-            return AIAgentCommandStageView()
-                .environment(state)
-                .environment(AIAgentCommandViewEventHandler())
-                .environment(self.makeAppearance(theme))
+        }
+    }
+
+    @MainActor
+    func test_storeAICommandDone() {
+        captureSnapshotPair(
+            named: "storeAICommandDone", layout: .fixed(width: 440, height: 320),
+            snapshotDirectory: catalogSnapshotDirectory()
+        ) { theme in
+            self.commandStageView(theme)
         }
     }
 }

--- a/Presentations/CalendarScenes/Snapshots/CalendarScenesCatalogSnapshots.swift
+++ b/Presentations/CalendarScenes/Snapshots/CalendarScenesCatalogSnapshots.swift
@@ -183,6 +183,69 @@ extension CalendarScenesCatalogSnapshots {
             .environment(appearance)
         }
     }
+    /// 달력을 위로 스크롤해 일별 목록만 남은 상태 — 앱에 별도의 할일 목록 화면은 없다.
+    @MainActor
+    func test_storeTodoList() {
+        captureSnapshotPair(
+            named: "storeTodoList", layout: .fullScreen, snapshotDirectory: catalogSnapshotDirectory()
+        ) { theme in
+            let appearance = self.makeStoreAppearance(theme)
+
+            let dayListState = DayEventListViewState()
+            dayListState.bind(
+                CatalogDayEventListViewModel(extraTodoKeys: [
+                    "catalog.todo::send_invoice",
+                    "catalog.todo::renew_passport",
+                    "catalog.todo::return_books"
+                ]),
+                appearance
+            )
+            RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+
+            let pendingDone = PendingCompleteTodoState()
+            pendingDone.ids = ["todo1"]
+
+            return VStack(spacing: 0) {
+                self.storeCalendarHeaderView(appearance)
+                ScrollView {
+                    DayEventListView()
+                        .environment(dayListState)
+                        .environment(pendingDone)
+                        .environment(DayEventListViewEventHandler())
+                }
+            }
+            .background(appearance.colorSet.bg0.asColor)
+            .environment(appearance)
+        }
+    }
+
+    /// 하단에 고정 버튼이 있는 유일한 스토어 장면이라 safe area 를 여기서 직접 넣는다 —
+    /// 합성 단계의 상단 인셋은 그만큼 화면 아래를 버려서 버튼이 잘린다.
+    @MainActor
+    func test_storeSharePreview() {
+        captureSnapshotPair(
+            named: "storeSharePreview", layout: .fullScreen, snapshotDirectory: catalogSnapshotDirectory()
+        ) { theme in
+            let appearance = self.makeStoreAppearance(theme)
+
+            let state = SharePreviewViewState()
+            state.bind(CatalogSharePreviewViewModel())
+            RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+
+            return VStack(spacing: 0) {
+                Color.clear.frame(height: StoreSafeArea.top)
+                SharePreviewView()
+                    .environment(state)
+                    .environment(SharePreviewViewEventHandler())
+                    // 세그먼트 컨트롤은 선택 배경을 첫 레이아웃 뒤에 그린다 — 안 기다리면 pill 이 빈다
+                    .onAppear { RunLoop.main.run(until: Date().addingTimeInterval(0.3)) }
+                Color.clear.frame(height: StoreSafeArea.bottom)
+            }
+            .background(appearance.colorSet.bg0.asColor)
+            .environment(appearance)
+        }
+    }
+
 }
 
 
@@ -324,6 +387,13 @@ private struct CatalogCalendarEvent: CalendarEvent {
 /// DayEventListViewState 의 필드가 fileprivate 라 bind(viewModel:appearance:) 경로로만 채울 수 있다.
 private final class CatalogDayEventListViewModel: DayEventListViewModel, @unchecked Sendable {
 
+    /// 달력 없이 목록만 채우는 화면은 기본 구성으로는 아래가 비어, 그 화면만 할일을 더 얹는다.
+    private let extraTodoKeys: [String]
+
+    init(extraTodoKeys: [String] = []) {
+        self.extraTodoKeys = extraTodoKeys
+    }
+
     private enum Constant {
         /// 2026-03-12(목) 00:00 ~ 03-13 00:00 KST
         static let todayRange: Range<TimeInterval> = 1_773_241_200..<1_773_327_600
@@ -352,7 +422,9 @@ private final class CatalogDayEventListViewModel: DayEventListViewModel, @unchec
         let todos: [TodoEventCellViewModel] = [
             self.currentTodoCell("todo1", "catalog.todo::water_plants".catalogLocalized()),
             self.currentTodoCell("todo2", "catalog.todo::book_flight".catalogLocalized())
-        ]
+        ] + self.extraTodoKeys.enumerated().map { index, key in
+            self.currentTodoCell("todo-extra-\(index)", key.catalogLocalized())
+        }
         let schedules: [ScheduleEventCellViewModel] = [
             ScheduleEvent(uuid: "sc1", name: "catalog.event::design_review".catalogLocalized(), time: .at(Constant.designReviewTime)),
             ScheduleEvent(uuid: "sc2", name: "catalog.event::lunch".catalogLocalized(), time: .period(Constant.lunchPeriod)),
@@ -426,6 +498,145 @@ private final class CatalogDayEventListViewModel: DayEventListViewModel, @unchec
     func attachListener(_ listener: any DayEventListSceneListener) { }
 }
 
+
+
+/// SharePreviewViewState 의 표시 필드가 fileprivate 라 bind(_:) 경로로만 채울 수 있다.
+private final class CatalogSharePreviewViewModel: SharePreviewViewModel, @unchecked Sendable {
+
+    private enum Constant {
+        /// 2026-03-08(일) 00:00 ~ 03-15 00:00 KST — 한 주를 공유하는 상태
+        static let weekRange: Range<TimeInterval> = 1_772_895_600..<1_773_500_400
+        static let sprintTime: TimeInterval = 1_773_016_200                         // 03-09 09:30
+        static let releaseTime: TimeInterval = 1_773_118_800                        // 03-10 14:00
+        static let reviewTime: TimeInterval = 1_773_275_400                         // 03-12 09:30
+        static let lunchPeriod: Range<TimeInterval> = 1_773_370_800..<1_773_374_400 // 03-13 12:00~13:00
+        /// 03-09 ~ 03-11 종일
+        static let tripPeriod: Range<TimeInterval> = 1_772_982_000..<1_773_154_800
+    }
+
+    private let timeZone = TimeZone(identifier: "Asia/Seoul")!
+
+    private lazy var events: [any CalendarEvent] = {
+        return [
+            ScheduleEvent(
+                uuid: "share-sprint", name: "catalog.event::sprint_planning".catalogLocalized(),
+                time: .at(Constant.sprintTime)
+            ) |> \.eventTagId .~ StoreCatalogEventTag.work.tagId,
+            ScheduleEvent(
+                uuid: "share-release", name: "catalog.event::release_day".catalogLocalized(),
+                time: .at(Constant.releaseTime)
+            ),
+            ScheduleEvent(
+                uuid: "share-review", name: "catalog.event::design_review".catalogLocalized(),
+                time: .at(Constant.reviewTime)
+            ) |> \.eventTagId .~ StoreCatalogEventTag.work.tagId,
+            ScheduleEvent(
+                uuid: "share-lunch", name: "catalog.event::lunch".catalogLocalized(),
+                time: .period(Constant.lunchPeriod)
+            ) |> \.eventTagId .~ StoreCatalogEventTag.family.tagId,
+            ScheduleEvent(
+                uuid: "share-trip", name: "catalog.event::trip".catalogLocalized(),
+                time: .allDay(
+                    Constant.tripPeriod, secondsFromGMT: TimeInterval(self.timeZone.secondsFromGMT())
+                )
+            ) |> \.eventTagId .~ StoreCatalogEventTag.family.tagId
+        ]
+        .flatMap { ScheduleCalendarEvent.events(from: $0, in: self.timeZone) }
+    }()
+
+    private lazy var currentTodos: [TodoCalendarEvent] = {
+        return [
+            ("share-todo-water", "catalog.todo::water_plants"),
+            ("share-todo-flight", "catalog.todo::book_flight")
+        ].map { id, key in
+            TodoCalendarEvent(current: TodoEvent(uuid: id, name: key.catalogLocalized()), isForemost: false)
+        }
+    }()
+
+    private lazy var lines: [SharePreviewLineModel] = {
+        let eventLines = self.events.map {
+            SharePreviewLineModel($0, range: Constant.weekRange, timeZone: self.timeZone, isShort: false)
+        }
+        let todoLines = self.currentTodos.map {
+            SharePreviewLineModel($0, range: Constant.weekRange, timeZone: self.timeZone, isShort: false)
+        }
+        return todoLines + eventLines
+    }()
+
+    private var composer: SharePreviewSectionComposer {
+        return SharePreviewSectionComposer(timeZone: self.timeZone)
+    }
+
+    private lazy var sections: [SharePreviewSectionModel] = self.composer.sections(of: self.lines)
+
+    private lazy var headerText: String = self.composer.rangeHeaderText(
+        of: self.sections, in: Constant.weekRange, kind: .week
+    )
+
+    private lazy var imageContent: ShareImageContentModel = ShareImageContentComposer(
+        timeZone: self.timeZone, is24hourForm: false
+    )
+    .listContent(
+        events: self.events, currentTodos: self.currentTodos,
+        range: Constant.weekRange, excludedEventIds: []
+    )
+
+    var isTagFilterExpanded: AnyPublisher<Bool, Never> {
+        Just(false).eraseToAnyPublisher()
+    }
+    var tagCellViewModels: AnyPublisher<[SharePreviewTagCellViewModel], Never> {
+        let models = [StoreCatalogEventTag.work, .family, .health, .study].map {
+            SharePreviewTagCellViewModel(tagId: $0.tagId, name: $0.customTag.name, isOn: true)
+        }
+        return Just(models).eraseToAnyPublisher()
+    }
+    var lineModels: AnyPublisher<[SharePreviewLineModel], Never> {
+        Just(self.lines).eraseToAnyPublisher()
+    }
+    var sectionModels: AnyPublisher<[SharePreviewSectionModel], Never> {
+        Just(self.sections).eraseToAnyPublisher()
+    }
+    var dateHeaderText: AnyPublisher<String, Never> {
+        Just(self.headerText).eraseToAnyPublisher()
+    }
+    var includeTagName: AnyPublisher<Bool, Never> {
+        Just(false).eraseToAnyPublisher()
+    }
+    var isShareEnabled: AnyPublisher<Bool, Never> {
+        Just(true).eraseToAnyPublisher()
+    }
+    var format: AnyPublisher<SharePreviewFormat, Never> {
+        Just(.image).eraseToAnyPublisher()
+    }
+    var imageContentModel: AnyPublisher<ShareImageContentModel?, Never> {
+        Just(self.imageContent).eraseToAnyPublisher()
+    }
+    var imageHeaderText: AnyPublisher<String, Never> {
+        Just(self.headerText).eraseToAnyPublisher()
+    }
+    /// 프로덕션은 format == .text 일 때만 노출한다
+    var isIncludeTagNameOptionVisible: AnyPublisher<Bool, Never> {
+        Just(false).eraseToAnyPublisher()
+    }
+
+    func prepare() { }
+    func toggleTagFilterExpanded() { }
+    func toggleTag(_ tagId: EventTagId) { }
+    func selectAllTags() { }
+    func deselectAllTags() { }
+    func toggleLine(_ eventId: String) { }
+    func toggleIncludeTagName(_ newValue: Bool) { }
+    func selectFormat(_ format: SharePreviewFormat) { }
+    func share() { }
+    func close() { }
+}
+
+
+/// 다이나믹 아일랜드 기기의 상하 safe area (pt)
+private enum StoreSafeArea {
+    static let top: CGFloat = 59
+    static let bottom: CGFloat = 34
+}
 
 private enum StoreCatalogEventTag: String {
     case work

--- a/Presentations/CommonPresentation/Snapshots/AppStoreCaptionSnapshots.swift
+++ b/Presentations/CommonPresentation/Snapshots/AppStoreCaptionSnapshots.swift
@@ -53,6 +53,44 @@ final class AppStoreCaptionSnapshots: XCTestCase {
 }
 
 
+// MARK: - 맞춤형 제품 페이지 캡션 (#1029)
+
+/// 원고는 gitignore 대상이라 신선한 클론·CI 에는 없다 — 그때는 건너뛴다.
+extension AppStoreCaptionSnapshots {
+
+    private var customProductPageCaptionsPath: String {
+        return "\(self.repositoryRootPath)/fastlane/custom_product_pages/captions.json"
+    }
+
+    @MainActor
+    func test_customProductPageCaptions() throws {
+        let path = self.customProductPageCaptionsPath
+        guard let data = FileManager.default.contents(atPath: path) else {
+            throw XCTSkip("captions.json 이 없다 — 맞춤형 제품 페이지 원고를 아직 안 채웠다 (\(path))")
+        }
+        guard let language = self.currentTestLanguage else {
+            XCTFail("AppleLanguages 를 읽을 수 없다 — -testLanguage 없이 돌린 것이다")
+            return
+        }
+        let captions = try JSONDecoder().decode([String: [String: String]].self, from: data)
+
+        captions.keys.sorted().forEach { sceneId in
+            guard let caption = captions[sceneId]?[language] else {
+                XCTFail("\(sceneId): \(language) 캡션 원고가 없다")
+                return
+            }
+            captureSnapshotPair(
+                named: sceneId,
+                layout: .fixed(width: self.canvasWidth, height: self.canvasHeight),
+                snapshotDirectory: catalogSnapshotDirectory()
+            ) { _ in
+                self.captionView(caption)
+            }
+        }
+    }
+}
+
+
 // MARK: - caption view
 
 extension AppStoreCaptionSnapshots {

--- a/Presentations/EventDetailScene/Snapshots/EventDetailSceneCatalogSnapshots.swift
+++ b/Presentations/EventDetailScene/Snapshots/EventDetailSceneCatalogSnapshots.swift
@@ -49,8 +49,8 @@ final class EventDetailSceneCatalogSnapshots: XCTestCase {
             )
             state.selectedRepeat = "eventDetail.repeating.everySomeWeek:title".localized(with: 2)
             state.selectedNotificationTimeText = "event_notification_setting::option_title::before_minutes".localized(with: 10)
-            state.enterPlaceName = "catalog.place::startup_hub".catalogLocalized()
-            state.selectedPlace = .customPlace("catalog.place::startup_hub".catalogLocalized())
+            state.enterPlaceName = "catalog.place::meeting_room".catalogLocalized()
+            state.selectedPlace = .customPlace("catalog.place::meeting_room".catalogLocalized())
             state.memo = "catalog.memo::wireframes".catalogLocalized()
             state.isSavable = true
             return EventDetailView()
@@ -180,7 +180,7 @@ extension EventDetailSceneCatalogSnapshots {
                 .init(self.start, .current), .init(self.end, .current)
             )
             state.repeatOptionText = "eventDetail.repeating.everyWeek:title".localized()
-            state.location = "catalog.place::startup_hub".catalogLocalized()
+            state.location = "catalog.place::meeting_room".catalogLocalized()
             state.conferenceData = self.googleConference
             state.attendees = self.googleAttendees
             state.memo = "catalog.memo::wireframes".catalogLocalized()

--- a/Supports/SnapshotTestHelpKit/Resources/ca.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/ca.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Sala de reunions, 2a planta";
 "catalog.memo::wireframes" = "Portar els wireframes impresos.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/cs.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/cs.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Zasedací místnost, 2. patro";
 "catalog.memo::wireframes" = "Vzít vytištěné drátěné modely.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/da.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/da.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Mødelokale, 2. sal";
 "catalog.memo::wireframes" = "Tag de printede wireframes med.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/de.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/de.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Besprechungsraum, 2. OG";
 "catalog.memo::wireframes" = "Ausgedruckte Wireframes mitnehmen.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/el.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/el.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Αίθουσα συσκέψεων, 2ος όροφος";
 "catalog.memo::wireframes" = "Να πάρω τα εκτυπωμένα wireframes.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/en.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/en.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Meeting room 2F";
 "catalog.memo::wireframes" = "Bring the printed wireframes.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/es.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/es.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Sala de reuniones, 2.ª planta";
 "catalog.memo::wireframes" = "Llevar los wireframes impresos.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/fi.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/fi.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Kokoushuone, 2. kerros";
 "catalog.memo::wireframes" = "Ota tulostetut rautalankamallit mukaan.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/fr.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/fr.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Salle de réunion, 2e étage";
 "catalog.memo::wireframes" = "Apporter les wireframes imprimés.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/hi.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/hi.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "मीटिंग रूम, दूसरी मंज़िल";
 "catalog.memo::wireframes" = "प्रिंट किए हुए वायरफ़्रेम साथ ले जाना।";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/hr.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/hr.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Sala za sastanke, 2. kat";
 "catalog.memo::wireframes" = "Ponijeti isprintane žičane modele.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/hu.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/hu.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Tárgyaló, 2. emelet";
 "catalog.memo::wireframes" = "Vidd magaddal a kinyomtatott drótvázakat.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/id.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/id.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Ruang rapat, lantai 2";
 "catalog.memo::wireframes" = "Bawa wireframe yang sudah dicetak.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/it.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/it.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Sala riunioni, 2° piano";
 "catalog.memo::wireframes" = "Portare i wireframe stampati.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/ja.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/ja.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "ソウル・スタートアップハブ";
+"catalog.place::meeting_room" = "2階 会議室";
 "catalog.memo::wireframes" = "印刷したワイヤーフレームを持っていく。";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/ko.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/ko.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "서울 창업허브";
+"catalog.place::meeting_room" = "2층 회의실";
 "catalog.memo::wireframes" = "출력한 와이어프레임 챙기기.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/ms.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/ms.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Bilik mesyuarat, tingkat 2";
 "catalog.memo::wireframes" = "Bawa wireframe yang dicetak.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/nb.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/nb.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Møterom, 2. etasje";
 "catalog.memo::wireframes" = "Ta med de utskrevne wireframene.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/nl.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/nl.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Vergaderruimte, 2e etage";
 "catalog.memo::wireframes" = "Geprinte wireframes meenemen.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/pl.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/pl.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Sala konferencyjna, 2. piętro";
 "catalog.memo::wireframes" = "Zabrać wydrukowane makiety.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/pt-BR.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/pt-BR.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Sala de reunião, 2º andar";
 "catalog.memo::wireframes" = "Levar os wireframes impressos.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/ro.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/ro.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Sală de ședințe, etajul 2";
 "catalog.memo::wireframes" = "Ia wireframe-urile printate.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/ru.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/ru.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Переговорная, 2-й этаж";
 "catalog.memo::wireframes" = "Взять распечатанные вайрфреймы.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/sk.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/sk.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Zasadacia miestnosť, 2. poschodie";
 "catalog.memo::wireframes" = "Vziať vytlačené drôtené modely.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/sv.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/sv.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Mötesrum, plan 2";
 "catalog.memo::wireframes" = "Ta med de utskrivna wireframesen.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/th.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/th.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "ห้องประชุมชั้น 2";
 "catalog.memo::wireframes" = "เอาแบบร่างที่ปรินต์ไว้ไปด้วย";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/tr.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/tr.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Toplantı odası, 2. kat";
 "catalog.memo::wireframes" = "Basılı wireframe'leri yanına al.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/uk.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/uk.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Переговорна, 2-й поверх";
 "catalog.memo::wireframes" = "Взяти роздруковані вайрфрейми.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/vi.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/vi.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "Seoul Startup Hub";
+"catalog.place::meeting_room" = "Phòng họp tầng 2";
 "catalog.memo::wireframes" = "Mang theo bản wireframe đã in.";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/zh-Hans.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/zh-Hans.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "首尔创业中心";
+"catalog.place::meeting_room" = "二楼会议室";
 "catalog.memo::wireframes" = "带上打印好的线框图。";
 
 // MARK: - 이벤트 타입

--- a/Supports/SnapshotTestHelpKit/Resources/zh-Hant.lproj/CatalogStrings.strings
+++ b/Supports/SnapshotTestHelpKit/Resources/zh-Hant.lproj/CatalogStrings.strings
@@ -26,7 +26,7 @@
 
 // MARK: - 이벤트 상세
 
-"catalog.place::startup_hub" = "首爾創業中心";
+"catalog.place::meeting_room" = "二樓會議室";
 "catalog.memo::wireframes" = "帶上列印好的線框圖。";
 
 // MARK: - 이벤트 타입

--- a/TodoCalendarApp/AppExtensions/Widget/Snapshots/WidgetCatalogSnapshots.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Snapshots/WidgetCatalogSnapshots.swift
@@ -197,7 +197,7 @@ final class WidgetCatalogSnapshots: XCTestCase {
                 tagColorHex: "#2F6FED",
                 eventDate: eventDate,
                 startDate: eventDate.addingTimeInterval(-75 * 60),
-                placeName: "catalog.place::startup_hub".catalogLocalized()
+                placeName: "catalog.place::meeting_room".catalogLocalized()
             )
             return EventCountdownLockScreenView(
                 model: EventCountdownActivityViewModel(attributes, state),

--- a/fastlane/custom_product_pages/README.md
+++ b/fastlane/custom_product_pages/README.md
@@ -1,0 +1,64 @@
+# 맞춤형 제품 페이지 (Custom Product Page)
+
+App Store 맞춤형 제품 페이지의 원고·설정·산출물이 사는 자리다. 절차 정본은 `custom-product-page` 스킬,
+합성 규칙 정본은 유저 문서 `CPP지침-맞춤형-제품-페이지-3종-명세.md` 다.
+
+**이 README 말고는 전부 gitignore 대상이다** (`.gitignore` 의 `fastlane/custom_product_pages/*`).
+마케팅 원고와 산출 이미지를 public 레포에 두지 않는다.
+
+## 구조
+
+```
+custom_product_pages/
+  README.md                                        # 이 파일 (유일한 커밋 대상)
+  captions.json                                    # 장면 → 언어별 캡션. 스냅샷 테스트의 입력
+  pages.json                                       # 페이지 → ASC id + 장면 배치 순서
+  <page_id>/<ASC로케일>/promotional_text.txt        # 프로모션 문구 (170자 이내)
+  <page_id>/images/<ASC로케일>/<NN>_<장면>.png       # 업로드 산출물 (1320×2868, 알파 없음)
+```
+
+로케일 코드는 lproj 가 아니라 **ASC 코드**다 — 6개가 다르고 매핑표는 `fastlane/metadata/README.md`.
+
+## captions.json
+
+최상위 키가 장면 id, 그 아래가 **lproj 언어 코드**다 (`-testLanguage` 가 lproj 코드를 넘긴다).
+
+```json
+{
+  "C1": { "ko": "잠금화면에서 오늘 할일을 바로", "en": "Today's to-dos, right on the Lock Screen" },
+  "C2": { "ko": "…", "en": "…" }
+}
+```
+
+`AppStoreCaptionSnapshots.test_customProductPageCaptions` 가 이 파일을 읽어 캡션 이미지를 그린다.
+파일이 없으면 그 케이스는 `XCTSkip` 으로 건너뛴다 — 신선한 클론·CI 에는 이 파일이 없다.
+
+## pages.json
+
+`scenes` 는 정확히 6개, 순서가 곧 스토어 라인업 순서다. `ascPageId` 는 `create` 가 채운다.
+
+```json
+{
+  "cpp-widget": { "ascPageId": "", "scenes": ["C1", "C2", "C3", "C4", "C5", "C6"] }
+}
+```
+
+장면 id → 실제 화면의 대응은 코드에 있다 (`scripts/cpp_scenes.py` 의 `SCENES`).
+
+## 돌리는 순서
+
+```sh
+scripts/capture-appstore-screenshots.sh ko          # 먼저 한 언어로 확인
+python3 scripts/compose-cpp-screenshots.py --locale ko
+# 유저 확인 후
+scripts/capture-appstore-screenshots.sh --all
+python3 scripts/compose-cpp-screenshots.py --all-locales
+
+export PATH="/opt/homebrew/opt/ruby/bin:$PATH"
+bundle exec ruby scripts/asc-custom-product-page.rb create
+bundle exec ruby scripts/asc-custom-product-page.rb push-text   --all-pages --all-locales
+bundle exec ruby scripts/asc-custom-product-page.rb push-images --all-pages --all-locales
+```
+
+**텍스트가 먼저다** — 이미지는 로케일에 매달리므로 부모가 없으면 못 올린다.
+심사 제출은 콘솔에서 유저가 한다.

--- a/scripts/ai_sheet.py
+++ b/scripts/ai_sheet.py
@@ -9,7 +9,7 @@
 
 from PIL import Image, ImageDraw
 
-SCREEN = (1206, 2622)          # iPhone 17 @3x — 카탈로그 촬영 규격과 같다
+SCREEN = (1206, 2622)          # iPhone 17 @3x — 카탈로그 촬영 기본 규격. 앱스토어 스샷은 자기 규격을 넘긴다
 DIM_RATIO = 0.3                # .black.withAlphaComponent(0.3)
 SHEET_CORNER = 30              # topLeadingRadius/topTrailingRadius 10pt @3x
 SHEET_PADDING = 48             # BottomSlideView 가 시트 콘텐츠에 주는 .padding() 16pt @3x
@@ -50,23 +50,23 @@ def extended_to_bottom(sheet, height):
     return extended
 
 
-def compose(background, sheet):
-    screen = background.convert("RGB").resize(SCREEN, Image.LANCZOS)
-    dimmed = Image.blend(screen, Image.new("RGB", SCREEN, (0, 0, 0)), DIM_RATIO)
+def compose(background, sheet, screen_size=SCREEN):
+    screen = background.convert("RGB").resize(screen_size, Image.LANCZOS)
+    dimmed = Image.blend(screen, Image.new("RGB", screen_size, (0, 0, 0)), DIM_RATIO)
 
     cropped = sheet.convert("RGB")
     cropped = cropped.crop((0, sheet_top(cropped), cropped.width, cropped.height))
-    ratio = SCREEN[0] / cropped.width
-    cropped = cropped.resize((SCREEN[0], round(cropped.height * ratio)), Image.LANCZOS)
+    ratio = screen_size[0] / cropped.width
+    cropped = cropped.resize((screen_size[0], round(cropped.height * ratio)), Image.LANCZOS)
 
     # 시트 배경은 .ignoresSafeArea(edges: .bottom) 으로 홈 인디케이터까지 내려가고 콘텐츠는
     # 그 위에서 끝난다. 고정 프레임 스냅샷엔 그 여백이 없어 버튼이 화면 끝에 붙어 나온다.
     cropped = extended_to_bottom(cropped, SAFE_AREA_BOTTOM)
 
-    if cropped.height >= SCREEN[1]:
+    if cropped.height >= screen_size[1]:
         raise SystemExit("✗ AI 시트가 화면을 다 덮는다 — 뒤 캘린더가 안 보인다")
 
     dimmed.paste(
-        cropped, (0, SCREEN[1] - cropped.height), rounded_top_mask(cropped.size, SHEET_CORNER)
+        cropped, (0, screen_size[1] - cropped.height), rounded_top_mask(cropped.size, SHEET_CORNER)
     )
     return dimmed

--- a/scripts/asc-custom-product-page.rb
+++ b/scripts/asc-custom-product-page.rb
@@ -1,0 +1,638 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# App Store Connect 맞춤형 제품 페이지(Custom Product Page)를 만들고 채운다.
+#
+# usage (PATH 는 docs/appstore-connect-operations.md §1, 자격증명은 secret/README.md):
+#   export PATH="/opt/homebrew/opt/ruby/bin:$PATH"
+#   bundle exec ruby scripts/asc-custom-product-page.rb list
+#   bundle exec ruby scripts/asc-custom-product-page.rb create
+#   bundle exec ruby scripts/asc-custom-product-page.rb push-text   (--page <id>|--all-pages) (--locale <ASC로케일>|--all-locales) [--dry-run]
+#   bundle exec ruby scripts/asc-custom-product-page.rb push-images (--page <id>|--all-pages) (--locale <ASC로케일>|--all-locales) [--dry-run]
+#
+# fastlane deliver 는 맞춤형 제품 페이지를 모른다. 그래서 lane 이 아니라 spaceship 의
+# raw ASC 클라이언트를 직접 쓴다 (asc-in-app-event.rb 와 같은 구조).
+#
+# **인앱 이벤트와 커밋 페이로드가 다르다** — 여기는 appScreenshots 라 sourceFileChecksum 을
+# 반드시 싣는다. appEventScreenshots 에 실으면 거부되는 그 필드다.
+
+require "digest"
+require "json"
+require "spaceship"
+
+REQUIRED_ENV = {
+  "ASC_KEY_ID" => "App Store Connect > 사용자 및 액세스 > 통합에서 발급한 키 ID",
+  "ASC_ISSUER_ID" => "같은 화면의 Issuer ID",
+  "ASC_KEY_CONTENT" => "AuthKey_<키ID>.p8 를 base64 로 인코딩한 값 — base64 -i AuthKey_<키ID>.p8"
+}.freeze
+
+SECRET_KEYS = %w[key_id issuer_id key_filepath].freeze
+
+ROOT = File.expand_path("..", __dir__)
+CONFIG_ROOT = ENV["CPP_CONFIG_ROOT"] || File.join(ROOT, "fastlane", "custom_product_pages")
+METADATA_ROOT = File.join(ROOT, "fastlane", "metadata")
+
+PROMOTIONAL_TEXT_FILE = "promotional_text.txt"
+PROMOTIONAL_TEXT_LIMIT = 170
+SCREENSHOT_DISPLAY_TYPE = "APP_IPHONE_67"
+SCENES_PER_PAGE = 6
+
+# deliver 가 로케일이 아닌 용도로 쓰는 하위 디렉토리 (fastlane/Fastfile 과 같은 목록)
+NON_LOCALE_METADATA_DIRS = %w[
+  review_information
+  trade_representative_contact_information
+  app_clip_review_information
+].freeze
+
+def abort_with(message)
+  warn(message)
+  exit(1)
+end
+
+# 자격증명 파일 경로. 테스트가 실제 자격증명을 안 집게 덮어쓸 수 있어야 한다.
+def secret_path
+  ENV["ASC_SECRET_FILE"] || File.join(ROOT, "secret", "asc-api-key.json")
+end
+
+def credentials_from_env
+  missing = REQUIRED_ENV.select { |name, _| ENV[name].to_s.strip.empty? }
+  return nil unless missing.empty?
+
+  {
+    key_id: ENV.fetch("ASC_KEY_ID"),
+    issuer_id: ENV.fetch("ASC_ISSUER_ID"),
+    key: ENV.fetch("ASC_KEY_CONTENT"),
+    is_key_content_base64: true
+  }
+end
+
+# .p8 은 base64 로 바꾸지 않는다 — Token.create 가 filepath 를 직접 읽는다.
+def credentials_from_secret_file
+  path = secret_path
+  return nil unless File.exist?(path)
+
+  parsed = begin
+    JSON.parse(File.read(path))
+  rescue JSON::ParserError => error
+    abort_with("#{path} 가 JSON 이 아니다 — #{error.message}\n\n형식은 secret/README.md")
+  end
+
+  absent = SECRET_KEYS.reject { |key| parsed[key].to_s.strip.empty? == false }
+  abort_with("#{path} 에 #{absent.join(", ")} 가 없다 — 형식은 secret/README.md") unless absent.empty?
+
+  key_filepath = File.expand_path(parsed["key_filepath"])
+  unless File.exist?(key_filepath)
+    abort_with("key_filepath 가 가리키는 #{key_filepath} 가 없다 — .p8 을 옮겼거나 경로가 틀렸다")
+  end
+
+  { key_id: parsed["key_id"], issuer_id: parsed["issuer_id"], filepath: key_filepath }
+end
+
+def credentials
+  resolved = credentials_from_env || credentials_from_secret_file
+  return resolved if resolved
+
+  abort_with(<<~MESSAGE)
+    App Store Connect 자격증명을 못 찾았다. 둘 중 하나를 갖춰라.
+
+    (1) #{secret_path} — 형식은 secret/README.md
+        { "key_id": "...", "issuer_id": "...", "key_filepath": "/절대/경로/AuthKey_<키ID>.p8" }
+
+    (2) 환경변수 셋 (CI 처럼 파일을 못 두는 자리)
+    #{REQUIRED_ENV.map { |name, hint| "    #{name} — #{hint}" }.join("\n")}
+  MESSAGE
+end
+
+def bundle_identifier
+  appfile = File.join(ROOT, "fastlane", "Appfile")
+  match = File.read(appfile)[/app_identifier\(["']([^"']+)["']\)/, 1]
+  return match if match
+
+  abort_with("fastlane/Appfile 에서 app_identifier 를 못 읽었다")
+end
+
+def authenticated_client
+  Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.create(**credentials)
+  Spaceship::ConnectAPI.tunes_request_client
+end
+
+class ASCCustomProductPageClient
+  def initialize(client:)
+    @client = client
+  end
+
+  def app_id(bundle_id:)
+    apps = @client.get(v1("apps"), { "filter[bundleId]" => bundle_id }).body["data"] || []
+    apps.first&.dig("id")
+  end
+
+  def pages(app_id:)
+    paged(v1("apps/#{app_id}/appCustomProductPages"), { "limit" => 200 })
+  end
+
+  # 페이지 하나만 만들 수는 없다 — 버전과 기본 로케일까지 한 요청에 실어야 통과한다.
+  # 함께 만드는 리소스는 included 에 두고 `${lid}` 로 서로를 가리킨다.
+  # visible 은 CREATE 에 못 싣는다 (ASC 가 요청 전체를 거부한다).
+  def create_page(app_id:, name:, primary_locale:)
+    version_lid = "${cpp-version}"
+    localization_lid = "${cpp-localization}"
+    body = {
+      data: {
+        type: "appCustomProductPages",
+        attributes: { name: name },
+        relationships: {
+          app: { data: { type: "apps", id: app_id } },
+          appCustomProductPageVersions: {
+            data: [{ type: "appCustomProductPageVersions", id: version_lid }]
+          }
+        }
+      },
+      included: [
+        {
+          type: "appCustomProductPageVersions",
+          id: version_lid,
+          relationships: {
+            appCustomProductPageLocalizations: {
+              data: [{ type: "appCustomProductPageLocalizations", id: localization_lid }]
+            }
+          }
+        },
+        {
+          type: "appCustomProductPageLocalizations",
+          id: localization_lid,
+          attributes: { locale: primary_locale }
+        }
+      ]
+    }
+    @client.post(v1("appCustomProductPages"), body).body["data"]
+  end
+
+  def primary_locale(app_id:)
+    @client.get(v1("apps/#{app_id}")).body.dig("data", "attributes", "primaryLocale")
+  end
+
+  # 페이지를 만들면 버전이 딸려 오는 것이 보통이지만 보장은 없다 — 없으면 만든다.
+  def version(page_id:)
+    existing = paged(
+      v1("appCustomProductPages/#{page_id}/appCustomProductPageVersions"), { "limit" => 50 }
+    )
+    return existing.first unless existing.empty?
+
+    body = {
+      data: {
+        type: "appCustomProductPageVersions",
+        relationships: {
+          appCustomProductPage: { data: { type: "appCustomProductPages", id: page_id } }
+        }
+      }
+    }
+    @client.post(v1("appCustomProductPageVersions"), body).body["data"]
+  end
+
+  def localizations(version_id:)
+    paged(
+      v1("appCustomProductPageVersions/#{version_id}/appCustomProductPageLocalizations"),
+      { "limit" => 200 }
+    ).each_with_object({}) do |entry, collected|
+      locale = entry.dig("attributes", "locale")
+      collected[locale] = entry if locale
+    end
+  end
+
+  def create_localization(version_id:, locale:, promotional_text:)
+    body = {
+      data: {
+        type: "appCustomProductPageLocalizations",
+        attributes: { locale: locale, promotionalText: promotional_text },
+        relationships: {
+          appCustomProductPageVersion: {
+            data: { type: "appCustomProductPageVersions", id: version_id }
+          }
+        }
+      }
+    }
+    @client.post(v1("appCustomProductPageLocalizations"), body).body["data"]
+  end
+
+  # PATCH 에는 locale 을 싣지 않는다 — 생성 시점에만 정해지는 값이다.
+  def update_localization(id:, promotional_text:)
+    body = {
+      data: {
+        type: "appCustomProductPageLocalizations",
+        id: id,
+        attributes: { promotionalText: promotional_text }
+      }
+    }
+    @client.patch(v1("appCustomProductPageLocalizations/#{id}"), body).body["data"]
+  end
+
+  def screenshot_set(localization_id:)
+    existing = paged(
+      v1("appCustomProductPageLocalizations/#{localization_id}/appScreenshotSets"),
+      { "limit" => 50 }
+    ).find { |entry| entry.dig("attributes", "screenshotDisplayType") == SCREENSHOT_DISPLAY_TYPE }
+    return existing if existing
+
+    body = {
+      data: {
+        type: "appScreenshotSets",
+        attributes: { screenshotDisplayType: SCREENSHOT_DISPLAY_TYPE },
+        relationships: {
+          appCustomProductPageLocalization: {
+            data: { type: "appCustomProductPageLocalizations", id: localization_id }
+          }
+        }
+      }
+    }
+    @client.post(v1("appScreenshotSets"), body).body["data"]
+  end
+
+  def screenshots(set_id:)
+    paged(v1("appScreenshotSets/#{set_id}/appScreenshots"), { "limit" => 50 })
+  end
+
+  def delete_screenshot(id:)
+    @client.delete(v1("appScreenshots/#{id}"))
+  end
+
+  # 예약(POST) → 바이너리 PUT → uploaded + 체크섬 PATCH commit 3단계.
+  def upload_screenshot(set_id:, path:)
+    bytes = File.binread(path)
+    reserved = @client.post(v1("appScreenshots"), {
+      data: {
+        type: "appScreenshots",
+        attributes: { fileSize: bytes.bytesize, fileName: File.basename(path) },
+        relationships: { appScreenshotSet: { data: { type: "appScreenshotSets", id: set_id } } }
+      }
+    }).body["data"]
+
+    Spaceship::ConnectAPI::FileUploader.upload(reserved.dig("attributes", "uploadOperations"), bytes)
+
+    @client.patch(v1("appScreenshots/#{reserved["id"]}"), {
+      data: {
+        type: "appScreenshots",
+        id: reserved["id"],
+        attributes: { uploaded: true, sourceFileChecksum: Digest::MD5.hexdigest(bytes) }
+      }
+    })
+
+    reserved
+  end
+
+  def screenshot(id:)
+    @client.get(v1("appScreenshots/#{id}")).body["data"]
+  end
+
+  # 업로드 순서가 곧 표시 순서가 아니다 — 세트의 관계를 순서대로 다시 쓴다.
+  def reorder(set_id:, screenshot_ids:)
+    body = { data: screenshot_ids.map { |id| { type: "appScreenshots", id: id } } }
+    @client.patch(v1("appScreenshotSets/#{set_id}/relationships/appScreenshots"), body)
+  end
+
+  private
+
+  # spaceship 의 tunes 클라이언트는 https://appstoreconnect.apple.com/iris/ 를 base 로 잡고,
+  # 리소스 경로는 전부 v1/ 로 시작한다.
+  def v1(path)
+    "v1/#{path}"
+  end
+
+  # ASC 는 200건이 페이지 상한이라 links.next 를 따라가야 전량이 나온다.
+  def paged(path, params)
+    collected = []
+    response = @client.get(path, params)
+    loop do
+      body = response.body
+      collected.concat(body["data"] || [])
+      next_url = body.dig("links", "next")
+      break unless next_url
+
+      response = @client.get(next_url)
+    end
+    collected
+  end
+end
+
+def page_client
+  ASCCustomProductPageClient.new(client: authenticated_client)
+end
+
+def resolved_app(client)
+  bundle_id = bundle_identifier
+  app_id = client.app_id(bundle_id: bundle_id)
+  abort_with("bundleId #{bundle_id} 로 앱을 못 찾았다 — 키에 이 앱 권한이 있는지 확인해라") unless app_id
+  app_id
+end
+
+# MARK: - 설정
+
+def pages_path
+  File.join(CONFIG_ROOT, "pages.json")
+end
+
+def load_pages
+  path = pages_path
+  abort_with("#{path} 가 없다 — 페이지 구성을 먼저 만들어라") unless File.exist?(path)
+
+  parsed = begin
+    JSON.parse(File.read(path))
+  rescue JSON::ParserError => error
+    abort_with("#{path} 가 JSON 이 아니다 — #{error.message}")
+  end
+
+  broken = parsed.filter_map do |page_id, config|
+    scenes = config["scenes"] || []
+    "#{page_id} — 장면이 #{scenes.size}개다 (#{SCENES_PER_PAGE}개여야 한다)" if scenes.size != SCENES_PER_PAGE
+  end
+  abort_with(broken.join("\n")) unless broken.empty?
+  parsed
+end
+
+def save_pages(pages)
+  File.write(pages_path, "#{JSON.pretty_generate(pages)}\n")
+end
+
+def target_pages(pages, page_option, all_pages)
+  if all_pages && page_option
+    abort_with("--page 와 --all-pages 는 함께 못 쓴다")
+  end
+  return pages.keys if all_pages
+
+  abort_with("--page <page_id> 또는 --all-pages 중 하나가 필요하다") unless page_option
+  unless pages.key?(page_option)
+    abort_with("모르는 페이지: #{page_option} — 아는 것은 #{pages.keys.join(", ")}")
+  end
+  [page_option]
+end
+
+# 로케일 축의 정본은 fastlane/metadata 의 디렉토리 이름(ASC 코드)이다.
+def metadata_locales
+  Dir.children(METADATA_ROOT).sort.select do |name|
+    File.directory?(File.join(METADATA_ROOT, name)) && !NON_LOCALE_METADATA_DIRS.include?(name)
+  end
+end
+
+def target_locales(locale_option, all_locales)
+  return metadata_locales if all_locales
+
+  abort_with("--locale <ASC로케일> 또는 --all-locales 중 하나가 필요하다") unless locale_option
+  [locale_option]
+end
+
+def asc_page_id(pages, page_id)
+  id = pages.dig(page_id, "ascPageId").to_s.strip
+  abort_with("#{page_id} 의 ascPageId 가 비었다 — `create` 를 먼저 돌려라") if id.empty?
+  id
+end
+
+def promotional_text(page_id, locale)
+  path = File.join(CONFIG_ROOT, page_id, locale, PROMOTIONAL_TEXT_FILE)
+  return nil unless File.exist?(path)
+
+  File.read(path).strip
+end
+
+# 위반을 첫 건에서 멈추지 않고 전량 모은다 — 31개 로케일을 한 번에 고치게 한다.
+def text_violations(page_ids, locales)
+  page_ids.flat_map do |page_id|
+    locales.filter_map do |locale|
+      text = promotional_text(page_id, locale)
+      next "#{page_id}/#{locale} — #{PROMOTIONAL_TEXT_FILE} 이 없거나 비었다" if text.nil? || text.empty?
+      next if text.length <= PROMOTIONAL_TEXT_LIMIT
+
+      "#{page_id}/#{locale} — #{text.length}자 (상한 #{PROMOTIONAL_TEXT_LIMIT})"
+    end
+  end
+end
+
+def image_paths(page_id, locale)
+  directory = File.join(CONFIG_ROOT, page_id, "images", locale)
+  Dir.glob(File.join(directory, "*.png")).sort
+end
+
+def image_violations(page_ids, locales)
+  page_ids.flat_map do |page_id|
+    locales.filter_map do |locale|
+      count = image_paths(page_id, locale).size
+      next if count == SCENES_PER_PAGE
+
+      "#{page_id}/#{locale} — 이미지가 #{count}장이다 (#{SCENES_PER_PAGE}장이어야 한다)"
+    end
+  end
+end
+
+# MARK: - 서브커맨드
+
+def run_list
+  client = page_client
+  pages = client.pages(app_id: resolved_app(client))
+  if pages.empty?
+    puts("맞춤형 제품 페이지가 없다 — `create` 로 만들어라")
+    return
+  end
+
+  puts(format("%-38s  %-20s  %s", "ID", "NAME", "VISIBLE"))
+  pages.each do |entry|
+    attributes = entry["attributes"] || {}
+    puts(format("%-38s  %-20s  %s", entry["id"], attributes["name"], attributes["visible"]))
+  end
+  puts("\n#{pages.size}건")
+end
+
+def run_create
+  pages = load_pages
+  client = page_client
+  app_id = resolved_app(client)
+  primary_locale = client.primary_locale(app_id: app_id)
+  existing = client.pages(app_id: app_id).each_with_object({}) do |entry, collected|
+    collected[entry.dig("attributes", "name")] = entry["id"]
+  end
+
+  pages.each do |page_id, config|
+    if !config["ascPageId"].to_s.strip.empty?
+      puts("· #{page_id} — 이미 #{config["ascPageId"]}")
+      next
+    end
+    if existing.key?(page_id)
+      config["ascPageId"] = existing[page_id]
+      puts("· #{page_id} — ASC 에 이미 있다, id 만 채운다 (#{existing[page_id]})")
+      next
+    end
+    created = client.create_page(app_id: app_id, name: page_id, primary_locale: primary_locale)
+    config["ascPageId"] = created["id"]
+    puts("✓ #{page_id} → #{created["id"]}")
+  end
+
+  save_pages(pages)
+  puts("\n#{pages_path} 에 ascPageId 를 채웠다")
+end
+
+def print_text_plan(page_ids, locales, existing_by_page)
+  puts(format("%-14s  %-10s  %-8s  %s", "PAGE", "LOCALE", "ACTION", "길이"))
+  page_ids.each do |page_id|
+    locales.each do |locale|
+      text = promotional_text(page_id, locale).to_s
+      action = existing_by_page[page_id].key?(locale) ? "PATCH" : "POST"
+      puts(format("%-14s  %-10s  %-8s  %d", page_id, locale, action, text.length))
+    end
+  end
+end
+
+def run_push_text(page_option, all_pages, locale_option, all_locales, dry_run)
+  pages = load_pages
+  page_ids = target_pages(pages, page_option, all_pages)
+  locales = target_locales(locale_option, all_locales)
+
+  violations = text_violations(page_ids, locales)
+  unless violations.empty?
+    abort_with("원고가 ASC 제약을 어겼다 — #{violations.size}건\n\n#{violations.map { |line| "  #{line}" }.join("\n")}")
+  end
+
+  client = page_client
+  versions = page_ids.to_h { |page_id| [page_id, client.version(page_id: asc_page_id(pages, page_id))["id"]] }
+  existing_by_page = versions.transform_values { |version_id| client.localizations(version_id: version_id) }
+  print_text_plan(page_ids, locales, existing_by_page)
+
+  if dry_run
+    puts("\n--dry-run — 아무것도 올리지 않았다")
+    return
+  end
+
+  page_ids.each do |page_id|
+    print("▶︎ [#{page_id}] ")
+    locales.each do |locale|
+      text = promotional_text(page_id, locale)
+      entry = existing_by_page[page_id][locale]
+      if entry
+        client.update_localization(id: entry["id"], promotional_text: text)
+      else
+        client.create_localization(version_id: versions[page_id], locale: locale, promotional_text: text)
+      end
+      print(".")
+    end
+    puts
+  end
+
+  missing = page_ids.flat_map do |page_id|
+    filled = client.localizations(version_id: versions[page_id]).keys
+    (locales - filled).map { |locale| "#{page_id}/#{locale}" }
+  end
+  abort_with("올린 뒤 재조회했는데 #{missing.size}개가 비었다: #{missing.join(" ")}") unless missing.empty?
+  puts("✓ #{page_ids.size}페이지 × #{locales.size}개 로케일 — ASC 재조회로 확인됨")
+end
+
+def print_image_plan(page_ids, locales)
+  puts(format("%-14s  %-10s  %-6s  %s", "PAGE", "LOCALE", "장수", "합계(KB)"))
+  page_ids.each do |page_id|
+    locales.each do |locale|
+      paths = image_paths(page_id, locale)
+      kilobytes = paths.sum { |path| File.size(path) } / 1024
+      puts(format("%-14s  %-10s  %-6d  %d", page_id, locale, paths.size, kilobytes))
+    end
+  end
+end
+
+# ASC 가 자산을 처리하는 데 시간이 걸린다. COMPLETE 가 되기 전에 넘어가면 콘솔에 안 붙은 채로 남는다.
+def await_delivery(client, screenshot_id)
+  30.times do
+    state = client.screenshot(id: screenshot_id).dig("attributes", "assetDeliveryState") || {}
+    return true if state["state"] == "COMPLETE"
+
+    if state["state"] == "FAILED"
+      messages = (state["errors"] || []).map { |error| [error["code"], error["description"]].compact.join(" - ") }
+      warn("    ✗ 업로드 실패 — #{messages.join(" / ")}")
+      return false
+    end
+    sleep(2)
+  end
+  warn("    ✗ 60초 안에 COMPLETE 가 안 됐다 (screenshot #{screenshot_id})")
+  false
+end
+
+# 기존 스크린샷을 지우고 다시 올린다 — 안 지우면 6장 위에 6장이 더 쌓인다.
+def replace_screenshots(client, set_id, paths)
+  client.screenshots(set_id: set_id).each { |entry| client.delete_screenshot(id: entry["id"]) }
+
+  uploaded = paths.map { |path| client.upload_screenshot(set_id: set_id, path: path) }
+  delivered = uploaded.map { |entry| await_delivery(client, entry["id"]) }
+  client.reorder(set_id: set_id, screenshot_ids: uploaded.map { |entry| entry["id"] })
+  delivered.all?
+end
+
+def run_push_images(page_option, all_pages, locale_option, all_locales, dry_run)
+  pages = load_pages
+  page_ids = target_pages(pages, page_option, all_pages)
+  locales = target_locales(locale_option, all_locales)
+
+  violations = image_violations(page_ids, locales)
+  unless violations.empty?
+    abort_with(
+      "합성한 이미지가 라인업과 다르다 — #{violations.size}건\n\n" \
+      "#{violations.map { |line| "  #{line}" }.join("\n")}\n\n" \
+      "compose-cpp-screenshots.py 를 먼저 돌려라"
+    )
+  end
+
+  print_image_plan(page_ids, locales)
+  if dry_run
+    puts("\n--dry-run — 아무것도 올리지 않았다")
+    return
+  end
+
+  client = page_client
+  failed = []
+  page_ids.each do |page_id|
+    version_id = client.version(page_id: asc_page_id(pages, page_id))["id"]
+    existing = client.localizations(version_id: version_id)
+    orphans = locales - existing.keys
+    unless orphans.empty?
+      abort_with("이미지가 매달릴 로케일이 ASC 에 없다: #{page_id} — #{orphans.join(" ")}\n\npush-text 를 먼저 돌려라")
+    end
+
+    puts("▶︎ [#{page_id}]")
+    locales.each do |locale|
+      set = client.screenshot_set(localization_id: existing[locale]["id"])
+      ok = begin
+        replace_screenshots(client, set["id"], image_paths(page_id, locale))
+      rescue StandardError => error
+        warn("    ✗ #{locale} — #{error.class}: #{error.message}")
+        false
+      end
+      failed << "#{page_id}/#{locale}" unless ok
+      print(ok ? "." : "x")
+    end
+    puts
+  end
+
+  abort_with("실패한 페이지·로케일 #{failed.size}개: #{failed.join(" ")}") unless failed.empty?
+  puts("✓ #{page_ids.size}페이지 × #{locales.size}개 로케일 × #{SCENES_PER_PAGE}장 — 전부 COMPLETE")
+end
+
+# MARK: - 인자 파싱
+
+def option_value(argv, name)
+  index = argv.index(name)
+  return nil unless index
+
+  argv[index + 1]
+end
+
+def main(argv)
+  command = argv.shift
+  dry_run = argv.delete("--dry-run") ? true : false
+  all_pages = argv.delete("--all-pages") ? true : false
+  all_locales = argv.delete("--all-locales") ? true : false
+  page_option = option_value(argv, "--page")
+  locale_option = option_value(argv, "--locale")
+
+  case command
+  when "list" then run_list
+  when "create" then run_create
+  when "push-text" then run_push_text(page_option, all_pages, locale_option, all_locales, dry_run)
+  when "push-images" then run_push_images(page_option, all_pages, locale_option, all_locales, dry_run)
+  else
+    abort_with(File.read(__FILE__).lines[3..14].map { |line| line.sub(/^# ?/, "") }.join)
+  end
+end
+
+main(ARGV) if $PROGRAM_NAME == __FILE__

--- a/scripts/asc-custom-product-page.test.sh
+++ b/scripts/asc-custom-product-page.test.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# asc-custom-product-page.rb 의 네트워크 없이 도는 가드 회귀 테스트.
+# 자격증명을 전부 지운 채로 돌려 "검증이 인증보다 앞선다"까지 함께 확인한다.
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT" || exit 1
+export PATH="/opt/homebrew/opt/ruby/bin:$PATH"
+PASS=0; FAIL=0
+
+FIXTURE="$ROOT/snapshot-appstore/_cpp_asc_test"
+export CPP_CONFIG_ROOT="$FIXTURE"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+# ASC_SECRET_FILE 을 없는 경로로 돌려, 이 기기에 실제 secret/asc-api-key.json 이 있어도
+# 테스트가 그걸 집어 네트워크를 타지 않게 한다.
+run() {
+  env -u ASC_KEY_ID -u ASC_ISSUER_ID -u ASC_KEY_CONTENT \
+    ASC_SECRET_FILE=/nonexistent/asc-api-key.json \
+    bundle exec ruby scripts/asc-custom-product-page.rb "$@" 2>&1
+}
+
+assert_contains() { # desc pattern actual
+  if printf '%s' "$3" | grep -qF -- "$2"; then
+    PASS=$((PASS+1))
+  else
+    FAIL=$((FAIL+1)); echo "FAIL: $1"; echo "  pattern [$2] not in:"; printf '%s\n' "$3" | sed 's/^/    /'
+  fi
+}
+assert_not_contains() { # desc pattern actual
+  if printf '%s' "$3" | grep -qF -- "$2"; then
+    FAIL=$((FAIL+1)); echo "FAIL: $1"; echo "  pattern [$2] unexpectedly present"
+  else
+    PASS=$((PASS+1))
+  fi
+}
+
+write_page_config() { # scenes_json
+  mkdir -p "$FIXTURE"
+  cat > "$FIXTURE/pages.json" <<JSON
+{ "page-a": { "ascPageId": "", "scenes": $1 } }
+JSON
+}
+
+write_text() { # locale text
+  mkdir -p "$FIXTURE/page-a/$1"
+  printf '%s' "$2" > "$FIXTURE/page-a/$1/promotional_text.txt"
+}
+
+write_images() { # locale count
+  mkdir -p "$FIXTURE/page-a/images/$1"
+  rm -f "$FIXTURE/page-a/images/$1"/*.png
+  for index in $(seq 1 "$2"); do
+    printf 'x' > "$FIXTURE/page-a/images/$1/$(printf '%02d' "$index")_C$index.png"
+  done
+}
+
+# --- 인자·설정 검증은 인증보다 앞선다 ---
+write_page_config '["C1", "C2", "C3", "C4", "C5", "C6"]'
+write_text ko "짧은 문구"
+write_images ko 6
+
+assert_contains "--page 와 --all-pages 를 함께 주면 끊는다" \
+  "함께 못 쓴다" "$(run push-text --page page-a --all-pages --locale ko)"
+assert_not_contains "그 오류에서 자격증명 안내가 뜨지 않는다" \
+  "자격증명을 못 찾았다" "$(run push-text --page page-a --all-pages --locale ko)"
+
+assert_contains "모르는 페이지는 끊는다" \
+  "모르는 페이지: nope" "$(run push-text --page nope --locale ko)"
+
+assert_contains "페이지 인자가 없으면 끊는다" \
+  "--page <page_id> 또는 --all-pages" "$(run push-text --locale ko)"
+
+assert_contains "로케일 인자가 없으면 끊는다" \
+  "--locale <ASC로케일> 또는 --all-locales" "$(run push-text --page page-a)"
+
+# --- pages.json 자체 검증 ---
+write_page_config '["C1", "C2", "C3", "C4", "C5"]'
+assert_contains "페이지당 6장이 아니면 끊는다" \
+  "장면이 5개다" "$(run push-text --page page-a --locale ko)"
+
+# --- 프로모션 문구 상한 ---
+write_page_config '["C1", "C2", "C3", "C4", "C5", "C6"]'
+LONG_TEXT="$(python3 -c 'print("가" * 171)')"
+write_text ko "$LONG_TEXT"
+write_text ja "$LONG_TEXT"
+OVERFLOW="$(run push-text --page page-a --all-locales --dry-run)"
+assert_contains "170자 초과를 잡는다" "171자 (상한 170)" "$OVERFLOW"
+assert_contains "위반을 첫 건에서 멈추지 않고 전량 모은다" "page-a/ja" "$OVERFLOW"
+assert_not_contains "상한 위반에서 자격증명 안내가 뜨지 않는다" "자격증명을 못 찾았다" "$OVERFLOW"
+
+write_text ko "짧은 문구"
+assert_contains "원고가 없는 로케일을 잡는다" \
+  "promotional_text.txt 이 없거나 비었다" "$(run push-text --page page-a --locale zh-Hans)"
+
+# --- 이미지 장수 ---
+write_images ko 5
+assert_contains "이미지가 6장이 아니면 끊는다" \
+  "이미지가 5장이다" "$(run push-images --page page-a --locale ko --dry-run)"
+assert_not_contains "장수 오류에서 자격증명 안내가 뜨지 않는다" \
+  "자격증명을 못 찾았다" "$(run push-images --page page-a --locale ko --dry-run)"
+
+# --- 검증을 통과하면 그제서야 인증으로 간다 ---
+write_images ko 6
+assert_contains "검증을 통과한 dry-run 은 계획을 찍는다" \
+  "--dry-run — 아무것도 올리지 않았다" "$(run push-images --page page-a --locale ko --dry-run)"
+assert_contains "push-text 는 dry-run 도 ASC 를 읽어야 해 자격증명을 요구한다" \
+  "자격증명을 못 찾았다" "$(run push-text --page page-a --locale ko --dry-run)"
+
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/capture-appstore-screenshots.sh
+++ b/scripts/capture-appstore-screenshots.sh
@@ -7,8 +7,11 @@
 #
 # 결과: snapshot-appstore/<lang>/<NN-슬러그>.png (gitignore 대상, 언어별 격리)
 #       snapshot-appstore/<lang>/captions/<NN-슬러그>.png — 합성 캔버스 상단에 얹을 캡션
-#       snapshot-appstore/<lang>/widgets/<슬러그>.png — 홈화면 합성 전 위젯 원본
-# 홈화면 위젯 스샷은 위젯 원본을 홈화면에 합성해 만드는 별도 단계다 — 여기서는 원본까지만 뽑는다.
+#       snapshot-appstore/<lang>/captions/cpp/<장면>.png — 맞춤형 제품 페이지 캡션
+#       snapshot-appstore/<lang>/widgets/<슬러그>.png — 홈화면·잠금화면 합성 전 위젯 원본
+#       snapshot-appstore/<lang>/sheets/<슬러그>.png — 캘린더 위에 얹을 시트 조각
+# 홈화면·잠금화면 스샷은 위젯 원본을 배경에 합성해 만드는 별도 단계다 — 여기서는 원본까지만 뽑는다.
+# 기본 스토어 페이지와 맞춤형 제품 페이지가 장면을 나눠 쓰므로 한 실행이 양쪽을 다 뜬다.
 #
 # capture-guide-screenshots.sh 와 촬영 절차는 같고 세 가지가 다르다:
 #   - 6.9" 업로드 규격(1320×2868)이 나오는 iPhone 16 Pro Max 전용 시뮬레이터를 쓴다.
@@ -47,6 +50,7 @@ SUITES=(
     "SettingSceneSnapshots|SettingSceneCatalogSnapshots|SettingScene"
     "CommonPresentationSnapshots|AppStoreCaptionSnapshots|CommonPresentation"
     "TodoCalendarAppWidgetSnapshots|WidgetCatalogSnapshots|Widget"
+    "AIAgentSceneSnapshots|AIAgentSceneCatalogSnapshots|AIAgentScene"
 )
 
 # <업로드 파일명>|<모듈 디렉토리>/<스위트>/<캡처 파일명>
@@ -56,6 +60,8 @@ MAPPING=(
     "03-event-detail|EventDetailScene/EventDetailSceneCatalogSnapshots/test_eventDetail.eventDetail-light.png"
     "04-google-event|EventDetailScene/EventDetailSceneCatalogSnapshots/test_storeGoogleEventDetail.storeGoogleEventDetail-light.png"
     "06-appearance|SettingScene/SettingSceneCatalogSnapshots/test_appearanceSetting.appearanceSetting-light.png"
+    "07-todo-list|CalendarScenes/CalendarScenesCatalogSnapshots/test_storeTodoList.storeTodoList-light.png"
+    "08-share-preview|CalendarScenes/CalendarScenesCatalogSnapshots/test_storeSharePreview.storeSharePreview-light.png"
 )
 
 # 캡션·위젯 원본 — 화면 규격이 아니라 각자의 캔버스 규격이라 규격 검사·알파 제거 대상이 아니다
@@ -75,6 +81,29 @@ WIDGET_MAPPING=(
     "foremost|Widget/WidgetCatalogSnapshots/test_widgetForemost.widget-foremost-light.png"
     "month|Widget/WidgetCatalogSnapshots/test_widgetMonth.widget-month-light.png"
     "ai-command|Widget/WidgetCatalogSnapshots/test_widgetAICommand.widget-ai-command-light.png"
+    # 잠금화면 조각만 dark 다 — lock_screen.py 가 검정 배경을 lighten 으로 떨궈 벽지 위에 얹는다
+    "lockscreen-foremost|Widget/WidgetCatalogSnapshots/test_widgetLockScreenForemost.lockscreen-foremost-dark.png"
+    "lockscreen-next|Widget/WidgetCatalogSnapshots/test_widgetLockScreenNext.lockscreen-next-dark.png"
+    "lockscreen-next-remain|Widget/WidgetCatalogSnapshots/test_widgetLockScreenNextRemain.lockscreen-next-remain-dark.png"
+    "lockscreen-live-activity|Widget/WidgetCatalogSnapshots/test_widgetLockScreenLiveActivity.lockscreen-live-activity-dark.png"
+)
+
+# 캘린더 위에 얹을 시트 조각 — 화면 규격이 아니라 시트 자기 크기다
+SHEET_MAPPING=(
+    "ai-command-processing|AIAgentScene/AIAgentSceneCatalogSnapshots/test_storeAICommandProcessing.storeAICommandProcessing-light.png"
+    "ai-command-done|AIAgentScene/AIAgentSceneCatalogSnapshots/test_storeAICommandDone.storeAICommandDone-light.png"
+)
+
+# 맞춤형 제품 페이지 캡션 — 장면 id 가 곧 파일명이다
+CPP_CAPTION_MAPPING=(
+    "C1|CommonPresentation/AppStoreCaptionSnapshots/test_customProductPageCaptions.C1-light.png"
+    "C2|CommonPresentation/AppStoreCaptionSnapshots/test_customProductPageCaptions.C2-light.png"
+    "C3|CommonPresentation/AppStoreCaptionSnapshots/test_customProductPageCaptions.C3-light.png"
+    "C4|CommonPresentation/AppStoreCaptionSnapshots/test_customProductPageCaptions.C4-light.png"
+    "C5|CommonPresentation/AppStoreCaptionSnapshots/test_customProductPageCaptions.C5-light.png"
+    "C6|CommonPresentation/AppStoreCaptionSnapshots/test_customProductPageCaptions.C6-light.png"
+    "C7|CommonPresentation/AppStoreCaptionSnapshots/test_customProductPageCaptions.C7-light.png"
+    "C8|CommonPresentation/AppStoreCaptionSnapshots/test_customProductPageCaptions.C8-light.png"
 )
 
 latest_ios_runtime() {
@@ -169,7 +198,7 @@ capture_lang() {
 
     local out="$ROOT/snapshot-appstore/$lang"
     rm -rf "$out"
-    mkdir -p "$out/captions" "$out/widgets"
+    mkdir -p "$out/captions/cpp" "$out/widgets" "$out/sheets"
     for entry in "${MAPPING[@]}" ; do
         IFS='|' read -r name source <<< "$entry"
         local src="$ROOT/snapshot-catalog/$source"
@@ -188,7 +217,19 @@ capture_lang() {
         [ -f "$src" ] || { echo "  ✗ 누락: $source"; return 1; }
         cp "$src" "$out/widgets/$name.png"
     done
-    echo "  ✓ [$lang] ${#MAPPING[@]}장 + 캡션 ${#CAPTION_MAPPING[@]}장 + 위젯 원본 ${#WIDGET_MAPPING[@]}종 → snapshot-appstore/$lang/"
+    for entry in "${SHEET_MAPPING[@]}" ; do
+        IFS='|' read -r name source <<< "$entry"
+        local src="$ROOT/snapshot-catalog/$source"
+        [ -f "$src" ] || { echo "  ✗ 누락: $source"; return 1; }
+        cp "$src" "$out/sheets/$name.png"
+    done
+    for entry in "${CPP_CAPTION_MAPPING[@]}" ; do
+        IFS='|' read -r name source <<< "$entry"
+        local src="$ROOT/snapshot-catalog/$source"
+        [ -f "$src" ] || { echo "  ✗ 누락: $source — fastlane/custom_product_pages/captions.json 에 $lang 원고가 있는지 확인해라"; return 1; }
+        cp "$src" "$out/captions/cpp/$name.png"
+    done
+    echo "  ✓ [$lang] ${#MAPPING[@]}장 + 캡션 ${#CAPTION_MAPPING[@]}+${#CPP_CAPTION_MAPPING[@]}장 + 위젯 원본 ${#WIDGET_MAPPING[@]}종 + 시트 ${#SHEET_MAPPING[@]}종 → snapshot-appstore/$lang/"
 
     verify_and_strip_alpha "$python_bin" "$out" || return 1
 

--- a/scripts/compose-appstore-screenshots.py
+++ b/scripts/compose-appstore-screenshots.py
@@ -13,14 +13,14 @@ usage:
 non-transferable 이라 public 레포에 커밋하지 않고 캐시 디렉토리에 받아 쓴다.
 """
 
-import shutil
-import subprocess
 import sys
-import tempfile
-from collections import Counter
 from pathlib import Path
 
-from PIL import Image, ImageChops, ImageDraw, ImageFilter
+from PIL import Image
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from device_bezel import load_bezel, screen_hole  # noqa: E402
+from store_screen import home_screen, inset_screenshot  # noqa: E402
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -29,13 +29,6 @@ CANVAS_COLOR = "#F5F5F7"
 DEVICE_WIDTH = 1150
 DEVICE_TOP = 620
 CAPTION_TOP = 100
-# iPhone 16 Pro Max 상단 safe area 62pt @3x — 콘텐츠가 Dynamic Island 밑에 깔리지 않게 한다
-SCREEN_TOP_INSET = 186
-
-BEZEL_URL = "https://devimages-cdn.apple.com/design/resources/download/Bezel-iPhone-16.dmg"
-BEZEL_IN_DMG = "PNG/iPhone 16 Pro Max/iPhone 16 Pro Max - Black Titanium - Portrait.png"
-BEZEL_CACHE_DIR = Path.home() / "Library/Caches/todocalendar-appstore-bezel"
-BEZEL_CACHE_PATH = BEZEL_CACHE_DIR / "iPhone-16-Pro-Max-Black-Titanium-Portrait.png"
 
 ALL_LANGS = [
     "en", "ko", "ja", "zh-Hans", "zh-Hant", "vi", "th", "es", "fr", "it", "pt-BR",
@@ -58,16 +51,6 @@ SLUGS = [
 ]
 
 HOME_SCREEN_SLUG = "05-widgets"
-HOME_SCREEN_WIDGETS = ["today-and-next", "month"]
-# 라이트 테마 위젯이 떠 보이는 배경 — 홈화면 벽지 자리라 앱 컬러셋과 무관하다
-WALLPAPER_TOP_COLOR = (58, 74, 128)
-WALLPAPER_BOTTOM_COLOR = (146, 122, 168)
-WIDGET_RADIUS = 78                  # 위젯 코너 26pt @3x — 캡처에 구워진 곡률과 같은 값
-WIDGET_TOP = 430
-WIDGET_GAP = 90
-WIDGET_SHADOW_BLUR = 34
-WIDGET_SHADOW_OFFSET = 14
-WIDGET_SHADOW_ALPHA = 90
 
 
 def asc_locale(lang):
@@ -79,124 +62,7 @@ def upload_name(slug):
     return f"{number}_{rest}.png"
 
 
-# MARK: - 베젤 확보
-
-def download_bezel():
-    BEZEL_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory() as workspace:
-        dmg_path = Path(workspace) / "bezel.dmg"
-        print(f"▶︎ 베젤 내려받는 중 — {BEZEL_URL}")
-        subprocess.run(["curl", "-fsSL", "-o", str(dmg_path), BEZEL_URL], check=True)
-
-        mount_point = Path(workspace) / "mount"
-        mount_point.mkdir()
-        # dmg 에 SLA 가 걸려 있어 동의 입력 없이는 attach 가 멈춘다
-        subprocess.run(
-            f'yes | hdiutil attach "{dmg_path}" -mountpoint "{mount_point}" -nobrowse -readonly',
-            shell=True, check=True, capture_output=True,
-        )
-        try:
-            source = mount_point / BEZEL_IN_DMG
-            if not source.exists():
-                raise SystemExit(f"✗ dmg 안에 {BEZEL_IN_DMG} 가 없다 — 베젤 배포 구조가 바뀌었다")
-            shutil.copyfile(source, BEZEL_CACHE_PATH)
-        finally:
-            subprocess.run(["hdiutil", "detach", str(mount_point)], check=False, capture_output=True)
-    print(f"  ✓ 캐시 — {BEZEL_CACHE_PATH}")
-
-
-def load_bezel():
-    if not BEZEL_CACHE_PATH.exists():
-        download_bezel()
-    return Image.open(BEZEL_CACHE_PATH).convert("RGBA")
-
-
-def screen_hole(bezel):
-    """베젤 갱신에도 안 깨지게 좌표를 박지 않고 알파 채널 flood-fill 로 화면 구멍을 찾는다."""
-    transparent = bezel.getchannel("A").point(lambda alpha: 255 if alpha == 0 else 0)
-    seed = (bezel.width // 2, bezel.height // 2)
-    if transparent.getpixel(seed) != 255:
-        raise SystemExit("✗ 베젤 중앙이 투명하지 않다 — 화면 구멍을 못 찾는다")
-    ImageDraw.floodfill(transparent, seed, 128)
-    mask = transparent.point(lambda value: 255 if value == 128 else 0)
-    box = mask.getbbox()
-    if box is None:
-        raise SystemExit("✗ 화면 구멍 영역이 비었다")
-    return mask, box
-
-
-# MARK: - 홈화면 위젯
-
-def wallpaper(size):
-    width, height = size
-    column = Image.new("RGB", (1, height))
-    painter = ImageDraw.Draw(column)
-    for y in range(height):
-        ratio = y / (height - 1)
-        painter.point((0, y), tuple(
-            round(top + (bottom - top) * ratio)
-            for top, bottom in zip(WALLPAPER_TOP_COLOR, WALLPAPER_BOTTOM_COLOR)
-        ))
-    return column.resize((width, height), Image.BILINEAR).convert("RGBA")
-
-
-def trim_widget_margin(capture):
-    """위젯 캡처엔 위젯 바깥 여백이 함께 들어 있다 — 그대로 얹으면 카드 테두리가 이중으로 보인다."""
-    opaque = capture.convert("RGB")
-    background = Image.new("RGB", opaque.size, opaque.getpixel((0, 0)))
-    difference = ImageChops.difference(opaque, background).convert("L")
-    box = difference.point(lambda value: 255 if value > 6 else 0).getbbox()
-    if box is None:
-        raise SystemExit("✗ 위젯 캡처가 배경색 한 장이다 — 잘라낼 내용이 없다")
-    return capture.crop(box)
-
-
-def rounded(widget, radius):
-    mask = Image.new("L", widget.size, 0)
-    ImageDraw.Draw(mask).rounded_rectangle(
-        [0, 0, widget.width - 1, widget.height - 1], radius=radius, fill=255
-    )
-    shaped = widget.convert("RGBA")
-    shaped.putalpha(mask)
-    return shaped
-
-
-def paste_with_shadow(screen, widget, position):
-    shadow = Image.new("RGBA", screen.size, (0, 0, 0, 0))
-    cast = Image.new("RGBA", widget.size, (0, 0, 0, WIDGET_SHADOW_ALPHA))
-    cast.putalpha(widget.getchannel("A").point(lambda alpha: alpha * WIDGET_SHADOW_ALPHA // 255))
-    shadow.paste(cast, (position[0], position[1] + WIDGET_SHADOW_OFFSET), cast)
-    screen.alpha_composite(shadow.filter(ImageFilter.GaussianBlur(WIDGET_SHADOW_BLUR)))
-    screen.alpha_composite(widget, position)
-
-
-def home_screen(source_dir, size):
-    widgets = []
-    for name in HOME_SCREEN_WIDGETS:
-        path = source_dir / "widgets" / f"{name}.png"
-        if not path.exists():
-            raise SystemExit(f"  ✗ 누락: {path.relative_to(ROOT)} — 먼저 촬영 스크립트를 돌려라")
-        with Image.open(path) as capture:
-            widgets.append(rounded(trim_widget_margin(capture), WIDGET_RADIUS))
-
-    screen = wallpaper(size)
-    top = WIDGET_TOP
-    for widget in widgets:
-        paste_with_shadow(screen, widget, ((size[0] - widget.width) // 2, top))
-        top += widget.height + WIDGET_GAP
-    return screen
-
-
 # MARK: - 합성
-
-def inset_screenshot(screenshot, size):
-    """상단에 화면 배경색 인셋을 둔 뒤 구멍 크기에 맞춰 자른다."""
-    top_row = [screenshot.getpixel((x, 0)) for x in range(screenshot.width)]
-    background = Counter(top_row).most_common(1)[0][0]
-    inset = Image.new("RGBA", size, background)
-    inset.paste(screenshot, (0, SCREEN_TOP_INSET))
-    return inset
-
 
 def screen_image(slug, source_dir, size):
     if slug == HOME_SCREEN_SLUG:

--- a/scripts/compose-cpp-screenshots.py
+++ b/scripts/compose-cpp-screenshots.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""촬영한 장면을 맞춤형 제품 페이지(CPP) 업로드용 스샷으로 합성한다.
+
+usage:
+    python3 scripts/compose-cpp-screenshots.py --locale <lang> [--page <page_id>]
+    python3 scripts/compose-cpp-screenshots.py --all-locales
+
+입력: snapshot-appstore/<lang>/ 촬영 산출물 + captions/cpp/<장면>.png
+출력: fastlane/custom_product_pages/<page_id>/images/<ASC 로케일>/<NN>_<장면>.png (1320×2868 / 알파 없음)
+
+기하는 `compose-appstore-screenshots.py` 와 같은 값을 쓴다 — 기본 스토어 페이지와 네 CPP 가
+한 앱으로 보여야 한다 (명세 §4-1).
+
+**인앱 이벤트와 달리 캡션을 이미지 안에 넣는다** — 스토어 스샷은 그게 표준이다 (명세 §4 서두).
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import cpp_scenes  # noqa: E402
+from device_bezel import load_bezel, screen_hole  # noqa: E402
+
+ROOT = Path(__file__).resolve().parent.parent
+# 회귀 테스트가 실제 원고를 안 건드리게 덮어쓸 수 있어야 한다 (asc-in-app-event.rb 의 ASC_SECRET_FILE 과 같은 처리)
+CONFIG_ROOT = Path(os.environ.get("CPP_CONFIG_ROOT") or (ROOT / "fastlane" / "custom_product_pages"))
+
+UPLOAD_SIZE = (1320, 2868)
+CANVAS_COLOR = "#F5F5F7"
+DEVICE_WIDTH = 1150
+DEVICE_TOP = 620
+CAPTION_TOP = 100
+SCENES_PER_PAGE = 6
+
+ALL_LANGS = [
+    "en", "ko", "ja", "zh-Hans", "zh-Hant", "vi", "th", "es", "fr", "it", "pt-BR",
+    "ca", "de", "nl", "sv", "da", "nb", "fi", "pl", "cs", "sk", "hu", "ru", "uk",
+    "ro", "el", "hr", "tr", "id", "ms", "hi",
+]
+
+# lproj ↔ ASC 로케일이 다른 6개 (fastlane/metadata/README.md 매핑표와 같은 값)
+ASC_LOCALES = {
+    "en": "en-US", "de": "de-DE", "es": "es-ES",
+    "fr": "fr-FR", "nl": "nl-NL", "nb": "no",
+}
+
+
+def asc_locale(lang):
+    return ASC_LOCALES.get(lang, lang)
+
+
+def load_pages():
+    path = CONFIG_ROOT / "pages.json"
+    if not path.exists():
+        raise SystemExit(f"✗ {path.relative_to(ROOT)} 가 없다 — 페이지 구성을 먼저 만들어라")
+    pages = json.loads(path.read_text())
+    for page_id, config in pages.items():
+        scenes = config.get("scenes") or []
+        if len(scenes) != SCENES_PER_PAGE:
+            raise SystemExit(
+                f"✗ {page_id} 의 장면이 {len(scenes)}개다 — {SCENES_PER_PAGE}개여야 한다"
+            )
+    return pages
+
+
+def upload_name(order, scene_id):
+    return f"{order + 1:02d}_{scene_id}.png"
+
+
+def compose_scene(scene_id, source_dir, caption, bezel, hole_mask, hole_box):
+    hole_size = (hole_box[2] - hole_box[0], hole_box[3] - hole_box[1])
+    screen = cpp_scenes.scene(scene_id, source_dir, hole_size)
+
+    device = Image.new("RGBA", bezel.size, (0, 0, 0, 0))
+    device.paste(screen, (hole_box[0], hole_box[1]), hole_mask.crop(hole_box))
+    device.paste(bezel, (0, 0), bezel)
+
+    device_height = round(DEVICE_WIDTH * bezel.height / bezel.width)
+    device = device.resize((DEVICE_WIDTH, device_height), Image.LANCZOS)
+
+    canvas = Image.new("RGB", UPLOAD_SIZE, CANVAS_COLOR)
+    canvas.paste(caption.convert("RGB"), ((UPLOAD_SIZE[0] - caption.width) // 2, CAPTION_TOP))
+    canvas.paste(device, ((UPLOAD_SIZE[0] - DEVICE_WIDTH) // 2, DEVICE_TOP), device)
+    return canvas
+
+
+def caption_image(scene_id, source_dir):
+    path = source_dir / "captions" / "cpp" / f"{scene_id}.png"
+    if not path.exists():
+        raise SystemExit(
+            f"✗ 누락: {path.relative_to(ROOT)} — "
+            "captions.json 에 그 언어 원고를 넣고 다시 촬영해라"
+        )
+    return Image.open(path)
+
+
+def compose_lang(lang, pages, bezel, hole_mask, hole_box):
+    source_dir = ROOT / "snapshot-appstore" / lang
+    # 한 장면이 여러 페이지에 다른 번호로 들어간다 — 로케일당 한 번만 합성한다
+    needed = sorted({scene for config in pages.values() for scene in config["scenes"]})
+    composed = {}
+    for scene_id in needed:
+        with caption_image(scene_id, source_dir) as caption:
+            composed[scene_id] = compose_scene(
+                scene_id, source_dir, caption, bezel, hole_mask, hole_box
+            )
+
+    out_dirs = []
+    for page_id, config in pages.items():
+        out = CONFIG_ROOT / page_id / "images" / asc_locale(lang)
+        out.mkdir(parents=True, exist_ok=True)
+        # 라인업이 바뀌면 지난 회차 산출물이 남고, 업로드는 디렉토리째 읽는다
+        for stale in out.glob("*.png"):
+            stale.unlink()
+        for order, scene_id in enumerate(config["scenes"]):
+            composed[scene_id].save(out / upload_name(order, scene_id))
+        out_dirs.append(out)
+
+    print(f"  ✓ [{lang}] 장면 {len(composed)}종 → {len(pages)}페이지 × {SCENES_PER_PAGE}장")
+    return out_dirs
+
+
+def verify(out_dirs, pages):
+    """지침 §7 중 기계가 볼 수 있는 항목 — 해상도·알파·장수·라인업 순서."""
+    failures = []
+    for out in out_dirs:
+        page_id = out.parent.parent.name
+        expected = [
+            upload_name(order, scene_id)
+            for order, scene_id in enumerate(pages[page_id]["scenes"])
+        ]
+        actual = sorted(path.name for path in out.glob("*.png"))
+        if actual != sorted(expected):
+            failures.append(f"{out.relative_to(ROOT)}: 라인업이 다르다 — {actual}")
+            continue
+        for name in expected:
+            with Image.open(out / name) as image:
+                if image.size != UPLOAD_SIZE:
+                    failures.append(f"{out.relative_to(ROOT)}/{name}: {image.size} — 규격 아님")
+                if image.mode != "RGB" or "transparency" in image.info:
+                    failures.append(f"{out.relative_to(ROOT)}/{name}: 알파가 남았다")
+    if failures:
+        print("\n".join(f"  ✗ {message}" for message in failures), file=sys.stderr)
+        raise SystemExit(1)
+    print(f"✓ {len(out_dirs)}개 페이지·로케일 × {SCENES_PER_PAGE}장 — 해상도·알파·라인업 순서 확인됨")
+    print("  기계가 못 보는 항목은 스킬 체크리스트로: 캡션 오탈자 / 언어 혼용 없음 / 더미에 실명 없음 / MCP·타사 UI 없음")
+
+
+def main(argv):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--locale")
+    parser.add_argument("--all-locales", action="store_true")
+    parser.add_argument("--page")
+    args = parser.parse_args(argv)
+
+    if args.all_locales:
+        langs = ALL_LANGS
+    elif args.locale:
+        langs = [args.locale]
+    else:
+        raise SystemExit("✗ --locale <lang> 또는 --all-locales 중 하나가 필요하다")
+
+    pages = load_pages()
+    if args.page:
+        if args.page not in pages:
+            raise SystemExit(f"✗ 모르는 페이지: {args.page} — 아는 것은 {', '.join(pages)}")
+        pages = {args.page: pages[args.page]}
+
+    bezel = load_bezel()
+    hole_mask, hole_box = screen_hole(bezel)
+
+    out_dirs = [
+        out for lang in langs
+        for out in compose_lang(lang, pages, bezel, hole_mask, hole_box)
+    ]
+    verify(out_dirs, pages)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/scripts/compose-cpp-screenshots.test.sh
+++ b/scripts/compose-cpp-screenshots.test.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# compose-cpp-screenshots.py 합성 규칙 회귀.
+# 명세의 하드 제약(정확한 해상도·알파 없음·페이지당 6장·§3 배치 순서)이 코드로 지켜지는지 본다.
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT" || exit 1
+PASS=0; FAIL=0
+
+LANG_ID="_cpp_test"
+SOURCE_DIR="snapshot-appstore/$LANG_ID"
+# CONFIG_ROOT 는 ROOT 안이어야 한다 — 스크립트가 에러 문구에 상대 경로를 쓴다
+CONFIG_DIR="snapshot-appstore/_cpp_test_config"
+export CPP_CONFIG_ROOT="$ROOT/$CONFIG_DIR"
+trap 'rm -rf "$ROOT/$SOURCE_DIR" "$ROOT/$CONFIG_DIR"' EXIT
+
+assert() { # desc actual_exit
+  if [ "$2" -eq 0 ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); echo "FAIL: $1"; fi
+}
+
+rm -rf "$SOURCE_DIR" "$CONFIG_DIR"
+mkdir -p "$CONFIG_DIR"
+
+cat > "$CONFIG_DIR/pages.json" <<'JSON'
+{
+  "page-a": { "ascPageId": "", "scenes": ["C1", "C2", "C3", "C4", "C5", "C6"] },
+  "page-b": { "ascPageId": "", "scenes": ["C3", "C1", "C2", "C6", "C5", "C4"] }
+}
+JSON
+
+# 촬영 산출물 대역 — 규격만 같으면 기하 검증엔 충분하다.
+# 단색 한 장으로는 안 된다: 위젯 여백 제거와 시트 상단 탐지가 배경 아닌 픽셀을 찾는다
+python3 - "$SOURCE_DIR" <<'PY'
+import sys
+from pathlib import Path
+from PIL import Image, ImageDraw
+
+root = Path(sys.argv[1])
+(root / "widgets").mkdir(parents=True, exist_ok=True)
+(root / "sheets").mkdir(parents=True, exist_ok=True)
+(root / "captions" / "cpp").mkdir(parents=True, exist_ok=True)
+
+
+def block(size, background, box, fill):
+    image = Image.new("RGB", size, background)
+    ImageDraw.Draw(image).rectangle(box, fill=fill)
+    return image
+
+
+for slug in ["01-calendar", "02-repeat-options", "07-todo-list", "08-share-preview"]:
+    block((1320, 2868), (245, 245, 247), (80, 200, 1240, 2400), (30, 90, 200)).save(root / f"{slug}.png")
+
+widgets = [
+    "today-and-next", "month",
+    "lockscreen-foremost", "lockscreen-next", "lockscreen-next-remain", "lockscreen-live-activity",
+]
+for name in widgets:
+    block((480, 480), (0, 0, 0), (40, 40, 440, 440), (210, 210, 220)).save(root / "widgets" / f"{name}.png")
+
+for name in ["ai-command-processing", "ai-command-done"]:
+    block((1320, 900), (255, 255, 255), (120, 300, 1200, 800), (60, 60, 90)).save(root / "sheets" / f"{name}.png")
+
+for index in range(1, 9):
+    block((1320, 420), (245, 245, 247), (200, 150, 1120, 270), (29, 29, 31)).save(
+        root / "captions" / "cpp" / f"C{index}.png"
+    )
+print("stand-in ok")
+PY
+
+python3 scripts/compose-cpp-screenshots.py --locale "$LANG_ID" > /tmp/cpp-compose-test.log 2>&1
+assert "합성이 성공한다" $?
+
+python3 - "$CONFIG_DIR" <<'PY'
+import sys
+from pathlib import Path
+from PIL import Image
+
+config = Path(sys.argv[1])
+failures = []
+
+expected = {
+    "page-a": ["01_C1.png", "02_C2.png", "03_C3.png", "04_C4.png", "05_C5.png", "06_C6.png"],
+    "page-b": ["01_C3.png", "02_C1.png", "03_C2.png", "04_C6.png", "05_C5.png", "06_C4.png"],
+}
+for page, names in expected.items():
+    out = config / page / "images" / "_cpp_test"
+    actual = sorted(path.name for path in out.glob("*.png"))
+    if actual != names:
+        failures.append(f"{page}: 라인업 {actual}")
+
+for page in expected:
+    for path in (config / page / "images" / "_cpp_test").glob("*.png"):
+        with Image.open(path) as image:
+            if image.size != (1320, 2868):
+                failures.append(f"{path.name}: {image.size}")
+            if image.mode != "RGB":
+                failures.append(f"{path.name}: mode={image.mode}")
+
+# 같은 장면은 페이지가 달라도 같은 이미지여야 한다 — 번호만 바뀐다
+a_c3 = (config / "page-a" / "images" / "_cpp_test" / "03_C3.png").read_bytes()
+b_c3 = (config / "page-b" / "images" / "_cpp_test" / "01_C3.png").read_bytes()
+if a_c3 != b_c3:
+    failures.append("C3 이 페이지마다 다르게 합성됐다")
+
+if failures:
+    print("\n".join(failures))
+    sys.exit(1)
+PY
+assert "해상도·알파·라인업 순서·장면 재사용이 명세대로다" $?
+
+python3 scripts/compose-cpp-screenshots.py --locale "$LANG_ID" --page page-a > /dev/null 2>&1
+test -f "$CONFIG_DIR/page-a/images/_cpp_test/01_C1.png"
+assert "--page 로 지정한 페이지를 만든다" $?
+
+python3 scripts/compose-cpp-screenshots.py --locale "$LANG_ID" --page no-such-page > /dev/null 2>&1
+test $? -ne 0
+assert "모르는 페이지는 끊는다" $?
+
+python3 scripts/compose-cpp-screenshots.py > /dev/null 2>&1
+test $? -ne 0
+assert "로케일 인자가 없으면 끊는다" $?
+
+cat > "$CONFIG_DIR/pages.json" <<'JSON'
+{ "page-a": { "ascPageId": "", "scenes": ["C1", "C2", "C3", "C4", "C5", "CX"] } }
+JSON
+python3 scripts/compose-cpp-screenshots.py --locale "$LANG_ID" > /dev/null 2>&1
+test $? -ne 0
+assert "모르는 장면은 끊는다" $?
+
+cat > "$CONFIG_DIR/pages.json" <<'JSON'
+{ "page-a": { "ascPageId": "", "scenes": ["C1", "C2", "C3", "C4", "C5"] } }
+JSON
+python3 scripts/compose-cpp-screenshots.py --locale "$LANG_ID" > /dev/null 2>&1
+test $? -ne 0
+assert "페이지당 6장이 아니면 끊는다" $?
+
+cat > "$CONFIG_DIR/pages.json" <<'JSON'
+{ "page-a": { "ascPageId": "", "scenes": ["C1", "C2", "C3", "C4", "C5", "C6"] } }
+JSON
+rm -f "$SOURCE_DIR/captions/cpp/C1.png"
+python3 scripts/compose-cpp-screenshots.py --locale "$LANG_ID" > /dev/null 2>&1
+test $? -ne 0
+assert "캡션이 없으면 끊는다" $?
+
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/cpp_scenes.py
+++ b/scripts/cpp_scenes.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""맞춤형 제품 페이지(CPP) 장면 C1~C8 을 목업 구멍 크기의 화면 한 장으로 만든다.
+
+명세의 장면 목록은 유저 문서 `CPP지침-맞춤형-제품-페이지-3종-명세.md` §2 가 정본이다.
+입력은 전부 `scripts/capture-appstore-screenshots.sh` 가 언어별로 남긴 촬영 산출물이고,
+조립이 필요한 장면(잠금화면·홈화면·AI 시트)은 각 전용 모듈이 맡는다.
+"""
+
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import ai_sheet  # noqa: E402
+import lock_screen  # noqa: E402
+import store_screen  # noqa: E402
+
+ROOT = Path(__file__).resolve().parent.parent
+
+CALENDAR_SCREEN = "01-calendar"
+# lock_screen.compose 의 인자 순서 — 인라인·다음 일정·남은 시간·라이브 액티비티
+LOCK_SCREEN_WIDGETS = [
+    "lockscreen-foremost", "lockscreen-next", "lockscreen-next-remain", "lockscreen-live-activity"
+]
+
+
+def opened(path):
+    if not path.exists():
+        raise SystemExit(
+            f"✗ 누락: {path.relative_to(ROOT)} — "
+            "scripts/capture-appstore-screenshots.sh 로 그 언어를 먼저 촬영해라"
+        )
+    return Image.open(path)
+
+
+def lock_screen_scene(source_dir, size):
+    pieces = [opened(source_dir / "widgets" / f"{name}.png") for name in LOCK_SCREEN_WIDGETS]
+    return lock_screen.compose(*pieces)
+
+
+def home_screen_scene(source_dir, size):
+    return store_screen.home_screen(source_dir, size)
+
+
+def app_screen_scene(slug, top_inset=True):
+    """`top_inset` 은 상단 safe area 자리를 여기서 만들지 여부다.
+
+    인셋은 화면을 아래로 밀고 넘치는 만큼을 버리므로, 하단에 고정 UI 가 있는 화면은 꺼야 한다 —
+    그런 화면은 촬영 케이스가 safe area 를 이미 포함해 찍는다.
+    """
+    def build(source_dir, size):
+        with opened(source_dir / f"{slug}.png") as screenshot:
+            if not top_inset:
+                return screenshot.convert("RGB")
+            return store_screen.inset_screenshot(screenshot.convert("RGBA"), size)
+    return build
+
+
+def ai_sheet_scene(sheet_name):
+    """캘린더 위에 시트가 떠 있는 화면 — 배경도 상단 인셋을 거쳐야 헤더가 화면 끝에 안 붙는다."""
+    def build(source_dir, size):
+        background = app_screen_scene(CALENDAR_SCREEN)(source_dir, size)
+        with opened(source_dir / "sheets" / f"{sheet_name}.png") as sheet:
+            return ai_sheet.compose(background, sheet, screen_size=size)
+    return build
+
+
+SCENES = {
+    "C1": lock_screen_scene,
+    "C2": home_screen_scene,
+    "C3": app_screen_scene("01-calendar"),
+    "C4": app_screen_scene("07-todo-list"),
+    "C5": app_screen_scene("03-event-detail"),
+    # 공유 화면은 하단에 공유하기 버튼이 고정돼 있다 — 촬영이 safe area 를 이미 포함한다
+    "C6": app_screen_scene("08-share-preview", top_inset=False),
+    "C7": ai_sheet_scene("ai-command-processing"),
+    "C8": ai_sheet_scene("ai-command-done"),
+}
+
+
+def scene(scene_id, source_dir, size):
+    """`size` 는 베젤 화면 구멍 크기다 — 반환값이 그와 다르면 목업에 안 맞는다."""
+    build = SCENES.get(scene_id)
+    if build is None:
+        raise SystemExit(f"✗ 모르는 장면: {scene_id} — 아는 것은 {', '.join(sorted(SCENES))}")
+    composed = build(source_dir, size).convert("RGB")
+    return composed if composed.size == size else composed.resize(size, Image.LANCZOS)

--- a/scripts/store_screen.py
+++ b/scripts/store_screen.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""App Store 규격 화면 조립 — 촬영 원본에 상단 인셋을 두거나, 위젯을 홈화면으로 얹는다.
+
+목업 구멍에 그대로 들어갈 크기의 화면 한 장을 만드는 것이 이 모듈의 전부다.
+기본 스토어 페이지(`compose-appstore-screenshots.py`)와 맞춤형 제품 페이지(`cpp_scenes.py`)가
+같은 화면을 써야 두 라인업의 톤이 갈리지 않는다.
+
+잠금화면판은 `lock_screen.py`, 시트 오버레이는 `ai_sheet.py` 가 같은 자리를 맡는다.
+"""
+
+from collections import Counter
+from pathlib import Path
+
+from PIL import Image, ImageChops, ImageDraw, ImageFilter
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# iPhone 16 Pro Max 상단 safe area 62pt @3x — 콘텐츠가 Dynamic Island 밑에 깔리지 않게 한다
+SCREEN_TOP_INSET = 186
+
+HOME_SCREEN_WIDGETS = ["today-and-next", "month"]
+# 라이트 테마 위젯이 떠 보이는 배경 — 홈화면 벽지 자리라 앱 컬러셋과 무관하다
+WALLPAPER_TOP_COLOR = (58, 74, 128)
+WALLPAPER_BOTTOM_COLOR = (146, 122, 168)
+WIDGET_RADIUS = 78                  # 위젯 코너 26pt @3x — 캡처에 구워진 곡률과 같은 값
+WIDGET_TOP = 430
+WIDGET_GAP = 90
+WIDGET_SHADOW_BLUR = 34
+WIDGET_SHADOW_OFFSET = 14
+WIDGET_SHADOW_ALPHA = 90
+
+
+def inset_screenshot(screenshot, size, top_inset=SCREEN_TOP_INSET):
+    """상단에 화면 배경색 인셋을 둔 뒤 구멍 크기에 맞춰 자른다."""
+    top_row = [screenshot.getpixel((x, 0)) for x in range(screenshot.width)]
+    background = Counter(top_row).most_common(1)[0][0]
+    inset = Image.new("RGBA", size, background)
+    inset.paste(screenshot, (0, top_inset))
+    return inset
+
+
+def wallpaper(size):
+    width, height = size
+    column = Image.new("RGB", (1, height))
+    painter = ImageDraw.Draw(column)
+    for y in range(height):
+        ratio = y / (height - 1)
+        painter.point((0, y), tuple(
+            round(top + (bottom - top) * ratio)
+            for top, bottom in zip(WALLPAPER_TOP_COLOR, WALLPAPER_BOTTOM_COLOR)
+        ))
+    return column.resize((width, height), Image.BILINEAR).convert("RGBA")
+
+
+def trim_widget_margin(capture):
+    """위젯 캡처엔 위젯 바깥 여백이 함께 들어 있다 — 그대로 얹으면 카드 테두리가 이중으로 보인다."""
+    opaque = capture.convert("RGB")
+    background = Image.new("RGB", opaque.size, opaque.getpixel((0, 0)))
+    difference = ImageChops.difference(opaque, background).convert("L")
+    box = difference.point(lambda value: 255 if value > 6 else 0).getbbox()
+    if box is None:
+        raise SystemExit("✗ 위젯 캡처가 배경색 한 장이다 — 잘라낼 내용이 없다")
+    return capture.crop(box)
+
+
+def rounded(widget, radius):
+    mask = Image.new("L", widget.size, 0)
+    ImageDraw.Draw(mask).rounded_rectangle(
+        [0, 0, widget.width - 1, widget.height - 1], radius=radius, fill=255
+    )
+    shaped = widget.convert("RGBA")
+    shaped.putalpha(mask)
+    return shaped
+
+
+def paste_with_shadow(screen, widget, position):
+    shadow = Image.new("RGBA", screen.size, (0, 0, 0, 0))
+    cast = Image.new("RGBA", widget.size, (0, 0, 0, WIDGET_SHADOW_ALPHA))
+    cast.putalpha(widget.getchannel("A").point(lambda alpha: alpha * WIDGET_SHADOW_ALPHA // 255))
+    shadow.paste(cast, (position[0], position[1] + WIDGET_SHADOW_OFFSET), cast)
+    screen.alpha_composite(shadow.filter(ImageFilter.GaussianBlur(WIDGET_SHADOW_BLUR)))
+    screen.alpha_composite(widget, position)
+
+
+def home_screen(source_dir, size, widget_names=None):
+    widgets = []
+    for name in widget_names or HOME_SCREEN_WIDGETS:
+        path = source_dir / "widgets" / f"{name}.png"
+        if not path.exists():
+            raise SystemExit(f"  ✗ 누락: {path.relative_to(ROOT)} — 먼저 촬영 스크립트를 돌려라")
+        with Image.open(path) as capture:
+            widgets.append(rounded(trim_widget_margin(capture), WIDGET_RADIUS))
+
+    screen = wallpaper(size)
+    top = WIDGET_TOP
+    for widget in widgets:
+        paste_with_shadow(screen, widget, ((size[0] - widget.width) // 2, top))
+        top += widget.height + WIDGET_GAP
+    return screen


### PR DESCRIPTION
Apple Ads 키워드별 랜딩과 커뮤니티 링크 랜딩에 쓸 맞춤형 제품 페이지 4종(`cpp-widget`·`cpp-todo`·`cpp-calendar`·`cpp-ai`)을 31개 로케일로 만들어 App Store Connect 에 올렸다. 절차는 다시 돌릴 수 있게 스킬로 남긴다.

## 문제

`deliver` 는 맞춤형 제품 페이지를 모른다. 로케일이 31개고 페이지마다 스크린샷 6장이 붙어 손으로는 감당이 안 된다 — 이미지만 4 × 6 × 31 = 744장이다.

## 접근

**기존 스토어 스샷 파이프라인을 그대로 태운다.** 같은 장면 8종(C1~C8)을 순서만 바꿔 페이지마다 6장씩 재사용하므로, 로케일당 장면을 한 번씩만 합성하고 페이지별로 재배열한다. 촬영도 기본 스토어 페이지와 한 실행에 함께 뜬다 — 31개 언어를 두 번 돌리지 않는다.

- **공용 모듈 분리** — 상단 safe area 인셋과 홈화면 위젯 배치를 `store_screen` 으로, 베젤 확보를 `device_bezel` 하나로 모았다. 맞춤형 제품 페이지가 세 번째 소비자라 중복을 여기서 없앴고, 기본 스토어 페이지 산출물이 변경 전과 바이트 동일한 것을 확인했다.
- **없던 장면 신설** — 할일 목록·일정 공유·AI 명령 처리중/완료를 카탈로그 케이스로 만들었다. 앱에 전용 할일 목록 화면이 없어 달력을 걷어낸 일별 목록으로 재현했고, AI 입력은 빈 입력창 대신 명령이 그대로 보이는 처리 중 상태를 쓴다.
- **원고는 데이터로** — 캡션·프로모션 문구를 설정 파일로 분리해 로케일 추가가 코드 수정 없이 돈다. 캡션은 기존 스토어 캡션과 같은 렌더러를 타 서체·크기가 8장 전체에서 통일된다.
- **업로드는 spaceship raw 클라이언트로** — 페이지 생성부터 문구·스크린샷까지 덮는다. 올린 뒤 재조회로 대조하고, 이미지는 `assetDeliveryState` 가 `COMPLETE` 가 될 때까지 기다린다.

## 함께 고친 것

`catalog.place::startup_hub` 가 27개 언어에서 영어로 남아 그 언어 스샷에 라틴 문자가 섞였고, 서울창업허브는 실존 기관이라 스토어 이미지 지침의 실명 금지에도 걸렸다. 키를 `catalog.place::meeting_room` 으로 바꾸고 31개 언어를 가상 장소로 채웠다 — 기본 스토어 페이지의 이벤트 상세 스샷도 같이 해소된다.

## 남은 과제

공유 화면의 세그먼트 컨트롤이 스냅샷에서 선택 배경을 안 그린다. 실기기에서는 정상이고 커밋된 검증 스냅샷도 원래 같은 상태다 — 고치려면 스냅샷 타겟에 호스트 앱을 붙여야 하고 그럼 커밋된 검증 스냅샷이 전부 재기록되므로 #1032 로 분리했다.

## 유저 검증 대기

- **CPP 링크가 App Store 앱에서 실제로 열리는지** — 실기기·실계정이 필요하고 심사 통과 후에만 확인된다
- **Apple Ads 키워드 그룹과 페이지 연결** — ASC·Ads 콘솔 작업
- **심사 제출** — 콘솔에서 직접
