### PR TITLE
CI와 로컬이 같은 테스트 시뮬레이터를 쓰게 통합한다

### DIFF
--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -87,7 +87,7 @@ description: Use when writing or modifying code in this project — 구현 착�
 - **증분 빌드 유지** — 반복 빌드·테스트는 증분을 전제로 돈다:
   - `xcodebuild clean`·DerivedData 삭제 금지 (빌드 오염 진단 같은 명시적 사유가 있을 때만)
   - `-derivedDataPath`로 새 경로를 만들지 않는다 — 기본 공유 DerivedData가 증분의 원천. `./DerivedData` + reset은 pr_test.yml의 CI 전용 패턴이니 로컬에 복제 금지
-  - destination(시뮬레이터)을 바꾸지 않는다 — run-all-tests.sh의 UDID 고정을 따른다. destination이 바뀌면 전 모듈 재빌드
+  - destination(시뮬레이터)을 바꾸지 않는다 — `scripts/ensure-test-simulator.sh`가 돌려주는 기기(iPhone 16 / iOS 18.0)를 따른다. 단발 `xcodebuild`도 같다. destination이 바뀌면 전 모듈 재빌드
 - **객체 시그니처(특히 init) 변경 시 콜사이트 전수 grep** — 수정 전에 참조처를 확인한다. 이 짝은 스크립트가 못 잡는다.
 - Query/Command 분리 유지 — 읽기와 사이드이펙트를 한 흐름에 섞지 않는다.
 

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -17,8 +17,17 @@ description: Use when the user wants to run tests for the TodoCalendar project -
 ./scripts/run-all-tests.sh Domain Repository
 
 # destination 오버라이드
