### PR TITLE
[#1039] 오늘 버튼을 이벤트 목록 날짜 헤더로 옮기고 연도 표시를 키운다

### DIFF
--- a/Presentations/CalendarScenes/Snapshots/CalendarScenesCatalogSnapshots.swift
+++ b/Presentations/CalendarScenes/Snapshots/CalendarScenesCatalogSnapshots.swift
@@ -480,7 +480,12 @@ private final class CatalogDayEventListViewModel: DayEventListViewModel, @unchec
         Just(0).eraseToAnyPublisher()
     }
 
+    var isShowReturnToToday: AnyPublisher<Bool, Never> {
+        Just(false).eraseToAnyPublisher()
+    }
+
     func selectedDayChanaged(_ newDay: CurrentSelectDayModel, and eventThatDay: [any CalendarEvent]) { }
+    func selectedDayIsToday(_ isToday: Bool) { }
     func addNewTodoQuickly(withName: String) { }
     func makeTodoEvent(with givenName: String) { }
     func makeEvent() { }
@@ -496,6 +501,7 @@ private final class CatalogDayEventListViewModel: DayEventListViewModel, @unchec
     func submitAIAgent(_ text: String) { }
     func handleAIEntryButtonTap() { }
     func showAIGuide() { }
+    func returnToToday() { }
     func attachListener(_ listener: any DayEventListSceneListener) { }
 }
 

--- a/Presentations/CalendarScenes/Snapshots/CalendarScenesSnapshots.swift
+++ b/Presentations/CalendarScenes/Snapshots/CalendarScenesSnapshots.swift
@@ -235,7 +235,12 @@ private final class FakeDayEventListViewModel: DayEventListViewModel, @unchecked
         Just(0).eraseToAnyPublisher()
     }
 
+    var isShowReturnToToday: AnyPublisher<Bool, Never> {
+        Just(false).eraseToAnyPublisher()
+    }
+
     func selectedDayChanaged(_ newDay: CurrentSelectDayModel, and eventThatDay: [any CalendarEvent]) { }
+    func selectedDayIsToday(_ isToday: Bool) { }
     func addNewTodoQuickly(withName: String) { }
     func makeTodoEvent(with givenName: String) { }
     func makeEvent() { }
@@ -251,5 +256,6 @@ private final class FakeDayEventListViewModel: DayEventListViewModel, @unchecked
     func submitAIAgent(_ text: String) { }
     func handleAIEntryButtonTap() { }
     func showAIGuide() { }
+    func returnToToday() { }
     func attachListener(_ listener: any DayEventListSceneListener) { }
 }

--- a/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperScene+Builder.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperScene+Builder.swift
@@ -20,6 +20,7 @@ protocol CalendarPaperSceneInteractor: Sendable, AnyObject, MonthSceneListener, 
     func selectToday()
     func selectDay(_ day: CalendarDay)
     func scrollToVoiceInput()
+    func selectedDayIsToday(_ isToday: Bool)
 }
 //
 protocol CalendarPaperSceneListener: AnyObject {
@@ -28,6 +29,7 @@ protocol CalendarPaperSceneListener: AnyObject {
         on month: CalendarMonth, didChange selectedDay: CurrentSelectDayModel
     )
     func calendarPaperDidRequestShowAICommand()
+    func calendarPaperDidRequestReturnToToday()
 }
 
 // MARK: - CalendarPaperScene

--- a/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarPaper/CalendarPaperViewModel.swift
@@ -88,8 +88,16 @@ extension CalendarPaperViewModelImple {
         self.listener?.calendarPaper(on: self.currentMonth, didChange: currentSelectedDay)
     }
 
