### PR TITLE
[#1070] 캠페인 상황판 실시간 추적 세분화 — 활동 로그·sync 시점 확대·Artifact 수동 전환

### DIFF
--- a/.claude/scripts/campaign-board-sync.sh
+++ b/.claude/scripts/campaign-board-sync.sh
@@ -14,26 +14,16 @@ mkdir -p "$DEST" 2>/dev/null || { echo "campaign-board-sync: $DEST 생성 실패
 for SRC in "$REPO/docs/operations/$ISSUE/campaign.md" \
            "$REPO/docs/operations/$ISSUE"/opord*.md \
            "$REPO/.operations/$ISSUE/campaign-progress.md" \
-           "$REPO/.operations/$ISSUE/progress.md"; do
+           "$REPO/.operations/$ISSUE/progress.md" \
+           "$REPO/.operations/$ISSUE/activity.md"; do
   [ -f "$SRC" ] || continue
   cp "$SRC" "$DEST/" 2>/dev/null || echo "campaign-board-sync: 복사 실패 — $SRC" >&2
 done
 
 # 스풀만 갱신하면 화면은 옛 상태로 남는다 — 렌더까지가 한 호출이다.
-RENDERED=0
 if [ -f "$BOARD/render.py" ]; then
-  if python3 "$BOARD/render.py" >/dev/null 2>&1; then
-    RENDERED=1
-  else
-    echo "campaign-board-sync: 렌더 실패 — 재게시 보류" >&2
-  fi
+  python3 "$BOARD/render.py" >/dev/null 2>&1 || echo "campaign-board-sync: 렌더 실패" >&2
 fi
 
-# 원격 미러는 Artifact tool 이 필요해 스크립트가 못 한다 — 호출자에게 남은 한 걸음을 지시한다.
-# 이번 호출이 실제로 렌더한 board.html 일 때만 지시한다 — 렌더가 실패하면 파일은 남아도 옛 내용이다.
-URL=""
-[ -s "$BOARD/artifact-url.txt" ] && URL=$(tr -d '\r\n' < "$BOARD/artifact-url.txt")
-if [ "$RENDERED" -eq 1 ] && [ -n "$URL" ] && [ -f "$BOARD/board.html" ]; then
-  echo "재게시 필요: $BOARD/board.html 을 $URL 로 Artifact 재게시하라"
-fi
+# Artifact 재게시는 수동이다 (#1070) — 유저가 요청한 세션만 board.html 을 artifact-url.txt 의 URL 로 재게시한다.
 exit 0

--- a/.claude/scripts/campaign-board-sync.test.sh
+++ b/.claude/scripts/campaign-board-sync.test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# campaign-board-sync.sh 회귀 테스트 — 스풀 부재 no-op·부분 복사·전체 복사·렌더·재게시 지시 게이팅·실패 비차단 검증
+# campaign-board-sync.sh 회귀 테스트 — 스풀 부재 no-op·부분 복사·전체 복사·렌더·재게시 지시 부재·실패 비차단 검증
 cd "$(dirname "$0")" || exit 1
 PASS=0; FAIL=0
 
@@ -23,6 +23,7 @@ echo "campaign" > "$REPO/docs/operations/500/campaign.md"
 echo "ledger" > "$REPO/.operations/500/campaign-progress.md"
 echo "opord" > "$REPO/docs/operations/500/opord.md"
 echo "progress" > "$REPO/.operations/500/progress.md"
+echo "- 09-09 20:00 activity" > "$REPO/.operations/500/activity.md"
 echo "plan only" > "$REPO/docs/operations/501/campaign.md"
 
 BOARD="$TMP_DIR/board"
@@ -32,7 +33,7 @@ OUT=$(CAMPAIGN_BOARD_DIR="$BOARD" REPO_ROOT="$REPO" bash campaign-board-sync.sh 
 assert_eq "spool_absent_noop_exit0" "rc=0" "$OUT"
 assert_no_file "spool_absent_creates_nothing" "$BOARD"
 
-# 2. 전체 복사 — 4파일 모두
+# 2. 전체 복사 — 5파일 모두
 mkdir -p "$BOARD/state"
 RC=$(CAMPAIGN_BOARD_DIR="$BOARD" REPO_ROOT="$REPO" bash campaign-board-sync.sh 500 2>/dev/null; echo $?)
 assert_eq "all_files_exit0" "0" "$RC"
@@ -40,6 +41,7 @@ assert_file "all_copied_campaign" "$BOARD/state/500/campaign.md"
 assert_file "all_copied_ledger" "$BOARD/state/500/campaign-progress.md"
 assert_file "all_copied_opord" "$BOARD/state/500/opord.md"
 assert_file "all_copied_progress" "$BOARD/state/500/progress.md"
+assert_file "all_copied_activity" "$BOARD/state/500/activity.md"
 
 # 3. 부분 복사 — 계획만 있는 이슈는 있는 것만
 RC=$(CAMPAIGN_BOARD_DIR="$BOARD" REPO_ROOT="$REPO" bash campaign-board-sync.sh 501 2>/dev/null; echo $?)
@@ -67,37 +69,29 @@ CAMPAIGN_BOARD_DIR="$BOARD" REPO_ROOT="$REPO" bash campaign-board-sync.sh 500 >/
 assert_file "render_invoked" "$BOARD/board.html"
 assert_eq "render_output" "rendered" "$(cat "$BOARD/board.html")"
 
-# 6. 재게시 지시 줄 — artifact-url.txt 가 있을 때만 stdout 에 나온다
-OUT=$(CAMPAIGN_BOARD_DIR="$BOARD" REPO_ROOT="$REPO" bash campaign-board-sync.sh 500 2>/dev/null)
-assert_eq "no_url_no_directive" "" "$OUT"
+# 6. 재게시 지시 없음 — Artifact 재게시는 수동이라(#1070) URL 파일이 있어도 stdout 은 조용하다
 echo "https://claude.ai/code/artifact/abc" > "$BOARD/artifact-url.txt"
 OUT=$(CAMPAIGN_BOARD_DIR="$BOARD" REPO_ROOT="$REPO" bash campaign-board-sync.sh 500 2>/dev/null)
-assert_eq "url_directive" "재게시 필요: $BOARD/board.html 을 https://claude.ai/code/artifact/abc 로 Artifact 재게시하라" "$OUT"
+assert_eq "url_no_directive" "" "$OUT"
 
-# 7. 빈 URL 파일 → 지시 줄 없음 (URL 자리가 빈 채로 나가면 세션이 빈 주소로 재게시한다)
-: > "$BOARD/artifact-url.txt"
-OUT=$(CAMPAIGN_BOARD_DIR="$BOARD" REPO_ROOT="$REPO" bash campaign-board-sync.sh 500 2>/dev/null)
-assert_eq "empty_url_no_directive" "" "$OUT"
-echo "https://claude.ai/code/artifact/abc" > "$BOARD/artifact-url.txt"
-
-# 8. 렌더 실패 → 비차단(exit 0)이되 지시 줄은 억제한다 — 남아있는 board.html 은 옛 내용이라 재게시하면 안 된다
+# 7. 렌더 실패 → 비차단(exit 0), stderr 로만 남긴다
 echo "STALE" > "$BOARD/board.html"
 echo "import sys; sys.exit(1)" > "$BOARD/render.py"
 OUT=$(CAMPAIGN_BOARD_DIR="$BOARD" REPO_ROOT="$REPO" bash campaign-board-sync.sh 500 2>/dev/null)
 ERR=$(CAMPAIGN_BOARD_DIR="$BOARD" REPO_ROOT="$REPO" bash campaign-board-sync.sh 500 2>&1 >/dev/null)
 RC=$(CAMPAIGN_BOARD_DIR="$BOARD" REPO_ROOT="$REPO" bash campaign-board-sync.sh 500 >/dev/null 2>&1; echo $?)
 assert_eq "render_failure_exit0" "0" "$RC"
-assert_eq "render_failure_no_directive" "" "$OUT"
+assert_eq "render_failure_silent_stdout" "" "$OUT"
 assert_eq "render_failure_keeps_stale_file" "STALE" "$(cat "$BOARD/board.html")"
 case "$ERR" in *"렌더 실패"*) PASS=$((PASS+1));; *) FAIL=$((FAIL+1)); echo "FAIL: render_failure_stderr — [$ERR]";; esac
 
-# 9. render.py 부재 → 이번 호출이 렌더한 게 없으니 지시도 없다
+# 8. render.py 부재 → stdout 조용, 크래시 없음
 rm "$BOARD/render.py"
 OUT=$(CAMPAIGN_BOARD_DIR="$BOARD" REPO_ROOT="$REPO" bash campaign-board-sync.sh 500 2>/dev/null)
-assert_eq "no_renderer_no_directive" "" "$OUT"
+assert_eq "no_renderer_silent_stdout" "" "$OUT"
 rm "$BOARD/artifact-url.txt" "$BOARD/board.html"
 
-# 10. 인자 없음 → exit 0 + stderr 안내
+# 9. 인자 없음 → exit 0 + stderr 안내
 ERR=$(CAMPAIGN_BOARD_DIR="$BOARD" REPO_ROOT="$REPO" bash campaign-board-sync.sh 2>&1 >/dev/null; true)
 RC=$(CAMPAIGN_BOARD_DIR="$BOARD" REPO_ROOT="$REPO" bash campaign-board-sync.sh >/dev/null 2>&1; echo $?)
 assert_eq "no_arg_exit0" "0" "$RC"

--- a/.claude/skills/campaign/SKILL.md
+++ b/.claude/skills/campaign/SKILL.md
@@ -74,7 +74,7 @@ DP 의 PR 이 생성돼 종결보고가 오면 (pr 스킬이 호출한다):
 
 - 경로: `.operations/<상위이슈>/campaign-progress.md` — gitignore 대상, 시점 무관 자유 갱신.
 - 서식: `<!-- progress -->` 헤딩 + 현재 국면 줄 + 원장 표 `| DP | 상태 미착수/착수/실행/검토/머지 | 이슈# | 브랜치 | base | PR# | 비고 |`.
-- 갱신 시점: DP 착수(issue 단계)·PR 생성·종결보고 접수·머지·branch 발동. 갱신마다 **이슈 본문 미러 재조립** — 본문 = `campaign.md` 전문 + 진행 파일 내용, `gh issue edit <상위이슈> --body-file` 로. 다른 세션·워크트리는 이슈 본문에서 상태를 복원한다. 상황판 동기화가 미러와 짝이다 — 미러를 재조립할 때마다 `.claude/scripts/campaign-board-sync.sh <이슈번호>` 를 함께 호출한다. 스크립트가 스풀 복사와 정적 렌더까지 하고, 렌더가 성공했고 원격 미러가 개통돼 있을 때만 `재게시 필요:` 줄을 뱉는다 — 그 줄이 나오면 지시한 파일을 지시한 URL 로 Artifact 재게시하는 것까지가 한 재조립이다. 줄을 흘리면 원격 미러만 스풀보다 뒤처져 유저가 옛 상태를 본다. 실패 비차단이라 절차를 막지 않는다.
+- 갱신 시점: DP 착수(issue 단계)·PR 생성·종결보고 접수·머지·branch 발동. 갱신마다 **이슈 본문 미러 재조립** — 본문 = `campaign.md` 전문 + 진행 파일 내용, `gh issue edit <상위이슈> --body-file` 로. 다른 세션·워크트리는 이슈 본문에서 상태를 복원한다. 상황판 동기화가 미러와 짝이다 — 미러를 재조립할 때마다 `.claude/scripts/campaign-board-sync.sh <이슈번호>` 를 함께 호출한다 (스크립트가 스풀 복사와 정적 렌더까지 한다, 실패 비차단). Artifact 재게시는 자동으로 하지 않는다 — 유저가 상황판 원격 미러를 요청할 때만 그 세션이 `~/.claude/campaign-board/board.html` 을 `~/.claude/campaign-board/artifact-url.txt` 의 URL 로 수동 재게시한다.
 
 ## 6. 종료 기록 — skill_end
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -24,7 +24,7 @@ description: Use when writing or modifying code in this project — 구현 착�
 
 **작전명령 유무로 흐름만 갈리고 절차는 동일하다:**
 
-- **작전명령 있음** (`docs/operations/<이슈>/opord.md`, 부록 A 가 태스크 순서) → superpowers executing-plans/subagent-driven-development가 부록 A 를 이끈다. 첫 태스크 착수 시 진행 파일(`.operations/<이슈>/progress.md`)의 `명령 상태:` 를 `실행` 으로 갱신하고, 태스크 완료·커밋마다 진행 파일의 태스크 표(상태·커밋 sha·보고)를 갱신한 뒤 이슈 본문 미러를 재조립한다 (opord §6·§8 — SDD ledger 와 별개, 진행 파일은 커밋하지 않는다). 각 태스크에 아래 절차를 적용한다.
+- **작전명령 있음** (`docs/operations/<이슈>/opord.md`, 부록 A 가 태스크 순서) → superpowers executing-plans/subagent-driven-development가 부록 A 를 이끈다. 첫 태스크 착수 시 진행 파일(`.operations/<이슈>/progress.md`)의 `명령 상태:` 를 `실행` 으로 갱신하고, 태스크 완료·커밋마다 진행 파일의 태스크 표(상태·커밋 sha·보고)를 갱신한 뒤 이슈 본문 미러를 재조립한다 (opord §6·§8 — SDD ledger 와 별개, 진행 파일은 커밋하지 않는다). **태스크 착수 시에도** 태스크 표의 그 행 상태를 `실행` 으로 갱신하고, 태스크 착수·GREEN·커밋·보고·블로커 같은 유의미한 활동마다 활동 로그(`.operations/<이슈>/activity.md`, opord §8 서식)에 한 줄 append 한다 — **진행 파일·활동 로그를 쓸 때마다 `.claude/scripts/campaign-board-sync.sh <이슈>` 를 짝으로 호출한다** (실패 비차단, 이슈 미러 재조립은 기존 시점 유지 — 활동마다 재조립하지 않는다). 각 태스크에 아래 절차를 적용한다.
 - **작전명령 없음** (구두지시·즉흥 수정) → superpowers TDD + 이 스킬만으로 진행한다. 계획 단계만 빠질 뿐, rules 확인 → 패턴 파악 → 구현 → 완료 판정은 동일하게 탄다.
 - **페어 프로그래밍 모드** (유저가 명시 선언한 세션) → 턴 규칙·TDD 수준·커밋 시점은 pair-programming 스킬이 이끈다. 이 스킬은 프로젝트 종속 규칙(rules·tuist generate·짝지어진 두 위치·콜사이트 grep) 공급자로만 동작한다.
 - **서브에이전트 dispatch 구현** (subagent-driven-development·병렬 dispatch 등) → 서브에이전트는 이 스킬을 스스로 invoke하지 못한다. dispatch하는 메인 세션이 첫 브리프 작성 전에 이 스킬을 invoke하고, 아래 절차를 브리프로 승계시킨다. "내가 직접 코드를 안 만지니 해당 없음"은 성립하지 않는다 — 코드 diff가 시작되는 주체가 누구든 발동한다. 갭 보고 루프(rules·플랜)의 유저 반문은 메인 세션이 중계한다 — 브리프에 "갭 발견 시 추측으로 채우지 말고 보고 후 중단"을 명시한다. 축1 선언·리팩터 게이트 선언은 브리프 승계와 컨트롤러 검수로 갈음한다 — 컨트롤러가 매 GREEN마다 선언을 재생산하지 않는다 (직접 구현 시에만 선언 관문).

--- a/.claude/skills/opord/SKILL.md
+++ b/.claude/skills/opord/SKILL.md
@@ -119,8 +119,8 @@ description: Use when writing an operation order (작전명령) for a single-PR 
 
 - 경로: `docs/operations/<이슈번호>/opord.md`. DP 면 `opord-<DP>.md`.
 - 커밋 층과 진행 층을 가른다 — **커밋 층**(1~5절·부록 A~D)은 초안 커밋(실행 브랜치 첫 커밋)과 단편명령(부록 D) 반영 때만 커밋한다. **진행**(명령 상태·태스크 진행)은 진행 파일(§8)에 자유 갱신하고 커밋하지 않는다 — 상태 전용 커밋을 만들지 않는다 (#1043 e1d38c9b 재발 방지).
-- 이슈 본문 = 커밋 층 전문 + `<!-- progress -->` 블록. 초안 저장 직후·재가 직후와 진행 갱신마다 재조립한다 — opord.md 와 progress.md 를 이어 붙여 `gh issue edit <N> --body-file <합본>`. 별도 요약 코멘트는 없다(kickoff A-4 갈음). 마커 코멘트도 없다 — 본문 자체가 최신 확정 상태다. 보고 봇 코멘트(확인보고·종결보고 등 게시 줄이 ○인 것)는 이 금지의 대상이 아니다 — 그건 히스토리 층이다(issue 스킬).
-- 상황판 동기화가 미러와 짝이다 — 미러를 재조립할 때마다 `.claude/scripts/campaign-board-sync.sh <이슈번호>` 를 함께 호출한다. 스크립트가 스풀 복사와 정적 렌더까지 하고, 렌더가 성공했고 원격 미러가 개통돼 있을 때만 `재게시 필요:` 줄을 뱉는다 — 그 줄이 나오면 지시한 파일을 지시한 URL 로 Artifact 재게시하는 것까지가 한 재조립이다. 줄을 흘리면 원격 미러만 스풀보다 뒤처져 유저가 옛 상태를 본다. 실패 비차단이라 절차를 막지 않는다.
+- 이슈 본문 = 커밋 층 전문 + `<!-- progress -->` 블록. 초안 저장 직후·재가 직후와 태스크 완료·§6 상태 전이 갱신마다 재조립한다 — 태스크 착수 표기·활동 로그는 board-sync 만 타고 미러 재조립 대상이 아니다(§8·implement §착수) — opord.md 와 progress.md 를 이어 붙여 `gh issue edit <N> --body-file <합본>`. 별도 요약 코멘트는 없다(kickoff A-4 갈음). 마커 코멘트도 없다 — 본문 자체가 최신 확정 상태다. 보고 봇 코멘트(확인보고·종결보고 등 게시 줄이 ○인 것)는 이 금지의 대상이 아니다 — 그건 히스토리 층이다(issue 스킬).
+- 상황판 동기화는 미러보다 잦다 — 미러 재조립 때만이 아니라 **진행 파일·활동 로그(§8)를 쓸 때마다** `.claude/scripts/campaign-board-sync.sh <이슈번호>` 를 짝으로 호출한다 (스크립트가 스풀 복사와 정적 렌더까지 한다, 실패 비차단). Artifact 재게시는 자동으로 하지 않는다 — 유저가 상황판 원격 미러를 요청할 때만 그 세션이 `~/.claude/campaign-board/board.html` 을 `~/.claude/campaign-board/artifact-url.txt` 의 URL 로 수동 재게시한다.
 - 부록 A Step 체크박스는 커밋 층에선 실행 지시서 원형([ ]) 그대로 두고, 미러 재조립 시 진행 파일 기준 완료된 태스크의 Step 만 [x] 로 치환해 싣는다 — 갱신 주체·시점은 태스크 완료(implement)다.
 
 ## 8. 진행 파일 ↔ SDD ledger
@@ -128,9 +128,10 @@ description: Use when writing an operation order (작전명령) for a single-PR 
 둘 다 쓴다 — 층이 다르다:
 
 - **진행 파일 `.operations/<이슈번호>/progress.md`** = 계획 층의 진행 정본 (옛 부록 E 대체). 서식: `<!-- progress -->` 헤딩 + `명령 상태:` 줄 + 태스크 표 `| 태스크 | 상태 | 커밋 | 보고 |` (정기보고 근거). gitignore 대상이지만 이슈 본문 미러로 GitHub 에 남는다 — 다른 세션·워크트리는 이슈 본문에서 복원한다.
+- **활동 로그 `.operations/<이슈번호>/activity.md`** = 실행 층의 실시간 피드 — 상황판 드릴다운이 읽는다. 태스크 착수·GREEN·커밋·보고·블로커처럼 유의미한 활동마다 `- MM-DD HH:MM 내용` 한 줄을 append 한다 (갱신 주체는 implement). gitignore 대상이고 이슈 미러엔 싣지 않는다 — 미러는 확정 상태, 활동 로그는 흐름이다.
 - **SDD `.superpowers/sdd/<plan-basename>/progress.md`** = superpowers 플러그인의 실행 층 장부. ruling·복구·재개용 — 플러그인 소관이라 그대로 둔다.
 
-진행 파일 갱신은 태스크 완료·커밋 시점 + §6 상태 전이 시점, ledger 갱신은 SDD 절차대로.
+진행 파일 갱신은 태스크 상태 전이(착수 시 `실행` 표기 포함)·완료·커밋 시점 + §6 상태 전이 시점, ledger 갱신은 SDD 절차대로.
 
 ## 9. 종료 기록 — skill_end
 


### PR DESCRIPTION
## 문제

상황판 스풀이 마일스톤(재가·태스크 완료·미러 재조립) 시점에만 갱신돼, 태스크 하나가 도는 몇 시간 동안 화면에 아무것도 안 쌓인다 — 실측으로 두 DP 세션(#751·#1069)이 실행 중인데 상황판은 "재가 · 0완료"에 멈춰 보였다. 또 sync 스크립트가 `재게시 필요:` 지시 줄을 뱉어, 유저가 원격 열람을 안 쓰는 동안에도 세션들이 문언을 따라 Artifact 를 자동 재게시하게 된다.

## 접근

닫는 이슈: #1070

- **활동 로그 신설** — `.operations/<이슈>/activity.md` 에 태스크 착수·GREEN·커밋·보고·블로커마다 `- MM-DD HH:MM 내용` 한 줄 append (정의는 opord §8, 갱신 주체는 implement §착수). 이슈 미러엔 안 싣는다 — 미러는 확정 상태, 활동 로그는 흐름이다.
- **sync 시점 확대** — 진행 파일·활동 로그를 쓸 때마다 `campaign-board-sync.sh` 를 짝으로 호출 (이슈 미러 재조립은 기존 시점 유지). 태스크 착수 시에도 태스크 표의 그 행을 `실행` 으로 갱신해 완료 전 상태가 화면에 보인다.
- **Artifact 재게시 수동 전환** — 스크립트의 `재게시 필요:` 지시 줄과 조항의 이행 의무를 제거하고, 유저가 요청한 세션만 `board.html` 을 `artifact-url.txt` 의 URL 로 재게시한다. 실시간성은 로컬 서버(SSE)와 sync 시점 확대가 담당한다.

상황판 앱 쪽(활동 피드 드릴다운·DP 칩 진행률·FRAGO/즉시보고 강조·재렌더 시 드릴다운 유지)은 레포 밖 `~/.claude/campaign-board/` 라 이 PR 에 없다 — 파서 24 TC·sync 24 TC GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015B8TeUXsaJhG5rqt6kib9j