### PR TITLE
[#1087] Today 위젯을 AppIntentConfiguration 으로 전환해 기존 배치 위젯 유지를 실증한다

### DIFF
--- a/TodoCalendarApp/AppExtensions/Widget/Snapshots/WidgetCatalogSnapshots.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Snapshots/WidgetCatalogSnapshots.swift
@@ -266,7 +266,7 @@ final class WidgetCatalogSnapshots: XCTestCase {
     @MainActor
     func test_widgetAICommand() {
         self.capture("widget-ai-command", family: .systemSmall, canvas: WidgetCanvas.small) {
-            AICommandShortcutWidgetView()
+            AICommandShortcutWidgetView(setting: .init())
         }
     }
 }

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Intents/TodayWidgetConfigurationIntent.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Intents/TodayWidgetConfigurationIntent.swift
@@ -1,0 +1,18 @@
+//
+//  TodayWidgetConfigurationIntent.swift
+//  TodoCalendarApp
+//
+//  Created by sudo.park on 9/11/26.
+//  Copyright © 2026 com.sudo.park. All rights reserved.
+//
+
+import Foundation
+import AppIntents
+
+
+// MARK: - Intent
+
+struct TodayWidgetConfigurationIntent: WidgetConfigurationIntent {
+    
+    static let title: LocalizedStringResource = ""
+}

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/TodayWidget/TodayWidget.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/TodayWidget/TodayWidget.swift
@@ -40,7 +40,11 @@ struct TodayWidget: Widget {
     let kind: String = "TodaySummary"
     
     var body: some WidgetConfiguration {
-        StaticConfiguration(kind: kind, provider: TodayWidgetTimelineProvider()) { entry in
+        AppIntentConfiguration(
+            kind: kind,
+            intent: TodayWidgetConfigurationIntent.self,
+            provider: TodayWidgetTimelineProvider()
+        ) { entry in
             TodayWidgetView(entry: entry)
                 .containerBackground(entry.backgroundShape, for: .widget)
         }

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/TodayWidget/TodayWidgetTimelineProvider.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/TodayWidget/TodayWidgetTimelineProvider.swift
@@ -16,54 +16,54 @@ import CalendarPresentation
 import WidgetScenes
 
 
-struct TodayWidgetTimelineProvider: TimelineProvider {
+struct TodayWidgetTimelineProvider: AppIntentTimelineProvider {
     
+    typealias Intent = TodayWidgetConfigurationIntent
     typealias Entry = ResultTimelineEntry<TodayWidgetViewModel>
     
-    func placeholder(in context: Context) -> ResultTimelineEntry<TodayWidgetViewModel> {
+    init() { }
+}
+
+extension TodayWidgetTimelineProvider {
+    
+    func placeholder(in context: Context) -> Entry {
         let now = Date()
         return .init(date: now) { TodayWidgetViewModel.sample() }
     }
     
-    func getSnapshot(in context: Context, completion: @Sendable @escaping (ResultTimelineEntry<TodayWidgetViewModel>) -> Void) {
+    func snapshot(
+        for configuration: TodayWidgetConfigurationIntent,
+        in context: Context
+    ) async -> Entry {
         
         guard context.isPreview == false
         else {
-            completion(
-                .init(date: Date()) { TodayWidgetViewModel.sample() }
-            )
-            return
+            return self.placeholder(in: context)
         }
-        self.getEntry { entry in
-            completion(entry)
-        }
+        return await self.loadEntry()
     }
     
-    func getTimeline(in context: Context, completion: @Sendable @escaping (Timeline<ResultTimelineEntry<TodayWidgetViewModel>>) -> Void) {
+    func timeline(
+        for configuration: TodayWidgetConfigurationIntent,
+        in context: Context
+    ) async -> Timeline<Entry> {
         
-        self.getEntry { entry in
-            let timeline = Timeline(entries: [entry], policy: .after(Date().nextUpdateTime))
-            completion(timeline)
-        }
+        let entry = await self.loadEntry()
+        return Timeline(entries: [entry], policy: .after(Date().nextUpdateTime))
     }
     
-    private func getEntry(_ completion: @Sendable @escaping (Entry) -> Void) {
+    private func loadEntry() async -> Entry {
         
-        Task {
-            let builder = WidgetViewModelProviderBuilder(base: .init())
-            let viewModelProvider = await builder.makeTodayViewModelProvider()
-            let now = Date()
-            do {
-                let model = try await viewModelProvider.getTodayViewModel(for: now)
-                completion(
-                    .init(date: now, result: .success(model))
-                    |> \.background .~ model.widgetSetting.background
-                )
-            } catch {
-                completion(
-                    .init(date: now, result: .failure(.init(error: error)))
-                )
-            }
+        let builder = WidgetViewModelProviderBuilder(base: .init())
+        let viewModelProvider = await builder.makeTodayViewModelProvider()
+        let now = Date()
+        do {
+            let model = try await viewModelProvider.getTodayViewModel(for: now)
+            return .init(date: now, result: .success(model))
+                |> \.background .~ model.widgetSetting.background
+            
+        } catch {
+            return .init(date: now, result: .failure(.init(error: error)))
         }
     }
 }


### PR DESCRIPTION
## 문제

#1086 의 4층(홈에 놓인 개별 위젯 인스턴스마다 다르게 꾸미기)은 위젯 인스턴스에 정체성이 있어야 서는데, 그 자리가 `WidgetConfiguration` 의 AppIntent 파라미터뿐이다. 배치 가능한 위젯 20종 중 16종이 아직 `StaticConfiguration` 이라 전 위젯 전환이 따라붙는데, **전환해도 이미 홈에 배치된 기존 유저 위젯이 살아남는지**가 검증된 적이 없다. Apple 문서에 마이그레이션 보장 명시가 없고, 깨지면 "기존 유저 것을 안 빼앗는다"(#721 승계)가 무너져 캠페인의 층 구성 자체를 재검토해야 한다.

작전계획 #1086 의 단계 0 위력수색이다. 저장 계약·템플릿 스키마가 이 가정 위에 굳기 전에, 머지가 하나도 나가기 전에 판정한다.

## 접근

Today 하나만 골라 파라미터 없는 빈 Intent 로 전환한다. 꾸미기 파라미터는 일부러 얹지 않았다 — 이 PR 이 판정해야 하는 건 "전환 그 자체가 안전한가"뿐이고, 기능을 섞으면 깨졌을 때 원인이 갈린다.

- `TodayWidgetConfigurationIntent` 신설. 파라미터 0개라 편집 UI 에 뜰 항목도, 신규 로컬라이즈 키도 없다. 뒤 DP(DP-2.3)가 여기에 템플릿 파라미터를 얹는다.
- `TodayWidget.body` 를 `AppIntentConfiguration(kind:intent:provider:)` 로. `kind` 문자열 `"TodaySummary"` 는 그대로다 — 기존 위젯이 살아남는 전제가 kind 유지다.
- `TodayWidgetTimelineProvider` 를 `AppIntentTimelineProvider` 로. completion 기반 `getEntry` 를 `loadEntry` async 로 옮긴 것뿐이라 적재 동작은 같고, 형제 `EventListWidgetTimeLineProvider` 의 구조를 그대로 따랐다.

첫 커밋은 이번 작업과 별개로 발견한 것이다. `WidgetCatalogSnapshots` 가 #1069 에서 바뀐 `AICommandShortcutWidgetView(setting:)` 시그니처를 안 따라가 컴파일 단계에서 죽어 있었고(로컬 전용 스킴이라 CI 가 못 잡는다), 이 PR 의 검증 수단이 그 스킴이라 먼저 살렸다.

## 검증

- `TodoCalendarAppWidget` 71건 통과, `TodoCalendarAppWidgetSnapshots` 19건 통과 (뷰 코드 무변경 — 모양 불변)
- `.appex/Metadata.appintents/extract.actionsdata` 에 `TodoCalendarAppWidget.TodayWidgetConfigurationIntent` 등록 확인

## 유저 검증 대기 — A1 실기

**항목**: Static → AppIntent 전환 후 기존 배치 위젯 유지 (작전계획 #1086 가정 A1, 결정지점 D1)

**방법**: ① develop 빌드를 기기·시뮬레이터에 설치 → ② 홈에 Today 위젯 배치 → ③ 이 브랜치 빌드를 같은 자리에 덮어 설치

**판정 기준**: 배치해둔 Today 위젯이 placeholder 로 바뀌거나 홈에서 사라지지 않고, 내용이 그대로 갱신되면 A1 성립 → #1086 단계 1 진입. 하나라도 깨지면 D1 → branch B1(전환 범위 축소)로 계획 재배열.

이 확인 전에는 머지하지 않는다.