-DESTINATION='platform=iOS Simulator,name=iPhone 16,OS=18.1' ./scripts/run-all-tests.sh
+DESTINATION='platform=iOS Simulator,name=iPhone 16,OS=18.0' ./scripts/run-all-tests.sh
 ```
+
+## 시뮬레이터
+
+`DESTINATION` 을 안 주면 `scripts/ensure-test-simulator.sh` 가 **iPhone 16 / iOS 18.0** 을
+확보해 UDID 로 넘긴다 — 없으면 만든다. CI(`pr_test.yml`)도 같은 스크립트를 부르므로
+로컬과 CI 의 실행 기기가 갈리지 않는다.
+
+기기·OS 를 바꿔야 하면 그 스크립트 한 곳만 고친다. 촬영 기준(snapshot-check §3 — iPhone 17
+/ iOS 26.2)과는 별개다 — 스냅샷은 시뮬 상태에 의존해 전용기를 따로 쓴다.
 
 ## Available Schemes
 

--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -175,10 +175,14 @@ jobs:
     defaults:
       run:
         shell: bash -eo pipefail {0}
-    env:
-      DESTINATION: 'platform=iOS Simulator,name=iPhone 16,OS=18.1'
     steps:
       - uses: actions/checkout@v5
+
+      - name: Ensure test simulator
+        run: |
+          set -euo pipefail
+          udid="$(scripts/ensure-test-simulator.sh)"
+          echo "DESTINATION=platform=iOS Simulator,id=${udid}" >> "$GITHUB_ENV"
 
       - name: Setup dummy config
         run: |

--- a/scripts/ensure-test-simulator.sh
+++ b/scripts/ensure-test-simulator.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# 테스트 실행용 시뮬레이터를 확보하고 UDID 를 표준출력으로 돌려준다.
+#
+# usage:
+#   UDID="$(scripts/ensure-test-simulator.sh)"
+#   xcodebuild test -destination "platform=iOS Simulator,id=$UDID" ...
+#
+# 로컬(run-all-tests.sh)과 CI(pr_test.yml)가 이 스크립트 하나를 공유한다.
+# 양쪽이 각자 destination 을 박아두면 서로 다른 OS 로 갈리고, 그중 한쪽 런타임이
+# Xcode 갱신으로 사라져도 다른 쪽은 초록이라 발견이 늦는다.
+set -euo pipefail
+
+SIMULATOR_NAME='iPhone 16'
+SIMULATOR_DEVICE_TYPE='com.apple.CoreSimulator.SimDeviceType.iPhone-16'
+SIMULATOR_RUNTIME='com.apple.CoreSimulator.SimRuntime.iOS-18-0'
+RUNTIME_LABEL='iOS 18.0'
+
+simulator_udid() {
+    xcrun simctl list devices available --json \
+        | python3 -c '
+import json, sys
+name = sys.argv[1]
+for runtime, devices in json.load(sys.stdin)["devices"].items():
+    if not runtime.endswith("iOS-18-0"):
+        continue
+    for device in devices:
+        if device["name"] == name:
+            print(device["udid"])
+            sys.exit(0)
+' "$SIMULATOR_NAME"
+}
+
+udid="$(simulator_udid)"
+if [ -n "$udid" ]; then
+    echo "$udid"
+    exit 0
+fi
+
+if ! xcrun simctl list runtimes | grep -q "$RUNTIME_LABEL"; then
+    cat >&2 <<MSG
+✗ $RUNTIME_LABEL 시뮬레이터 런타임이 없다.
+  Xcode 갱신으로 런타임이 빠졌으면 다시 설치하거나,
+  이 스크립트의 SIMULATOR_RUNTIME·RUNTIME_LABEL 을 설치된 런타임으로 올려라.
+  여기 한 곳만 고치면 로컬과 CI 가 함께 따라온다.
+MSG
+    exit 1
+fi
+
+echo "▶︎ '$SIMULATOR_NAME' 생성 ($RUNTIME_LABEL)" >&2
+xcrun simctl create "$SIMULATOR_NAME" "$SIMULATOR_DEVICE_TYPE" "$SIMULATOR_RUNTIME"

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -12,12 +12,10 @@ set -o pipefail
 
 WORKSPACE="TodoCalendar.xcworkspace"
 
-# CI 환경에서는 이름 기반, 로컬에서는 UDID 기반 시뮬레이터 지정
-if [ "${CI}" = "true" ]; then
-  DESTINATION="${DESTINATION:-platform=iOS Simulator,name=iPhone 16,OS=18.1}"
-else
-  SIMULATOR_UDID="76C24428-6AA8-461F-AE91-E748F8D2769E"  # iPhone 16, iOS 18.0
-  DESTINATION="${DESTINATION:-platform=iOS Simulator,id=${SIMULATOR_UDID}}"
+# 시뮬레이터는 CI·로컬이 같은 것을 쓴다 — 해석은 ensure-test-simulator.sh 가 단독으로 한다
+if [ -z "${DESTINATION:-}" ]; then
+  SIMULATOR_UDID="$("$(dirname "${BASH_SOURCE[0]}")/ensure-test-simulator.sh")"
+  DESTINATION="platform=iOS Simulator,id=${SIMULATOR_UDID}"
 fi
 
 ALL_SCHEMES=(


### PR DESCRIPTION
CI 가 브랜치와 무관하게 전부 깨져 있었다. 원인은 테스트 실행 기기가 **CI 와 로컬에 따로 박혀 있던 것**이다 — CI(`pr_test.yml`)는 `iPhone 16 / iOS 18.1`, 로컬(`run-all-tests.sh`)은 `iPhone 16 / iOS 18.0`.

러너 Xcode 가 갱신되면서 18.1 시뮬레이터 런타임이 사라지자 CI 만 죽었다. 증상은 테스트 실패가 아니라 destination 해석 실패라, 첫 스킴(`Domain`)에서 **테스트를 한 줄도 안 돌린 채** exit 70 으로 끝났다. 로컬은 18.0 을 보고 있어 계속 초록이었고, 그래서 발견이 늦었다.

### 접근

기기 정의를 `scripts/ensure-test-simulator.sh` 한 곳으로 모으고 CI·로컬이 그걸 함께 부르게 했다. 이제 두 경로가 구조적으로 갈릴 수 없고, 기기·OS 를 옮길 일이 생기면 고칠 자리도 한 곳이다. 시뮬레이터가 없으면 만들고, 런타임 자체가 없으면 무엇을 고쳐야 하는지 적어 실패한다 — 이번처럼 원인이 안 보이는 destination 덤프로 끝나지 않게.

실행 기기는 **로컬이 쓰던 iPhone 16 / iOS 18.0 으로 통일**했다. 스크립트가 돌려주는 UDID 가 기존 `run-all-tests.sh` 에 하드코딩돼 있던 값과 같아서, 로컬 동작은 그대로고 CI 만 로컬 쪽으로 내려온다. 최신 OS 로 올리는 건 테스트가 도는 OS 자체를 바꾸는 일이라 이번 범위에서 뺐다.

촬영 기준(snapshot-check §3 — iPhone 17 / iOS 26.2)과는 계속 별개다. 스냅샷은 시뮬 상태(언어·외관)에 의존해 전용기를 따로 쓴다.

### 검증

`./scripts/run-all-tests.sh Extensions` 로 스크립트 경유 실행이 기존과 같은 시뮬(`76C24428-…`)로 붙어 통과하는 것을 확인했다. CI 쪽 경로는 이 PR 의 체크가 곧 검증이다 — 초록이면 destination 해석이 복구된 것이다.