+    func selectedDayIsToday(_ isToday: Bool) {
+        self.eventListInteractor.selectedDayIsToday(isToday)
+    }
+
     func dayEventListDidRequestShowAICommand() {
         self.listener?.calendarPaperDidRequestShowAICommand()
+    }
+
+    func dayEventListDidRequestReturnToToday() {
+        self.listener?.calendarPaperDidRequestReturnToToday()
     }
 
     func monthScene(didRequestShare range: Range<TimeInterval>, kind: CalendarShareRangeKind) {

--- a/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
@@ -219,8 +219,15 @@ final class CalendarViewModelImple: CalendarViewModel, @unchecked Sendable {
         .sink(receiveValue: { [weak self] selected in
             logger.log(level: .debug, "select day changed: \(selected)")
             self?.listener?.calendarScene(focusChangedTo: selected)
+            self?.notifySelectedDayIsTodayToFocusedPaper(selected.isCurrentDay)
         })
         .store(in: self.cancellables)
+    }
+
+    private func notifySelectedDayIsTodayToFocusedPaper(_ isToday: Bool) {
+        guard let focusedIndex = self.subject.monthsInCurrentRange.value?.focusedIndex
+        else { return }
+        self.calendarPaperInteractors?[safe: focusedIndex]?.selectedDayIsToday(isToday)
     }
     
     private func bindRefreshHoliday() {
@@ -494,6 +501,10 @@ extension CalendarViewModelImple: CalendarPaperSceneListener {
         let newMap = self.subject.selectedDayPerMonths.value
             |> key(month) .~ selectedDay
         self.subject.selectedDayPerMonths.send(newMap)
+    }
+
+    func calendarPaperDidRequestReturnToToday() {
+        self.listener?.calendarSceneDidRequestReturnToToday()
     }
 
     func calendarPaperDidRequestShowAICommand() {

--- a/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/CalendarViewModel.swift
@@ -504,7 +504,7 @@ extension CalendarViewModelImple: CalendarPaperSceneListener {
     }
 
     func calendarPaperDidRequestReturnToToday() {
-        self.listener?.calendarSceneDidRequestReturnToToday()
+        self.moveFocusToToday()
     }
 
     func calendarPaperDidRequestShowAICommand() {

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListScene+Builder.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListScene+Builder.swift
@@ -20,11 +20,13 @@ protocol DayEventListSceneInteractor: AnyObject {
         _ newDay: CurrentSelectDayModel,
         and eventThatDay: [any CalendarEvent]
     )
+    func selectedDayIsToday(_ isToday: Bool)
 }
 
 protocol DayEventListSceneListener: AnyObject {
 
     func dayEventListDidRequestShowAICommand()
+    func dayEventListDidRequestReturnToToday()
 }
 
 // MARK: - DayEventListScene

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListView.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListView.swift
@@ -50,6 +50,7 @@ enum DayEventListScrollAnchor {
     fileprivate var aiAgentState: AIAgentState = .idle
     fileprivate var recognizingText: String = ""
     fileprivate var voiceLevel: Float = 0
+    fileprivate var isShowReturnToToday: Bool = false
 
     fileprivate var isVoiceListening: Bool {
         if case .listening(.voice) = aiAgentState { return true }
@@ -136,6 +137,15 @@ enum DayEventListScrollAnchor {
             .receive(on: RunLoop.main)
             .sink { [weak self] level in self?.voiceLevel = level }
             .store(in: self.cancellables)
+
+        viewModel.isShowReturnToToday
+            .receive(on: RunLoop.main)
+            .sink(receiveValue: { [weak self, weak appearance] isShow in
+                appearance?.withAnimationIfNeed {
+                    self?.isShowReturnToToday = isShow
+                }
+            })
+            .store(in: self.cancellables)
     }
 }
 
@@ -159,6 +169,7 @@ final class DayEventListViewEventHandler: Observable {
     var submitAIAgent: (String) -> Void = { _ in }
     var handleAIEntryButtonTap: () -> Void = { }
     var showAIGuide: () -> Void = { }
+    var returnToToday: () -> Void = { }
 
     func bind(
         _ viewModel: any DayEventListViewModel,
@@ -185,6 +196,7 @@ final class DayEventListViewEventHandler: Observable {
         self.submitAIAgent = viewModel.submitAIAgent(_:)
         self.handleAIEntryButtonTap = viewModel.handleAIEntryButtonTap
         self.showAIGuide = viewModel.showAIGuide
+        self.returnToToday = viewModel.returnToToday
     }
 }
 
@@ -351,6 +363,29 @@ struct DayEventListView: View {
             }
     }
 
+    private func returnToTodayView() -> some View {
+        Button {
+            self.isFocusInput = false
+            self.appearance.impactIfNeed()
+            self.eventHandler.returnToToday()
+        } label: {
+            HStack(spacing: Metric.Spacing.xsmall) {
+                Image(systemName: "arrow.uturn.right")
+                    .resizable()
+                    .frame(width: 15, height: 15)
+                Text("TODAY".localized())
+                    .font(self.appearance.fontSet.subNormalWithBold.asFont)
+            }
+            .foregroundStyle(self.appearance.colorSet.text0.asColor)
+            .padding(.horizontal, spacing: .small)
+            .padding(.vertical, spacing: .xsmall)
+            .overlay {
+                RoundedRectangle(cornerRadius: Metric.Radius.large)
+                    .stroke(self.appearance.colorSet.text0.asColor, lineWidth: 1.5)
+            }
+        }
+    }
+
     private func dateInfoView() -> some View {
         VStack(alignment: .leading) {
 
@@ -374,6 +409,10 @@ struct DayEventListView: View {
                             self.appearance.fontSet.size(20+appearance.eventTextAdditionalSize, weight: .semibold).asFont
                         )
                         .foregroundColor(self.appearance.colorSet.text2.asColor)
+                }
+
+                if self.state.isShowReturnToToday {
+                    self.returnToTodayView()
                 }
 
                 Spacer()

--- a/Presentations/CalendarScenes/Sources/DayEventList/DayEventListViewModel.swift
+++ b/Presentations/CalendarScenes/Sources/DayEventList/DayEventListViewModel.swift
@@ -68,6 +68,7 @@ protocol DayEventListViewModel: AnyObject, Sendable, DayEventListSceneInteractor
     func submitAIAgent(_ text: String)
     func handleAIEntryButtonTap()
     func showAIGuide()
+    func returnToToday()
     func attachListener(_ listener: any DayEventListSceneListener)
 
     // presenter
@@ -79,6 +80,7 @@ protocol DayEventListViewModel: AnyObject, Sendable, DayEventListSceneInteractor
     var aiAgentState: AnyPublisher<AIAgentState, Never> { get }
     var recognizingText: AnyPublisher<String, Never> { get }
     var voiceLevel: AnyPublisher<Float, Never> { get }
+    var isShowReturnToToday: AnyPublisher<Bool, Never> { get }
 }
 
 
@@ -140,6 +142,7 @@ final class DayEventListViewModelImple: DayEventListViewModel, @unchecked Sendab
         let pendingTodoEvents = CurrentValueSubject<[PendingTodoEventCellViewModel], Never>([])
         let isSignedIn = CurrentValueSubject<Bool, Never>(false)
         let aiAgentState = CurrentValueSubject<AIAgentState?, Never>(nil)
+        let selectedDayIsToday = CurrentValueSubject<Bool, Never>(true)
     }
 
     private let cancellables = CancelBag()
@@ -174,6 +177,10 @@ extension DayEventListViewModelImple {
         self.subject.currentDayAndEventLists.send(
             .init(currentDay: newDay, events: eventThatDay)
         )
+    }
+
+    func selectedDayIsToday(_ isToday: Bool) {
+        self.subject.selectedDayIsToday.send(isToday)
     }
 
     func addNewTodoQuickly(withName: String) {
@@ -297,6 +304,10 @@ extension DayEventListViewModelImple {
         self.router?.routeToAIGuide()
     }
 
+    func returnToToday() {
+        self.listener?.dayEventListDidRequestReturnToToday()
+    }
+
     private static func isCommandPhase(_ state: AIAgentState) -> Bool {
         switch state {
         case .processing, .confirm, .done, .failed: return true
@@ -316,6 +327,13 @@ extension DayEventListViewModelImple {
 // MARK: - DayEventListViewModelImple Presenter
 
 extension DayEventListViewModelImple {
+
+    var isShowReturnToToday: AnyPublisher<Bool, Never> {
+        return self.subject.selectedDayIsToday
+            .map { !$0 }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
 
     var foremostEventModel: AnyPublisher<
         (any EventCellViewModel)?, Never

--- a/Presentations/CalendarScenes/Tests/Calendar/CalendarDeepLinkHandlerImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Calendar/CalendarDeepLinkHandlerImpleTests.swift
@@ -179,7 +179,6 @@ private final class SpyCalendarInteractor: CalendarSceneInteractor, @unchecked S
     }
     var didCalls: [Call] = []
 
-    func moveFocusToToday() { }
 
     var didMoveToPreviousMonth: Bool?
     func moveToPreviousMonth() {

--- a/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
@@ -1210,6 +1210,48 @@ extension CalendarViewModelImpleTests {
     }
 }
 
+// MARK: - 선택일이 오늘인지 하향 전달
+
+extension CalendarViewModelImpleTests {
+
+    func testViewModel_whenSelectedDayChanged_notifyIsTodayToFocusedPaperOnly() async throws {
+        // given
+        let viewModel = self.makeViewModel(
+            today: .init(year: 2023, month: 08, day: 02, weekDay: 3)
+        )
+        try await self.prepareInitialMonths(viewModel)
+
+        // when
+        viewModel.calendarPaper(on: .init(year: 2023, month: 08), didChange: .dummy(2023, 08, 02))
+        viewModel.calendarPaper(on: .init(year: 2023, month: 08), didChange: .dummy(2023, 08, 03))
+
+        // then
+        try await self.assertSelectedDayIsTodays([[], [true, false], []])
+        withExtendedLifetime(viewModel) { }
+    }
+
+    func testViewModel_whenPaperRequestReturnToToday_notifyToListener() {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        viewModel.calendarPaperDidRequestReturnToToday()
+
+        // then
+        XCTAssertEqual(self.spyListener.didRequestReturnToToday, true)
+    }
+
+    private var selectedDayIsTodays: [[Bool]] {
+        return self.spyRouter.spyInteractors.map { $0.didSelectedDayIsTodays }
+    }
+
+    private func assertSelectedDayIsTodays(_ expected: [[Bool]]) async throws {
+        try await self.waitEffect("하향 전달 \(expected) 도달") { self.selectedDayIsTodays == expected }
+        try await Task.sleep(for: .milliseconds(50))
+        XCTAssertEqual(self.selectedDayIsTodays, expected)
+    }
+}
+
 // MARK: - 외부 진입점의 AI 입력 요청 (requestAIEntry)
 
 extension CalendarViewModelImpleTests {
@@ -1405,9 +1447,15 @@ private extension CalendarViewModelImpleTests {
             self.didScrollToVoiceInputCount += 1
         }
 
+        var didSelectedDayIsTodays: [Bool] = []
+        func selectedDayIsToday(_ isToday: Bool) {
+            self.didSelectedDayIsTodays.append(isToday)
+        }
+
         func monthScene(didChange currentSelectedDay: CurrentSelectDayModel, and eventsThatDay: [any CalendarEvent]) { }
         func monthScene(didRequestShare range: Range<TimeInterval>, kind: CalendarShareRangeKind) { }
         func dayEventListDidRequestShowAICommand() { }
+        func dayEventListDidRequestReturnToToday() { }
     }
     
     final class SpyListener: CalendarSceneListener, @unchecked Sendable {
@@ -1416,6 +1464,11 @@ private extension CalendarViewModelImpleTests {
         
         func calendarScene(focusChangedTo selected: SelectDayInfo) {
             self.didSelectionChanged?(selected)
+        }
+
+        var didRequestReturnToToday: Bool?
+        func calendarSceneDidRequestReturnToToday() {
+            self.didRequestReturnToToday = true
         }
     }
     

--- a/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/Calendar/CalendarViewModelImpleTests.swift
@@ -1230,15 +1230,26 @@ extension CalendarViewModelImpleTests {
         withExtendedLifetime(viewModel) { }
     }
 
-    func testViewModel_whenPaperRequestReturnToToday_notifyToListener() {
+    func testViewModel_whenPaperRequestReturnToToday_moveFocusToToday() async throws {
         // given
-        let viewModel = self.makeViewModel()
+        let viewModel = self.makeViewModel(
+            today: .init(year: 2023, month: 08, day: 02, weekDay: 3)
+        )
+        try await self.prepareInitialMonths(viewModel)
+        viewModel.focusChanged(from: 1, to: 2)
 
         // when
         viewModel.calendarPaperDidRequestReturnToToday()
 
         // then
-        XCTAssertEqual(self.spyListener.didRequestReturnToToday, true)
+        try await self.waitEffect("오늘이 속한 달로 되돌아온다") {
+            self.spyRouter.spyInteractors.map { $0.currentMonth } == [
+                .init(year: 2023, month: 07),
+                .init(year: 2023, month: 08),
+                .init(year: 2023, month: 09)
+            ]
+        }
+        XCTAssertEqual(self.spyRouter.spyInteractors.map { $0.didSelectTodayRequested }, [nil, true, nil])
     }
 
     private var selectedDayIsTodays: [[Bool]] {
@@ -1464,11 +1475,6 @@ private extension CalendarViewModelImpleTests {
         
         func calendarScene(focusChangedTo selected: SelectDayInfo) {
             self.didSelectionChanged?(selected)
-        }
-
-        var didRequestReturnToToday: Bool?
-        func calendarSceneDidRequestReturnToToday() {
-            self.didRequestReturnToToday = true
         }
     }
     

--- a/Presentations/CalendarScenes/Tests/CalendarPaper/CalendarPaperViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/CalendarPaper/CalendarPaperViewModelImpleTests.swift
@@ -141,6 +141,28 @@ extension CalendarPaperViewModelImpleTests {
         )
     }
 
+    func testViewModel_whenSelectedDayIsTodayChanged_notifyToEventList() {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        viewModel.selectedDayIsToday(false)
+
+        // then
+        XCTAssertEqual(self.spyEventListInteractor.didSelectedDayIsToday, false)
+    }
+
+    func testViewModel_whenEventListRequestReturnToToday_notifyToListener() {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        viewModel.dayEventListDidRequestReturnToToday()
+
+        // then
+        XCTAssertEqual(self.spyListner.didRequestReturnToToday, true)
+    }
+
     func testViewModel_whenMonthSceneRequestsShare_routesToSharePreview() {
         // given
         let viewModel = self.makeViewModel()
@@ -194,6 +216,11 @@ extension CalendarPaperViewModelImpleTests {
             self.selectedDays.append(newDay)
             self.selectedDayEvents.append(eventThatDay)
         }
+
+        var didSelectedDayIsToday: Bool?
+        func selectedDayIsToday(_ isToday: Bool) {
+            self.didSelectedDayIsToday = isToday
+        }
     }
     
     private final class SpyCalendarPaperSceneListener: CalendarPaperSceneListener {
@@ -206,6 +233,11 @@ extension CalendarPaperViewModelImpleTests {
         var didRequestShowAICommand: Bool?
         func calendarPaperDidRequestShowAICommand() {
             self.didRequestShowAICommand = true
+        }
+
+        var didRequestReturnToToday: Bool?
+        func calendarPaperDidRequestReturnToToday() {
+            self.didRequestReturnToToday = true
         }
     }
 }

--- a/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
+++ b/Presentations/CalendarScenes/Tests/DayEventList/DayEventListViewModelImpleTests.swift
@@ -1414,6 +1414,75 @@ extension DayEventListViewModelImpleTests {
         func dayEventListDidRequestShowAICommand() {
             self.didRequestShowAICommand = true
         }
+
+        var didRequestReturnToToday: Bool?
+        func dayEventListDidRequestReturnToToday() {
+            self.didRequestReturnToToday = true
+        }
+    }
+}
+
+// MARK: - 오늘로 돌아가기 버튼 노출
+
+extension DayEventListViewModelImpleTests {
+
+    func testViewModel_whenSelectedDayIsNotToday_showReturnToToday() {
+        // given
+        let expect = expectation(description: "오늘이 아닌 날을 고르면 오늘 버튼을 보인다")
+        expect.expectedFulfillmentCount = 2
+        let viewModel = self.makeViewModel()
+
+        // when
+        let isShows = self.waitOutputs(expect, for: viewModel.isShowReturnToToday) {
+            viewModel.selectedDayIsToday(false)
+        }
+
+        // then
+        XCTAssertEqual(isShows, [false, true])
+    }
+
+    func testViewModel_whenSelectedDayIsToday_hideReturnToToday() {
+        // given
+        let expect = expectation(description: "다시 오늘을 고르면 오늘 버튼을 감춘다")
+        expect.expectedFulfillmentCount = 3
+        let viewModel = self.makeViewModel()
+
+        // when
+        let isShows = self.waitOutputs(expect, for: viewModel.isShowReturnToToday) {
+            viewModel.selectedDayIsToday(false)
+            viewModel.selectedDayIsToday(true)
+        }
+
+        // then
+        XCTAssertEqual(isShows, [false, true, false])
+    }
+
+    func testViewModel_whenReturnToToday_notifyToListener() {
+        // given
+        let viewModel = self.makeViewModel()
+
+        // when
+        viewModel.returnToToday()
+
+        // then
+        XCTAssertEqual(self.spyListener.didRequestReturnToToday, true)
+    }
+
+    func testViewModel_whenSelectedDayIsTodayRepeated_notEmitDuplicate() {
+        // given
+        let expect = expectation(description: "같은 날짜 상태가 반복돼도 중복 방출하지 않는다")
+        expect.expectedFulfillmentCount = 3
+        let viewModel = self.makeViewModel()
+
+        // when
+        let isShows = self.waitOutputs(expect, for: viewModel.isShowReturnToToday) {
+            viewModel.selectedDayIsToday(false)
+            viewModel.selectedDayIsToday(false)
+            viewModel.selectedDayIsToday(true)
+        }
+
+        // then
+        XCTAssertEqual(isShows, [false, true, false])
     }
 }
 

--- a/Presentations/Scenes/Sources/Scenes+Calendar.swift
+++ b/Presentations/Scenes/Sources/Scenes+Calendar.swift
@@ -13,7 +13,6 @@ import Domain
 
 public protocol CalendarSceneInteractor: Sendable, AnyObject {
 
-    func moveFocusToToday()
     func moveDay(_ day: CalendarDay, withClearPresented: Bool)
     func moveToPreviousMonth()
     func moveToNextMonth()
@@ -30,7 +29,6 @@ extension CalendarSceneInteractor {
 public protocol CalendarSceneListener: Sendable, AnyObject {
     
     func calendarScene(focusChangedTo selected: SelectDayInfo)
-    func calendarSceneDidRequestReturnToToday()
 }
 
 public protocol CalendarScene: Scene where Interactor == any CalendarSceneInteractor {

--- a/Presentations/Scenes/Sources/Scenes+Calendar.swift
+++ b/Presentations/Scenes/Sources/Scenes+Calendar.swift
@@ -30,6 +30,7 @@ extension CalendarSceneInteractor {
 public protocol CalendarSceneListener: Sendable, AnyObject {
     
     func calendarScene(focusChangedTo selected: SelectDayInfo)
+    func calendarSceneDidRequestReturnToToday()
 }
 
 public protocol CalendarScene: Scene where Interactor == any CalendarSceneInteractor {

--- a/TodoCalendarApp/Sources/Main/MainViewController.swift
+++ b/TodoCalendarApp/Sources/Main/MainViewController.swift
@@ -406,7 +406,7 @@ private final class HeaderView: UIView {
         self.monthLabel.font = fontSet.bigMonth
         self.monthLabel.textColor = colorSet.text0
         
-        self.yearLabel.font = fontSet.normal
+        self.yearLabel.font = fontSet.size(22, weight: .semibold)
         self.yearLabel.textColor = colorSet.text0
         
         switch self.migrationStatus {

--- a/TodoCalendarApp/Sources/Main/MainViewController.swift
+++ b/TodoCalendarApp/Sources/Main/MainViewController.swift
@@ -126,13 +126,6 @@ extension MainViewController {
             })
             .store(in: self.cancellables)
         
-        self.viewModel.isShowReturnToToday
-            .receive(on: RunLoop.main)
-            .sink(receiveValue: { [weak self] show in
-                self?.headerView.returnTodayView.isHidden = !show
-            })
-            .store(in: self.cancellables)
-        
         self.viewModel.temporaryUserDataMigrationStatus
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [weak self] status in
@@ -177,12 +170,6 @@ extension MainViewController {
             })
             .store(in: self.cancellables)
 
-        self.headerView.returnTodayView.addTapGestureRecognizerPublisher()
-            .sink(receiveValue: { [weak self] in
-                self?.viewModel.returnToToday()
-            })
-            .store(in: self.cancellables)
-        
         self.headerView.migrationButton.addTapGestureRecognizerPublisher()
             .sink(receiveValue: { [weak self] in
                 self?.viewAppearance.impactIfNeed()
@@ -305,9 +292,6 @@ private final class HeaderView: UIView {
     private let titleStackView = UIStackView()
     let previousMonthButton = UIButton()
     let nextMonthButton = UIButton()
-    let returnTodayView = UIView()
-    private let returnTodayImage = UIImageView()
-    private let returnTodayLabel = UILabel()
     private let buttonsStackView = UIStackView()
     let migrationButton = UIButton()
     let jumpButton = UIButton()
@@ -380,40 +364,11 @@ private final class HeaderView: UIView {
             $0.heightAnchor.constraint(equalToConstant: 44)
         }
 
-        self.addSubview(returnTodayView)
-        returnTodayView.autoLayout.active(with: self) {
-            $0.centerXAnchor.constraint(equalTo: $1.centerXAnchor).setupPriority(.defaultLow)
-            $0.centerYAnchor.constraint(equalTo: $1.centerYAnchor)
-            $0.leadingAnchor.constraint(greaterThanOrEqualTo: self.nextMonthButton.trailingAnchor, constant: 8).setupPriority(.defaultHigh)
-        }
-        
-        self.returnTodayView.addSubview(returnTodayImage)
-        returnTodayImage.autoLayout.active {
-            $0.widthAnchor.constraint(equalToConstant: 15)
-            $0.heightAnchor.constraint(equalToConstant: 15)
-            $0.leadingAnchor.constraint(equalTo: returnTodayView.leadingAnchor, constant: 8)
-            $0.centerYAnchor.constraint(equalTo: returnTodayView.centerYAnchor)
-        }
-        
-        self.returnTodayView.addSubview(returnTodayLabel)
-        returnTodayLabel.autoLayout.active {
-            $0.leadingAnchor.constraint(equalTo: returnTodayImage.trailingAnchor, constant: 4)
-            $0.trailingAnchor.constraint(equalTo: returnTodayView.trailingAnchor, constant: -8)
-            $0.topAnchor.constraint(equalTo: returnTodayView.topAnchor, constant: 6)
-            $0.bottomAnchor.constraint(equalTo: returnTodayView.bottomAnchor, constant: -6)
-        }
-        
-        self.returnTodayView.layer.borderWidth = 1.5
-        self.returnTodayView.clipsToBounds = true
-        self.returnTodayView.layer.cornerRadius = 12
-        self.returnTodayLabel.text = "TODAY".localized()
-        self.returnTodayView.isHidden = true
-        
         self.addSubview(buttonsStackView)
         buttonsStackView.autoLayout.active {
             $0.centerYAnchor.constraint(equalTo: self.centerYAnchor)
             $0.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -16)
-            $0.leadingAnchor.constraint(greaterThanOrEqualTo: returnTodayView.trailingAnchor, constant: 4)
+            $0.leadingAnchor.constraint(greaterThanOrEqualTo: self.nextMonthButton.trailingAnchor, constant: 4)
         }
         buttonsStackView.spacing = 8
         
@@ -453,14 +408,6 @@ private final class HeaderView: UIView {
         
         self.yearLabel.font = fontSet.normal
         self.yearLabel.textColor = colorSet.text0
-        
-        self.returnTodayImage.tintColor = colorSet.text0
-        self.returnTodayImage.image = UIImage(systemName: "arrow.uturn.right")
-        
-        self.returnTodayLabel.font = fontSet.subNormalWithBold
-        self.returnTodayLabel.textColor = colorSet.text0
-        
-        self.returnTodayView.layer.borderColor = colorSet.text0.cgColor
         
         switch self.migrationStatus {
         case .migrating:

--- a/TodoCalendarApp/Sources/Main/MainViewModel.swift
+++ b/TodoCalendarApp/Sources/Main/MainViewModel.swift
@@ -243,9 +243,6 @@ extension MainViewModelImple {
         self.subject.focusedDayInfo.send(selected)
     }
 
-    func calendarSceneDidRequestReturnToToday() {
-        self.calendarSceneInteractor?.moveFocusToToday()
-    }
     
     func jumpDate() {
         guard let current = self.subject.focusedDayInfo.value else { return }

--- a/TodoCalendarApp/Sources/Main/MainViewModel.swift
+++ b/TodoCalendarApp/Sources/Main/MainViewModel.swift
@@ -39,7 +39,6 @@ protocol MainViewModel: AnyObject, Sendable, MainSceneInteractor {
 
     // interactor
     func prepare()
-    func returnToToday()
     func moveToPreviousMonth()
     func moveToNextMonth()
     func handleMigration()
@@ -51,7 +50,6 @@ protocol MainViewModel: AnyObject, Sendable, MainSceneInteractor {
 
     // presenter
     var currentMonth: AnyPublisher<CurrentMonth, Never> { get }
-    var isShowReturnToToday: AnyPublisher<Bool, Never> { get }
     var temporaryUserDataMigrationStatus: AnyPublisher<TemporaryUserDataMigrationStatus?, Never> { get }
     var isLoadingCalendarEvents: AnyPublisher<Bool, Never> { get }
     var isLoadingAllEvents: AnyPublisher<Bool, Never> { get }
@@ -209,10 +207,6 @@ extension MainViewModelImple {
             .store(in: self.cancellables)
     }
     
-    func returnToToday() {
-        self.calendarSceneInteractor?.moveFocusToToday()
-    }
-
     func moveToPreviousMonth() {
         self.calendarSceneInteractor?.moveToPreviousMonth()
     }
@@ -247,6 +241,10 @@ extension MainViewModelImple {
     
     func calendarScene(focusChangedTo selected: SelectDayInfo) {
         self.subject.focusedDayInfo.send(selected)
+    }
+
+    func calendarSceneDidRequestReturnToToday() {
+        self.calendarSceneInteractor?.moveFocusToToday()
     }
     
     func jumpDate() {
@@ -297,14 +295,6 @@ extension MainViewModelImple {
         
         return self.subject.focusedDayInfo
             .compactMap(transform)
-            .removeDuplicates()
-            .eraseToAnyPublisher()
-    }
-    
-    var isShowReturnToToday: AnyPublisher<Bool, Never> {
-        return self.subject.focusedDayInfo
-            .compactMap { $0 }
-            .map { !$0.isCurrentDay }
             .removeDuplicates()
             .eraseToAnyPublisher()
     }

--- a/TodoCalendarApp/TodoCalendarAppTests/ApplicationRootViewModelImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/ApplicationRootViewModelImpleTests.swift
@@ -121,7 +121,6 @@ private final class SpyMainSceneInteractor: MainSceneInteractor, @unchecked Send
     }
 
     func calendarScene(focusChangedTo selected: SelectDayInfo) { }
-    func calendarSceneDidRequestReturnToToday() { }
     func daySelectDialog(didSelect day: SelectDayInfo) { }
 }
 

--- a/TodoCalendarApp/TodoCalendarAppTests/ApplicationRootViewModelImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/ApplicationRootViewModelImpleTests.swift
@@ -121,6 +121,7 @@ private final class SpyMainSceneInteractor: MainSceneInteractor, @unchecked Send
     }
 
     func calendarScene(focusChangedTo selected: SelectDayInfo) { }
+    func calendarSceneDidRequestReturnToToday() { }
     func daySelectDialog(didSelect day: SelectDayInfo) { }
 }
 

--- a/TodoCalendarApp/TodoCalendarAppTests/MainViewModelImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/MainViewModelImpleTests.swift
@@ -263,16 +263,6 @@ extension MainViewModelImpleTests {
         XCTAssertEqual(months.map { $0.yearText }, [nil, nil, nil, "2022"])
     }
     
-    func testViewModel_whenCalendarSceneRequestReturnToToday_moveFocusToToday() {
-        // given
-        let viewModel = self.makeViewModel()
-
-        // when
-        viewModel.calendarSceneDidRequestReturnToToday()
-
-        // then
-        XCTAssertEqual(self.spyRouter.interactor.didFocusMovedToToday, true)
-    }
      
     func testViewModel_rouetToEventTypeSettingScene() {
         // given
@@ -474,11 +464,6 @@ extension MainViewModelImpleTests {
     
     private class SpyCalendarInteractor: CalendarSceneInteractor, @unchecked Sendable {
         
-        var didFocusMovedToToday: Bool?
-        func moveFocusToToday() {
-            self.didFocusMovedToToday = true
-        }
-
         var didMoveToPreviousMonth: Bool?
         func moveToPreviousMonth() {
             self.didMoveToPreviousMonth = true

--- a/TodoCalendarApp/TodoCalendarAppTests/MainViewModelImpleTests.swift
+++ b/TodoCalendarApp/TodoCalendarAppTests/MainViewModelImpleTests.swift
@@ -263,38 +263,13 @@ extension MainViewModelImpleTests {
         XCTAssertEqual(months.map { $0.yearText }, [nil, nil, nil, "2022"])
     }
     
-    func testViewModle_whenFocusChanged_updateIsShowReturnToToday() {
+    func testViewModel_whenCalendarSceneRequestReturnToToday_moveFocusToToday() {
         // given
-        let expect = expectation(description: "update is show today")
-        expect.expectedFulfillmentCount = 4
         let viewModel = self.makeViewModel()
-        
+
         // when
-        let isShow = self.waitOutputs(expect, for: viewModel.isShowReturnToToday) {
-            viewModel.calendarScene(focusChangedTo: .init(2023, 08, 1, isCurrentYear: true, isCurrentDay: true))
-            viewModel.calendarScene(focusChangedTo: .init(2023, 09, 1, isCurrentYear: true, isCurrentDay: false))
-            viewModel.calendarScene(focusChangedTo: .init(2023, 10, 1, isCurrentYear: true, isCurrentDay: false))
-            viewModel.calendarScene(focusChangedTo: .init(2023, 09, 1, isCurrentYear: true, isCurrentDay: false))
-            viewModel.calendarScene(focusChangedTo: .init(2023, 08, 1, isCurrentYear: true, isCurrentDay: true))
-            viewModel.calendarScene(focusChangedTo: .init(2023, 08, 2, isCurrentYear: true, isCurrentDay: false))
-        }
-        
-        // then
-        XCTAssertEqual(isShow, [false, true, false, true])
-    }
-    
-    // request return to today
-    func testViewModel_requestReturnToToday() {
-        // given
-        let expect = expectation(description: "wait-return to today show")
-        let viewModel = self.makeViewModel()
-        
-        // when
-        let _ = self.waitFirstOutput(expect, for: viewModel.isShowReturnToToday) {
-            viewModel.calendarScene(focusChangedTo: .init(2023, 09, 1, isCurrentYear: true, isCurrentDay: false))
-        }
-        viewModel.returnToToday()
-        
+        viewModel.calendarSceneDidRequestReturnToToday()
+
         // then
         XCTAssertEqual(self.spyRouter.interactor.didFocusMovedToToday, true)
     }


### PR DESCRIPTION
오늘 버튼이 상단 헤더에서 월 제목과 도구 버튼 사이에 끼어 있었다. 연도 표시가 그 틈에 눌려 14pt 로 작았고, 버튼이 실제로 날짜를 다루는 자리(선택 날짜·이벤트 목록)와 멀어 맥락도 약했다.

버튼을 이벤트 목록의 날짜 헤더로 옮기고, 비워진 상단 공간만큼 연도를 키웠다. 옮기면서 판정의 소유는 바꾸지 않았다 — 버튼이 보일지 말지는 이미 그 값을 계산하던 `CalendarViewModelImple` 이 계속 정해 아래로 내려보낸다. 값은 UI 판단(`shouldShow`)이 아니라 사실(`isToday`)로 흘려, 보이는 조건(`!isToday`)의 결정은 표시처인 `DayEventListViewModelImple` 이 한다.

- 노출 조건 하향 — `CalendarViewModelImple.bindFocusedMonthChanged` 의 기존 sink 가 포커스된 paper 하나에만 `selectedDayIsToday` 를 보낸다. 판정이 복제되지 않고, 포커스 전환과 값 갱신이 한 지점에서 일어난다
- 탭 위임 상향 — `DayEventListViewModelImple.returnToToday` → Paper → Calendar. 기존 `dayEventListDidRequestShowAICommand` 체인과 동형이고, `CalendarViewModelImple` 이 요청을 받은 자리에서 자기 `moveFocusToToday()` 를 호출해 끝낸다
- `MainViewModel` 은 오늘로 복귀에 더 이상 관여하지 않는다. `isShowReturnToToday`·`returnToToday()` 가 사라지고, 이 경로를 위해 뚫려 있던 `CalendarSceneInteractor.moveFocusToToday()` 도 프로덕션 소비자가 없어져 걷었다 — `Presentations/Scenes` 변경이 순감이다

## 이벤트 전달 흐름

노출 조건은 판정처에서 표시처로 내려가고, 탭은 표시처에서 소유처로 올라간다.

### 노출 조건 — 하향

```mermaid
flowchart TD
    A[CalendarUsecase.currentDay] --> CL
    B[subject.focusedMonth] --> CL
    C[subject.selectedDayPerMonths] --> CL
    CL["CombineLatest3 — CalendarViewModelImple.bindFocusedMonthChanged"] --> S["SelectDayInfo(isCurrentDay:)"]
    S --> M1["listener.calendarScene(focusChangedTo:) → MainViewModelImple<br/>(currentMonth · jumpDate 용, 오늘 버튼과 무관)"]
    S --> N["notifySelectedDayIsTodayToFocusedPaper<br/>포커스된 paper 하나만"]
    N --> P["CalendarPaperViewModelImple.selectedDayIsToday — 중계만"]
    D["DayEventListViewModelImple.selectedDayIsToday<br/>subject.selectedDayIsToday · 초기값 true = 숨김"]
    P --> D
    D --> E["isShowReturnToToday — 반전 후 removeDuplicates<br/>노출 판정은 여기서"]
    E --> F[DayEventListViewState.isShowReturnToToday]
    F --> G["DayEventListView.returnToTodayView()"]
```

### 탭 — 상향

```mermaid
sequenceDiagram
    participant V as DayEventListView
    participant DEL as DayEventListViewModelImple
    participant CP as CalendarPaperViewModelImple
    participant CV as CalendarViewModelImple
    V->>DEL: returnToToday()
    DEL->>CP: dayEventListDidRequestReturnToToday()
    CP->>CV: calendarPaperDidRequestReturnToToday()
    CV->>CV: moveFocusToToday() → paper.selectToday() → MonthViewModel.clearDaySelection()
    Note over CV,DEL: 선택일이 오늘로 바뀌어 하향 흐름이 다시 돌고 버튼이 숨는다
```

판정이 하향 흐름 한 곳에만 있다. 값을 `shouldShow` 가 아니라 사실(`isToday`)로 내려보내 표시처가 자기 노출을 정하고, 상향 흐름은 그 판정의 주인인 `CalendarViewModelImple` 에 도달해 하향 흐름의 입력을 바꾼다 — 그 결과가 다시 내려와 버튼이 사라지며 루프가 닫힌다. 두 흐름이 같은 객체에서 만나 모듈 경계를 넘지 않는다.

## 최종상태 대조

| 항목 | 판정 | 근거 |
|---|---|---|
| 오늘이 아닌 날 선택 시 목록 날짜 헤더에 오늘 버튼 노출 | 달성 | `DayEventListViewModelImpleTests.testViewModel_whenSelectedDayIsNotToday_showReturnToToday` |
| 오늘 선택 시 사라짐 | 달성 | 같은 파일 `..._whenSelectedDayIsToday_hideReturnToToday` |
| 탭하면 오늘로 이동 | 달성 | 3단 체인 TC + `CalendarViewModelImpleTests.testViewModel_whenPaperRequestReturnToToday_moveFocusToToday` |
| 상단 헤더에 어떤 상태에서도 오늘 버튼 없음 | 달성 | `MainViewController.HeaderView` 에서 선언·레이아웃·스타일·바인딩 전부 제거 |
| 연도가 14pt 보다 크게 | 부분 | 22pt semibold 로 교체. 실제 크기감은 육안 미확인 |
| 새 로컬라이즈 키 없음 | 달성 | `"TODAY"` 를 그대로 옮김 (원래도 미등록 키라 fallback 으로 영문 노출) |

## 알려진 한계

- 스와이프로 옆 달에 막 진입해 그 달의 선택일이 아직 정해지기 전 짧은 구간에는 오늘 버튼이 뜨지 않는다. `MonthViewModel` 의 선택 통지가 오면 채워진다 — 과다 노출이 아니라 미노출 방향이라 잘못된 버튼이 보이지는 않는다.
- `Presentations/Scenes/` 를 건드려(요구사항 한 줄 제거) CI 테스트가 Presentation 전 스킴 + TodoCalendarApp 으로 퍼진다. 변경은 순감이다.

## 유저 검증 대기

시뮬레이터 육안으로 확인이 필요하다 — 유닛 테스트가 덮지 않는 레이아웃·스타일이다.

1. 오늘이 아닌 날을 골랐을 때 목록 날짜 헤더에 오늘 버튼이 뜨고, 탭하면 오늘로 이동하는가
2. 음력 표시를 켜고 공휴일명이 있는 날에서 날짜 헤더가 한 줄에 들어가는가
3. 상단 헤더에서 오늘 버튼이 빠진 뒤 도구 버튼 묶음이 월 제목과 겹치지 않는가
4. 다른 해로 이동했을 때 연도 22pt semibold 가 월 제목(32pt)에 눌리지 않고 읽히는가 — 답답하면 `titleStackView.spacing` 을 4 → 6 으로 올리는 것이 우발계획이다

테스트 배포 빌드 20 으로 확인 가능하다.

## 리뷰어 체크리스트

- 노출 조건도 탭 처리도 CalendarScenes 안에서 닫히고 Main 을 왕복하지 않는가
- 걷어낸 `CalendarSceneInteractor.moveFocusToToday()` 를 참조하던 자리가 남지 않았는가
- `selectedDayIsToday` 가 포커스된 paper 에만 가는가 (`CalendarViewModelImpleTests.testViewModel_whenSelectedDayChanged_notifyIsTodayToFocusedPaperOnly`)
- 옮긴 버튼의 시각 스펙이 원본과 같은가 — 테두리 1.5pt · `Metric.Radius.large`(12) · `arrow.uturn.right` 15×15 · `fontSet.subNormalWithBold`
- `Snapshots/` 의 Fake 둘이 프로토콜 변경에 맞춰 갱신됐는가 (이 스킴은 CI 가 안 돌린다)
