### PR TITLE
[#918] 브랜치·빌드번호로 TestFlight 배포를 돌리는 레인과 스킬

### DIFF
--- a/.claude/skills/test-deploy/SKILL.md
+++ b/.claude/skills/test-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-deploy
-description: Use when the user wants a test build distributed to Firebase App Distribution — 개발 완료·핫픽스 검증 시점에 특정 브랜치를 테스터에게 내보내는 절차. 피처플래그를 켠 빌드도 배포 브랜치를 따서 내보낸다. Triggers on "테스트 배포 돌려", "이 브랜치 배포해서 확인해볼게", "ddayWidget 켜서 배포해줘". Does NOT trigger on TestFlight·앱스토어 제출(#918 후속 레인 소관), 테스트 실행(run-tests 스킬), PR 생성(pr 스킬), 코드 수정(implement 스킬) — 이 스킬의 FeatureFlag.swift 편집은 사전 규정된 리터럴 치환이라 별도 발동 대상이 아니다.
+description: Use when the user wants a test build distributed to Firebase App Distribution — 개발 완료·핫픽스 검증 시점에 특정 브랜치를 테스터에게 내보내는 절차. 피처플래그를 켠 빌드도 배포 브랜치를 따서 내보낸다. Triggers on "테스트 배포 돌려", "이 브랜치 배포해서 확인해볼게", "ddayWidget 켜서 배포해줘". Does NOT trigger on TestFlight 업로드(testflight-deploy 스킬)·앱스토어 심사 제출, 테스트 실행(run-tests 스킬), PR 생성(pr 스킬), 코드 수정(implement 스킬) — 이 스킬의 FeatureFlag.swift 편집은 사전 규정된 리터럴 치환이라 별도 발동 대상이 아니다.
 argument-hint: "[flags]"
 ---
 

--- a/.claude/skills/testflight-deploy/SKILL.md
+++ b/.claude/skills/testflight-deploy/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: testflight-deploy
+description: Use when the user wants a build uploaded to TestFlight — 핫픽스·릴리즈 후보를 App Store 서명으로 빌드해 ASC 에 올리는 절차. dSYM 을 Firebase Crashlytics 에 함께 올린다. Triggers on "테플 올려", "TestFlight 배포해줘", "이 브랜치 테플로 빌드해". Does NOT trigger on Firebase App Distribution 테스트 배포(test-deploy 스킬), 심사 제출·릴리즈 발행(#918 후속 단계), 버전업(수동), 테스트 실행(run-tests 스킬).
+argument-hint: "<브랜치명> <빌드번호>"
+---
+
+# TestFlight Deploy — TodoCalendar
+
+Fastlane 레인 `ios testflight_deploy`로 App Store 서명 빌드를 만들어 App Store Connect TestFlight 에 올린다. dSYM 은 Firebase Crashlytics 에 함께 올린다. 인자 없이 도는 GitHub Actions dispatch 는 없고, 로컬에서 브랜치·빌드번호를 받아 직접 실행한다.
+
+## 사전 조건
+
+1. 환경변수 3종 `ASC_KEY_ID` / `ASC_ISSUER_ID` / `ASC_KEY_CONTENT` — 없으면 `required_env`가 레인을 세운다.
+   값은 볼트 `~/Documents/sudo/secrets/TodoCalendar/asc.env`에 있다 (발급 절차는 `secret/README.md`). 레인은 비대화형 셸에서 도는데 `~/.zshrc`는 대화형에서만 읽히므로 5단계가 이 파일을 직접 `source` 한다 — `zsh -ic`로 값을 확인해도 레인에 들어간다는 근거가 아니다.
+   ```bash
+   test -f ~/Documents/sudo/secrets/TodoCalendar/asc.env
+   ```
+2. `match AppStore` 프로파일 4종이 로컬에 설치돼 있을 것 — `com.sudo.park.TodoCalendarApp` + `.Widget` + `.IntentExtensions` + `.Share`. 확인 명령:
+   ```bash
+   for f in ~/Library/MobileDevice/Provisioning\ Profiles/*.mobileprovision; do
+     security cms -D -i "$f" 2>/dev/null | plutil -extract Name raw -
+   done | grep "match AppStore com.sudo.park.TodoCalendarApp"
+   ```
+3. 러너 볼트 `/Users/sudo.park/Desktop/actions/secrets/TodoCalendar`에 실 config 3종이 있을 것 — `install/install.sh`가 깔아두는 건 더미라 그대로 빌드하면 잘못된 API 호스트·Firebase 프로젝트로 나간다.
+4. 빌드번호는 사람이 정한다 — 같은 `CFBundleShortVersionString` 안에서 이미 ASC 에 올라간 값과 겹치면 업로드가 거부된다. App Store Connect > TestFlight 에서 마지막 빌드번호를 확인하고 +1 한다.
+
+## 절차
+
+각 명령 블록은 자족적으로 쓴다 — Bash 도구는 작업 디렉토리만 유지하고 셸 변수는 블록이 끝나면 사라진다.
+
+1. **인자 검증** — 브랜치명·빌드번호 둘 다 있어야 한다. 빌드번호가 정수가 아니면 중단한다. 하나라도 없으면 배포하지 않고 무엇이 빠졌는지 보고한다.
+
+2. **미커밋 변경 가드**
+   ```bash
+   git status --porcelain
+   ```
+   출력이 있으면 중단한다. 브랜치를 갈아타면 미커밋 변경이 대상 브랜치로 따라간다. config 3종은 `.gitignore` 대상이라 이 가드에 안 걸린다.
+
+3. **원래 브랜치 기억 + 대상 브랜치 체크아웃**
+   ```bash
+   git rev-parse --abbrev-ref HEAD   # 출력값을 6단계 복귀에 쓴다
+   git fetch origin
+   git checkout <브랜치명>
+   ```
+
+4. **실 config 배치**
+   ```bash
+   SECRETS_DIR=/Users/sudo.park/Desktop/actions/secrets/TodoCalendar
+   test -d "$SECRETS_DIR"
+   cp "$SECRETS_DIR/InfoPlist_Secrets.swift" Tuist/ProjectDescriptionHelpers/InfoPlist_Secrets.swift
+   cp "$SECRETS_DIR/GoogleService-Info.plist" TodoCalendarApp/Resources/GoogleService-Info.plist
+   cp "$SECRETS_DIR/secrets.json" TodoCalendarApp/Resources/secrets.json
+   ```
+
+5. **프로젝트 생성 + 빌드번호 스탬프 + 레인 실행** — 스탬프는 `tuist generate` 뒤에 와야 한다. generate 가 Derived InfoPlist 를 `Project+AppVersion.swift` 값으로 다시 쓰기 때문이다.
+   ```bash
+   export PATH="/opt/homebrew/opt/ruby/bin:$PATH"
+   source "$HOME/Documents/sudo/secrets/TodoCalendar/asc.env"
+   mise exec -- tuist install
+   mise exec -- tuist generate --no-open
+   for target in TodoCalendarApp TodoCalendarAppWidget TodoCalendarAppIntentExtensions TodoCalendarAppShare; do
+     plutil -replace CFBundleVersion -string "<빌드번호>" \
+       "TodoCalendarApp/Derived/InfoPlists/${target}-Info.plist"
+   done
+   bundle exec fastlane ios testflight_deploy
+   ```
+
+6. **원래 브랜치로 복귀** — 성공·실패 무관하게 돌아온다.
+   ```bash
+   git checkout <3단계에서 기억한 브랜치>
+   ```
+
+## 결과 보고 형식
+
+성공: 버전(`Project+AppVersion.swift`의 `appVersion`)·빌드번호·브랜치·커밋 short SHA + ASC TestFlight 링크 `https://appstoreconnect.apple.com/apps` + "ASC 처리에 10~30분 걸리고, 처리가 끝나면 내부 테스터에게 자동으로 간다."
+
+실패: 실패한 단계(빌드 / 업로드 / 심볼) + fastlane 상위 에러. 업로드는 성공했는데 심볼만 실패한 경우는 구분해서 보고한다 — 빌드는 이미 ASC 에 올라갔으므로 같은 빌드번호로 재실행하면 업로드에서 거부된다.
+
+## 한계
+
+- 버전(`CFBundleShortVersionString`)은 브랜치 값 그대로다. 버전업이 필요하면 `Project+AppVersion.swift`를 먼저 고쳐 커밋하고 그 브랜치로 돌린다.
+- 심사 제출·외부 테스터 그룹 배포는 이 스킬 밖이다 (ASC 콘솔에서 직접).
+- CI 가 없어 로컬 체크아웃을 갈아탄다 — 다른 세션이 같은 워크트리를 쓰고 있으면 충돌한다.
+
+## 종료 기록 — skill_end
+
+배포 결과(성공: 버전·빌드번호·브랜치·커밋 SHA / 실패: 실패 단계·상위 에러)를 보고한 직후 기록한다 (명령·compliance 규칙은 CLAUDE.md §1). 실패 보고도 절차 완료다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ tuist generate --no-open      # 파일 추가/삭제 후 재실행 필수
 | 파일·프레임워크 추가 | add-file / add-framework 스킬 |
 | 테스트 실행 | run-tests 스킬 (스킴 목록 정본) |
 | 테스트 빌드 배포 | test-deploy 스킬 (Firebase App Distribution) |
+| TestFlight 업로드 | testflight-deploy 스킬 (App Store 서명 + dSYM Crashlytics 업로드) |
 | 새 버전 출시 변경내용 작성 | release-notes 스킬 (한글 초안 → 31개 로케일 → ASC 업로드) |
 | 앱 내 이벤트 현지화·이미지·업로드 | in-app-event 스킬 (한글 원고 → 31개 로케일 → 촬영·합성 → ASC 업로드) |
 | 맞춤형 제품 페이지 제작·업로드 | custom-product-page 스킬 (한글 원고 → 31개 로케일 → 촬영·합성 → ASC 업로드) |

--- a/docs/troubleshooting/2026-09-03-google-token-expiry-recurs-on-pre-fix-build.md
+++ b/docs/troubleshooting/2026-09-03-google-token-expiry-recurs-on-pre-fix-build.md
@@ -1,0 +1,24 @@
+---
+issue: "#1016"
+subdomain: ExternalCalendar
+symptoms: [구글 캘린더 연동 만료, 401 Invalid Credentials, 토큰 갱신 타임아웃, 백그라운드 진입 후 만료 다이얼로그, 재현 빌드가 수정 이전]
+resolution: non-issue
+---
+
+# 구글 캘린더 만료 알림이 다시 떴는데, 재현 빌드가 수정 이전 버전이었다
+
+- **증상**: 401 로 토큰 갱신이 돌고 갱신은 성공했는데 연동 만료 알림이 떴다. #1016 이 같은 증상으로 이미 수정된 뒤라 회귀로 의심됐다.
+- **근본 원인**: 결함이 아니라 빌드 시점 문제. 재현 빌드는 Firebase 테스트 배포 `2.9.7(11)` — 빌드번호 11 은 `test_deploy.yml` 워크플로 run number 이고, run #11 은 2026-08-26 커밋 `b83d7c7d` 로 나갔다. #1016 수정 머지는 2026-08-28 이라 두 일 차이로 안 탔다. 해당 커밋의 `GoogleAPIAuthenticator.refresh` catch 는 에러 종류를 안 가리고 `removeCredential()` + `didRefreshFailed` 를 때리고, 판정 기준 `Error+ServerResponse.swift` 는 파일 자체가 없다.
+- **해결**: 수정 없음. 최신 브랜치로 테스트 배포를 다시 떠서 확인한다. 수정은 develop(2026-08-28)·v3.0.0(2026-09-02 태그)에 포함.
+- **기각 방향**: 조회 요청 타임아웃이 만료 처리를 유발한다 — Alamofire `AuthenticationInterceptor.retry` 가 `request.response` 없으면 첫 guard 에서 `.doNotRetry` 라 갱신 자체를 안 태운다. 만료 알림의 유일한 발화점은 `GoogleAPIAuthenticator.refresh` 의 catch 하나다.
+- **기각 방향**: 같은 빌드에서 광고 배너가 안 보이는 것도 결함이다 — `AdExposureUsecaseImple.isBannerAdAllowed` 가 `isStarted && planId == .free` 이고 사용자가 유료 플랜이라 미노출이 정상 동작이다.
+
+## 빌드번호로 배포 시점을 특정하는 법
+
+테스트 배포 빌드번호는 `test_deploy.yml` 의 run number 다 (`Project+AppVersion.swift` 의 `buildNumber` 가 아니다 — 그쪽은 릴리즈 빌드용이라 테스트 배포 번호와 이력이 안 맞는다).
+
+```bash
+gh run list --workflow test_deploy.yml --limit 40 \
+  --json number,createdAt,headBranch,headSha
+git merge-base --is-ancestor <수정커밋> <headSha> && echo 포함 || echo 미포함
+```

--- a/docs/troubleshooting/INDEX.md
+++ b/docs/troubleshooting/INDEX.md
@@ -33,3 +33,4 @@
 - [2026-08-25 CI 가 브랜치와 무관하게 매번 다른 테스트에서 타임아웃으로 깨진다](2026-08-25-ci-wallclock-timeout-flaky.md) — Infra / workaround / CI 반복 실패·Exceeded timeout of·매번 다른 테스트·로컬은 통과
 - [2026-08-26 `Text(timerInterval:)` 을 좁은 행에 넣으면 크래시하거나 자릿수가 `--` 로 빠진다](2026-08-26-live-activity-timer-text-layout-traps.md) — Event / fixed / 라이브액티비티 잠금화면 크래시·LayoutSubview.place·GeometryReaderLayout·카운트다운 1:15:--·fixedSize
 - [2026-08-29 `upload_app_store_metadata` 가 에러 없이 아무것도 안 올린다](2026-08-29-deliver-metadata-upload-silent-noop.md) — Infra / fixed / fastlane deliver 무반응·ASC 로케일 활성화 안 됨·Preview.html 비어 있음·precheck found google·metadata_path 상대경로
+- [2026-09-03 구글 캘린더 만료 알림이 다시 떴는데, 재현 빌드가 수정 이전 버전이었다](2026-09-03-google-token-expiry-recurs-on-pre-fix-build.md) — ExternalCalendar / non-issue / 구글 연동 만료·401 Invalid Credentials·토큰 갱신 타임아웃·재현 빌드가 수정 이전

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,6 +6,15 @@ def required_env(name, hint)
   value
 end
 
+def asc_api_key
+  app_store_connect_api_key(
+    key_id: required_env("ASC_KEY_ID", "App Store Connect > 사용자 및 액세스 > 통합에서 발급한 키 ID"),
+    issuer_id: required_env("ASC_ISSUER_ID", "같은 화면의 Issuer ID"),
+    key_content: required_env("ASC_KEY_CONTENT", "AuthKey_<키ID>.p8 를 base64 로 인코딩한 값 — base64 -i AuthKey_<키ID>.p8"),
+    is_key_content_base64: true
+  )
+end
+
 # fastlane 은 액션을 프로젝트 루트로 chdir 해서 실행하는데 FastlaneFolder.path 는 상대경로("./")를
 # 돌려준다 — 레인 본문에서 절대경로로 굳히지 않으면 가드와 액션이 서로 다른 디렉토리를 본다
 def app_store_metadata_path
@@ -228,6 +237,43 @@ platform :ios do
     )
   end
 
+  desc "App Store 서명 IPA 를 빌드해 TestFlight 에 올리고 dSYM 을 Crashlytics 에 업로드"
+  lane :testflight_deploy do
+    build_app(
+      workspace: "TodoCalendar.xcworkspace",
+      scheme: "TodoCalendarApp",
+      configuration: "Release",
+      export_method: "app-store",
+      export_options: {
+        signingStyle: "manual",
+        signingCertificate: "Apple Distribution",
+        provisioningProfiles: {
+          "com.sudo.park.TodoCalendarApp" => "match AppStore com.sudo.park.TodoCalendarApp",
+          "com.sudo.park.TodoCalendarApp.Widget" => "match AppStore com.sudo.park.TodoCalendarApp.Widget",
+          "com.sudo.park.TodoCalendarApp.IntentExtensions" => "match AppStore com.sudo.park.TodoCalendarApp.IntentExtensions",
+          "com.sudo.park.TodoCalendarApp.Share" => "match AppStore com.sudo.park.TodoCalendarApp.Share"
+        }
+      },
+      output_directory: "build",
+      output_name: "TodoCalendarApp.ipa",
+      clean: false
+    )
+
+    upload_to_testflight(
+      api_key: asc_api_key,
+      ipa: lane_context[SharedValues::IPA_OUTPUT_PATH],
+      # 업로드까지만 한다 — 내부 테스터는 ASC 처리가 끝나면 자동으로 받는다
+      skip_waiting_for_build_processing: true
+    )
+
+    upload_symbols_to_crashlytics(
+      dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH],
+      gsp_path: "TodoCalendarApp/Resources/GoogleService-Info.plist",
+      # Firebase 를 SPM 으로 받아 Pods 경로가 없다. 기본 탐색이 실패하므로 바이너리를 직접 짚는다
+      binary_path: ".build/checkouts/firebase-ios-sdk/Crashlytics/upload-symbols"
+    )
+  end
+
   desc "fastlane/metadata 의 텍스트 메타데이터만 App Store Connect 에 올리고 precheck 로 검사 (바이너리·스크린샷 제외, 심사 제출은 콘솔에서 직접)"
   lane :upload_app_store_metadata do
     metadata_path = app_store_metadata_path
@@ -235,12 +281,7 @@ platform :ios do
     ensure_required_locale_fields!(metadata_path)
     warn_missing_release_notes(metadata_path)
 
-    api_key = app_store_connect_api_key(
-      key_id: required_env("ASC_KEY_ID", "App Store Connect > 사용자 및 액세스 > 통합에서 발급한 키 ID"),
-      issuer_id: required_env("ASC_ISSUER_ID", "같은 화면의 Issuer ID"),
-      key_content: required_env("ASC_KEY_CONTENT", "AuthKey_<키ID>.p8 를 base64 로 인코딩한 값 — base64 -i AuthKey_<키ID>.p8"),
-      is_key_content_base64: true
-    )
+    api_key = asc_api_key
 
     deliver(
       api_key: api_key,
@@ -273,12 +314,7 @@ platform :ios do
     ensure_screenshot_slots_complete!(screenshots_path)
     ensure_screenshots_meet_upload_spec!(screenshots_path)
 
-    api_key = app_store_connect_api_key(
-      key_id: required_env("ASC_KEY_ID", "App Store Connect > 사용자 및 액세스 > 통합에서 발급한 키 ID"),
-      issuer_id: required_env("ASC_ISSUER_ID", "같은 화면의 Issuer ID"),
-      key_content: required_env("ASC_KEY_CONTENT", "AuthKey_<키ID>.p8 를 base64 로 인코딩한 값 — base64 -i AuthKey_<키ID>.p8"),
-      is_key_content_base64: true
-    )
+    api_key = asc_api_key
 
     deliver(
       api_key: api_key,


### PR DESCRIPTION
## 문제

핫픽스 라인에서 TestFlight 업로드가 전부 수동이었다. 더 급한 건 dSYM 쪽인데, Crashlytics 에 심볼을 올리는 자리가 코드베이스 어디에도 없었다 — `FirebaseCrashlytics` 의존만 있고 upload-symbols 를 부르는 스크립트 phase 도 fastlane 레인도 없다. 비트코드가 꺼져 있어 ASC 도 dSYM 을 돌려주지 않으므로, 로컬 아카이브를 잃으면 그 빌드의 크래시는 영영 심볼리케이션이 안 된다.

## 접근

- `Fastfile` 의 `testflight_deploy` — App Store 서명 IPA 를 빌드해 `upload_to_testflight` 로 올리고, 같은 레인이 이어서 `upload_symbols_to_crashlytics` 로 dSYM 을 올린다. 업로드까지만 하고 ASC 처리 완료는 기다리지 않는다. `test_deploy` 의 `TEST_DEPLOY` 컴파일 조건은 넣지 않는다 — 디버그 플로팅 로거가 딸려 간다
- `Fastfile` 의 `asc_api_key` — ASC API 키 생성 블록이 두 레인에 같은 8줄로 복제돼 있었고 새 레인이 세 번째 소비자라 헬퍼로 뽑았다
- `.claude/skills/testflight-deploy/SKILL.md` — 브랜치명·빌드번호를 받아 미커밋 변경 가드 → 체크아웃 → 볼트 실 config 배치 → `tuist generate` 후 빌드번호 스탬프 → 레인 실행 → 원래 브랜치 복귀까지를 절차로 고정한다. 빌드번호를 generate **뒤에** 찍는 게 핵심 — generate 가 Derived InfoPlist 를 `Project+AppVersion.swift` 값으로 되돌린다

## 유저 검증 대기

레인이 실제로 도는지는 실배포로만 확인된다. ASC API 키 환경변수와 빌드번호 소비가 필요해 이 PR 에서는 못 돌렸다. 판정 기준 셋:

- ASC TestFlight 에 해당 버전·빌드번호가 뜨는가
- Firebase Crashlytics dSYM 관리 화면에 이번 빌드의 UUID 가 올라갔는가
- 설치한 빌드에 디버그 플로팅 로거가 **안** 뜨는가 (`TEST_DEPLOY` 미주입 확인)

## 남은 과제

#918 의 나머지 단계 — 버전업 자동화, 태그·릴리즈 발행, 심사 제출, e2e — 는 이번 PR 밖이다. CI 워크플로우도 만들지 않았다 (로컬 실행 전용).
