### PR TITLE
[#1013] 구글 참석 응답 문구 29개 언어 번역

### DIFF
--- a/Supports/Extensions/Resources/ca.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ca.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Desconegut";
 "eventDetail::gogoleEvent::attendees" = "Assistents (%d persones)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Organitzador";
+"eventDetail::gogoleEvent::attendees::me" = "Tu";
+"eventDetail::gogoleEvent::attendees::response::title" = "Hi assistireu?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Sí";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Potser";
+"eventDetail::gogoleEvent::attendees::response::declined" = "No";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Sense resposta";
 "eventDetail::gogoleEvent::conference::accessCode" = "Codi d'accés";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Codi de la reunió";
 "eventDetail::gogoleEvent::conference::passCode" = "Codi PIN";

--- a/Supports/Extensions/Resources/cs.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/cs.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Neznámý";
 "eventDetail::gogoleEvent::attendees" = "Účastníci (%d osob)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Organizátor";
+"eventDetail::gogoleEvent::attendees::me" = "Vy";
+"eventDetail::gogoleEvent::attendees::response::title" = "Zúčastníte se?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Ano";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Možná";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Ne";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Bez odpovědi";
 "eventDetail::gogoleEvent::conference::accessCode" = "Přístupový kód";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Kód schůzky";
 "eventDetail::gogoleEvent::conference::passCode" = "Kód pro vstup";

--- a/Supports/Extensions/Resources/da.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/da.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Ukendt";
 "eventDetail::gogoleEvent::attendees" = "Deltagere (%d personer)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Arrangør";
+"eventDetail::gogoleEvent::attendees::me" = "Dig";
+"eventDetail::gogoleEvent::attendees::response::title" = "Deltager du?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Ja";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Måske";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Nej";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Intet svar";
 "eventDetail::gogoleEvent::conference::accessCode" = "Adgangskode";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Mødekode";
 "eventDetail::gogoleEvent::conference::passCode" = "Pinkode";

--- a/Supports/Extensions/Resources/de.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/de.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Unbekannt";
 "eventDetail::gogoleEvent::attendees" = "Teilnehmer (%d Personen)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Organisator";
+"eventDetail::gogoleEvent::attendees::me" = "Sie";
+"eventDetail::gogoleEvent::attendees::response::title" = "Nehmen Sie teil?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Ja";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Vielleicht";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Nein";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Keine Antwort";
 "eventDetail::gogoleEvent::conference::accessCode" = "Zugangscode";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Meeting-Code";
 "eventDetail::gogoleEvent::conference::passCode" = "Passcode";

--- a/Supports/Extensions/Resources/el.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/el.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Άγνωστο";
 "eventDetail::gogoleEvent::attendees" = "Συμμετέχοντες (%d άτομα)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Διοργανωτής";
+"eventDetail::gogoleEvent::attendees::me" = "Εσείς";
+"eventDetail::gogoleEvent::attendees::response::title" = "Θα συμμετάσχετε;";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Ναι";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Ίσως";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Όχι";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Καμία απάντηση";
 "eventDetail::gogoleEvent::conference::accessCode" = "Κωδικός πρόσβασης";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Κωδικός συνάντησης";
 "eventDetail::gogoleEvent::conference::passCode" = "Κωδικός εισόδου";

--- a/Supports/Extensions/Resources/es.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/es.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Desconocido";
 "eventDetail::gogoleEvent::attendees" = "Invitados (%d personas)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Organizador";
+"eventDetail::gogoleEvent::attendees::me" = "Tú";
+"eventDetail::gogoleEvent::attendees::response::title" = "¿Vas a asistir?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Sí";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Quizás";
+"eventDetail::gogoleEvent::attendees::response::declined" = "No";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Sin respuesta";
 "eventDetail::gogoleEvent::conference::accessCode" = "Código de acceso";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Código de la reunión";
 "eventDetail::gogoleEvent::conference::passCode" = "Código PIN";

--- a/Supports/Extensions/Resources/fi.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/fi.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Tuntematon";
 "eventDetail::gogoleEvent::attendees" = "Osallistujat (%d henkilöä)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Järjestäjä";
+"eventDetail::gogoleEvent::attendees::me" = "Sinä";
+"eventDetail::gogoleEvent::attendees::response::title" = "Osallistutko?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Kyllä";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Ehkä";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Ei";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Ei vastausta";
 "eventDetail::gogoleEvent::conference::accessCode" = "Pääsykoodi";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Kokouskoodi";
 "eventDetail::gogoleEvent::conference::passCode" = "Tunnuskoodi";

--- a/Supports/Extensions/Resources/fr.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/fr.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Inconnu";
 "eventDetail::gogoleEvent::attendees" = "Participants (%d personnes)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Organisateur";
+"eventDetail::gogoleEvent::attendees::me" = "Vous";
+"eventDetail::gogoleEvent::attendees::response::title" = "Participerez-vous ?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Oui";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Peut-être";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Non";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Sans réponse";
 "eventDetail::gogoleEvent::conference::accessCode" = "Code d'accès";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Code de réunion";
 "eventDetail::gogoleEvent::conference::passCode" = "Code secret";

--- a/Supports/Extensions/Resources/hi.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/hi.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "अज्ञात";
 "eventDetail::gogoleEvent::attendees" = "उपस्थित लोग (%d लोग)";
 "eventDetail::gogoleEvent::attendees::organizer" = "आयोजक";
+"eventDetail::gogoleEvent::attendees::me" = "आप";
+"eventDetail::gogoleEvent::attendees::response::title" = "क्या आप शामिल होंगे?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "हाँ";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "शायद";
+"eventDetail::gogoleEvent::attendees::response::declined" = "नहीं";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "कोई जवाब नहीं";
 "eventDetail::gogoleEvent::conference::accessCode" = "एक्सेस कोड";
 "eventDetail::gogoleEvent::conference::meetingCode" = "मीटिंग कोड";
 "eventDetail::gogoleEvent::conference::passCode" = "पास कोड";

--- a/Supports/Extensions/Resources/hr.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/hr.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Nepoznato";
 "eventDetail::gogoleEvent::attendees" = "Sudionici (%d osoba)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Organizator";
+"eventDetail::gogoleEvent::attendees::me" = "Vi";
+"eventDetail::gogoleEvent::attendees::response::title" = "Hoćete li prisustvovati?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Da";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Možda";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Ne";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Bez odgovora";
 "eventDetail::gogoleEvent::conference::accessCode" = "Pristupni kod";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Kod sastanka";
 "eventDetail::gogoleEvent::conference::passCode" = "Kod za prolaz";

--- a/Supports/Extensions/Resources/hu.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/hu.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Ismeretlen";
 "eventDetail::gogoleEvent::attendees" = "Résztvevők (%d fő)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Szervező";
+"eventDetail::gogoleEvent::attendees::me" = "Ön";
+"eventDetail::gogoleEvent::attendees::response::title" = "Részt vesz?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Igen";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Talán";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Nem";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Nincs válasz";
 "eventDetail::gogoleEvent::conference::accessCode" = "Hozzáférési kód";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Értekezletkód";
 "eventDetail::gogoleEvent::conference::passCode" = "Belépőkód";

--- a/Supports/Extensions/Resources/id.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/id.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Tidak diketahui";
 "eventDetail::gogoleEvent::attendees" = "Peserta (%d orang)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Penyelenggara";
+"eventDetail::gogoleEvent::attendees::me" = "Anda";
+"eventDetail::gogoleEvent::attendees::response::title" = "Akan hadir?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Ya";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Mungkin";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Tidak";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Belum ada jawaban";
 "eventDetail::gogoleEvent::conference::accessCode" = "Kode Akses";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Kode Rapat";
 "eventDetail::gogoleEvent::conference::passCode" = "Kode Sandi";

--- a/Supports/Extensions/Resources/it.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/it.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Sconosciuto";
 "eventDetail::gogoleEvent::attendees" = "Partecipanti (%d persone)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Organizzatore";
+"eventDetail::gogoleEvent::attendees::me" = "Tu";
+"eventDetail::gogoleEvent::attendees::response::title" = "Parteciperai?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Sì";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Forse";
+"eventDetail::gogoleEvent::attendees::response::declined" = "No";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Nessuna risposta";
 "eventDetail::gogoleEvent::conference::accessCode" = "Codice di accesso";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Codice riunione";
 "eventDetail::gogoleEvent::conference::passCode" = "Codice di passaggio";

--- a/Supports/Extensions/Resources/ja.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ja.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "不明";
 "eventDetail::gogoleEvent::attendees" = "参加者（%d人）";
 "eventDetail::gogoleEvent::attendees::organizer" = "主催者";
+"eventDetail::gogoleEvent::attendees::me" = "自分";
+"eventDetail::gogoleEvent::attendees::response::title" = "参加しますか？";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "はい";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "未定";
+"eventDetail::gogoleEvent::attendees::response::declined" = "いいえ";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "未回答";
 "eventDetail::gogoleEvent::conference::accessCode" = "アクセスコード";
 "eventDetail::gogoleEvent::conference::meetingCode" = "会議コード";
 "eventDetail::gogoleEvent::conference::passCode" = "パスコード";

--- a/Supports/Extensions/Resources/ms.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ms.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Tidak diketahui";
 "eventDetail::gogoleEvent::attendees" = "Peserta (%d orang)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Penganjur";
+"eventDetail::gogoleEvent::attendees::me" = "Anda";
+"eventDetail::gogoleEvent::attendees::response::title" = "Akan hadir?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Ya";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Mungkin";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Tidak";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Tiada jawapan";
 "eventDetail::gogoleEvent::conference::accessCode" = "Kod Akses";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Kod Mesyuarat";
 "eventDetail::gogoleEvent::conference::passCode" = "Kod Laluan";

--- a/Supports/Extensions/Resources/nb.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/nb.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Ukjent";
 "eventDetail::gogoleEvent::attendees" = "Deltakere (%d personer)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Arrangør";
+"eventDetail::gogoleEvent::attendees::me" = "Deg";
+"eventDetail::gogoleEvent::attendees::response::title" = "Skal du delta?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Ja";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Kanskje";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Nei";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Ingen svar";
 "eventDetail::gogoleEvent::conference::accessCode" = "Tilgangskode";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Møtekode";
 "eventDetail::gogoleEvent::conference::passCode" = "Hemmelig kode";

--- a/Supports/Extensions/Resources/nl.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/nl.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Onbekend";
 "eventDetail::gogoleEvent::attendees" = "Deelnemers (%d personen)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Organisator";
+"eventDetail::gogoleEvent::attendees::me" = "Jij";
+"eventDetail::gogoleEvent::attendees::response::title" = "Ben je erbij?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Ja";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Misschien";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Nee";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Geen reactie";
 "eventDetail::gogoleEvent::conference::accessCode" = "Toegangscode";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Vergadercode";
 "eventDetail::gogoleEvent::conference::passCode" = "Pascode";

--- a/Supports/Extensions/Resources/pl.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/pl.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Nieznany";
 "eventDetail::gogoleEvent::attendees" = "Uczestnicy (%d osób)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Organizator";
+"eventDetail::gogoleEvent::attendees::me" = "Ty";
+"eventDetail::gogoleEvent::attendees::response::title" = "Czy weźmiesz udział?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Tak";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Może";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Nie";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Brak odpowiedzi";
 "eventDetail::gogoleEvent::conference::accessCode" = "Kod dostępu";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Kod spotkania";
 "eventDetail::gogoleEvent::conference::passCode" = "Kod dostępu";

--- a/Supports/Extensions/Resources/pt-BR.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/pt-BR.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Desconhecido";
 "eventDetail::gogoleEvent::attendees" = "Participantes (%d pessoas)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Organizador";
+"eventDetail::gogoleEvent::attendees::me" = "Você";
+"eventDetail::gogoleEvent::attendees::response::title" = "Você vai participar?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Sim";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Talvez";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Não";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Sem resposta";
 "eventDetail::gogoleEvent::conference::accessCode" = "Código de acesso";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Código da reunião";
 "eventDetail::gogoleEvent::conference::passCode" = "Senha de acesso";

--- a/Supports/Extensions/Resources/ro.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ro.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Necunoscut";
 "eventDetail::gogoleEvent::attendees" = "Participanți (%d persoane)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Organizator";
+"eventDetail::gogoleEvent::attendees::me" = "Dvs.";
+"eventDetail::gogoleEvent::attendees::response::title" = "Veți participa?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Da";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Poate";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Nu";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Fără răspuns";
 "eventDetail::gogoleEvent::conference::accessCode" = "Cod de acces";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Cod al întâlnirii";
 "eventDetail::gogoleEvent::conference::passCode" = "Cod de trecere";

--- a/Supports/Extensions/Resources/ru.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/ru.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Неизвестно";
 "eventDetail::gogoleEvent::attendees" = "Участники (%d чел.)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Организатор";
+"eventDetail::gogoleEvent::attendees::me" = "Вы";
+"eventDetail::gogoleEvent::attendees::response::title" = "Вы придёте?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Да";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Возможно";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Нет";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Нет ответа";
 "eventDetail::gogoleEvent::conference::accessCode" = "Код доступа";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Код встречи";
 "eventDetail::gogoleEvent::conference::passCode" = "Код пропуска";

--- a/Supports/Extensions/Resources/sk.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/sk.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Neznámy";
 "eventDetail::gogoleEvent::attendees" = "Účastníci (%d osôb)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Organizátor";
+"eventDetail::gogoleEvent::attendees::me" = "Vy";
+"eventDetail::gogoleEvent::attendees::response::title" = "Zúčastníte sa?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Áno";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Možno";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Nie";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Bez odpovede";
 "eventDetail::gogoleEvent::conference::accessCode" = "Prístupový kód";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Kód stretnutia";
 "eventDetail::gogoleEvent::conference::passCode" = "Kód na vstup";

--- a/Supports/Extensions/Resources/sv.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/sv.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Okänd";
 "eventDetail::gogoleEvent::attendees" = "Deltagare (%d personer)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Organisatör";
+"eventDetail::gogoleEvent::attendees::me" = "Du";
+"eventDetail::gogoleEvent::attendees::response::title" = "Kommer du?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Ja";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Kanske";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Nej";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Inget svar";
 "eventDetail::gogoleEvent::conference::accessCode" = "Åtkomstkod";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Möteskod";
 "eventDetail::gogoleEvent::conference::passCode" = "Lösenordskod";

--- a/Supports/Extensions/Resources/th.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/th.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "ไม่ทราบ";
 "eventDetail::gogoleEvent::attendees" = "ผู้เข้าร่วม (%dคน)";
 "eventDetail::gogoleEvent::attendees::organizer" = "ผู้จัด";
+"eventDetail::gogoleEvent::attendees::me" = "คุณ";
+"eventDetail::gogoleEvent::attendees::response::title" = "คุณจะเข้าร่วมไหม?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "ใช่";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "ไม่แน่ใจ";
+"eventDetail::gogoleEvent::attendees::response::declined" = "ไม่";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "ยังไม่ตอบ";
 "eventDetail::gogoleEvent::conference::accessCode" = "รหัสเข้าใช้งาน";
 "eventDetail::gogoleEvent::conference::meetingCode" = "รหัสการประชุม";
 "eventDetail::gogoleEvent::conference::passCode" = "รหัสผ่าน";

--- a/Supports/Extensions/Resources/tr.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/tr.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Bilinmiyor";
 "eventDetail::gogoleEvent::attendees" = "Katılımcılar (%d kişi)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Organizatör";
+"eventDetail::gogoleEvent::attendees::me" = "Siz";
+"eventDetail::gogoleEvent::attendees::response::title" = "Katılacak mısınız?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Evet";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Belki";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Hayır";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Yanıt yok";
 "eventDetail::gogoleEvent::conference::accessCode" = "Erişim Kodu";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Toplantı Kodu";
 "eventDetail::gogoleEvent::conference::passCode" = "Geçiş Kodu";

--- a/Supports/Extensions/Resources/uk.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/uk.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Невідомо";
 "eventDetail::gogoleEvent::attendees" = "Учасники (%d осіб)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Організатор";
+"eventDetail::gogoleEvent::attendees::me" = "Ви";
+"eventDetail::gogoleEvent::attendees::response::title" = "Ви візьмете участь?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Так";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Можливо";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Ні";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Немає відповіді";
 "eventDetail::gogoleEvent::conference::accessCode" = "Код доступу";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Код зустрічі";
 "eventDetail::gogoleEvent::conference::passCode" = "Код перепустки";

--- a/Supports/Extensions/Resources/vi.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/vi.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "Không xác định";
 "eventDetail::gogoleEvent::attendees" = "Người tham dự (%d người)";
 "eventDetail::gogoleEvent::attendees::organizer" = "Người tổ chức";
+"eventDetail::gogoleEvent::attendees::me" = "Bạn";
+"eventDetail::gogoleEvent::attendees::response::title" = "Bạn sẽ tham dự chứ?";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "Có";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "Có thể";
+"eventDetail::gogoleEvent::attendees::response::declined" = "Không";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "Chưa trả lời";
 "eventDetail::gogoleEvent::conference::accessCode" = "Mã truy cập";
 "eventDetail::gogoleEvent::conference::meetingCode" = "Mã cuộc họp";
 "eventDetail::gogoleEvent::conference::passCode" = "Mã số";

--- a/Supports/Extensions/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/zh-Hans.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "未知";
 "eventDetail::gogoleEvent::attendees" = "参与者（%d人）";
 "eventDetail::gogoleEvent::attendees::organizer" = "组织者";
+"eventDetail::gogoleEvent::attendees::me" = "我";
+"eventDetail::gogoleEvent::attendees::response::title" = "您参加吗？";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "参加";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "待定";
+"eventDetail::gogoleEvent::attendees::response::declined" = "不参加";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "未回复";
 "eventDetail::gogoleEvent::conference::accessCode" = "访问代码";
 "eventDetail::gogoleEvent::conference::meetingCode" = "会议代码";
 "eventDetail::gogoleEvent::conference::passCode" = "通行码";

--- a/Supports/Extensions/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Supports/Extensions/Resources/zh-Hant.lproj/Localizable.strings
@@ -313,6 +313,12 @@
 "eventDetail::gogoleEvent::attendee::unknown" = "不明";
 "eventDetail::gogoleEvent::attendees" = "出席者（%d人）";
 "eventDetail::gogoleEvent::attendees::organizer" = "主辦人";
+"eventDetail::gogoleEvent::attendees::me" = "我";
+"eventDetail::gogoleEvent::attendees::response::title" = "您要出席嗎？";
+"eventDetail::gogoleEvent::attendees::response::accepted" = "出席";
+"eventDetail::gogoleEvent::attendees::response::tentative" = "待定";
+"eventDetail::gogoleEvent::attendees::response::declined" = "不出席";
+"eventDetail::gogoleEvent::attendees::response::needsAction" = "未回覆";
 "eventDetail::gogoleEvent::conference::accessCode" = "存取代碼";
 "eventDetail::gogoleEvent::conference::meetingCode" = "會議代碼";
 "eventDetail::gogoleEvent::conference::passCode" = "通行碼";


### PR DESCRIPTION
## 문제

구글 이벤트 참석 응답(RSVP, #876)이 en·ko lproj에만 문구를 두고 머지됐다. `NSLocalizedString`은 키 단위 en fallback이 없어서, 나머지 29개 언어에서는 참석자 행과 응답 액션시트에 `eventDetail::gogoleEvent::attendees::response::accepted` 같은 **키 원문이 그대로 노출**된다. 3.0.1 릴리즈 노트가 이 기능을 광고하므로 배포 전에 소진해야 한다.

## 접근

`Supports/Extensions/Resources/<29개>.lproj/Localizable.strings`에 6키를 채운다. 번역은 자유번역이 아니라 세 축을 각 파일에서 확인해 맞췄다:

- **용어** — 그 언어가 이미 쓰는 `attendees`·`organizer` 값과 같은 계열로 (zh-Hant 出席者/主辦人 → 出席/不出席)
- **존대 레지스터** — 파일의 기존 확인 다이얼로그가 T/V 중 무엇을 쓰는지 대조 (de `Möchten Sie…` → `Nehmen Sie teil?`, es `¿Quieres…?` → `¿Vas a asistir?`)
- **응답 3종의 UI 관례** — 그 언어 캘린더가 쓰는 형태 (ja はい/未定/いいえ, zh-Hans 参加/待定/不参加). 자기 행 라벨은 CJK만 1인칭 관례를 유지한다 (ja 自分, zh 我 — ko 나와 같은 축)

## 검증

- `python3 scripts/check-localization-parity.py` — 전 언어 0 위반 (대기 키 없음)
- 31개 `Localizable.strings` 전부 `plutil -lint` 통과
- `Extensions` 스킴 4 tests / 0 failures
