### PR TITLE
[#1089] EventList Intent 에 파라미터를 추가해 기존 인스턴스 설정값 보존을 실증한다

### DIFF
--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Base+Factory/WidgetViewModelProviderBuilder.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Base+Factory/WidgetViewModelProviderBuilder.swift
@@ -137,7 +137,8 @@ extension WidgetViewModelProviderBuilder {
     
     func makeEventListViewModelProvider(
         shouldSkipCheckCacheReset: Bool = false,
-        targetEventTagIds: [EventTagId]?
+        targetEventTagIds: [EventTagId]?,
+        excludeAllDayEvent: Bool
     ) async -> EventListWidgetViewModelProvider {
         
         if !shouldSkipCheckCacheReset {
@@ -158,6 +159,7 @@ extension WidgetViewModelProviderBuilder {
         
         return EventListWidgetViewModelProvider(
             targetEventTagIds: targetEventTagIds,
+            excludeAllDayEvents: excludeAllDayEvent,
             eventsFetchUsecase: fetchUsecase,
             appSettingRepository: appSettingRepository,
             calendarSettingRepository: calendarSettingRepository,
@@ -376,7 +378,8 @@ extension WidgetViewModelProviderBuilder {
         
         let eventList = await self.makeEventListViewModelProvider(
             shouldSkipCheckCacheReset: true,
-            targetEventTagIds: [targetEventTagId]
+            targetEventTagIds: [targetEventTagId],
+            excludeAllDayEvent: false
         )
         
         let month = await self.makeMonthViewModelProvider(
@@ -413,7 +416,8 @@ extension WidgetViewModelProviderBuilder {
         
         let eventList = await self.makeEventListViewModelProvider(
             shouldSkipCheckCacheReset: true,
-            targetEventTagIds: [targetEventTagId]
+            targetEventTagIds: [targetEventTagId],
+            excludeAllDayEvent: false
         )
 
         let foremost = await self.makeForemostEventWidgetViewModelProvider()

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Intents/EventTypeSelectIntent.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Intents/EventTypeSelectIntent.swift
@@ -155,6 +155,9 @@ struct EventTypeSelectIntent: WidgetConfigurationIntent {
     
     @Parameter(title: "Event Types", default: nil)
     var eventTypes: [EventTypeEntity]?
+    
+    @Parameter(title: "Exclude all day event", default: false)
+    var excludeAllDayEvent: Bool
 }
 
 

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/EventListWidget/EventListWidgetTimeLineProvider.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/EventListWidget/EventListWidgetTimeLineProvider.swift
@@ -45,19 +45,22 @@ extension EventListWidgetTimeLineProvider {
             return self.placeholder(in: context)
         }
         
-        return await self.loadEntry(configuration.eventTypes, context)
+        return await self.loadEntry(configuration.eventTypes, configuration.excludeAllDayEvent, context)
     }
     
     func timeline(
         for configuration: EventTypeSelectIntent, in context: Context
     ) async -> Timeline<ResultTimelineEntry<EventListWidgetViewModel>> {
         
-        let entry = await self.loadEntry(configuration.eventTypes, context)
+        let entry = await self.loadEntry(
+            configuration.eventTypes, configuration.excludeAllDayEvent, context
+        )
         return Timeline(entries: [entry], policy: .after(Date().nextUpdateTime))
     }
     
     private func loadEntry(
         _ selected: [EventTypeEntity]?,
+        _ excludeAllDayEvent: Bool,
         _ context: Context
     ) async -> Entry {
         
@@ -65,7 +68,9 @@ extension EventListWidgetTimeLineProvider {
         let size = EventListWidgetSize(context.family)
         
         let builder = WidgetViewModelProviderBuilder(base: .init())
-        let viewModelProvider = await builder.makeEventListViewModelProvider(targetEventTagIds: tagIds)
+        let viewModelProvider = await builder.makeEventListViewModelProvider(
+            targetEventTagIds: tagIds, excludeAllDayEvent: excludeAllDayEvent
+        )
         let now = Date()
         do {
             let model = try await viewModelProvider.getEventListViewModel(

--- a/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/EventListWidget/EventListWidgetViewModelProvider.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Sources/Widgets/EventListWidget/EventListWidgetViewModelProvider.swift
@@ -111,6 +111,7 @@ extension EventListWidgetSize {
 final class EventListWidgetViewModelProvider {
     
     private let targetEventTagIds: [EventTagId]?
+    private let excludeAllDayEvents: Bool
     private let eventsFetchUsecase: any CalendarEventFetchUsecase
     private let appSettingRepository: any AppSettingRepository
     private let calendarSettingRepository: any CalendarSettingRepository
@@ -118,12 +119,14 @@ final class EventListWidgetViewModelProvider {
     
     init(
         targetEventTagIds: [EventTagId]?,
+        excludeAllDayEvents: Bool,
         eventsFetchUsecase: any CalendarEventFetchUsecase,
         appSettingRepository: any AppSettingRepository,
         calendarSettingRepository: any CalendarSettingRepository,
         localeProvider: any LocaleProvider
     ) {
         self.targetEventTagIds = targetEventTagIds
+        self.excludeAllDayEvents = excludeAllDayEvents
         self.eventsFetchUsecase = eventsFetchUsecase
         self.appSettingRepository = appSettingRepository
         self.calendarSettingRepository = calendarSettingRepository
@@ -189,13 +192,20 @@ extension EventListWidgetViewModelProvider {
         _ timeZone: TimeZone
     ) async throws -> CalendarEvents {
         let total = try await self.eventsFetchUsecase.fetchEvents(in: range, timeZone)
-        guard let selecteds = self.targetEventTagIds.map({ Set($0) })
-        else {
-            return total
+        
+        var currents = total.currentTodos
+        var eventWithTimes = total.eventWithTimes
+        if let selecteds = self.targetEventTagIds.map({ Set($0) }) {
+            currents = currents.filter { selecteds.contains($0.eventTagId) }
+            eventWithTimes = eventWithTimes.filter { selecteds.contains($0.eventTagId) }
         }
+        if self.excludeAllDayEvents {
+            eventWithTimes = eventWithTimes.filter { !($0.eventTime?.isAllDay ?? false) }
+        }
+        
         return total
-            |> \.currentTodos .~ total.currentTodos.filter { selecteds.contains($0.eventTagId) }
-            |> \.eventWithTimes .~ total.eventWithTimes.filter { selecteds.contains($0.eventTagId) }
+            |> \.currentTodos .~ currents
+            |> \.eventWithTimes .~ eventWithTimes
     }
 }
 

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/Doubles/StubCalendarEventsFetchUescase.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/Doubles/StubCalendarEventsFetchUescase.swift
@@ -18,6 +18,7 @@ class StubCalendarEventsFetchUescase: CalendarEventFetchUsecase {
     var hasCurrentTodo: Bool = true
     var hasEventAtStartDate: Bool = true
     var hasHoliday: Bool = true
+    var hasAllDayEvent: Bool = false
     var withoutAnyEvents: Bool = false
     
     func fetchEvents(
@@ -45,6 +46,19 @@ class StubCalendarEventsFetchUescase: CalendarEventFetchUsecase {
             if let holidayEvent = HolidayCalendarEvent(holiday, in: timeZone) {
                 sender.eventWithTimes.append(holidayEvent)
             }
+        }
+        
+        if !withoutAnyEvents && hasAllDayEvent {
+            let allDaySchedule = ScheduleEvent(
+                uuid: "allday", name: "allday_event",
+                time: .allDay(
+                    range.lowerBound..<range.lowerBound+24*3600,
+                    secondsFromGMT: TimeInterval(timeZone.secondsFromGMT())
+                )
+            )
+            sender.eventWithTimes.append(
+                contentsOf: ScheduleCalendarEvent.events(from: allDaySchedule, in: timeZone)
+            )
         }
         
         if !withoutAnyEvents {

--- a/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/EventListWidgetViewModelProviderTests.swift
+++ b/TodoCalendarApp/AppExtensions/Widget/Tests/ViewModelProviders/EventListWidgetViewModelProviderTests.swift
@@ -22,7 +22,9 @@ class EventListWidgetViewModelProviderTests: BaseTestCase {
         selectTagIds: [EventTagId]? = nil,
         withCurrentTodo: Bool = true,
         withStartDateEvent: Bool = true,
-        withoutAnyEventsIncludeHoliday: Bool = false
+        withoutAnyEventsIncludeHoliday: Bool = false,
+        withAllDayEvent: Bool = false,
+        excludeAllDayEvents: Bool = false
     ) -> EventListWidgetViewModelProvider {
         
         let fetchUsecase = StubCalendarEventsFetchUescase()
@@ -30,12 +32,14 @@ class EventListWidgetViewModelProviderTests: BaseTestCase {
         fetchUsecase.hasEventAtStartDate = withStartDateEvent
         fetchUsecase.withoutAnyEvents = withoutAnyEventsIncludeHoliday
         fetchUsecase.hasHoliday = !withoutAnyEventsIncludeHoliday
+        fetchUsecase.hasAllDayEvent = withAllDayEvent
         
         let calendarSettingRepository = StubCalendarSettingRepository()
         let appSettingRepository = StubAppSettingRepository()
         
         return .init(
             targetEventTagIds: selectTagIds,
+            excludeAllDayEvents: excludeAllDayEvents,
             eventsFetchUsecase: fetchUsecase,
             appSettingRepository: appSettingRepository,
             calendarSettingRepository: calendarSettingRepository,
@@ -85,6 +89,33 @@ extension EventListWidgetViewModelProviderTests {
         XCTAssertEqual(firstDateModel?.events.map { $0.name }, [
             "todo_at_start"
         ])
+    }
+    
+    func testProvider_whenNotExcludeAllDayEvents_containsAllDayEvent() async throws {
+        // given
+        let provider = self.makeProvider(withAllDayEvent: true)
+        
+        // when
+        let viewModel = try await provider.getEventListViewModel(for: self.refDate, widgetSize: .small)
+        
+        // then
+        let firstDateModel = viewModel.pages.first?.sections[safe: 1]
+        XCTAssertEqual(
+            firstDateModel?.events.map { $0.name }.sorted(),
+            ["allday_event", "todo_at_start"]
+        )
+    }
+    
+    func testProvider_whenExcludeAllDayEvents_filterOutAllDayEvent() async throws {
+        // given
+        let provider = self.makeProvider(withAllDayEvent: true, excludeAllDayEvents: true)
+        
+        // when
+        let viewModel = try await provider.getEventListViewModel(for: self.refDate, widgetSize: .small)
+        
+        // then
+        let firstDateModel = viewModel.pages.first?.sections[safe: 1]
+        XCTAssertEqual(firstDateModel?.events.map { $0.name }, ["todo_at_start"])
     }
     
     func testProvider_whenCurrentTodoNotExists_doNotProvideCurrentTodoDayModel() async throws {
@@ -220,6 +251,7 @@ extension EventListWidgetViewModelProviderTests {
         
         return EventListWidgetViewModelProvider(
             targetEventTagIds: nil,
+            excludeAllDayEvents: false,
             eventsFetchUsecase: usecase,
             appSettingRepository: appSettingRepository,
             calendarSettingRepository: calendarSettingRepository,
@@ -242,6 +274,7 @@ extension EventListWidgetViewModelProviderTests {
         )
         let provider = EventListWidgetViewModelProvider(
             targetEventTagIds: nil,
+            excludeAllDayEvents: false,
             eventsFetchUsecase: usecase,
             appSettingRepository: StubAppSettingRepository(),
             calendarSettingRepository: StubCalendarSettingRepository(),
@@ -491,6 +524,7 @@ extension EventListWidgetViewModelProviderTests {
         
         return EventListWidgetViewModelProvider(
             targetEventTagIds: nil,
+            excludeAllDayEvents: false,
             eventsFetchUsecase: usecase,
             appSettingRepository: appSettingRepository,
             calendarSettingRepository: calendarSettingRepository,
@@ -590,6 +624,7 @@ extension EventListWidgetViewModelProviderTests {
         let appSettingRepository = StubAppSettingRepository()
         return .init(
             targetEventTagIds: nil,
+            excludeAllDayEvents: false,
             eventsFetchUsecase: fetchUsecase,
             appSettingRepository: appSettingRepository,
             calendarSettingRepository: calendarSettingRepository,
@@ -674,6 +709,7 @@ extension EventListWidgetViewModelProviderTests {
         let appSettingRepository = StubAppSettingRepository()
         return .init(
             targetEventTagIds: tagIds,
+            excludeAllDayEvents: false,
             eventsFetchUsecase: fetchUsecase,
             appSettingRepository: appSettingRepository,
             calendarSettingRepository: calendarSettingRepository,

--- a/docs/spec/widgets.md
+++ b/docs/spec/widgets.md
@@ -136,6 +136,7 @@ TodoToggleIntent.perform()
 ```
 EventTypeSelectIntent (WidgetConfigurationIntent)
 ├── eventTypes: [EventTypeEntity]?  — 선택된 태그 목록
+└── excludeAllDayEvent: Bool = false — 하루종일 이벤트 제외
 
 EventListComponentSelectIntent (WidgetConfigurationIntent)
 ├── eventTypes: [EventTypeEntity]?  — 선택된 태그 목록


### PR DESCRIPTION
## 문제

#1086 의 단계 0 위력수색 두 번째 과업이다. 선행 PR #1088 이 A1(Configuration 종류 전환 시 기존 배치 위젯 유지)을 확인했지만, 남은 가정 A7 은 다른 질문이다 — **이미 `AppIntentConfiguration` 인 위젯의 Intent 에 파라미터를 추가**했을 때 기존 인스턴스가 설정값을 잃지 않느냐다.

#1086 의 DP-2.3·DP-3.2 가 전부 그 동작이고, 특히 DP-3.2 는 `eventTypes` 를 설정해둔 EventList 인스턴스에 템플릿 파라미터를 얹는다. 코드베이스에 선례가 없고(DDay·EventList 모두 파라미터를 갖고 태어났다) Apple 문서에도 마이그레이션 보장 명시가 없다. 깨지면 branch B3 로 위젯군별 Intent 를 확정 파라미터 세트로 한 번에 내보내도록 DP 편성을 다시 짜야 하는데, 그 재편을 저장 계약·템플릿 스키마가 굳은 뒤에 하면 늦다.

## 접근

EventList 를 대상으로 골랐다. Today 는 #1088 에서 파라미터 0개인 빈 Intent 로 전환돼 보존할 설정값 자체가 없어서, 파라미터를 추가해봐야 A1 과 같은 관찰만 반복한다. EventList 는 `eventTypes` 를 갖고 릴리즈돼 있어 "값이 설정된 인스턴스"를 만들 수 있고, A7 이 실제로 걸리는 DP-3.2 와 같은 조건이 된다.

추가하는 파라미터는 `excludeAllDayEvent` 다. 형제 `EventListComponentSelectIntent` 에 이미 있는 축이라 새 개념이 아니고, 필터까지 실제로 연결해서 기본값이 적용된 걸 눈으로 확인할 수 있다.

- 필터는 `EventListWidgetViewModelProvider.loadEventList` 에서 태그 필터 뒤에 순차 적용한다. 기존 태그 필터가 `guard let` 조기 반환이라 두 필터가 함께 걸리지 않아, 형제 `TodayAndNextWidgetViewModelProvider` 와 같은 누적 형태로 풀었다.
- 복합 위젯(EventAndMonth·EventAndForemost)은 인스턴스 설정이 없어 `false` 를 명시해 기존 동작을 유지한다.
- `docs/spec/widgets.md §4.1` 의 Intent 구조 정본도 함께 갱신했다.

## 검증

- `TodoCalendarAppWidget` 73건 통과 — 신규 TC 2건(`excludeAllDayEvents` on/off 양쪽)이 필터 분기를 각 방향에서 찌른다
- `extract.actionsdata` 에 `excludeAllDayEvent` 2건 등록 확인 (`EventTypeSelectIntent` + 기존 `EventListComponentSelectIntent`)
- `StubCalendarEventsFetchUescase.hasAllDayEvent` 는 기본 꺼짐 opt-in 이라 기존 TC 기대값 불변

## 유저 검증 대기 — A7 실기

**항목**: 배포된 Intent 에 파라미터 추가 시 기존 배치 인스턴스의 설정값 보존 (작전계획 #1086 가정 A7, 결정지점 D5)

**방법**: ① 기기에 이미 깔린 빌드 #18 상태에서 **EventList 위젯을 홈에 배치하고 위젯 편집으로 `eventTypes`(표시할 이벤트 종류)를 지정**한다 → ② 이 브랜치 빌드를 덮어 설치한다

**판정 기준**: ⓐ 위젯이 placeholder 화·제거되지 않고 ⓑ 지정해둔 `eventTypes` 가 그대로 유지되며 ⓒ 위젯 편집에 "Exclude all day event" 가 꺼진 상태로 새로 뜨면 A7 성립 → #1086 단계 1 진입. 하나라도 어긋나면 D5 → branch B3.

이 확인 전에는 머지하지 않는다.
