### PR TITLE
[#1036] Siri 트리거를 시스템 캘린더와 겹치지 않는 보편 발화로 바꾼다

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -87,7 +87,7 @@ description: Use when writing or modifying code in this project — 구현 착�
 - **증분 빌드 유지** — 반복 빌드·테스트는 증분을 전제로 돈다:
   - `xcodebuild clean`·DerivedData 삭제 금지 (빌드 오염 진단 같은 명시적 사유가 있을 때만)
   - `-derivedDataPath`로 새 경로를 만들지 않는다 — 기본 공유 DerivedData가 증분의 원천. `./DerivedData` + reset은 pr_test.yml의 CI 전용 패턴이니 로컬에 복제 금지
-  - destination(시뮬레이터)을 바꾸지 않는다 — run-all-tests.sh의 UDID 고정을 따른다. destination이 바뀌면 전 모듈 재빌드
+  - destination(시뮬레이터)을 바꾸지 않는다 — `scripts/ensure-test-simulator.sh`가 돌려주는 기기(iPhone 16 / iOS 18.0)를 따른다. 단발 `xcodebuild`도 같다. destination이 바뀌면 전 모듈 재빌드
 - **객체 시그니처(특히 init) 변경 시 콜사이트 전수 grep** — 수정 전에 참조처를 확인한다. 이 짝은 스크립트가 못 잡는다.
 - Query/Command 분리 유지 — 읽기와 사이드이펙트를 한 흐름에 섞지 않는다.
 

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -17,8 +17,17 @@ description: Use when the user wants to run tests for the TodoCalendar project -
 ./scripts/run-all-tests.sh Domain Repository
 
 # destination 오버라이드
-DESTINATION='platform=iOS Simulator,name=iPhone 16,OS=18.1' ./scripts/run-all-tests.sh
+DESTINATION='platform=iOS Simulator,name=iPhone 16,OS=18.0' ./scripts/run-all-tests.sh
 ```
+
+## 시뮬레이터
+
+`DESTINATION` 을 안 주면 `scripts/ensure-test-simulator.sh` 가 **iPhone 16 / iOS 18.0** 을
+확보해 UDID 로 넘긴다 — 없으면 만든다. CI(`pr_test.yml`)도 같은 스크립트를 부르므로
+로컬과 CI 의 실행 기기가 갈리지 않는다.
+
+기기·OS 를 바꿔야 하면 그 스크립트 한 곳만 고친다. 촬영 기준(snapshot-check §3 — iPhone 17
+/ iOS 26.2)과는 별개다 — 스냅샷은 시뮬 상태에 의존해 전용기를 따로 쓴다.
 
 ## Available Schemes
 

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -175,10 +175,14 @@ jobs:
     defaults:
       run:
         shell: bash -eo pipefail {0}
-    env:
-      DESTINATION: 'platform=iOS Simulator,name=iPhone 16,OS=18.1'
     steps:
       - uses: actions/checkout@v5
+
+      - name: Ensure test simulator
+        run: |
+          set -euo pipefail
+          udid="$(scripts/ensure-test-simulator.sh)"
+          echo "DESTINATION=platform=iOS Simulator,id=${udid}" >> "$GITHUB_ENV"
 
       - name: Setup dummy config
         run: |

--- a/TodoCalendarApp/Resources/Localize/ca.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/ca.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Ei, ${applicationName}";
+"Request in ${applicationName}" = "Petició a ${applicationName}";
+"Ask ${applicationName}" = "Pregunta-ho a ${applicationName}";
+"Send a request to ${applicationName}" = "Envia una petició a ${applicationName}";
 "Add with AI in ${applicationName}" = "Afegeix amb IA a ${applicationName}";
-"Add a schedule in ${applicationName}" = "Afegeix una cita a ${applicationName}";
-"Add a to-do in ${applicationName}" = "Afegeix una tasca a ${applicationName}";
-"Add with AI" = "Afegeix amb IA";
+"Send" = "Envia";

--- a/TodoCalendarApp/Resources/Localize/ca.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/ca.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Afegeix amb IA";
-"Send what you say to AI and let it create your events and to-dos." = "Envieu el que dieu a la IA perquè creï els vostres esdeveniments i tasques.";
+"Send" = "Envia";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Envieu el que dieu a la IA perquè afegeixi, canviï, completi o elimini els vostres esdeveniments i tasques.";
 "Command" = "Ordre";
-"What would you like to add?" = "Què voldríeu afegir?";
+"What should I do?" = "Què voleu que faci?";
 "Got it. I'll notify you when it's done." = "Entesos. Us avisaré quan estigui llest.";
 "Sign in to the app first to use AI." = "Inicieu sessió a l'app abans d'utilitzar la IA.";
 "You've used up your AI credits for today." = "Heu esgotat els vostres crèdits d'IA d'avui.";

--- a/TodoCalendarApp/Resources/Localize/cs.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/cs.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Hej, ${applicationName}";
+"Request in ${applicationName}" = "Požadavek v ${applicationName}";
+"Ask ${applicationName}" = "Zeptat se aplikace ${applicationName}";
+"Send a request to ${applicationName}" = "Poslat požadavek aplikaci ${applicationName}";
 "Add with AI in ${applicationName}" = "Přidat pomocí AI v ${applicationName}";
-"Add a schedule in ${applicationName}" = "Přidat termín v ${applicationName}";
-"Add a to-do in ${applicationName}" = "Přidat úkol v ${applicationName}";
-"Add with AI" = "Přidat pomocí AI";
+"Send" = "Poslat";

--- a/TodoCalendarApp/Resources/Localize/cs.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/cs.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Přidat pomocí AI";
-"Send what you say to AI and let it create your events and to-dos." = "Pošlete AI to, co řeknete, a nechte ji vytvořit vaše termíny a úkoly.";
+"Send" = "Poslat";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Pošlete AI to, co řeknete, a nechte ji přidat, změnit, dokončit nebo smazat vaše termíny a úkoly.";
 "Command" = "Příkaz";
-"What would you like to add?" = "Co byste chtěli přidat?";
+"What should I do?" = "Co mám udělat?";
 "Got it. I'll notify you when it's done." = "Rozumím. Dám vám vědět, až to bude hotové.";
 "Sign in to the app first to use AI." = "Nejprve se přihlaste do aplikace, abyste mohli použít AI.";
 "You've used up your AI credits for today." = "Vyčerpali jste dnešní kredity AI.";

--- a/TodoCalendarApp/Resources/Localize/da.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/da.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Hej ${applicationName}";
+"Request in ${applicationName}" = "Anmodning til ${applicationName}";
+"Ask ${applicationName}" = "Spørg ${applicationName}";
+"Send a request to ${applicationName}" = "Send en anmodning til ${applicationName}";
 "Add with AI in ${applicationName}" = "Tilføj med AI i ${applicationName}";
-"Add a schedule in ${applicationName}" = "Tilføj en aftale i ${applicationName}";
-"Add a to-do in ${applicationName}" = "Tilføj en opgave i ${applicationName}";
-"Add with AI" = "Tilføj med AI";
+"Send" = "Send";

--- a/TodoCalendarApp/Resources/Localize/da.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/da.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Tilføj med AI";
-"Send what you say to AI and let it create your events and to-dos." = "Send det, du siger, til AI, så opretter den dine aftaler og opgaver.";
+"Send" = "Send";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Send det, du siger, til AI, så den kan tilføje, ændre, fuldføre eller slette dine aftaler og opgaver.";
 "Command" = "Kommando";
-"What would you like to add?" = "Hvad vil du gerne tilføje?";
+"What should I do?" = "Hvad skal jeg gøre?";
 "Got it. I'll notify you when it's done." = "Modtaget. Jeg giver dig besked, når det er klar.";
 "Sign in to the app first to use AI." = "Log ind i appen først for at bruge AI.";
 "You've used up your AI credits for today." = "Du har brugt alle dine AI-kreditter for i dag.";

--- a/TodoCalendarApp/Resources/Localize/de.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/de.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Hey ${applicationName}";
+"Request in ${applicationName}" = "Anfrage an ${applicationName}";
+"Ask ${applicationName}" = "${applicationName} etwas fragen";
+"Send a request to ${applicationName}" = "Eine Anfrage an ${applicationName} senden";
 "Add with AI in ${applicationName}" = "Mit KI in ${applicationName} hinzufügen";
-"Add a schedule in ${applicationName}" = "Einen Termin in ${applicationName} hinzufügen";
-"Add a to-do in ${applicationName}" = "Eine Aufgabe in ${applicationName} hinzufügen";
-"Add with AI" = "Mit KI hinzufügen";
+"Send" = "Senden";

--- a/TodoCalendarApp/Resources/Localize/de.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/de.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Mit KI hinzufügen";
-"Send what you say to AI and let it create your events and to-dos." = "Senden Sie der KI, was Sie sagen, und lassen Sie sie Ihre Termine und Aufgaben erstellen.";
+"Send" = "Senden";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Senden Sie der KI, was Sie sagen, und lassen Sie sie Ihre Termine und Aufgaben hinzufügen, ändern, abschließen oder löschen.";
 "Command" = "Befehl";
-"What would you like to add?" = "Was möchten Sie hinzufügen?";
+"What should I do?" = "Was soll ich tun?";
 "Got it. I'll notify you when it's done." = "Alles klar. Ich benachrichtige Sie, wenn es fertig ist.";
 "Sign in to the app first to use AI." = "Melden Sie sich zuerst in der App an, um die KI zu nutzen.";
 "You've used up your AI credits for today." = "Sie haben Ihr heutiges KI-Guthaben aufgebraucht.";

--- a/TodoCalendarApp/Resources/Localize/el.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/el.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Έι ${applicationName}";
+"Request in ${applicationName}" = "Αίτημα στο ${applicationName}";
+"Ask ${applicationName}" = "Ρώτα το ${applicationName}";
+"Send a request to ${applicationName}" = "Στείλε αίτημα στο ${applicationName}";
 "Add with AI in ${applicationName}" = "Προσθήκη με AI στο ${applicationName}";
-"Add a schedule in ${applicationName}" = "Προσθήκη ραντεβού στο ${applicationName}";
-"Add a to-do in ${applicationName}" = "Προσθήκη εργασίας στο ${applicationName}";
-"Add with AI" = "Προσθήκη με AI";
+"Send" = "Στείλε";

--- a/TodoCalendarApp/Resources/Localize/el.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/el.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Προσθήκη με AI";
-"Send what you say to AI and let it create your events and to-dos." = "Στείλτε στο AI αυτό που λέτε για να δημιουργήσει τα ραντεβού και τις εργασίες σας.";
+"Send" = "Στείλε";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Στείλτε στο AI αυτό που λέτε για να προσθέσει, να αλλάξει, να ολοκληρώσει ή να διαγράψει τα ραντεβού και τις εργασίες σας.";
 "Command" = "Εντολή";
-"What would you like to add?" = "Τι θα θέλατε να προσθέσετε;";
+"What should I do?" = "Τι να κάνω;";
 "Got it. I'll notify you when it's done." = "Έγινε. Θα σας ειδοποιήσω όταν ολοκληρωθεί.";
 "Sign in to the app first to use AI." = "Συνδεθείτε πρώτα στην εφαρμογή για να χρησιμοποιήσετε το AI.";
 "You've used up your AI credits for today." = "Έχετε εξαντλήσει τις μονάδες AI για σήμερα.";

--- a/TodoCalendarApp/Resources/Localize/en.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/en.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Hey ${applicationName}";
+"Request in ${applicationName}" = "Request in ${applicationName}";
+"Ask ${applicationName}" = "Ask ${applicationName}";
+"Send a request to ${applicationName}" = "Send a request to ${applicationName}";
 "Add with AI in ${applicationName}" = "Add with AI in ${applicationName}";
-"Add a schedule in ${applicationName}" = "Add a schedule in ${applicationName}";
-"Add a to-do in ${applicationName}" = "Add a to-do in ${applicationName}";
-"Add with AI" = "Add with AI";
+"Send" = "Send";

--- a/TodoCalendarApp/Resources/Localize/en.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/en.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Add with AI";
-"Send what you say to AI and let it create your events and to-dos." = "Send what you say to AI and let it create your events and to-dos.";
+"Send" = "Send";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Send what you say to AI and let it add, change, complete, or delete your events and to-dos.";
 "Command" = "Command";
-"What would you like to add?" = "What would you like to add?";
+"What should I do?" = "What should I do?";
 "Got it. I'll notify you when it's done." = "Got it. I'll notify you when it's done.";
 "Sign in to the app first to use AI." = "Sign in to the app first to use AI.";
 "You've used up your AI credits for today." = "You've used up your AI credits for today.";

--- a/TodoCalendarApp/Resources/Localize/es.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/es.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Oye, ${applicationName}";
+"Request in ${applicationName}" = "Solicitud a ${applicationName}";
+"Ask ${applicationName}" = "Preguntarle a ${applicationName}";
+"Send a request to ${applicationName}" = "Enviar una solicitud a ${applicationName}";
 "Add with AI in ${applicationName}" = "Añadir con IA en ${applicationName}";
-"Add a schedule in ${applicationName}" = "Añadir un evento de calendario en ${applicationName}";
-"Add a to-do in ${applicationName}" = "Añadir una tarea en ${applicationName}";
-"Add with AI" = "Añadir con IA";
+"Send" = "Enviar";

--- a/TodoCalendarApp/Resources/Localize/es.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/es.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Añadir con IA";
-"Send what you say to AI and let it create your events and to-dos." = "Envía lo que dices a la IA para que cree tus eventos y tareas.";
+"Send" = "Enviar";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Envía lo que dices a la IA para que añada, cambie, complete o elimine tus eventos y tareas.";
 "Command" = "Comando";
-"What would you like to add?" = "¿Qué te gustaría añadir?";
+"What should I do?" = "¿Qué quieres que haga?";
 "Got it. I'll notify you when it's done." = "Entendido. Te avisaré cuando esté listo.";
 "Sign in to the app first to use AI." = "Inicia sesión en la app primero para usar la IA.";
 "You've used up your AI credits for today." = "Has agotado tus créditos de IA de hoy.";

--- a/TodoCalendarApp/Resources/Localize/fi.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/fi.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Hei ${applicationName}";
+"Request in ${applicationName}" = "Pyyntö sovellukseen ${applicationName}";
+"Ask ${applicationName}" = "Kysy sovellukselta ${applicationName}";
+"Send a request to ${applicationName}" = "Lähetä pyyntö sovellukselle ${applicationName}";
 "Add with AI in ${applicationName}" = "Lisää AI:lla sovelluksessa ${applicationName}";
-"Add a schedule in ${applicationName}" = "Lisää aikataulutapahtuma sovelluksessa ${applicationName}";
-"Add a to-do in ${applicationName}" = "Lisää tehtävä sovelluksessa ${applicationName}";
-"Add with AI" = "Lisää AI:lla";
+"Send" = "Lähetä";

--- a/TodoCalendarApp/Resources/Localize/fi.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/fi.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Lisää AI:lla";
-"Send what you say to AI and let it create your events and to-dos." = "Lähetä sanomasi AI:lle, niin se luo tapahtumasi ja tehtäväsi.";
+"Send" = "Lähetä";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Lähetä sanomasi AI:lle, niin se lisää, muuttaa, merkitsee valmiiksi tai poistaa tapahtumasi ja tehtäväsi.";
 "Command" = "Komento";
-"What would you like to add?" = "Mitä haluaisit lisätä?";
+"What should I do?" = "Mitä teen?";
 "Got it. I'll notify you when it's done." = "Selvä. Ilmoitan sinulle, kun se on valmis.";
 "Sign in to the app first to use AI." = "Kirjaudu ensin sisään sovellukseen käyttääksesi AI:ta.";
 "You've used up your AI credits for today." = "Olet käyttänyt tämän päivän AI-krediitit loppuun.";

--- a/TodoCalendarApp/Resources/Localize/fr.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/fr.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Hé ${applicationName}";
+"Request in ${applicationName}" = "Demande à ${applicationName}";
+"Ask ${applicationName}" = "Demander à ${applicationName}";
+"Send a request to ${applicationName}" = "Envoyer une demande à ${applicationName}";
 "Add with AI in ${applicationName}" = "Ajouter avec l'IA dans ${applicationName}";
-"Add a schedule in ${applicationName}" = "Ajouter un rendez-vous dans ${applicationName}";
-"Add a to-do in ${applicationName}" = "Ajouter une tâche dans ${applicationName}";
-"Add with AI" = "Ajouter avec l'IA";
+"Send" = "Envoyer";

--- a/TodoCalendarApp/Resources/Localize/fr.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/fr.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Ajouter avec l'IA";
-"Send what you say to AI and let it create your events and to-dos." = "Envoyez ce que vous dites à l'IA pour créer vos événements et tâches.";
+"Send" = "Envoyer";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Envoyez ce que vous dites à l'IA pour ajouter, modifier, terminer ou supprimer vos événements et tâches.";
 "Command" = "Commande";
-"What would you like to add?" = "Que souhaitez-vous ajouter ?";
+"What should I do?" = "Que dois-je faire ?";
 "Got it. I'll notify you when it's done." = "Compris. Je vous préviendrai une fois terminé.";
 "Sign in to the app first to use AI." = "Connectez-vous d'abord à l'app pour utiliser l'IA.";
 "You've used up your AI credits for today." = "Vous avez épuisé vos crédits IA pour aujourd'hui.";

--- a/TodoCalendarApp/Resources/Localize/hi.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/hi.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "अरे ${applicationName}";
+"Request in ${applicationName}" = "${applicationName} में अनुरोध";
+"Ask ${applicationName}" = "${applicationName} से पूछें";
+"Send a request to ${applicationName}" = "${applicationName} को अनुरोध भेजें";
 "Add with AI in ${applicationName}" = "${applicationName} में AI से जोड़ें";
-"Add a schedule in ${applicationName}" = "${applicationName} में अनुसूची जोड़ें";
-"Add a to-do in ${applicationName}" = "${applicationName} में कार्य जोड़ें";
-"Add with AI" = "AI से जोड़ें";
+"Send" = "भेजें";

--- a/TodoCalendarApp/Resources/Localize/hi.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/hi.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "AI से जोड़ें";
-"Send what you say to AI and let it create your events and to-dos." = "आप जो कहें उसे AI को भेजें और अपने इवेंट और कार्य बनवाएं।";
+"Send" = "भेजें";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "आप जो कहें उसे AI को भेजें और अपने इवेंट और कार्य जोड़ें, बदलें, पूरे करें या हटाएं।";
 "Command" = "कमांड";
-"What would you like to add?" = "आप क्या जोड़ना चाहेंगे?";
+"What should I do?" = "मैं क्या करूं?";
 "Got it. I'll notify you when it's done." = "ठीक है। पूरा होने पर मैं आपको बता दूँगा।";
 "Sign in to the app first to use AI." = "AI इस्तेमाल करने के लिए पहले ऐप में लॉगिन करें।";
 "You've used up your AI credits for today." = "आपने आज के अपने AI क्रेडिट इस्तेमाल कर लिए हैं।";

--- a/TodoCalendarApp/Resources/Localize/hr.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/hr.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Hej ${applicationName}";
+"Request in ${applicationName}" = "Zahtjev u ${applicationName}";
+"Ask ${applicationName}" = "Pitaj aplikaciju ${applicationName}";
+"Send a request to ${applicationName}" = "Pošalji zahtjev aplikaciji ${applicationName}";
 "Add with AI in ${applicationName}" = "Dodaj pomoću AI u ${applicationName}";
-"Add a schedule in ${applicationName}" = "Dodaj termin u ${applicationName}";
-"Add a to-do in ${applicationName}" = "Dodaj zadatak u ${applicationName}";
-"Add with AI" = "Dodaj pomoću AI";
+"Send" = "Pošalji";

--- a/TodoCalendarApp/Resources/Localize/hr.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/hr.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Dodaj pomoću AI";
-"Send what you say to AI and let it create your events and to-dos." = "Pošaljite AI-ju ono što kažete kako bi stvorio vaše termine i zadatke.";
+"Send" = "Pošalji";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Pošaljite AI-ju ono što kažete kako bi dodao, promijenio, dovršio ili izbrisao vaše termine i zadatke.";
 "Command" = "Naredba";
-"What would you like to add?" = "Što biste željeli dodati?";
+"What should I do?" = "Što da učinim?";
 "Got it. I'll notify you when it's done." = "U redu. Obavijestit ću vas kad bude gotovo.";
 "Sign in to the app first to use AI." = "Najprije se prijavite u aplikaciju da biste koristili AI.";
 "You've used up your AI credits for today." = "Iskoristili ste današnje AI kredite.";

--- a/TodoCalendarApp/Resources/Localize/hu.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/hu.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Hé, ${applicationName}";
+"Request in ${applicationName}" = "Kérés itt: ${applicationName}";
+"Ask ${applicationName}" = "Kérdezze meg itt: ${applicationName}";
+"Send a request to ${applicationName}" = "Kérés küldése itt: ${applicationName}";
 "Add with AI in ${applicationName}" = "Hozzáadás AI-val itt: ${applicationName}";
-"Add a schedule in ${applicationName}" = "Program hozzáadása itt: ${applicationName}";
-"Add a to-do in ${applicationName}" = "Feladat hozzáadása itt: ${applicationName}";
-"Add with AI" = "Hozzáadás AI-val";
+"Send" = "Küldés";

--- a/TodoCalendarApp/Resources/Localize/hu.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/hu.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Hozzáadás AI-val";
-"Send what you say to AI and let it create your events and to-dos." = "Küldje el az AI-nak, amit mond, hogy létrehozza az eseményeit és feladatait.";
+"Send" = "Küldés";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Küldje el az AI-nak, amit mond, hogy hozzáadja, módosítsa, elvégezze vagy törölje az eseményeit és feladatait.";
 "Command" = "Parancs";
-"What would you like to add?" = "Mit szeretne hozzáadni?";
+"What should I do?" = "Mit tegyek?";
 "Got it. I'll notify you when it's done." = "Rendben. Szólok, ha elkészült.";
 "Sign in to the app first to use AI." = "Az AI használatához előbb jelentkezzen be az appba.";
 "You've used up your AI credits for today." = "Mára elfogyott az AI kreditkeret.";

--- a/TodoCalendarApp/Resources/Localize/id.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/id.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Hai ${applicationName}";
+"Request in ${applicationName}" = "Permintaan ke ${applicationName}";
+"Ask ${applicationName}" = "Tanya ${applicationName}";
+"Send a request to ${applicationName}" = "Kirim permintaan ke ${applicationName}";
 "Add with AI in ${applicationName}" = "Tambah dengan AI di ${applicationName}";
-"Add a schedule in ${applicationName}" = "Tambah jadwal di ${applicationName}";
-"Add a to-do in ${applicationName}" = "Tambah tugas di ${applicationName}";
-"Add with AI" = "Tambah dengan AI";
+"Send" = "Kirim";

--- a/TodoCalendarApp/Resources/Localize/id.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/id.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Tambah dengan AI";
-"Send what you say to AI and let it create your events and to-dos." = "Kirim apa yang Anda katakan ke AI agar ia membuat jadwal dan tugas Anda.";
+"Send" = "Kirim";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Kirim apa yang Anda katakan ke AI agar ia menambah, mengubah, menyelesaikan, atau menghapus jadwal dan tugas Anda.";
 "Command" = "Perintah";
-"What would you like to add?" = "Apa yang ingin Anda tambahkan?";
+"What should I do?" = "Apa yang harus saya lakukan?";
 "Got it. I'll notify you when it's done." = "Baik. Saya akan memberi tahu Anda saat selesai.";
 "Sign in to the app first to use AI." = "Masuk ke aplikasi terlebih dahulu untuk menggunakan AI.";
 "You've used up your AI credits for today." = "Anda sudah menghabiskan kredit AI hari ini.";

--- a/TodoCalendarApp/Resources/Localize/it.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/it.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Ehi ${applicationName}";
+"Request in ${applicationName}" = "Richiesta a ${applicationName}";
+"Ask ${applicationName}" = "Chiedi a ${applicationName}";
+"Send a request to ${applicationName}" = "Invia una richiesta a ${applicationName}";
 "Add with AI in ${applicationName}" = "Aggiungi con l'IA in ${applicationName}";
-"Add a schedule in ${applicationName}" = "Aggiungi una pianificazione in ${applicationName}";
-"Add a to-do in ${applicationName}" = "Aggiungi un'attività da fare in ${applicationName}";
-"Add with AI" = "Aggiungi con l'IA";
+"Send" = "Invia";

--- a/TodoCalendarApp/Resources/Localize/it.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/it.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Aggiungi con l'IA";
-"Send what you say to AI and let it create your events and to-dos." = "Invia ciò che dici all'IA per creare i tuoi eventi e le cose da fare.";
+"Send" = "Invia";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Invia ciò che dici all'IA per aggiungere, modificare, completare o eliminare i tuoi eventi e le cose da fare.";
 "Command" = "Comando";
-"What would you like to add?" = "Cosa vuoi aggiungere?";
+"What should I do?" = "Cosa devo fare?";
 "Got it. I'll notify you when it's done." = "Ricevuto. Ti avviserò quando sarà fatto.";
 "Sign in to the app first to use AI." = "Accedi prima all'app per usare l'IA.";
 "You've used up your AI credits for today." = "Hai esaurito i crediti IA di oggi.";

--- a/TodoCalendarApp/Resources/Localize/ja.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/ja.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "ねえ、${applicationName}";
+"Request in ${applicationName}" = "${applicationName}にリクエスト";
+"Ask ${applicationName}" = "${applicationName}に頼む";
+"Send a request to ${applicationName}" = "${applicationName}にリクエストを送る";
 "Add with AI in ${applicationName}" = "${applicationName}でAIに追加";
-"Add a schedule in ${applicationName}" = "${applicationName}で予定を追加";
-"Add a to-do in ${applicationName}" = "${applicationName}でタスクを追加";
-"Add with AI" = "AIで追加";
+"Send" = "送る";

--- a/TodoCalendarApp/Resources/Localize/ja.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/ja.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "AIで追加";
-"Send what you say to AI and let it create your events and to-dos." = "話した内容をAIに送って、予定やタスクを作成します。";
+"Send" = "送る";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "話した内容をAIに送って、予定やタスクを追加・変更・完了・削除します。";
 "Command" = "コマンド";
-"What would you like to add?" = "何を追加しますか？";
+"What should I do?" = "何をしますか？";
 "Got it. I'll notify you when it's done." = "了解しました。完了したらお知らせします。";
 "Sign in to the app first to use AI." = "AIを使うには、先にアプリにログインしてください。";
 "You've used up your AI credits for today." = "本日のAIクレジットを使い切りました。";

--- a/TodoCalendarApp/Resources/Localize/ko.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/ko.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "${applicationName}야";
+"Request in ${applicationName}" = "${applicationName} 요청";
+"Ask ${applicationName}" = "${applicationName}한테 부탁해";
+"Send a request to ${applicationName}" = "${applicationName}한테 요청 보낼게";
 "Add with AI in ${applicationName}" = "${applicationName}에 AI로 추가";
-"Add a schedule in ${applicationName}" = "${applicationName}에 일정 추가";
-"Add a to-do in ${applicationName}" = "${applicationName}에 할일 추가";
-"Add with AI" = "AI로 추가";
+"Send" = "요청 보내기";

--- a/TodoCalendarApp/Resources/Localize/ko.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/ko.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "AI로 추가";
-"Send what you say to AI and let it create your events and to-dos." = "말한 내용을 AI에게 보내 일정과 할일을 만들어요.";
+"Send" = "요청 보내기";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "말한 내용을 AI에게 보내 일정과 할일을 추가·변경·완료·삭제해요.";
 "Command" = "명령";
-"What would you like to add?" = "무엇을 추가할까요?";
+"What should I do?" = "무엇을 할까요?";
 "Got it. I'll notify you when it's done." = "알겠어요. 완료되면 알려드릴게요.";
 "Sign in to the app first to use AI." = "AI를 사용하려면 먼저 앱에 로그인해주세요.";
 "You've used up your AI credits for today." = "오늘의 AI 크레딧을 모두 사용했어요.";

--- a/TodoCalendarApp/Resources/Localize/ms.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/ms.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Hai ${applicationName}";
+"Request in ${applicationName}" = "Permintaan kepada ${applicationName}";
+"Ask ${applicationName}" = "Tanya ${applicationName}";
+"Send a request to ${applicationName}" = "Hantar permintaan kepada ${applicationName}";
 "Add with AI in ${applicationName}" = "Tambah dengan AI dalam ${applicationName}";
-"Add a schedule in ${applicationName}" = "Tambah jadual dalam ${applicationName}";
-"Add a to-do in ${applicationName}" = "Tambah tugasan dalam ${applicationName}";
-"Add with AI" = "Tambah dengan AI";
+"Send" = "Hantar";

--- a/TodoCalendarApp/Resources/Localize/ms.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/ms.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Tambah dengan AI";
-"Send what you say to AI and let it create your events and to-dos." = "Hantar apa yang anda cakap kepada AI supaya ia mencipta jadual dan tugasan anda.";
+"Send" = "Hantar";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Hantar apa yang anda cakap kepada AI supaya ia menambah, mengubah, menyelesaikan atau memadam jadual dan tugasan anda.";
 "Command" = "Arahan";
-"What would you like to add?" = "Apa yang anda ingin tambah?";
+"What should I do?" = "Apa yang perlu saya lakukan?";
 "Got it. I'll notify you when it's done." = "Baik. Saya akan maklumkan apabila selesai.";
 "Sign in to the app first to use AI." = "Log masuk ke aplikasi dahulu untuk menggunakan AI.";
 "You've used up your AI credits for today." = "Anda telah menghabiskan kredit AI hari ini.";

--- a/TodoCalendarApp/Resources/Localize/nb.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/nb.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Hei ${applicationName}";
+"Request in ${applicationName}" = "Forespørsel til ${applicationName}";
+"Ask ${applicationName}" = "Spør ${applicationName}";
+"Send a request to ${applicationName}" = "Send en forespørsel til ${applicationName}";
 "Add with AI in ${applicationName}" = "Legg til med AI i ${applicationName}";
-"Add a schedule in ${applicationName}" = "Legg til en avtale i ${applicationName}";
-"Add a to-do in ${applicationName}" = "Legg til en oppgave i ${applicationName}";
-"Add with AI" = "Legg til med AI";
+"Send" = "Send";

--- a/TodoCalendarApp/Resources/Localize/nb.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/nb.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Legg til med AI";
-"Send what you say to AI and let it create your events and to-dos." = "Send det du sier til AI, så oppretter den avtalene og oppgavene dine.";
+"Send" = "Send";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Send det du sier til AI, så kan den legge til, endre, fullføre eller slette avtalene og oppgavene dine.";
 "Command" = "Kommando";
-"What would you like to add?" = "Hva vil du legge til?";
+"What should I do?" = "Hva skal jeg gjøre?";
 "Got it. I'll notify you when it's done." = "Skjønner. Jeg varsler deg når det er ferdig.";
 "Sign in to the app first to use AI." = "Logg inn i appen først for å bruke AI.";
 "You've used up your AI credits for today." = "Du har brukt opp AI-kredittene dine for i dag.";

--- a/TodoCalendarApp/Resources/Localize/nl.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/nl.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Hé ${applicationName}";
+"Request in ${applicationName}" = "Verzoek aan ${applicationName}";
+"Ask ${applicationName}" = "Iets aan ${applicationName} vragen";
+"Send a request to ${applicationName}" = "Een verzoek naar ${applicationName} sturen";
 "Add with AI in ${applicationName}" = "Met AI in ${applicationName} toevoegen";
-"Add a schedule in ${applicationName}" = "Een afspraak in ${applicationName} toevoegen";
-"Add a to-do in ${applicationName}" = "Een taak in ${applicationName} toevoegen";
-"Add with AI" = "Toevoegen met AI";
+"Send" = "Sturen";

--- a/TodoCalendarApp/Resources/Localize/nl.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/nl.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Toevoegen met AI";
-"Send what you say to AI and let it create your events and to-dos." = "Stuur wat je zegt naar AI en laat het je afspraken en taken aanmaken.";
+"Send" = "Sturen";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Stuur wat je zegt naar AI en laat het je afspraken en taken toevoegen, wijzigen, voltooien of verwijderen.";
 "Command" = "Opdracht";
-"What would you like to add?" = "Wat wil je toevoegen?";
+"What should I do?" = "Wat moet ik doen?";
 "Got it. I'll notify you when it's done." = "Begrepen. Ik laat het je weten zodra het klaar is.";
 "Sign in to the app first to use AI." = "Log eerst in op de app om AI te gebruiken.";
 "You've used up your AI credits for today." = "Je hebt je AI-credits voor vandaag opgebruikt.";

--- a/TodoCalendarApp/Resources/Localize/pl.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/pl.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Hej, ${applicationName}";
+"Request in ${applicationName}" = "Prośba do ${applicationName}";
+"Ask ${applicationName}" = "Zapytaj aplikację ${applicationName}";
+"Send a request to ${applicationName}" = "Wyślij prośbę do aplikacji ${applicationName}";
 "Add with AI in ${applicationName}" = "Dodaj z AI w ${applicationName}";
-"Add a schedule in ${applicationName}" = "Dodaj termin w ${applicationName}";
-"Add a to-do in ${applicationName}" = "Dodaj zadanie w ${applicationName}";
-"Add with AI" = "Dodaj z AI";
+"Send" = "Wyślij";

--- a/TodoCalendarApp/Resources/Localize/pl.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/pl.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Dodaj z AI";
-"Send what you say to AI and let it create your events and to-dos." = "Wyślij do AI to, co powiesz, aby utworzyć Twoje terminy i zadania.";
+"Send" = "Wyślij";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Wyślij do AI to, co powiesz, aby dodać, zmienić, ukończyć lub usunąć Twoje terminy i zadania.";
 "Command" = "Polecenie";
-"What would you like to add?" = "Co chciałbyś dodać?";
+"What should I do?" = "Co mam zrobić?";
 "Got it. I'll notify you when it's done." = "Rozumiem. Dam Ci znać, gdy będzie gotowe.";
 "Sign in to the app first to use AI." = "Zaloguj się najpierw w aplikacji, aby korzystać z AI.";
 "You've used up your AI credits for today." = "Wykorzystałeś dzisiejsze kredyty AI.";

--- a/TodoCalendarApp/Resources/Localize/pt-BR.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/pt-BR.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Ei, ${applicationName}";
+"Request in ${applicationName}" = "Solicitação ao ${applicationName}";
+"Ask ${applicationName}" = "Perguntar ao ${applicationName}";
+"Send a request to ${applicationName}" = "Enviar uma solicitação ao ${applicationName}";
 "Add with AI in ${applicationName}" = "Adicionar com IA no ${applicationName}";
-"Add a schedule in ${applicationName}" = "Adicionar um compromisso no ${applicationName}";
-"Add a to-do in ${applicationName}" = "Adicionar uma tarefa no ${applicationName}";
-"Add with AI" = "Adicionar com IA";
+"Send" = "Enviar";

--- a/TodoCalendarApp/Resources/Localize/pt-BR.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/pt-BR.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Adicionar com IA";
-"Send what you say to AI and let it create your events and to-dos." = "Envie o que você disser para a IA criar seus eventos e tarefas.";
+"Send" = "Enviar";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Envie o que você disser para a IA adicionar, alterar, concluir ou excluir seus eventos e tarefas.";
 "Command" = "Comando";
-"What would you like to add?" = "O que você gostaria de adicionar?";
+"What should I do?" = "O que devo fazer?";
 "Got it. I'll notify you when it's done." = "Entendido. Vou te avisar quando terminar.";
 "Sign in to the app first to use AI." = "Faça login no app primeiro para usar a IA.";
 "You've used up your AI credits for today." = "Você usou todos os seus créditos de IA hoje.";

--- a/TodoCalendarApp/Resources/Localize/ro.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/ro.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Hei, ${applicationName}";
+"Request in ${applicationName}" = "Cerere către ${applicationName}";
+"Ask ${applicationName}" = "Întreabă ${applicationName}";
+"Send a request to ${applicationName}" = "Trimite o cerere către ${applicationName}";
 "Add with AI in ${applicationName}" = "Adaugă cu AI în ${applicationName}";
-"Add a schedule in ${applicationName}" = "Adaugă o programare în ${applicationName}";
-"Add a to-do in ${applicationName}" = "Adaugă o sarcină în ${applicationName}";
-"Add with AI" = "Adaugă cu AI";
+"Send" = "Trimite";

--- a/TodoCalendarApp/Resources/Localize/ro.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/ro.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Adaugă cu AI";
-"Send what you say to AI and let it create your events and to-dos." = "Trimiteți către AI ce spuneți, ca să vă creeze programările și sarcinile.";
+"Send" = "Trimite";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Trimiteți către AI ce spuneți, ca să vă adauge, modifice, finalizeze sau șteargă programările și sarcinile.";
 "Command" = "Comandă";
-"What would you like to add?" = "Ce ați dori să adăugați?";
+"What should I do?" = "Ce să fac?";
 "Got it. I'll notify you when it's done." = "Am înțeles. Vă anunț când e gata.";
 "Sign in to the app first to use AI." = "Autentificați-vă mai întâi în aplicație ca să folosiți AI.";
 "You've used up your AI credits for today." = "V-ați epuizat creditele AI de azi.";

--- a/TodoCalendarApp/Resources/Localize/ru.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/ru.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Эй, ${applicationName}";
+"Request in ${applicationName}" = "Запрос в ${applicationName}";
+"Ask ${applicationName}" = "Спросить приложение ${applicationName}";
+"Send a request to ${applicationName}" = "Отправить запрос в ${applicationName}";
 "Add with AI in ${applicationName}" = "Добавить с помощью ИИ в ${applicationName}";
-"Add a schedule in ${applicationName}" = "Добавить встречу в ${applicationName}";
-"Add a to-do in ${applicationName}" = "Добавить задачу в ${applicationName}";
-"Add with AI" = "Добавить с помощью ИИ";
+"Send" = "Отправить";

--- a/TodoCalendarApp/Resources/Localize/ru.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/ru.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Добавить с помощью ИИ";
-"Send what you say to AI and let it create your events and to-dos." = "Отправьте ИИ то, что вы скажете, и он создаст ваши события и задачи.";
+"Send" = "Отправить";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Отправьте ИИ то, что вы скажете, и он добавит, изменит, завершит или удалит ваши события и задачи.";
 "Command" = "Команда";
-"What would you like to add?" = "Что вы хотите добавить?";
+"What should I do?" = "Что мне сделать?";
 "Got it. I'll notify you when it's done." = "Понял. Сообщу, когда будет готово.";
 "Sign in to the app first to use AI." = "Сначала войдите в приложение, чтобы использовать ИИ.";
 "You've used up your AI credits for today." = "Вы исчерпали кредиты ИИ на сегодня.";

--- a/TodoCalendarApp/Resources/Localize/sk.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/sk.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Hej, ${applicationName}";
+"Request in ${applicationName}" = "Požiadavka v ${applicationName}";
+"Ask ${applicationName}" = "Opýtať sa aplikácie ${applicationName}";
+"Send a request to ${applicationName}" = "Poslať požiadavku aplikácii ${applicationName}";
 "Add with AI in ${applicationName}" = "Pridať pomocou AI v ${applicationName}";
-"Add a schedule in ${applicationName}" = "Pridať termín v ${applicationName}";
-"Add a to-do in ${applicationName}" = "Pridať úlohu v ${applicationName}";
-"Add with AI" = "Pridať pomocou AI";
+"Send" = "Poslať";

--- a/TodoCalendarApp/Resources/Localize/sk.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/sk.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Pridať pomocou AI";
-"Send what you say to AI and let it create your events and to-dos." = "Pošlite AI to, čo poviete, a nechajte ju vytvoriť vaše termíny a úlohy.";
+"Send" = "Poslať";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Pošlite AI to, čo poviete, a nechajte ju pridať, zmeniť, dokončiť alebo odstrániť vaše termíny a úlohy.";
 "Command" = "Príkaz";
-"What would you like to add?" = "Čo by ste chceli pridať?";
+"What should I do?" = "Čo mám urobiť?";
 "Got it. I'll notify you when it's done." = "Rozumiem. Dám vám vedieť, keď to bude hotové.";
 "Sign in to the app first to use AI." = "Najprv sa prihláste do aplikácie, aby ste mohli používať AI.";
 "You've used up your AI credits for today." = "Vyčerpali ste dnešné kredity AI.";

--- a/TodoCalendarApp/Resources/Localize/sv.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/sv.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Hej ${applicationName}";
+"Request in ${applicationName}" = "Förfrågan till ${applicationName}";
+"Ask ${applicationName}" = "Fråga ${applicationName}";
+"Send a request to ${applicationName}" = "Skicka en förfrågan till ${applicationName}";
 "Add with AI in ${applicationName}" = "Lägg till med AI i ${applicationName}";
-"Add a schedule in ${applicationName}" = "Lägg till ett möte i ${applicationName}";
-"Add a to-do in ${applicationName}" = "Lägg till en uppgift i ${applicationName}";
-"Add with AI" = "Lägg till med AI";
+"Send" = "Skicka";

--- a/TodoCalendarApp/Resources/Localize/sv.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/sv.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Lägg till med AI";
-"Send what you say to AI and let it create your events and to-dos." = "Skicka det du säger till AI så skapar den dina möten och uppgifter.";
+"Send" = "Skicka";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Skicka det du säger till AI så kan den lägga till, ändra, slutföra eller ta bort dina möten och uppgifter.";
 "Command" = "Kommando";
-"What would you like to add?" = "Vad vill du lägga till?";
+"What should I do?" = "Vad ska jag göra?";
 "Got it. I'll notify you when it's done." = "Uppfattat. Jag meddelar dig när det är klart.";
 "Sign in to the app first to use AI." = "Logga in i appen först för att använda AI.";
 "You've used up your AI credits for today." = "Du har använt alla dina AI-krediter för idag.";

--- a/TodoCalendarApp/Resources/Localize/th.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/th.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "เฮ้ ${applicationName}";
+"Request in ${applicationName}" = "คำขอไปยัง ${applicationName}";
+"Ask ${applicationName}" = "ถาม ${applicationName}";
+"Send a request to ${applicationName}" = "ส่งคำขอไปยัง ${applicationName}";
 "Add with AI in ${applicationName}" = "เพิ่มด้วย AI ใน ${applicationName}";
-"Add a schedule in ${applicationName}" = "เพิ่มนัดหมายใน ${applicationName}";
-"Add a to-do in ${applicationName}" = "เพิ่มสิ่งที่ต้องทำใน ${applicationName}";
-"Add with AI" = "เพิ่มด้วย AI";
+"Send" = "ส่ง";

--- a/TodoCalendarApp/Resources/Localize/th.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/th.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "เพิ่มด้วย AI";
-"Send what you say to AI and let it create your events and to-dos." = "ส่งสิ่งที่คุณพูดให้ AI เพื่อสร้างนัดหมายและสิ่งที่ต้องทำให้คุณ";
+"Send" = "ส่ง";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "ส่งสิ่งที่คุณพูดให้ AI เพื่อเพิ่ม เปลี่ยน ทำเครื่องหมายว่าเสร็จ หรือลบนัดหมายและสิ่งที่ต้องทำของคุณ";
 "Command" = "คำสั่ง";
-"What would you like to add?" = "คุณต้องการเพิ่มอะไร?";
+"What should I do?" = "ให้ฉันทำอะไร?";
 "Got it. I'll notify you when it's done." = "รับทราบ เดี๋ยวแจ้งให้ทราบเมื่อเสร็จ";
 "Sign in to the app first to use AI." = "กรุณาเข้าสู่ระบบแอปก่อนใช้งาน AI";
 "You've used up your AI credits for today." = "คุณใช้เครดิต AI ของวันนี้หมดแล้ว";

--- a/TodoCalendarApp/Resources/Localize/tr.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/tr.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Hey ${applicationName}";
+"Request in ${applicationName}" = "${applicationName} uygulamasına istek";
+"Ask ${applicationName}" = "${applicationName} uygulamasına sor";
+"Send a request to ${applicationName}" = "${applicationName} uygulamasına istek gönder";
 "Add with AI in ${applicationName}" = "${applicationName} uygulamasında AI ile ekle";
-"Add a schedule in ${applicationName}" = "${applicationName} uygulamasında randevu ekle";
-"Add a to-do in ${applicationName}" = "${applicationName} uygulamasında görev ekle";
-"Add with AI" = "AI ile Ekle";
+"Send" = "Gönder";

--- a/TodoCalendarApp/Resources/Localize/tr.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/tr.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "AI ile Ekle";
-"Send what you say to AI and let it create your events and to-dos." = "Söylediklerinizi AI'ya gönderin, o da randevularınızı ve görevlerinizi oluştursun.";
+"Send" = "Gönder";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Söylediklerinizi AI'ya gönderin; randevularınızı ve görevlerinizi eklesin, değiştirsin, tamamlasın veya silsin.";
 "Command" = "Komut";
-"What would you like to add?" = "Ne eklemek istersiniz?";
+"What should I do?" = "Ne yapayım?";
 "Got it. I'll notify you when it's done." = "Anlaşıldı. Tamamlandığında size bildireceğim.";
 "Sign in to the app first to use AI." = "AI kullanmak için önce uygulamaya giriş yapın.";
 "You've used up your AI credits for today." = "Bugünkü AI kredinizi tükettiniz.";

--- a/TodoCalendarApp/Resources/Localize/uk.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/uk.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Гей, ${applicationName}";
+"Request in ${applicationName}" = "Запит у ${applicationName}";
+"Ask ${applicationName}" = "Запитати застосунок ${applicationName}";
+"Send a request to ${applicationName}" = "Надіслати запит застосунку ${applicationName}";
 "Add with AI in ${applicationName}" = "Додати за допомогою ШІ в ${applicationName}";
-"Add a schedule in ${applicationName}" = "Додати зустріч в ${applicationName}";
-"Add a to-do in ${applicationName}" = "Додати завдання в ${applicationName}";
-"Add with AI" = "Додати за допомогою ШІ";
+"Send" = "Надіслати";

--- a/TodoCalendarApp/Resources/Localize/uk.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/uk.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Додати за допомогою ШІ";
-"Send what you say to AI and let it create your events and to-dos." = "Надішліть ШІ те, що ви скажете, і він створить ваші зустрічі та завдання.";
+"Send" = "Надіслати";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Надішліть ШІ те, що ви скажете, і він додасть, змінить, завершить або видалить ваші зустрічі та завдання.";
 "Command" = "Команда";
-"What would you like to add?" = "Що б ви хотіли додати?";
+"What should I do?" = "Що мені зробити?";
 "Got it. I'll notify you when it's done." = "Зрозуміло. Повідомлю, коли буде готово.";
 "Sign in to the app first to use AI." = "Спочатку увійдіть в застосунок, щоб використовувати ШІ.";
 "You've used up your AI credits for today." = "Ви вичерпали кредити ШІ на сьогодні.";

--- a/TodoCalendarApp/Resources/Localize/vi.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/vi.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "Này ${applicationName}";
+"Request in ${applicationName}" = "Yêu cầu đến ${applicationName}";
+"Ask ${applicationName}" = "Hỏi ${applicationName}";
+"Send a request to ${applicationName}" = "Gửi yêu cầu đến ${applicationName}";
 "Add with AI in ${applicationName}" = "Thêm bằng AI trong ${applicationName}";
-"Add a schedule in ${applicationName}" = "Thêm lịch trình trong ${applicationName}";
-"Add a to-do in ${applicationName}" = "Thêm việc cần làm trong ${applicationName}";
-"Add with AI" = "Thêm bằng AI";
+"Send" = "Gửi";

--- a/TodoCalendarApp/Resources/Localize/vi.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/vi.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "Thêm bằng AI";
-"Send what you say to AI and let it create your events and to-dos." = "Gửi những gì bạn nói cho AI để tạo lịch trình và việc cần làm.";
+"Send" = "Gửi";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "Gửi những gì bạn nói cho AI để thêm, thay đổi, hoàn thành hoặc xóa lịch trình và việc cần làm.";
 "Command" = "Lệnh";
-"What would you like to add?" = "Bạn muốn thêm gì?";
+"What should I do?" = "Tôi nên làm gì?";
 "Got it. I'll notify you when it's done." = "Đã nhận. Tôi sẽ báo cho bạn khi xong.";
 "Sign in to the app first to use AI." = "Vui lòng đăng nhập vào ứng dụng trước khi dùng AI.";
 "You've used up your AI credits for today." = "Bạn đã dùng hết credit AI hôm nay.";

--- a/TodoCalendarApp/Resources/Localize/zh-Hans.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/zh-Hans.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "嘿，${applicationName}";
+"Request in ${applicationName}" = "向${applicationName}发请求";
+"Ask ${applicationName}" = "问${applicationName}";
+"Send a request to ${applicationName}" = "向${applicationName}发送请求";
 "Add with AI in ${applicationName}" = "在${applicationName}中用AI添加";
-"Add a schedule in ${applicationName}" = "在${applicationName}中添加日程";
-"Add a to-do in ${applicationName}" = "在${applicationName}中添加待办事项";
-"Add with AI" = "用AI添加";
+"Send" = "发送";

--- a/TodoCalendarApp/Resources/Localize/zh-Hans.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/zh-Hans.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "用AI添加";
-"Send what you say to AI and let it create your events and to-dos." = "把你说的内容发送给AI，让它为你创建日程和待办事项。";
+"Send" = "发送";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "把你说的内容发送给AI，让它为你添加、修改、完成或删除日程和待办事项。";
 "Command" = "指令";
-"What would you like to add?" = "你想添加什么？";
+"What should I do?" = "要我做什么？";
 "Got it. I'll notify you when it's done." = "好的，完成后会通知你。";
 "Sign in to the app first to use AI." = "请先登录应用才能使用AI。";
 "You've used up your AI credits for today." = "你今天的AI额度已用完。";

--- a/TodoCalendarApp/Resources/Localize/zh-Hant.lproj/AppShortcuts.strings
+++ b/TodoCalendarApp/Resources/Localize/zh-Hant.lproj/AppShortcuts.strings
@@ -1,4 +1,6 @@
+"Hey ${applicationName}" = "嘿，${applicationName}";
+"Request in ${applicationName}" = "向${applicationName}發請求";
+"Ask ${applicationName}" = "問${applicationName}";
+"Send a request to ${applicationName}" = "向${applicationName}傳送請求";
 "Add with AI in ${applicationName}" = "在${applicationName}中用AI新增";
-"Add a schedule in ${applicationName}" = "在${applicationName}中新增行程";
-"Add a to-do in ${applicationName}" = "在${applicationName}中新增待辦事項";
-"Add with AI" = "用AI新增";
+"Send" = "傳送";

--- a/TodoCalendarApp/Resources/Localize/zh-Hant.lproj/Localizable.strings
+++ b/TodoCalendarApp/Resources/Localize/zh-Hant.lproj/Localizable.strings
@@ -1,7 +1,8 @@
 "Add with AI" = "用AI新增";
-"Send what you say to AI and let it create your events and to-dos." = "把你說的內容傳送給AI，讓它為你建立行程和待辦事項。";
+"Send" = "傳送";
+"Send what you say to AI and let it add, change, complete, or delete your events and to-dos." = "把你說的內容傳送給AI，讓它為你新增、修改、完成或刪除行程和待辦事項。";
 "Command" = "指令";
-"What would you like to add?" = "你想新增什麼？";
+"What should I do?" = "要我做什麼？";
 "Got it. I'll notify you when it's done." = "好的，完成後會通知你。";
 "Sign in to the app first to use AI." = "請先登入應用程式才能使用AI。";
 "You've used up your AI credits for today." = "你今天的AI點數已經用完了。";

--- a/TodoCalendarApp/Sources/AppIntents/SendAICommandIntent.swift
+++ b/TodoCalendarApp/Sources/AppIntents/SendAICommandIntent.swift
@@ -12,17 +12,17 @@ import AppIntents
 
 struct SendAICommandIntent: AppIntent {
 
-    static let title: LocalizedStringResource = "Add with AI"
+    static let title: LocalizedStringResource = "Send"
 
     static let description = IntentDescription(
-        "Send what you say to AI and let it create your events and to-dos."
+        "Send what you say to AI and let it add, change, complete, or delete your events and to-dos."
     )
 
     static let openAppWhenRun: Bool = false
 
     @Parameter(
         title: "Command",
-        requestValueDialog: IntentDialog("What would you like to add?")
+        requestValueDialog: IntentDialog("What should I do?")
     )
     var commandText: String
 

--- a/TodoCalendarApp/Sources/AppIntents/TodoCalendarAppShortcuts.swift
+++ b/TodoCalendarApp/Sources/AppIntents/TodoCalendarAppShortcuts.swift
@@ -15,11 +15,13 @@ struct TodoCalendarAppShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: SendAICommandIntent(),
             phrases: [
-                "Add with AI in \(.applicationName)",
-                "Add a schedule in \(.applicationName)",
-                "Add a to-do in \(.applicationName)"
+                "Hey \(.applicationName)",
+                "Request in \(.applicationName)",
+                "Ask \(.applicationName)",
+                "Send a request to \(.applicationName)",
+                "Add with AI in \(.applicationName)"
             ],
-            shortTitle: "Add with AI",
+            shortTitle: "Send",
             systemImageName: "sparkles"
         )
     }

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -265,6 +265,10 @@ extension Project {
                 "LSApplicationQueriesSchemes": ["comgooglemaps"],
                 "ITSAppUsesNonExemptEncryption": false,
                 "CFBundleDisplayName": "To-do Calendar",
+                "INAlternativeAppNames": .array([
+                    .dictionary(["INAlternativeAppName": .string("Todo Calendar")]),
+                    .dictionary(["INAlternativeAppName": .string("투두캘린더")])
+                ]),
                 "CFBundleShortVersionString": "\(self.appVersion)",
                 "CFBundleVersion": "\(self.buildNumber)",
                 "BGTaskSchedulerPermittedIdentifiers": [

--- a/scripts/ensure-test-simulator.sh
+++ b/scripts/ensure-test-simulator.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# 테스트 실행용 시뮬레이터를 확보하고 UDID 를 표준출력으로 돌려준다.
+#
+# usage:
+#   UDID="$(scripts/ensure-test-simulator.sh)"
+#   xcodebuild test -destination "platform=iOS Simulator,id=$UDID" ...
+#
+# 로컬(run-all-tests.sh)과 CI(pr_test.yml)가 이 스크립트 하나를 공유한다.
+# 양쪽이 각자 destination 을 박아두면 서로 다른 OS 로 갈리고, 그중 한쪽 런타임이
+# Xcode 갱신으로 사라져도 다른 쪽은 초록이라 발견이 늦는다.
+set -euo pipefail
+
+SIMULATOR_NAME='iPhone 16'
+SIMULATOR_DEVICE_TYPE='com.apple.CoreSimulator.SimDeviceType.iPhone-16'
+SIMULATOR_RUNTIME='com.apple.CoreSimulator.SimRuntime.iOS-18-0'
+RUNTIME_LABEL='iOS 18.0'
+
+simulator_udid() {
+    xcrun simctl list devices available --json \
+        | python3 -c '
+import json, sys
+name = sys.argv[1]
+for runtime, devices in json.load(sys.stdin)["devices"].items():
+    if not runtime.endswith("iOS-18-0"):
+        continue
+    for device in devices:
+        if device["name"] == name:
+            print(device["udid"])
+            sys.exit(0)
+' "$SIMULATOR_NAME"
+}
+
+udid="$(simulator_udid)"
+if [ -n "$udid" ]; then
+    echo "$udid"
+    exit 0
+fi
+
+if ! xcrun simctl list runtimes | grep -q "$RUNTIME_LABEL"; then
+    cat >&2 <<MSG
+✗ $RUNTIME_LABEL 시뮬레이터 런타임이 없다.
+  Xcode 갱신으로 런타임이 빠졌으면 다시 설치하거나,
+  이 스크립트의 SIMULATOR_RUNTIME·RUNTIME_LABEL 을 설치된 런타임으로 올려라.
+  여기 한 곳만 고치면 로컬과 CI 가 함께 따라온다.
+MSG
+    exit 1
+fi
+
+echo "▶︎ '$SIMULATOR_NAME' 생성 ($RUNTIME_LABEL)" >&2
+xcrun simctl create "$SIMULATOR_NAME" "$SIMULATOR_DEVICE_TYPE" "$SIMULATOR_RUNTIME"

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -12,12 +12,10 @@ set -o pipefail
 
 WORKSPACE="TodoCalendar.xcworkspace"
 
-# CI 환경에서는 이름 기반, 로컬에서는 UDID 기반 시뮬레이터 지정
-if [ "${CI}" = "true" ]; then
-  DESTINATION="${DESTINATION:-platform=iOS Simulator,name=iPhone 16,OS=18.1}"
-else
-  SIMULATOR_UDID="76C24428-6AA8-461F-AE91-E748F8D2769E"  # iPhone 16, iOS 18.0
-  DESTINATION="${DESTINATION:-platform=iOS Simulator,id=${SIMULATOR_UDID}}"
+# 시뮬레이터는 CI·로컬이 같은 것을 쓴다 — 해석은 ensure-test-simulator.sh 가 단독으로 한다
+if [ -z "${DESTINATION:-}" ]; then
+  SIMULATOR_UDID="$("$(dirname "${BASH_SOURCE[0]}")/ensure-test-simulator.sh")"
+  DESTINATION="platform=iOS Simulator,id=${SIMULATOR_UDID}"
 fi
 
 ALL_SCHEMES=(


### PR DESCRIPTION
Siri 로 앱을 처음 부를 때 시스템 캘린더·미리알림에 발화가 가로채이고, 인텐트 문구가 전부 "추가" 프레이밍이라 서버가 이미 지원하는 수정·완료·삭제를 말로 시키기 어려웠다.

**충돌 제거** — 가로채이던 원인은 phrase 두 개가 시스템 앱이 소유한 일반 동사구(`일정 추가`·`할일 추가`)였던 것과, 앱을 부를 이름이 하이픈 붙은 `To-do Calendar` 하나뿐이었던 것이다. 일반 동사 phrase 를 걷어내고 `말하기`·`요청하기` 를 새로 열었다. 이미 발화를 외운 사용자를 위해 `AI로 추가` 는 남긴다. 여기에 `INAlternativeAppNames` 로 `Todo Calendar`·`투두캘린더` 별칭을 등록해 하이픈 표기나 한국어 발화로도 앱이 호명되게 했다.

**생성 프레이밍 제거** — 서버 AI 는 생성·수정·완료·삭제를 이미 다 처리한다(`docs/spec/ai-agent.md`). 막고 있던 건 클라의 문구뿐이라 인텐트 title·description·파라미터 다이얼로그에서 "추가"를 걷어냈다. Siri 가 되묻는 말이 `무엇을 할까요?` 로 바뀌어 "치과 다음 주로 옮겨줘" 같은 발화가 자연스럽게 들어온다. 서버·파이프라인 변경은 없다.

**31개 언어 동시 반영** — 미번역 언어에서는 Siri 가 키 원문(`Tell ${applicationName}`)을 읽어 그 언어 발화 자체가 성립하지 않는다. en/ko 선반영으로 미룰 수 없어 전 언어를 이번에 채웠다.

### 검증
빌드 산출물로 확인했다 — `extract.actionsdata` 의 phraseTemplates 3 개·title·shortTitle, 번들 `.strings`, `Info.plist` 의 `INAlternativeAppNames`. 로컬라이제이션은 전 언어 parity 0 위반 + `plutil -lint` 통과.

빌드 로그에 뜨는 `ca.lproj/AppShortcuts.strings` phrase 경고 2 건은 develop 에서도 동일하게 재현되는 기존 노이즈다.

**유저 검증 대기**: 실기기에서 Siri 로 `투두캘린더에 말하기`(및 en `Tell Todo Calendar`)를 불러 시스템 캘린더로 새지 않고 앱 인텐트가 잡히는지 확인. Siri 의 앱 이름 매칭·단축어 색인은 실기기에서만 판정된다.

### 남은 과제
사용 설명서(`sudopark/TodoCalendar-Terms` `guide/`) 의 Siri 섹션 31 개 언어 갱신 — 이 PR 머지 이후 별도로 진행한다.

Closes #1036
